### PR TITLE
General: Prevent silent data loss on save, Save As, and tab close

### DIFF
--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -231,6 +231,9 @@
     <!-- Tab close confirmation -->
     <string name="general_tab_close_confirmation_title">Close tab?</string>
     <string name="general_tab_close_confirmation_message">Are you sure you want to close \"%1$s\"?</string>
+    <string name="general_tab_close_unsaved_title">Unsaved changes</string>
+    <string name="general_tab_close_unsaved_message">\"%1$s\" has unsaved changes. Close and discard them?</string>
+    <string name="general_discard_action">Discard</string>
 
     <!-- Exit app -->
     <string name="general_press_back_again_to_exit">Press back again to exit</string>

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/EditorWorkspace.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/EditorWorkspace.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -176,7 +177,8 @@ class EditorWorkspace @AssistedInject constructor(
                     is State.Error -> Workspace.LifecycleState.Error(state.error)
                     is State.Ready -> Workspace.LifecycleState.Ready
                 }
-                _info.value = _info.value.copy(lifecycleState = lifecycle)
+                val hasUnsavedChanges = (state as? State.Ready)?.editor?.isModified == true
+                _info.update { it.copy(lifecycleState = lifecycle, hasUnsavedChanges = hasUnsavedChanges) }
             }
         }
 
@@ -202,10 +204,12 @@ class EditorWorkspace @AssistedInject constructor(
                     }
                 }
 
-                _info.value = _info.value.copy(
-                    operationCount = operationCount,
-                    attentionCount = attentionCount
-                )
+                _info.update {
+                    it.copy(
+                        operationCount = operationCount,
+                        attentionCount = attentionCount,
+                    )
+                }
                 log(tag, VERBOSE) { "Updated operation counts: active=$operationCount, attention=$attentionCount" }
             }
             .launchIn(workspaceScope)
@@ -301,7 +305,7 @@ class EditorWorkspace @AssistedInject constructor(
             else -> "Editor ${id.shortTag}"
         }
 
-        _info.value = _info.value.copy(title = newTitle.toCaString())
+        _info.update { it.copy(title = newTitle.toCaString()) }
         log(tag, DEBUG) { "Updated title to: $newTitle" }
     }
 

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/ChunkedTextBuffer.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/ChunkedTextBuffer.kt
@@ -173,6 +173,27 @@ class ChunkedTextBuffer @AssistedInject constructor(
         }
     }
 
+    /**
+     * Returns the full current document text by concatenating every chunk's decoded content in order.
+     *
+     * Deliberately offset-independent: it does not use the byte/char offset math that [getText] relies on,
+     * so it stays correct for BOM/multibyte documents where byte and char counts diverge. Loads all chunks
+     * into memory, so it is intended for whole-document operations (e.g. "Save As"), not hot paths.
+     */
+    suspend fun getFullText(): Result<String> {
+        return try {
+            val sb = StringBuilder()
+            for (meta in chunkMetadata.toList()) {
+                val chunk = chunkManager.loadChunk(meta.chunkId).getOrThrow()
+                sb.append(chunk.content)
+            }
+            Result.success(sb.toString())
+        } catch (e: Exception) {
+            log(tag, ERROR) { "Failed to assemble full text - ${e.asLog()}" }
+            Result.failure(e)
+        }
+    }
+
     suspend fun getTextForLine(lineNumber: Int): Result<String> {
         if (lineNumber < 0 || lineNumber >= _totalLines.value) {
             return Result.failure(IndexOutOfBoundsException("Line number $lineNumber is out of bounds"))

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/EditorEngine.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/EditorEngine.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import okio.Buffer
 import okio.Source
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.coroutineContext
@@ -301,8 +302,19 @@ class EditorEngine @AssistedInject constructor(
     suspend fun getContentStream(): Source = stateMutex.withLock {
         return when (val currentState = _state.value) {
             is EditorState.Loaded -> {
-                log(tag) { "Opening content stream for reading" }
-                currentState.resources.dataSource.openSource()
+                log(tag) { "Opening content stream for current buffer content" }
+                val buffer = currentState.resources.textBuffer
+                val text = buffer.getFullText().getOrThrow()
+                val source = buffer.contentSource.value
+                val charset = when (source) {
+                    is ContentSource.File -> source.detectedCharset
+                    is ContentSource.Memory -> Charsets.UTF_8
+                }
+                val bom = (source as? ContentSource.File)?.takeIf { it.hasBOM }?.bomBytes
+                Buffer().apply {
+                    if (bom != null) write(bom)
+                    write(text.toByteArray(charset))
+                }
             }
             else -> {
                 throw IllegalStateException("Cannot get content stream - no content available")

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/FileDataSource.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/FileDataSource.kt
@@ -9,6 +9,7 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.extensions.exists
 import eu.darken.butler.common.files.extensions.lookup
@@ -33,6 +34,7 @@ import java.io.FileNotFoundException
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.charset.CodingErrorAction
+import kotlin.uuid.Uuid
 
 /**
  * File-based data source implementation.
@@ -267,8 +269,13 @@ class FileDataSource @AssistedInject constructor(
     override suspend fun getSize(): Long = _contentSource.value.size
 
     /**
-     * Saves dirty chunks to file using atomic write pattern.
-     * Uses temp file + atomic rename to prevent corruption.
+     * Saves dirty chunks to the file without risking the original on failure.
+     *
+     * Local paths use a backup-swap: the original is renamed aside, the new content (written to a
+     * uniquely-named temp) is renamed into place, and the backup is removed only after the commit
+     * succeeds. On any failure the original is restored from the backup. SAF paths have no rename
+     * primitive, so the original bytes are copied to a uniquely-named backup, the document is
+     * overwritten in place, and the original is restored from the backup if the write fails.
      *
      * @param dirtyChunks List of modified chunks to save (will be merged with original content)
      */
@@ -310,42 +317,24 @@ class FileDataSource @AssistedInject constructor(
                         charset = fileSource.detectedCharset
                     )
 
-                    // Atomic save: write to temp file, then rename
-                    val tempPath = filePath.parent?.child("${filePath.name}.tmp")
-                        ?: throw IllegalStateException("Cannot create temp file - no parent directory")
+                    // BOM to prepend when writing the new content (restored verbatim from the original).
+                    val bom = if (fileSource.hasBOM) fileSource.bomBytes else null
 
-                    try {
-                        // Write merged content to temp file
-                        gatewaySwitch.file(tempPath, readWrite = true).use { handle ->
-                            handle.sink().buffer().use { sink ->
-                                // Restore BOM if original file had one
-                                if (fileSource.hasBOM && fileSource.bomBytes != null) {
-                                    sink.write(fileSource.bomBytes)
-                                    log(tag) { "Restored ${fileSource.bomBytes.size} byte BOM to saved file" }
-                                }
-                                sink.write(mergedContent)
-                            }
-                        }
+                    // Unique per-save artifact names so we never collide with or delete a user's own
+                    // files, and never touch artifacts from a different (e.g. crashed) save.
+                    val token = Uuid.random().toString().take(8)
+                    val parent = filePath.parent
+                        ?: throw IllegalStateException("Cannot save - no parent directory")
+                    val backupPath = parent.child("${filePath.name}.butler-save-bak-$token")
 
-                        // Atomic rename: temp file -> original file
-                        // Note: This requires the gateway to support rename/move operations
-                        // For now, we'll delete original and rename temp (not fully atomic but safer than direct write)
-                        gatewaySwitch.delete(filePath)
-                        gatewaySwitch.move(tempPath, filePath)
-
-                        log(tag) { "Successfully saved ${mergedContent.size} bytes using atomic write" }
-
-                    } catch (e: Exception) {
-                        // Clean up temp file on failure
-                        try {
-                            if (tempPath.exists(gatewaySwitch)) {
-                                gatewaySwitch.delete(tempPath)
-                            }
-                        } catch (cleanupError: Exception) {
-                            log(tag, ERROR) { "Failed to cleanup temp file: ${cleanupError.asLog()}" }
-                        }
-                        throw e
+                    if (filePath is LocalPath) {
+                        val tempPath = parent.child("${filePath.name}.butler-save-tmp-$token")
+                        commitViaBackupSwap(tempPath, backupPath, bom, mergedContent)
+                    } else {
+                        commitViaInPlace(backupPath, bom, mergedContent, originalBytes)
                     }
+
+                    log(tag) { "Saved ${mergedContent.size} bytes" }
 
                     // Update state
                     _isModified.value = false
@@ -369,6 +358,105 @@ class FileDataSource @AssistedInject constructor(
                 }
             }
         }
+
+    /**
+     * Writes [bom] (if any) followed by [body] to [target], truncating any existing content first and
+     * flushing to disk so the result is durable before it is treated as a recovery copy.
+     */
+    private suspend fun writeContent(target: APath<*>, bom: ByteArray?, body: ByteArray) {
+        gatewaySwitch.file(target, readWrite = true).use { handle ->
+            handle.resize(0)
+            handle.sink().buffer().use { sink ->
+                if (bom != null) sink.write(bom)
+                sink.write(body)
+                sink.flush()
+            }
+            handle.flush()
+        }
+    }
+
+    /** Best-effort removal of a save artifact; logs (never throws) if the delete fails or returns false. */
+    private suspend fun cleanupArtifact(path: APath<*>) {
+        runCatching {
+            if (path.exists(gatewaySwitch) && !gatewaySwitch.delete(path)) {
+                log(tag, WARN) { "Failed to delete leftover save artifact: $path" }
+            }
+        }.onFailure { log(tag, WARN) { "Error cleaning up save artifact $path: ${it.asLog()}" } }
+    }
+
+    /**
+     * Local-path commit: rename the original aside, rename the freshly-written temp into place, and
+     * drop the backup only after the commit succeeds. Restores the original on failure and always
+     * cleans up the temp artifact.
+     */
+    internal suspend fun commitViaBackupSwap(
+        tempPath: APath<*>,
+        backupPath: APath<*>,
+        bom: ByteArray?,
+        mergedContent: ByteArray,
+    ) {
+        var backedUp = false
+        try {
+            writeContent(tempPath, bom, mergedContent)
+            if (filePath.exists(gatewaySwitch)) {
+                check(gatewaySwitch.move(filePath, backupPath)) { "Backup move failed: $filePath -> $backupPath" }
+                backedUp = true
+            }
+            check(gatewaySwitch.move(tempPath, filePath)) { "Commit move failed: $tempPath -> $filePath" }
+        } catch (e: Exception) {
+            // Moves are atomic, so a failure here means the commit never landed and the original path
+            // is free; if we had moved the original aside, put it back.
+            if (backedUp) {
+                try {
+                    check(gatewaySwitch.move(backupPath, filePath)) { "Restore move returned false" }
+                    backedUp = false
+                } catch (restoreError: Exception) {
+                    log(tag, ERROR) { "Restore failed - original preserved at $backupPath: ${restoreError.asLog()}" }
+                    e.addSuppressed(restoreError)
+                }
+            }
+            cleanupArtifact(tempPath)
+            throw e
+        }
+
+        cleanupArtifact(backupPath)
+    }
+
+    /**
+     * SAF/non-local commit: no rename primitive is available, so copy the original bytes to a backup,
+     * overwrite the document in place, and restore from the backup on failure. Not atomic - process
+     * death mid-write can leave the file partial with the original preserved in [backupPath].
+     */
+    internal suspend fun commitViaInPlace(
+        backupPath: APath<*>,
+        bom: ByteArray?,
+        mergedContent: ByteArray,
+        originalBytes: ByteArray,
+    ) {
+        var backupReady = false
+        try {
+            gatewaySwitch.createFile(backupPath, createParents = false)
+            writeContent(backupPath, bom = null, body = originalBytes)
+            backupReady = true
+            writeContent(filePath, bom, mergedContent)
+        } catch (e: Exception) {
+            if (backupReady) {
+                // The in-place overwrite failed; the original may be partial. Restore it, and keep the
+                // backup as a recovery copy if the restore also fails.
+                runCatching { writeContent(filePath, bom = null, body = originalBytes) }
+                    .onFailure {
+                        log(tag, ERROR) { "Restore failed - original preserved at $backupPath: ${it.asLog()}" }
+                        e.addSuppressed(it)
+                    }
+            } else {
+                // Backup never completed; the original was not touched, so the partial backup is junk.
+                cleanupArtifact(backupPath)
+            }
+            throw e
+        }
+
+        cleanupArtifact(backupPath)
+    }
 
     override suspend fun close() = accessMutex.withLock {
         _contentSource.value = ContentSource.Memory(size = 0L)

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineContentStreamTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineContentStreamTest.kt
@@ -1,0 +1,124 @@
+package eu.darken.butler.editor.core.engine
+
+import eu.darken.butler.common.datastore.DataStoreValue
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.local.LocalFileSystemOps
+import eu.darken.butler.common.files.metadata.OwnershipResolver
+import eu.darken.butler.editor.core.EditorSettings
+import eu.darken.butler.editor.core.sources.EditorDataSource
+import eu.darken.butler.editor.core.sources.FileDataSource
+import eu.darken.butler.editor.core.sources.InMemoryDataSource
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okio.buffer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests for [EditorEngine.getContentStream], which backs "Save As".
+ *
+ * Regression guard: the stream must reflect the CURRENT (edited) buffer content, not the stale
+ * on-disk original, and must preserve the detected charset/BOM for file-backed documents.
+ */
+class EditorEngineContentStreamTest : ChunkedTextBufferTestBase() {
+
+    private val mockOwnershipResolver = mockk<OwnershipResolver>(relaxed = true)
+    private val fileSystemOps = LocalFileSystemOps(ownershipResolver = mockOwnershipResolver)
+
+    private fun createMockSettings(): EditorSettings {
+        val settings = mockk<EditorSettings>()
+        val undoStackSize = mockk<DataStoreValue<Int>>()
+        val undoMaxMemory = mockk<DataStoreValue<Long>>()
+        every { undoStackSize.flow } returns flowOf(100)
+        every { undoMaxMemory.flow } returns flowOf(10 * 1_048_576L)
+        every { settings.undoStackSize } returns undoStackSize
+        every { settings.undoMaxMemory } returns undoMaxMemory
+        return settings
+    }
+
+    private val inMemoryDataSourceFactory = object : InMemoryDataSource.Factory {
+        override fun create(workspaceId: Workspace.Id, initialContent: String) =
+            InMemoryDataSource(workspaceId, initialContent)
+    }
+    private val fileDataSourceFactory = object : FileDataSource.Factory {
+        override fun create(workspaceId: Workspace.Id, filePath: APath<*>, gatewaySwitch: GatewaySwitch) =
+            FileDataSource(workspaceId, filePath, gatewaySwitch)
+    }
+    private val chunkRepositoryFactory = object : ChunkRepository.Factory {
+        override fun create(workspaceId: Workspace.Id, dataSource: EditorDataSource) =
+            ChunkRepository(workspaceId, dataSource)
+    }
+    private val chunkManagerFactory = object : ChunkManager.Factory {
+        override fun create(workspaceId: Workspace.Id, chunkRepository: ChunkRepository, chunkSize: Long) =
+            ChunkManager(workspaceId, chunkRepository, chunkSize)
+    }
+    private val chunkedTextBufferFactory = object : ChunkedTextBuffer.Factory {
+        override fun create(
+            workspaceId: Workspace.Id,
+            chunkManager: ChunkManager,
+            chunkRepository: ChunkRepository,
+            maxUndoStackSize: Int,
+            maxUndoMemoryBytes: Long,
+        ) = ChunkedTextBuffer(workspaceId, chunkManager, chunkRepository, maxUndoStackSize, maxUndoMemoryBytes)
+    }
+
+    private fun createReadOnlyGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
+        coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        @Suppress("UNCHECKED_CAST")
+        coEvery { lookup(any(), any()) } coAnswers {
+            fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>
+        }
+        coEvery { file(any(), any()) } coAnswers {
+            fileSystemOps.file(firstArg<APath<*>>() as LocalPath, secondArg<Boolean>())
+        }
+    }
+
+    private suspend fun createEngine(
+        content: String? = null,
+        filePath: APath<*>? = null,
+        gateway: GatewaySwitch = mockk(),
+    ): EditorEngine = EditorEngine(
+        workspaceId = workspaceId,
+        filePath = filePath,
+        initialContent = content,
+        gatewaySwitch = gateway,
+        editorSettings = createMockSettings(),
+        fileDataSourceFactory = fileDataSourceFactory,
+        inMemoryDataSourceFactory = inMemoryDataSourceFactory,
+        chunkRepositoryFactory = chunkRepositoryFactory,
+        chunkManagerFactory = chunkManagerFactory,
+        chunkedTextBufferFactory = chunkedTextBufferFactory,
+    ).apply { initialize().getOrThrow() }
+
+    @Test
+    fun `getContentStream returns the edited buffer content, not the stale original`() = runTest {
+        val engine = createEngine(content = "Hello")
+        engine.setCursorPosition(TextPosition(offset = 5, line = 0, column = 5))
+        engine.insertText(" World")
+
+        val streamed = engine.getContentStream().buffer().use { it.readUtf8() }
+
+        streamed shouldBe "Hello World"
+    }
+
+    @Test
+    fun `getContentStream preserves the BOM for a file-backed document`(@TempDir tempDir: File) = runTest {
+        val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        val file = File(tempDir, "bom.txt").apply { writeBytes(bom + "Hello".toByteArray()) }
+        val engine = createEngine(filePath = LocalPath.build(file), gateway = createReadOnlyGateway())
+
+        val streamed = engine.getContentStream().buffer().use { it.readByteArray() }
+
+        streamed.toList() shouldBe (bom + "Hello".toByteArray()).toList()
+    }
+}

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceTest.kt
@@ -10,6 +10,7 @@ import eu.darken.butler.common.files.metadata.OwnershipResolver
 import eu.darken.butler.editor.core.engine.ChunkBoundary
 import eu.darken.butler.editor.core.engine.TextChunk
 import eu.darken.butler.workspace.core.Workspace
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.instanceOf
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.io.TempDir
 import testhelpers.BaseTest
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.IOException
 import kotlin.uuid.Uuid
 
 class FileDataSourceTest : BaseTest() {
@@ -69,6 +71,12 @@ class FileDataSourceTest : BaseTest() {
             val source = firstArg<APath<*>>() as LocalPath
             val target = secondArg<APath<*>>() as LocalPath
             source.file.renameTo(target.file)
+        }
+
+        // Mock createFile() - delegates to REAL file system operations
+        coEvery { createFile(any(), any()) } coAnswers {
+            val path = firstArg<APath<*>>() as LocalPath
+            path.file.createNewFile()
         }
     }
 
@@ -229,6 +237,137 @@ class FileDataSourceTest : BaseTest() {
         // Then: File timestamp unchanged (assuming implementation optimizes this)
         // Note: Depending on implementation, this may or may not update timestamp
         dataSource.isModified.value shouldBe false
+    }
+
+    // ==================== Safe-save (local backup-swap) Tests ====================
+
+    private fun dirtyChunk(content: String) =
+        TextChunk(id = TextChunk.ChunkId.generate(), content = content, lineCount = 1, isDirty = true)
+
+    @Test
+    fun `save failure preserves the original file and cleans up artifacts`(@TempDir tempDir: File) = runTest {
+        val gateway = createMockGateway()
+        // Fail the commit move (temp -> original); allow the backup and restore moves.
+        coEvery { gateway.move(any<APath<*>>(), any<APath<*>>()) } coAnswers {
+            val source = firstArg<APath<*>>() as LocalPath
+            val target = secondArg<APath<*>>() as LocalPath
+            if (source.name.contains("butler-save-tmp")) throw IOException("simulated commit failure")
+            source.file.renameTo(target.file)
+        }
+        val testFile = File(tempDir, "test.txt").apply { writeText("Hello World") }
+        val dataSource = FileDataSource(workspaceId, LocalPath.build(testFile), gateway).apply { open() }
+
+        val dirty = dirtyChunk("Goodbye")
+        shouldThrow<Exception> {
+            dataSource.save(listOf(dirty), boundaries(dirty to (0L to 7L)))
+        }
+
+        // Original intact, no leftover save artifacts.
+        testFile.readText() shouldBe "Hello World"
+        tempDir.listFiles()!!.none { it.name.contains("butler-save") } shouldBe true
+    }
+
+    @Test
+    fun `save failure via false move result also preserves the original`(@TempDir tempDir: File) = runTest {
+        val gateway = createMockGateway()
+        coEvery { gateway.move(any<APath<*>>(), any<APath<*>>()) } coAnswers {
+            val source = firstArg<APath<*>>() as LocalPath
+            val target = secondArg<APath<*>>() as LocalPath
+            if (source.name.contains("butler-save-tmp")) false else source.file.renameTo(target.file)
+        }
+        val testFile = File(tempDir, "test.txt").apply { writeText("Hello World") }
+        val dataSource = FileDataSource(workspaceId, LocalPath.build(testFile), gateway).apply { open() }
+
+        val dirty = dirtyChunk("Goodbye")
+        shouldThrow<Exception> {
+            dataSource.save(listOf(dirty), boundaries(dirty to (0L to 7L)))
+        }
+
+        testFile.readText() shouldBe "Hello World"
+        tempDir.listFiles()!!.none { it.name.contains("butler-save") } shouldBe true
+    }
+
+    @Test
+    fun `successful save leaves no temp or backup artifacts`(@TempDir tempDir: File) = runTest {
+        val testFile = File(tempDir, "test.txt").apply { writeText("Hello World") }
+        val dataSource = createDataSource(tempDir, "test.txt", "Hello World")
+
+        val dirty = dirtyChunk("Goodbye")
+        dataSource.save(listOf(dirty), boundaries(dirty to (0L to 7L)))
+
+        testFile.readText().take(7) shouldBe "Goodbye"
+        tempDir.listFiles()!!.none { it.name.contains("butler-save") } shouldBe true
+    }
+
+    @Test
+    fun `save failure never destroys the original even when restore fails`(@TempDir tempDir: File) = runTest {
+        val gateway = createMockGateway()
+        // Every move targeting the original (commit AND restore) fails.
+        coEvery { gateway.move(any<APath<*>>(), any<APath<*>>()) } coAnswers {
+            val source = firstArg<APath<*>>() as LocalPath
+            val target = secondArg<APath<*>>() as LocalPath
+            if (target.name == "test.txt") throw IOException("write barrier") else source.file.renameTo(target.file)
+        }
+        val testFile = File(tempDir, "test.txt").apply { writeText("Hello World") }
+        val dataSource = FileDataSource(workspaceId, LocalPath.build(testFile), gateway).apply { open() }
+
+        val dirty = dirtyChunk("Goodbye")
+        shouldThrow<Exception> {
+            dataSource.save(listOf(dirty), boundaries(dirty to (0L to 7L)))
+        }
+
+        // The original survives: restored in place, or preserved in the backup if restore also failed.
+        val survivors = tempDir.listFiles()!!
+            .filter { it.name == "test.txt" || it.name.contains("butler-save-bak") }
+            .map { it.readText() }
+        survivors.any { it == "Hello World" } shouldBe true
+    }
+
+    // ==================== Safe-save (in-place / non-local) Tests ====================
+
+    @Test
+    fun `commitViaInPlace overwrites in place and removes the backup on success`(@TempDir tempDir: File) = runTest {
+        val testFile = File(tempDir, "test.txt").apply { writeText("original") }
+        val dataSource = createDataSource(tempDir, "test.txt", "original")
+        val backupPath = LocalPath.build(File(tempDir, "test.txt.butler-save-bak-inplace"))
+
+        dataSource.commitViaInPlace(
+            backupPath = backupPath,
+            bom = null,
+            mergedContent = "NEW CONTENT".toByteArray(),
+            originalBytes = "original".toByteArray(),
+        )
+
+        testFile.readText() shouldBe "NEW CONTENT"
+        backupPath.file.exists() shouldBe false
+    }
+
+    @Test
+    fun `commitViaInPlace retains the backup when the overwrite fails`(@TempDir tempDir: File) = runTest {
+        val gateway = createMockGateway()
+        // Block read/write opens of the target document; backup writes still succeed.
+        coEvery { gateway.file(any(), any()) } coAnswers {
+            val path = firstArg<APath<*>>() as LocalPath
+            val readWrite = secondArg<Boolean>()
+            if (readWrite && path.name == "test.txt") throw IOException("doc not writable")
+            if (readWrite && !fileSystemOps.exists(path)) path.file.createNewFile()
+            fileSystemOps.file(path, readWrite)
+        }
+        val testFile = File(tempDir, "test.txt").apply { writeText("original") }
+        val dataSource = FileDataSource(workspaceId, LocalPath.build(testFile), gateway).apply { open() }
+        val backupPath = LocalPath.build(File(tempDir, "test.txt.butler-save-bak-inplace"))
+
+        shouldThrow<Exception> {
+            dataSource.commitViaInPlace(
+                backupPath = backupPath,
+                bom = null,
+                mergedContent = "NEW".toByteArray(),
+                originalBytes = "original".toByteArray(),
+            )
+        }
+
+        // Original content preserved in the backup for recovery.
+        backupPath.file.readText() shouldBe "original"
     }
 
     // ==================== Edge Case Tests ====================

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/Workspace.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/Workspace.kt
@@ -214,6 +214,12 @@ interface Workspace<ArgT : Workspace.Arguments> {
         val operationCount: Int = 0,
         val attentionCount: Int = 0,
         /**
+         * True when this workspace holds unsaved in-memory changes that would be lost on close.
+         * Domain signal: the close path uses it to require confirmation, the UI to warn the user.
+         * Workspaces without a dirty concept leave this false.
+         */
+        val hasUnsavedChanges: Boolean = false,
+        /**
          * ID of the workspace that created this workspace, if this is a sub-workspace.
          * Null for normal workspaces.
          *

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspaceOverlayContainer.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspaceOverlayContainer.kt
@@ -69,6 +69,7 @@ fun WorkspaceOverlayContainer(
                 is ManagerDialog.WorkspaceTargeted.CloseConfirmation -> {
                     WorkspaceCloseConfirmationDialog(
                         workspaceTitle = dialog.workspaceTitle,
+                        hasUnsavedChanges = dialog.hasUnsavedChanges,
                         onDismiss = { onDismissManagerDialog(dialog.targetWorkspaceId) },
                         onConfirm = { onConfirmManagerDialog(dialog) },
                     )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
@@ -52,6 +52,7 @@ sealed interface ManagerDialog {
             override val id: String,
             override val targetWorkspaceId: Workspace.Id,
             val workspaceTitle: CaString,
+            val hasUnsavedChanges: Boolean = false,
         ) : WorkspaceTargeted {
             override val isBlocking: Boolean = true
         }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceCloseConfirmationDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceCloseConfirmationDialog.kt
@@ -1,8 +1,10 @@
 package eu.darken.butler.workspace.ui.dialogs
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -16,25 +18,47 @@ import eu.darken.butler.common.R as CommonR
 @Composable
 fun WorkspaceCloseConfirmationDialog(
     workspaceTitle: CaString,
+    hasUnsavedChanges: Boolean = false,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
     PaneBoundAlertDialog(
         onDismissRequest = onDismiss,
         title = {
-            Text(text = stringResource(CommonR.string.general_tab_close_confirmation_title))
+            Text(
+                text = stringResource(
+                    if (hasUnsavedChanges) {
+                        CommonR.string.general_tab_close_unsaved_title
+                    } else {
+                        CommonR.string.general_tab_close_confirmation_title
+                    }
+                )
+            )
         },
         text = {
             Text(
                 text = stringResource(
-                    CommonR.string.general_tab_close_confirmation_message,
+                    if (hasUnsavedChanges) {
+                        CommonR.string.general_tab_close_unsaved_message
+                    } else {
+                        CommonR.string.general_tab_close_confirmation_message
+                    },
                     workspaceTitle.get(LocalContext.current)
                 )
             )
         },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text(text = stringResource(CommonR.string.general_close_action))
+                Text(
+                    text = stringResource(
+                        if (hasUnsavedChanges) {
+                            CommonR.string.general_discard_action
+                        } else {
+                            CommonR.string.general_close_action
+                        }
+                    ),
+                    color = if (hasUnsavedChanges) MaterialTheme.colorScheme.error else Color.Unspecified,
+                )
             }
         },
         dismissButton = {
@@ -51,6 +75,18 @@ fun WorkspaceCloseConfirmationDialog(
 private fun WorkspaceCloseConfirmationDialogPreview() {
     WorkspaceCloseConfirmationDialog(
         workspaceTitle = "My Documents".toCaString(),
+        onDismiss = {},
+        onConfirm = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceCloseConfirmationDialogUnsavedPreview() {
+    WorkspaceCloseConfirmationDialog(
+        workspaceTitle = "notes.txt".toCaString(),
+        hasUnsavedChanges = true,
         onDismiss = {},
         onConfirm = {},
     )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/CloseAllWorkspacesDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/CloseAllWorkspacesDialog.kt
@@ -1,17 +1,23 @@
 package eu.darken.butler.workspace.ui.manager
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import eu.darken.butler.workspace.R
 
 @Composable
 fun CloseAllWorkspacesDialog(
     visible: Boolean,
     workspaceCount: Int,
+    hasUnsavedChanges: Boolean = false,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
@@ -21,23 +27,39 @@ fun CloseAllWorkspacesDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.workspace_manager_close_all_title)) },
         text = {
-            val workspaceString = if (workspaceCount == 1) {
-                stringResource(R.string.workspace_manager_close_all_message_singular)
-            } else {
-                stringResource(R.string.workspace_manager_close_all_message_plural)
-            }
-            Text(
-                stringResource(
-                    R.string.workspace_manager_close_all_message,
-                    workspaceCount,
-                    workspaceString
+            Column {
+                val workspaceString = if (workspaceCount == 1) {
+                    stringResource(R.string.workspace_manager_close_all_message_singular)
+                } else {
+                    stringResource(R.string.workspace_manager_close_all_message_plural)
+                }
+                Text(
+                    stringResource(
+                        R.string.workspace_manager_close_all_message,
+                        workspaceCount,
+                        workspaceString
+                    )
                 )
-            )
+                if (hasUnsavedChanges) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.workspace_manager_close_all_unsaved_warning),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
         },
         confirmButton = {
             TextButton(onClick = onConfirm) {
                 Text(
-                    text = stringResource(R.string.workspace_manager_close_all_action),
+                    text = stringResource(
+                        if (hasUnsavedChanges) {
+                            R.string.workspace_manager_close_all_unsaved_action
+                        } else {
+                            R.string.workspace_manager_close_all_action
+                        }
+                    ),
                     color = MaterialTheme.colorScheme.error
                 )
             }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
@@ -149,6 +149,7 @@ fun WorkspaceButton(
         CloseAllWorkspacesDialog(
             visible = showCloseAllDialog,
             workspaceCount = state?.workspaceCount ?: 0,
+            hasUnsavedChanges = state?.hasUnsavedChanges == true,
             onDismiss = { showCloseAllDialog = false },
             onConfirm = {
                 showCloseAllDialog = false

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModel.kt
@@ -31,6 +31,7 @@ class WorkspaceButtonViewModel @Inject constructor(
             workspaceCount = it.workspaceCount,
             operationsCount = it.operationCount,
             attentionCount = it.attentionCount,
+            hasUnsavedChanges = it.infos.any { info -> info.hasUnsavedChanges },
         )
     }.asStateFlow()
 
@@ -58,6 +59,7 @@ class WorkspaceButtonViewModel @Inject constructor(
         val workspaceCount: Int = 0,
         val operationsCount: Int = 0,
         val attentionCount: Int = 0,
+        val hasUnsavedChanges: Boolean = false,
     )
 
 }

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -79,6 +79,8 @@
     <string name="workspace_manager_close_all_message_singular">tab</string>
     <string name="workspace_manager_close_all_message_plural">tabs</string>
     <string name="workspace_manager_close_all_action">Close all</string>
+    <string name="workspace_manager_close_all_unsaved_warning">Some tabs have unsaved changes that will be lost.</string>
+    <string name="workspace_manager_close_all_unsaved_action">Discard all</string>
     <string name="workspace_fab_close_all">Close all tabs</string>
     <string name="general_cancel_action">Cancel</string>
 

--- a/app/src/main/java/eu/darken/butler/workspace/core/PendingWorkspaceConfirmation.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/PendingWorkspaceConfirmation.kt
@@ -23,6 +23,7 @@ data class PendingWorkspaceConfirmation(
         data class WorkspaceCloseConfirmation(
             val workspaceId: Workspace.Id,
             val workspaceTitle: CaString,
+            val hasUnsavedChanges: Boolean = false,
         ) : ConfirmationData
 
         /**

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -271,11 +271,26 @@ class WorkspaceRepo @Inject constructor(
             is WorkspaceAction.Close -> {
                 log(TAG, INFO) { "Closing workspace with id ${action.id}" }
 
-                // Request confirmation if required
-                if (action.requireConfirmation) {
-                    val workspace = _workspaces.value.firstOrNull { it.id == action.id }
+                val workspace = _workspaces.value.firstOrNull { it.id == action.id }
+
+                // Confirm when explicitly requested OR when the workspace has unsaved changes.
+                val needsConfirmation = action.requireConfirmation ||
+                    workspace?.info?.value?.hasUnsavedChanges == true
+
+                if (needsConfirmation) {
                     if (workspace == null) {
                         log(TAG, WARN) { "Cannot request close confirmation - workspace ${action.id} not found" }
+                        return@withLock WorkspaceAction.Close.Result
+                    }
+
+                    // De-dupe: don't queue a second close confirmation for the same workspace.
+                    val alreadyPending = _pendingConfirmations.value.values.any {
+                        val data = it.data
+                        data is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation &&
+                            data.workspaceId == action.id
+                    }
+                    if (alreadyPending) {
+                        log(TAG) { "Close confirmation already pending for ${action.id}, ignoring duplicate" }
                         return@withLock WorkspaceAction.Close.Result
                     }
 
@@ -295,6 +310,7 @@ class WorkspaceRepo @Inject constructor(
                             data = PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation(
                                 workspaceId = action.id,
                                 workspaceTitle = workspaceInfo.title,
+                                hasUnsavedChanges = workspaceInfo.hasUnsavedChanges,
                             ),
                         ))
                     }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
@@ -146,6 +146,7 @@ fun WorkspaceManagerScreen(
     CloseAllWorkspacesDialog(
         visible = showCloseAllDialog,
         workspaceCount = state.workspaceCount,
+        hasUnsavedChanges = state.hasUnsavedChanges,
         onDismiss = { showCloseAllDialog = false },
         onConfirm = {
             onCloseAllWorkspaces()

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -78,6 +78,7 @@ class WorkspaceManagerViewModel @Inject constructor(
             filterOperations = filterOps,
             filterAttention = filterAtt,
             quickCreateItems = quickCreate,
+            hasUnsavedChanges = repoState.infos.any { it.hasUnsavedChanges },
         )
     }.asStateFlow()
 
@@ -176,6 +177,7 @@ class WorkspaceManagerViewModel @Inject constructor(
         val filterOperations: Boolean = false,
         val filterAttention: Boolean = false,
         val quickCreateItems: List<QuickCreateItem> = emptyList(),
+        val hasUnsavedChanges: Boolean = false,
     ) {
         val workspaceCount: Int = workspaces.size
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -136,6 +136,7 @@ class WorkspacesViewModel @Inject constructor(
                                 id = confirmationId,
                                 targetWorkspaceId = targetId,
                                 workspaceTitle = data.workspaceTitle,
+                                hasUnsavedChanges = data.hasUnsavedChanges,
                             )
                         }
                     }

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -6,6 +6,7 @@ import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coVerify
 import io.mockk.every
@@ -413,6 +414,59 @@ class WorkspaceRepoTest : BaseTest() {
 
             // Two manual tabs + (limit - 2) from the batch == limit; never the pre-fix total of limit + 2.
             createdWorkspaces shouldHaveSize WorkspaceRepo.FREE_TIER_WORKSPACE_LIMIT
+        }
+
+    private fun markDirty(id: Workspace.Id) {
+        val ws = fake(id)
+        ws.info.value = ws.info.value.copy(hasUnsavedChanges = true)
+    }
+
+    private fun Map<String, PendingWorkspaceConfirmation>.closeConfirmationsFor(id: Workspace.Id): Int =
+        values.count {
+            val data = it.data
+            data is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation &&
+                data.workspaceId == id
+        }
+
+    @Test
+    fun `closing a dirty workspace queues a confirmation instead of closing`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val id = repo.createTab()
+            markDirty(id)
+
+            repo.execute(WorkspaceAction.Close(id))
+
+            fake(id).released shouldBe false
+            repo.retrieve(id).first() shouldNotBe null
+            repo.pendingConfirmations.first().closeConfirmationsFor(id) shouldBe 1
+        }
+
+    @Test
+    fun `closing a clean workspace closes immediately without confirmation`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val id = repo.createTab()
+
+            repo.execute(WorkspaceAction.Close(id))
+
+            fake(id).released shouldBe true
+            repo.retrieve(id).first() shouldBe null
+            repo.pendingConfirmations.first() shouldBe emptyMap()
+        }
+
+    @Test
+    fun `repeated close on a dirty workspace queues only one confirmation`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val id = repo.createTab()
+            markDirty(id)
+
+            repo.execute(WorkspaceAction.Close(id))
+            repo.execute(WorkspaceAction.Close(id))
+            repo.execute(WorkspaceAction.Close(id))
+
+            repo.pendingConfirmations.first().closeConfirmationsFor(id) shouldBe 1
         }
 
     @Test


### PR DESCRIPTION
Fixes the high-severity **data-safety** findings from the editor-workspace review (multi-agent review + two rounds of Codex on plan and implementation).

## What this fixes

### 1. Save was destructive on failure (`FileDataSource`)
The old flow did `delete(original)` **then** `move(temp → original)`. If the move failed (cross-FS, SAF restriction, permission, process death), the original was already gone and only the temp was cleaned — the failure path *destroyed* user data.

- **Local paths**: backup-swap — rename the original aside, rename the freshly-written temp into place, drop the backup only after the commit lands; **restore the original on any failure**.
- **SAF / non-local** (no rename primitive exists): copy the original bytes to a backup, overwrite the document in place, **restore from the backup on failure**.
- Artifacts use unique `…butler-save-{tmp,bak}-<token>` names (never collide with or delete a user's files), are flushed for durability, and are always cleaned up. `move`/`delete` returning `false` or throwing is treated as failure.

### 2. `Save As` wrote stale bytes (`EditorEngine.getContentStream`)
It returned the raw on-disk original, so Save As would have persisted the *unmodified* file and dropped every edit. It now streams the **current edited buffer content** via a new `ChunkedTextBuffer.getFullText()` (offset-independent, so correct for BOM/multibyte), preserving the detected charset/BOM. (Latent today — no caller — but the API was wrong.)

### 3. Closing a tab silently discarded unsaved edits
`Workspace.Info` now exposes `hasUnsavedChanges`; `WorkspaceRepo` requires confirmation (de-duped per workspace) before closing a dirty tab, surfacing an unsaved-specific dialog. The **Close-all** dialogs (manager screen + workspace button) warn and show a *Discard all* action when any open tab is dirty.

## Tests
- `FileDataSourceTest`: save-failure recovery (commit throws / returns false / restore also fails → original always survives), no leftover artifacts on success, in-place overwrite + backup retention.
- `EditorEngineContentStreamTest`: Save As reflects edits; BOM preserved for file-backed docs.
- `WorkspaceRepoTest`: dirty close queues one confirmation (not closed), clean close closes immediately, repeated dirty close de-dupes to one.

All 318 editor-module tests and `WorkspaceRepoTest` pass; `app`, `app-workspace`, `app-workspace-editor` compile.

## Out of scope (documented follow-ups)
- A true single-op atomic gateway primitive (`REPLACE_EXISTING` / `renameDocument`) — the only path to atomic SAF saves; SAF is best-effort here.
- An `open()`-time reaper to auto-recover an orphaned `…butler-save-bak-*` left by a process death mid-save (data survives but is not auto-restored).
- The deeper engine-correctness findings (byte/char offset model, tab-column mispositioning, IME input) and the test-coverage gaps remain for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)