### PR TITLE
General: Fix freezes and stale sessions during root/Shizuku access

### DIFF
--- a/app-common-shell/src/main/java/eu/darken/butler/common/shell/SharedShell.kt
+++ b/app-common-shell/src/main/java/eu/darken/butler/common/shell/SharedShell.kt
@@ -61,7 +61,14 @@ class SharedShell(
         }
     }
 
-    val session = SharedResource(aTag, scope, source)
+    val session = SharedResource(
+        tag = aTag,
+        parentScope = scope,
+        source = source,
+        // A shell whose process has died must never be handed to a reuse: SharedResource caches the
+        // session and its async teardown can lag, so validate liveness and re-acquire a fresh shell.
+        isReusable = { it.isAlive() },
+    )
 
     override val sharedResource: SharedResource<FlowCmdShell.Session> = session
 

--- a/app-common-shell/src/test/java/eu/darken/butler/common/shell/SharedShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/butler/common/shell/SharedShellTest.kt
@@ -87,4 +87,18 @@ class SharedShellTest : BaseTest() {
             sharedShell.useRes { FlowCmd("echo test-$count").execute(it) }.isSuccessful shouldBe true
         }
     }
+
+    @Test fun `a dead shell session is never handed to a reuse`() = runTest2(autoCancel = true, timeout = 60.seconds) {
+        val sharedShell = SharedShell("BUTLER", this + Dispatchers.Default)
+
+        // `kill $$` makes the shell process exit mid-command -> the same failure mode as the reuse-with-cancel
+        // flake: the command sees no exit-code marker and throws (session died externally).
+        shouldThrow<Exception> {
+            sharedShell.useRes { FlowCmd("kill \$\$").execute(it) }
+        }
+
+        // The cached session is now dead but SharedResource's detach is asynchronous. Without the liveness
+        // check, the next get() reuses the dead session and fails the same way. It must instead get a fresh shell.
+        sharedShell.useRes { FlowCmd("echo after").execute(it) }.output shouldBe listOf("after")
+    }
 }

--- a/app-common/src/main/java/eu/darken/butler/common/sharedresource/SharedResource.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/sharedresource/SharedResource.kt
@@ -47,6 +47,14 @@ open class SharedResource<T : Any>(
      * Off by default — opt in per resource where silent failures are a known support pain point.
      */
     private val verboseLifecycle: Boolean = false,
+    /**
+     * Optional liveness check for a REUSED resource. Before handing back a cached generation, [get]
+     * validates its value with this; if it returns false the dead generation is detached and [get]
+     * retries with a fresh one. Guards against the window where a resource's backing has already died
+     * (e.g. a shell process exited) but the asynchronous onCompletion detach hasn't cleared [active]
+     * yet, so a reuse would otherwise be handed a dead resource. Null (default) disables validation.
+     */
+    private val isReusable: (suspend (T) -> Boolean)? = null,
 ) : KeepAlive {
     private val iTag = "$tag:SR"
     override val resourceId: String = iTag
@@ -56,6 +64,9 @@ open class SharedResource<T : Any>(
     }
 
     private val coreLock = Mutex()
+
+    /** Max times [get] will detach a dead reused generation and retry before giving up. */
+    private val reuseValidationAttempts = 5
 
     private val leaseScope = CoroutineScope(parentScope.newCoroutineContext(SupervisorJob()))
 
@@ -96,6 +107,76 @@ open class SharedResource<T : Any>(
         get() = active == null
 
     suspend fun get(): Resource<T> {
+        var attempt = 0
+        while (true) {
+            val (generation, value, lease) = try {
+                acquireGeneration()
+            } catch (e: StaleReuseAcquireException) {
+                // A REUSED generation died before producing a value — the failure belongs to that
+                // dying generation, not to this caller. It has been force-detached; retry fresh
+                // instead of rethrowing an error a moment-later call would never have seen.
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[${e.generationId}]-get() reused a dying generation, retrying" }
+                if (++attempt >= reuseValidationAttempts) {
+                    throw IllegalStateException(
+                        "[$iTag] kept acquiring dying generations after $attempt attempts",
+                        e.cause,
+                    )
+                }
+                continue
+            }
+
+            val reusable = isReusable
+            if (reusable != null) {
+                val alive = try {
+                    reusable(value)
+                } catch (e: Throwable) {
+                    // The validator threw, or the caller was cancelled at this suspension point. Release only
+                    // our provisional lease and propagate — do NOT tear down the shared generation for others.
+                    releaseProvisionalLease(lease, "reuse-validation-error")
+                    throw e
+                }
+                if (!alive) {
+                    // The cached generation's resource has died (e.g. its shell process exited) but the async
+                    // onCompletion detach hasn't cleared `active` yet, so acquireGeneration() handed back a dead
+                    // value. Drop our provisional lease + force-detach the stale generation, then retry for a fresh one.
+                    if (Bugs.isTrace) {
+                        log(iTag, DEBUG) { "[${generation.id}]-get() reused resource failed liveness check, detaching + retrying" }
+                    }
+                    detachInvalidReuse(generation, lease, "reuse-invalid")
+                    if (++attempt >= reuseValidationAttempts) {
+                        throw IllegalStateException("[$iTag] resource failed the reuse liveness check after $attempt attempts")
+                    }
+                    continue
+                }
+            }
+
+            // A concurrent close()/self-teardown may have force-closed every lease — including the one
+            // we just registered — between acquireGeneration() releasing coreLock and here. Handing
+            // that lease out would make the caller's first `.item` access throw ("closed resource");
+            // the generation is already torn down by whoever closed it, so simply retry.
+            if (lease.isClosed) {
+                if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}]-get() lease force-closed during acquisition, retrying" }
+                if (++attempt >= reuseValidationAttempts) {
+                    throw IllegalStateException("[$iTag] resource kept closing mid-acquisition after $attempt attempts")
+                }
+                continue
+            }
+
+            return Resource(value, lease)
+        }
+    }
+
+    /**
+     * Acquisition failed because a REUSED generation errored before producing a value. Retryable:
+     * the dying generation was force-detached, a fresh acquisition starts a new source. Never
+     * thrown for freshly-created generations — their startup failures propagate unchanged.
+     */
+    private class StaleReuseAcquireException(
+        val generationId: String,
+        override val cause: Throwable,
+    ) : Exception()
+
+    private suspend fun acquireGeneration(): Triple<Generation<T>, T, Lease> {
         val lId = "L:${Uuid.random().toString().takeLast(4)}"
         if (Bugs.isTrace) {
             val call = traceCall()
@@ -104,6 +185,7 @@ open class SharedResource<T : Any>(
 
         var lease: Lease? = null
         var gen: Generation<T>? = null
+        var reused = false
 
         coreLock.withLock("[$sId|$lId]-get()-sourcejob") {
             withContext(NonCancellable) {
@@ -128,6 +210,7 @@ open class SharedResource<T : Any>(
                 active?.let {
                     if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|$lId]-get() Source job already exists" }
                     gen = it
+                    reused = true
                     return@withContext
                 }
 
@@ -213,21 +296,73 @@ open class SharedResource<T : Any>(
             generation.ready.await()
         } catch (e: Throwable) {
             if (Bugs.isTrace) log(iTag, DEBUG) { "[${generation.id}|$lId]-get() await failed (${e.javaClass.simpleName}), releasing provisional lease" }
+            if (reused && e !is CancellationException) {
+                // We latched onto an already-running generation that then died before producing a value.
+                // Its startup error belongs to the caller that STARTED it, not to us — force-detach the
+                // corpse (async onCompletion teardown may not have run yet) and signal get() to retry fresh.
+                detachInvalidReuse(generation, lease!!, "stale-reuse")
+                throw StaleReuseAcquireException(generation.id, e)
+            }
             lease!!.close()
             throw e
         }
 
         val value = generation.value
         if (value == null) {
-            lease!!.close()
             val error = generation.error ?: IllegalStateException("Source produced no value")
             if (Bugs.isTrace) log(iTag, WARN) { "[${generation.id}|$lId]-get() no value, throwing $error" }
+            if (reused && error !is CancellationException) {
+                detachInvalidReuse(generation, lease!!, "stale-reuse")
+                throw StaleReuseAcquireException(generation.id, error)
+            }
+            lease!!.close()
             throw error
         }
 
         if (Bugs.isTrace) log(iTag) { "[${generation.id}|$lId]-get() returning value $value" }
-        return Resource(value, lease!!)
+        return Triple(generation, value, lease!!)
     }
+
+    /**
+     * Release only [lease] (under coreLock, as [closeLease] requires) and run the idle lease-check, for when
+     * acquisition fails after the provisional lease was taken — e.g. the reuse liveness validator threw or the
+     * caller was cancelled. Does NOT detach the generation, so other holders are unaffected. NonCancellable so
+     * the lease can't leak if we're being cancelled.
+     */
+    private suspend fun releaseProvisionalLease(lease: Lease, tag: String) = withContext(NonCancellable) {
+        coreLock.withLock("releaseProvisional-$tag") { closeLease(tag, lease) }
+        leaseCheck(tag, forced = false)
+    }
+
+    /**
+     * A reused generation failed the liveness check. Drop [lease] and, if [generation] is still active,
+     * force-detach it (mirrors the asynchronous onCompletion self-teardown) so a retrying get() starts a fresh
+     * generation. leaseCheckLock -> coreLock, the order leaseCheck()/onCompletion use. NonCancellable so a
+     * cancellation mid-detach can't strand a half-torn-down generation.
+     */
+    private suspend fun detachInvalidReuse(generation: Generation<T>, lease: Lease, tag: String) =
+        withContext(NonCancellable) {
+            val detached = leaseCheckLock.withLock {
+                val didDetach = coreLock.withLock("detachInvalidReuse-$tag") {
+                    if (active !== generation) {
+                        // Superseded: a fresh generation is already installed. Only drop our provisional lease.
+                        closeLease(tag, lease)
+                        false
+                    } else {
+                        closeLeasesLocked(tag) // closes every lease on the dead generation, including ours
+                        detachLocked(tag)
+                        true
+                    }
+                }
+                if (didDetach) {
+                    leaseCheckJob?.cancelAndJoin()
+                    leaseCheckJob = null
+                }
+                didDetach
+            }
+            // Superseded path only dropped one lease; idle-check the leases that remain.
+            if (!detached) leaseCheck(tag, forced = false)
+        }
 
     // Must be called with coreLock.withLock { }
     private suspend fun closeLease(tag: String, lease: Lease): Unit = withContext(NonCancellable) {
@@ -393,46 +528,81 @@ open class SharedResource<T : Any>(
      * When the root shell closes, the backup module needs to "close" too.
      * But the backupmodule, while open, keeps the root shell alive.
      */
-    suspend fun addChild(child: SharedResource<*>) = coreLock.withLock("addChild-${child.resourceId}") {
-        val existing = children[child]
-        if (existing != null && !existing.isClosed) {
-            if (Bugs.isTrace) {
-                log(iTag, VERBOSE) { "[$sId|_]-addChild() Already keeping child alive: $child" }
-            }
-            return@withLock
+    suspend fun addChild(child: SharedResource<*>) {
+        if (child === this) {
+            // Self-adoption would register our own lease as our own child, pinning this resource open
+            // until a forced close() (before the lock-scope rework it deadlocked on coreLock instead).
+            log(iTag, WARN) { "[$sId|_]-addChild() Ignoring attempt to adopt ourselves as our own child" }
+            return
         }
-        if (existing != null) {
-            // Stale child entry — drop it and fall through to re-adopt
-            if (Bugs.isTrace) {
+        // Decide under lock whether adoption is needed and pin the generation we are adopting FOR.
+        val adoptingGen = coreLock.withLock("addChild-check-${child.resourceId}") {
+            val existing = children[child]
+            if (existing != null && !existing.isClosed) {
+                if (Bugs.isTrace) {
+                    log(iTag, VERBOSE) { "[$sId|_]-addChild() Already keeping child alive: $child" }
+                }
+                return
+            }
+            if (existing != null && Bugs.isTrace) {
                 log(iTag, VERBOSE) { "[$sId|_]-addChild() Replacing stale closed child: $child" }
             }
-            children.remove(child)
-        }
 
-        if (isClosed) {
-            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Can't add child, we are not alive: $child" }
-            if (!child.isClosed) {
-                val trace = IllegalStateException("Tried to add open child to closed parent")
-                log(iTag, WARN) { "[$sId|_]-addChild() We are closed! Can't add open child $child:\n${trace.asLog()}" }
+            if (isClosed) {
+                if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Can't add child, we are not alive: $child" }
+                if (!child.isClosed) {
+                    val trace = IllegalStateException("Tried to add open child to closed parent")
+                    log(iTag, WARN) { "[$sId|_]-addChild() We are closed! Can't add open child $child:\n${trace.asLog()}" }
+                }
+                return
             }
-            return@withLock
+
+            if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Adding child to us: $child" }
+            active!! // !isClosed == (active != null)
         }
 
-        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Adding child to us: $child" }
-
+        // Acquire the child OFF our lock: child.get() can be expensive (e.g. launching a root helper takes
+        // seconds) and takes the CHILD's locks. Holding our coreLock across it would wedge every concurrent
+        // get()/close() on this resource for the whole child startup, and nested adoption chains
+        // (switch -> gateway -> root client) would hold multiple resource locks at once.
         val keepAlive = child.get()
-        val wrapped = Child(child, keepAlive)
-        children[child] = wrapped
 
-        if (Bugs.isTrace) {
-            val childrenSize = children.size
-            log(iTag, VERBOSE) { "[$sId|_]-addChild() Resource now has $childrenSize " }
-            if (Bugs.isTrace) {
-                children.onEachIndexed { index, entry ->
-                    log(iTag, VERBOSE) { "[$sId|_]-addChild() Now has #$index ${entry.value} " }
+        // Register under lock, re-validating the world we decided against — both our generation and the
+        // children map may have changed while we were acquiring the child. NonCancellable: once we hold the
+        // child's keep-alive, we must either register or release it — a cancellation in between would leak
+        // the acquisition and pin the child open forever.
+        val superfluous: KeepAlive? = withContext(NonCancellable) {
+            coreLock.withLock("addChild-register-${child.resourceId}") {
+                val existing = children[child]
+                when {
+                    existing != null && !existing.isClosed -> {
+                        // A concurrent addChild() adopted this child while we were acquiring it — keep theirs.
+                        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Lost adoption race, keeping existing: $child" }
+                        keepAlive
+                    }
+
+                    active !== adoptingGen -> {
+                        // The generation we adopted for was detached (or replaced) in the meantime; registering
+                        // now would attach a keep-alive that generation's detach-cleanup has already missed.
+                        if (Bugs.isTrace) log(iTag, VERBOSE) { "[$sId|_]-addChild() Parent generation gone during adoption: $child" }
+                        keepAlive
+                    }
+
+                    else -> {
+                        children[child] = Child(child, keepAlive)
+                        if (Bugs.isTrace) {
+                            log(iTag, VERBOSE) { "[$sId|_]-addChild() Resource now has ${children.size} " }
+                            children.onEachIndexed { index, entry ->
+                                log(iTag, VERBOSE) { "[$sId|_]-addChild() Now has #$index ${entry.value} " }
+                            }
+                        }
+                        null
+                    }
                 }
             }
         }
+        // Release a superfluous acquisition OFF our lock — closing takes the child's locks.
+        superfluous?.close()
     }
 
     override fun toString(): String =

--- a/app-common/src/test/java/eu/darken/butler/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/sharedresource/SharedResourceTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import okio.IOException
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -216,6 +217,21 @@ class SharedResourceTest : BaseTest() {
         srParent.addChild(srChild)
         srParent.addChild(srChild)
         srChild.isClosed shouldBe false
+
+        // A duplicate adoption must not leak a second keep-alive: closing the parent frees the child.
+        srParent.close()
+        srChild.isClosed shouldBe true
+    }
+
+    @Test fun `addChild ignores self-adoption`() = runTest2(autoCancel = true) {
+        val sr = SharedResource.createKeepAlive("test", this + Dispatchers.IO, Duration.ZERO)
+
+        val lease = sr.get()
+        sr.addChild(sr)
+        lease.close()
+
+        // Without the guard, the self-held child lease would keep us pinned open forever.
+        sr.isClosed shouldBe true
     }
 
     @Test fun `error during creation is forwarded`() = runTest2(autoCancel = true) {
@@ -952,5 +968,281 @@ class SharedResourceTest : BaseTest() {
         parent.isClosed shouldBe true   // detach completed despite the throwing child
         goodChildClosed shouldBe true   // iteration continued past the thrower (per-child runCatching)
         sourceTornDown shouldBe true    // source teardown was enqueued before the child loop, not stranded
+    }
+
+    @Test
+    fun `addChild does not hold the parent lock across child acquisition`(): Unit = runBlocking {
+        val childStarted = CompletableDeferred<Unit>()
+        val childGate = CompletableDeferred<Unit>()
+        val parent = SharedResource<Int>(
+            tag = "parent",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(1)
+                awaitCancellation()
+            },
+        )
+        val child = SharedResource<Int>(
+            tag = "child",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                childStarted.complete(Unit)
+                childGate.await() // a slow child startup, e.g. launching a root helper
+                emit(2)
+                awaitCancellation()
+            },
+        )
+
+        val parentLease = parent.get()
+        val adoption = launch(Dispatchers.IO) { parent.addChild(child) }
+        childStarted.await()
+
+        // While the child's slow startup is still in progress, the parent must stay fully usable —
+        // previously addChild held the parent's coreLock across child.get(), wedging this call.
+        val concurrent = withTimeout(5_000) { parent.get() }
+        concurrent.item shouldBe 1
+        concurrent.close()
+
+        childGate.complete(Unit)
+        adoption.join()
+        child.isClosed shouldBe false
+
+        parentLease.close()
+        parent.close()
+        child.isClosed shouldBe true
+    }
+
+    @Test
+    fun `addChild releases the child when the parent dies during adoption`(): Unit = runBlocking {
+        val childStarted = CompletableDeferred<Unit>()
+        val childGate = CompletableDeferred<Unit>()
+        val parent = SharedResource<Int>(
+            tag = "parent",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(1)
+                awaitCancellation()
+            },
+        )
+        val child = SharedResource<Int>(
+            tag = "child",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                childStarted.complete(Unit)
+                childGate.await()
+                emit(2)
+                awaitCancellation()
+            },
+        )
+
+        parent.get()
+        val adoption = launch(Dispatchers.IO) { parent.addChild(child) }
+        childStarted.await()
+
+        try {
+            // The generation the adoption was decided for dies while the child is still starting up.
+            // Off-thread + timeout so a regression (addChild holding coreLock across child.get() would
+            // block close() until childGate opens) fails the test instead of hanging the worker.
+            withTimeout(5_000) {
+                withContext(Dispatchers.IO) { parent.close() }
+            }
+        } finally {
+            childGate.complete(Unit)
+        }
+        parent.isClosed shouldBe true
+
+        adoption.join()
+
+        // ...so the acquired keep-alive must be released instead of registered — nothing may pin the
+        // child open on behalf of a parent generation whose cleanup already ran.
+        child.isClosed shouldBe true
+        parent.isClosed shouldBe true
+    }
+
+    @Test
+    fun `addChild propagates a failing child acquisition without leaking`(): Unit = runBlocking {
+        val parent = SharedResource<Int>(
+            tag = "parent",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(1)
+                awaitCancellation()
+            },
+        )
+        val child = SharedResource<Int>(
+            tag = "child",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow<Int> { throw IOException("child cannot start") },
+        )
+
+        val parentLease = parent.get()
+
+        // child.get() throws before any keep-alive exists — addChild must surface it, not swallow it.
+        shouldThrow<IOException> { parent.addChild(child) }
+
+        // Nothing was registered, and the failure did not corrupt the parent: it stays fully usable.
+        val stillWorks = withTimeout(5_000) { parent.get() }
+        stillWorks.item shouldBe 1
+        stillWorks.close()
+
+        parentLease.close()
+        parent.close()
+    }
+
+    @Test
+    fun `addChild replaces a stale closed child on re-adoption`() = runTest2(autoCancel = true) {
+        val srParent = SharedResource.createKeepAlive("parent", this + Dispatchers.IO, Duration.ZERO)
+        val srChild = SharedResource.createKeepAlive("child", this + Dispatchers.IO, Duration.ZERO)
+
+        val parentLease = srParent.get()
+
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe false
+
+        // Force the child closed out from under the parent, leaving a stale closed child entry.
+        srChild.close()
+        srChild.isClosed shouldBe true
+
+        // Re-adopting must replace the stale entry and revive the child, not treat it as already-kept.
+        srParent.addChild(srChild)
+        srChild.isClosed shouldBe false
+
+        parentLease.close()
+        srParent.close()
+        srChild.isClosed shouldBe true
+    }
+
+    @Test
+    fun `get re-acquires a fresh generation when a reused one fails the liveness check`() = runTest2 {
+        // Real dispatcher, like the other tests here: SharedResource's Lease.close uses runBlocking, which
+        // deadlocks a single-threaded test dispatcher.
+        val produced = AtomicInteger(0)
+        val liveThreshold = AtomicInteger(0) // resources with id > threshold are considered alive
+        val sr = SharedResource<Int>(
+            tag = "reuse-liveness",
+            parentScope = this + Dispatchers.IO,
+            source = flow {
+                emit(produced.incrementAndGet())
+                awaitCancellation()
+            },
+            isReusable = { it > liveThreshold.get() },
+        )
+
+        // A held lease pins generation 1 as `active`, so no idle-teardown can race this test.
+        val pin = sr.get()
+        pin.item shouldBe 1
+
+        // Resource 1 is now "dead" WITHOUT completing its source, so `active` still points at generation 1 —
+        // exactly the window where SharedResource's async detach hasn't cleared the dead generation yet.
+        liveThreshold.set(1)
+
+        // Without the fix, get() reuses the stale dead generation 1. With it, get() fails the liveness
+        // check, detaches generation 1, and re-acquires a fresh generation 2.
+        val second = sr.get()
+        second.item shouldBe 2
+
+        second.close()
+        pin.close()
+        sr.close()
+    }
+
+    @Test
+    fun `get retries when a concurrent close force-closes the lease mid-acquisition`() = runTest2 {
+        // Real dispatcher: Lease.close/close() use runBlocking.
+        val produced = AtomicInteger(0)
+        val closeTriggered = AtomicInteger(0)
+        lateinit var sr: SharedResource<Int>
+        sr = SharedResource(
+            tag = "close-race",
+            parentScope = this + Dispatchers.IO,
+            stopTimeout = Duration.ZERO,
+            source = flow {
+                emit(produced.incrementAndGet())
+                awaitCancellation()
+            },
+            // The validator runs in the window between lease registration (under coreLock) and get()
+            // returning — exactly where a concurrent close() can force-close the just-created lease.
+            // Trigger that close() deterministically on the first acquisition.
+            isReusable = {
+                if (closeTriggered.incrementAndGet() == 1) sr.close()
+                true
+            },
+        )
+
+        val resource = sr.get()
+        // Without the retry, get() hands back generation 1's force-closed lease and this access throws.
+        // With it, get() notices the closed lease and re-acquires a fresh generation.
+        resource.item shouldBe 2
+        resource.close()
+        sr.close()
+    }
+
+    @Test
+    fun `a reused generation dying before its first value does not poison the reusing caller`(): Unit = runBlocking {
+        val attempts = AtomicInteger(0)
+        val firstStarted = CompletableDeferred<Unit>()
+        val failFirst = CompletableDeferred<Unit>()
+
+        // Completed when the second get() has REUSED the running generation — the "Source job already
+        // exists" breadcrumb is logged under coreLock exactly where the reuse decision falls, and only
+        // a reusing caller emits it. Deterministic, unlike a sleep: without this the reuser could start
+        // only after generation 1 already failed, acquire a fresh generation, and pass vacuously.
+        val reuserLatched = CompletableDeferred<Unit>()
+        val capture = object : Logging.Logger {
+            override fun log(
+                priority: Logging.Priority,
+                tag: String,
+                message: String,
+                metaData: Map<String, Any>?,
+            ) {
+                if (tag == "stale-reuse:SR" && message.contains("Source job already exists")) {
+                    reuserLatched.complete(Unit)
+                }
+            }
+        }
+        Logging.install(capture)
+        try {
+            val sr = SharedResource<Int>(
+                tag = "stale-reuse",
+                parentScope = this + Dispatchers.IO,
+                stopTimeout = Duration.ZERO,
+                source = flow {
+                    if (attempts.incrementAndGet() == 1) {
+                        firstStarted.complete(Unit)
+                        failFirst.await()
+                        throw IOException("source died before producing a value")
+                    }
+                    emit(attempts.get())
+                    awaitCancellation()
+                },
+            )
+
+            val creator = async(Dispatchers.IO) { runCatching { sr.get() } }
+            firstStarted.await()
+            // The source is running but has produced no value yet, so this get() REUSES generation 1
+            // and awaits its ready-gate...
+            val reuser = async(Dispatchers.IO) { runCatching { sr.get() } }
+            reuserLatched.await()
+            // ...then generation 1 dies before ever producing a value.
+            failFirst.complete(Unit)
+
+            // The caller that STARTED the doomed source sees its original failure...
+            (creator.await().exceptionOrNull() is IOException) shouldBe true
+            // ...but the caller that merely latched onto the dying generation must not inherit that
+            // stale error — it retries onto a fresh generation instead.
+            val resource = reuser.await().getOrThrow()
+            resource.item shouldBe 2
+
+            resource.close()
+            sr.close()
+        } finally {
+            Logging.remove(capture)
+        }
     }
 }


### PR DESCRIPTION
Ports three merged SD Maid SE infrastructure fixes to the shared `SharedResource` keep-alive and `SharedShell` (Butler shares this code almost line-for-line).

## What changed

- **`addChild()` startup freeze** (upstream [#2524](https://github.com/d4rken-org/sdmaid-se/pull/2524)) — `addChild()` acquired the child (`child.get()`) **while holding the parent's `coreLock`**. Child startup can take seconds (launching a root helper, binding Shizuku), during which every concurrent `get()`/`close()`/lease-release on the parent was wedged; nested adoption chains held multiple resource locks at once. Reworked into three phases: decide under lock (pinning the generation being adopted for) → acquire the child off-lock → re-validate and register under lock, releasing a superfluous acquisition off-lock if a concurrent adoption won or the parent generation was replaced. Adds a `child === this` self-adoption guard (previously deadlocked on `coreLock`).

- **Dead-session reuse** (upstream [#2502](https://github.com/d4rken-org/sdmaid-se/pull/2502)) — `get()` now validates a reused generation via an optional `isReusable` predicate; a cached-but-dead resource (e.g. a shell whose process exited while the async detach lagged) is force-detached and a fresh one acquired. `SharedShell` opts in with `{ it.isAlive() }`, fixing rare *"shell session likely died externally"* errors on reuse.

- **Stale-reuse / close-race in `get()`** (upstream [#2523](https://github.com/d4rken-org/sdmaid-se/pull/2523)) — a reused generation that dies before its first value no longer poisons the reusing caller with the starter's error (it retries fresh); `get()` also retries if a concurrent `close()` force-closed the just-registered lease mid-acquisition.

## Tests

Ports the upstream regression tests (self-adoption, lock-not-held-across-acquisition, release-on-parent-death, reuse-liveness, close-race, stale-reuse) plus two extra `addChild` robustness cases (failing child acquisition, stale-closed re-adoption) and a `SharedShell` dead-session case. All 46 `SharedResourceTest` + `SharedShellTest` tests pass.

## Notes

Butler's only `SharedResource` with a live backing is `SharedShell` (root/ADB use a different lifecycle), so no other client needs the liveness validator. Implementation reviewed by Codex (no findings).

Excluded from this port: upstream #2476 (already present in Butler).