### PR TITLE
IO: Fix root/ADB connection loss when cancelling file scans

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/ConsumerGone.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/ConsumerGone.kt
@@ -1,0 +1,14 @@
+package eu.darken.butler.common.files.local.ipc
+
+import java.io.IOException
+
+/**
+ * Raised by a host-side IPC stream writer when the pipe write fails because the *consumer* went
+ * away — the client cancelled its collector (user-cancelled scan, `take(n)`) and closed its end,
+ * so there is nobody left to stream to. It is contained (logged, not rethrown) by the writer's
+ * `catch`, because rethrowing would fault the helper's unsupervised app scope, whose uncaught
+ * handler kills the whole privileged process (surfacing as a service-connection-lost error on the
+ * next IPC call). Wrapping ONLY the pipe write — not the marshalling — keeps genuine
+ * serialization/upstream failures propagating loudly instead of being silently swallowed.
+ */
+internal class ConsumerGone(cause: Throwable) : IOException(cause)

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/GenericOperationEventStreaming.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/GenericOperationEventStreaming.kt
@@ -9,6 +9,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.ipc.RemoteInputStream
 import eu.darken.butler.common.ipc.inputStream
 import eu.darken.butler.common.ipc.remoteInputStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +21,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString
+import java.io.IOException
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
@@ -61,17 +63,33 @@ fun <T : Parcelable> Flow<T>.toRemoteInputStream(
             val encodedEvent = parcel.marshall().toByteString().base64()
             parcel.recycle()
 
-            buffer.write(encodedEvent)
-            buffer.write('\n'.code)
-            buffer.flush()
+            // Only the pipe write can fail with the consumer gone; marshalling above stays unwrapped
+            // so genuine serialization errors still fault loudly.
+            try {
+                buffer.write(encodedEvent)
+                buffer.write('\n'.code)
+                buffer.flush()
+            } catch (e: IOException) {
+                throw ConsumerGone(e)
+            }
         }
-        .onCompletion {
-            buffer.flush()
-            buffer.close()
+        .onCompletion { cause ->
+            // Skip the final flush when the stream is unwinding on a failure/cancel (the consumer is
+            // likely gone, so flush would just throw again); always attempt close, ignoring failures.
+            if (cause == null) runCatching { buffer.flush() }
+            runCatching { buffer.close() }
         }
         .catch { e ->
-            log(TAG, ERROR) { "Event streaming failed: ${e.asLog()}" }
-            throw e
+            when {
+                e is CancellationException -> throw e
+                // The client closed its end (cancelled operation); nobody is left to stream to.
+                // Contain it — rethrowing would fault the helper's app scope and kill the process.
+                e is ConsumerGone -> log(TAG, WARN) { "Event streaming consumer gone: ${e.asLog()}" }
+                else -> {
+                    log(TAG, ERROR) { "Event streaming failed: ${e.asLog()}" }
+                    throw e
+                }
+            }
         }
         .launchIn(scope)
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/LocalPathLookupIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/LocalPathLookupIPCFlow.kt
@@ -10,6 +10,7 @@ import eu.darken.butler.common.flow.chunked
 import eu.darken.butler.common.ipc.RemoteInputStream
 import eu.darken.butler.common.ipc.inputStream
 import eu.darken.butler.common.ipc.remoteInputStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString
+import java.io.IOException
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
@@ -74,21 +76,37 @@ fun Flow<LocalPathLookup>.toRemoteInputStream(scope: CoroutineScope): RemoteInpu
             val encodedChunk = parcel.marshall().toByteString().base64()
             parcel.recycle()
 
-            buffer.write(encodedChunk)
-            buffer.write('\n'.code)
-            buffer.flush()
+            // Only the pipe write can fail with the consumer gone; marshalling above stays unwrapped
+            // so genuine serialization errors still fault loudly.
+            try {
+                buffer.write(encodedChunk)
+                buffer.write('\n'.code)
+                buffer.flush()
+            } catch (e: IOException) {
+                throw ConsumerGone(e)
+            }
 
             if (Bugs.isTrace) {
                 log(FileOpsHost.TAG, VERBOSE) { "WRITECHUNK: ${chunk.size} items to ${encodedChunk.length}B" }
             }
         }
-        .onCompletion {
-            buffer.flush()
-            buffer.close()
+        .onCompletion { cause ->
+            // Skip the final flush when the stream is unwinding on a failure/cancel (the consumer is
+            // likely gone, so flush would just throw again); always attempt close, ignoring failures.
+            if (cause == null) runCatching { buffer.flush() }
+            runCatching { buffer.close() }
         }
-        .catch {
-            log(FileOpsHost.TAG, ERROR) { "toRemoteInputStream failed: ${it.asLog()}" }
-            throw it
+        .catch { e ->
+            when {
+                e is CancellationException -> throw e
+                // The client closed its end (cancelled scan, take()); nobody is left to stream to.
+                // Contain it — rethrowing would fault the helper's app scope and kill the process.
+                e is ConsumerGone -> log(FileOpsHost.TAG, WARN) { "toRemoteInputStream consumer gone: ${e.asLog()}" }
+                else -> {
+                    log(FileOpsHost.TAG, ERROR) { "toRemoteInputStream failed: ${e.asLog()}" }
+                    throw e
+                }
+            }
         }
         .launchIn(scope)
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/LocalPathLookupIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/LocalPathLookupIPCFlowTest.kt
@@ -1,0 +1,97 @@
+package eu.darken.butler.common.files.local.ipc
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.ipc.inputStream
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.util.concurrent.CopyOnWriteArrayList
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class LocalPathLookupIPCFlowTest : BaseTest() {
+
+    private fun lookup(name: String) = LocalPathLookup(
+        lookedUp = LocalPath.build(name),
+        fileType = FileType.FILE,
+        size = 0L,
+        modifiedAt = null,
+    )
+
+    @Test
+    fun `consumer going away does not fault the host scope`() {
+        // Regression guard for #2506: when the client closes its end mid-stream (cancelled scan,
+        // take()), the host writer's next pipe write fails with "Pipe closed". That failure must be
+        // contained, not rethrown into `scope` — in production `scope` is the helper's unsupervised
+        // app scope, where an uncaught exception kills the privileged process (surfacing as
+        // ServiceConnectionLost on the next IPC call).
+        val uncaught = CopyOnWriteArrayList<Throwable>()
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(
+            supervisor + Dispatchers.IO + CoroutineExceptionHandler { _, e -> uncaught += e },
+        )
+        try {
+            runBlocking {
+                val source: Flow<LocalPathLookup> = flow {
+                    repeat(100_000) { emit(lookup("file$it")) }
+                }
+                val remote = source.toRemoteInputStream(scope)
+                val stream = remote.inputStream()
+
+                // Consume a little, then the consumer goes away and closes its end.
+                stream.read()
+                stream.close()
+
+                // The writer must unwind on the broken pipe instead of hanging or faulting the scope.
+                withTimeout(10_000) { supervisor.children.toList().joinAll() }
+                uncaught shouldBe emptyList<Throwable>()
+            }
+        } finally {
+            supervisor.cancel()
+        }
+    }
+
+    @Test
+    fun `a genuine upstream failure is still surfaced, not swallowed`() {
+        // The narrow containment must only swallow consumer-gone (ConsumerGone); a real source/
+        // marshalling failure must still fault loudly so it isn't silently turned into a truncated
+        // listing (Butler's stream has no terminal marker to detect truncation).
+        val uncaught = CopyOnWriteArrayList<Throwable>()
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(
+            supervisor + Dispatchers.IO + CoroutineExceptionHandler { _, e -> uncaught += e },
+        )
+        try {
+            runBlocking {
+                val source: Flow<LocalPathLookup> = flow {
+                    emit(lookup("file0"))
+                    throw IllegalStateException("source blew up")
+                }
+                source.toRemoteInputStream(scope)
+
+                withTimeout(10_000) { supervisor.children.toList().joinAll() }
+                // Genuine error propagated to the scope's handler rather than being contained.
+                uncaught.shouldNotBeEmpty()
+                (uncaught.any { it is IllegalStateException }) shouldBe true
+            }
+        } finally {
+            supervisor.cancel()
+        }
+    }
+}


### PR DESCRIPTION
Ports SD Maid SE [#2506](https://github.com/d4rken-org/sdmaid-se/pull/2506).

## The bug

When a scan is cancelled (or a consumer uses `take()`), the client closes its end of the IPC pipe. The host-side stream writer's next write then fails with *"Pipe closed"*. The writer **rethrew** that failure into the privileged helper's **unsupervised app scope**, whose uncaught-exception handler calls `exitProcess(1)` — killing the root/ADB process and surfacing as a *service-connection-lost* error on the next call.

## The fix (narrow containment)

- The write side (`buffer.write`/`flush`) is wrapped so a broken-pipe failure is raised as a private `ConsumerGone` and **contained** (logged, not rethrown).
- `onCompletion` is cause-aware: it skips the final flush while unwinding on a failure/cancel and always attempts close.
- **Marshalling stays outside the wrap**, and any genuine upstream/serialization error still faults loudly. This is deliberately narrower than upstream's contain-everything approach: Butler's stream has no terminal/truncation marker, so silently containing a real error would hand the client a truncated listing with no signal.

Applies to both host writers: `LocalPathLookupIPCFlow` (lookup/walk streaming) and `GenericOperationEventStreaming` (delete/copy/move events). Butler has no equivalent of upstream's third bulk `LocalPath` writer.

## Tests

Deterministic regression tests: a consumer closing the stream mid-flight does not fault the host scope, and a genuine upstream error is still surfaced to the scope handler. Implementation reviewed by Codex (no findings).