### PR TITLE
IO: Fix wrong symlink size and broken relative link targets

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalFileSystemOps.kt
@@ -11,7 +11,6 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
-import eu.darken.butler.common.files.core.local.readLink
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.WriteException
@@ -127,7 +126,17 @@ class LocalFileSystemOps @Inject constructor(
         var size: Long? = null
         if (options.fetchSize) {
             try {
-                size = path.file.length()
+                size = if (fileType == FileType.SYMBOLIC_LINK) {
+                    // File.length() follows the link and reports the TARGET's size; a symlink must report
+                    // its own node size. Os.lstat (NOFOLLOW) provides it. If lstat is unavailable, leave
+                    // size null and record an error rather than silently reporting the target's size.
+                    fstat?.st_size ?: run {
+                        errors.add("Size: lstat unavailable for symlink")
+                        null
+                    }
+                } else {
+                    path.file.length()
+                }
             } catch (e: Exception) {
                 errors.add("Size: ${e.message}")
             }
@@ -145,7 +154,10 @@ class LocalFileSystemOps @Inject constructor(
         var target: LocalPath? = null
         if (fileType == FileType.SYMBOLIC_LINK) {
             try {
-                target = path.file.readLink()?.let { LocalPath.build(it) }
+                // Reuse readSymbolicLink(): it resolves a relative target against the link's parent and
+                // normalizes it. Raw readLink() returned the stored target verbatim, so a relative
+                // "../x" became a bogus absolute "/../x" when passed to LocalPath.build().
+                target = readSymbolicLink(path)
             } catch (e: Exception) {
                 errors.add("Link target: ${e.message}")
             }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalFileSystemOpsTest.kt
@@ -875,4 +875,58 @@ class LocalFileSystemOpsTest : BaseTest() {
         lookup.ownership shouldBe null // Not requested
         lookup.permissions shouldBe null // Not requested
     }
+
+    @Test
+    fun `lookup - symlink reports its own size, not the target's`(@TempDir tempDir: File) = runTest {
+        val target = File(tempDir, "target.bin").apply { writeBytes(ByteArray(5000)) }
+        val link = File(tempDir, "link")
+        java.nio.file.Files.createSymbolicLink(link.toPath(), target.toPath())
+
+        val lookup = fileSystemOps.lookup(LocalPath.build(link), LookupOptions.BASE)
+
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // The link node, NOT the 5000-byte target — deletion only removes the link. (When lstat is
+        // unavailable size is null; either way it must never be the target's size.)
+        lookup.size shouldNotBe 5000L
+        lookup.target shouldBe LocalPath.build(target.path)
+    }
+
+    @Test
+    fun `lookup - relative symlink target is resolved against the link's parent`(@TempDir tempDir: File) = runTest {
+        File(tempDir, "realfile").apply { writeText("x") }
+        val link = File(tempDir, "rellink")
+        java.nio.file.Files.createSymbolicLink(link.toPath(), java.nio.file.Paths.get("realfile")) // relative
+
+        val lookup = fileSystemOps.lookup(LocalPath.build(link), LookupOptions.BASE)
+
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // Resolved to <parent>/realfile, not the old bogus "/realfile".
+        lookup.target shouldBe LocalPath.build(File(tempDir, "realfile").path)
+    }
+
+    @Test
+    fun `lookup - relative symlink target with parent traversal is normalized`(@TempDir tempDir: File) = runTest {
+        File(tempDir, "realfile").apply { writeText("x") }
+        val sub = File(tempDir, "sub").apply { mkdirs() }
+        val link = File(sub, "uplink")
+        java.nio.file.Files.createSymbolicLink(link.toPath(), java.nio.file.Paths.get("../realfile")) // traverses up
+
+        val lookup = fileSystemOps.lookup(LocalPath.build(link), LookupOptions.BASE)
+
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // <sub>/../realfile is lexically normalized to <tempDir>/realfile, not left as "/sub/../realfile".
+        lookup.target shouldBe LocalPath.build(File(tempDir, "realfile").path)
+    }
+
+    @Test
+    fun `lookup - broken symlink is still a SYMBOLIC_LINK`(@TempDir tempDir: File) = runTest {
+        val link = File(tempDir, "broken")
+        java.nio.file.Files.createSymbolicLink(link.toPath(), File(tempDir, "does-not-exist").toPath())
+
+        val lookup = fileSystemOps.lookup(LocalPath.build(link), LookupOptions.BASE)
+
+        lookup.fileType shouldBe FileType.SYMBOLIC_LINK
+        // The target is read from the link itself, so a missing target is still resolved & reported.
+        lookup.target shouldBe LocalPath.build(File(tempDir, "does-not-exist").path)
+    }
 }


### PR DESCRIPTION
Ports the two correctness fixes from SD Maid SE [#2493](https://github.com/d4rken-org/sdmaid-se/pull/2493). (Upstream's perf single-lstat consolidation is skipped — it conflicts with Butler's richer `LookupOptions`.)

## What changed in `LocalFileSystemOps.lookup()`

- **Symlink size** — a symlink's size was `File.length()`, which *follows* the link and returns the **target's** size (or 0 for a broken link). It now reports the link's own node size from the already-computed `Os.lstat` (NOFOLLOW). If `lstat` is unavailable, size is left `null` with an error rather than silently reporting the target's size. Regular files and directories are unchanged (still `File.length()`).

- **Relative link targets** — a symlink's target was built from the raw stored link text, so a relative target like `../x` became a bogus absolute `/../x`. `lookup()` now reuses the sibling `readSymbolicLink()` in the same class, which resolves a relative target against the link's parent and normalizes it. Broken links (target does not exist) still resolve and classify as `SYMBOLIC_LINK`.

## Tests

Adds regression tests: symlink reports its own size (never the target's), relative target resolved against the parent, parent-traversal (`../x`) normalized, and broken symlink still `SYMBOLIC_LINK`. All 69 `LocalFileSystemOpsTest` tests pass. Implementation reviewed by Codex (no findings).

Excluded from this port: upstream #2487 and #2495 (Butler's walker/lookup architecture already handles those cases).