### PR TITLE
Editor: Handle a file being deleted or unreadable while open

### DIFF
--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/EditorWorkspace.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/EditorWorkspace.kt
@@ -297,7 +297,7 @@ class EditorWorkspace @AssistedInject constructor(
             editorStateInternal.map { state ->
                 val file = state.contentSource as? ContentSource.File
                 state.isModified && file != null && file.canWrite && !file.isLikelyBinary &&
-                    state.externalChange == null
+                    !file.isBackingLost && state.externalChange == null
             }.distinctUntilChanged(),
             editorSettings.autoSaveEnabled.flow,
             editorSettings.autoSaveInterval.flow,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/BackingUnavailableException.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/BackingUnavailableException.kt
@@ -1,0 +1,25 @@
+package eu.darken.butler.editor.core.engine
+
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.error.HasLocalizedError
+import eu.darken.butler.common.error.LocalizedError
+import eu.darken.butler.common.error.LocalizedErrorContext
+import eu.darken.butler.editor.R
+import java.io.IOException
+
+/**
+ * The backing file became unreadable while open (deleted or read permission lost). The piece
+ * table can no longer materialize original bytes, so the document is served read-only from what
+ * is still cached and edits/saves are refused until the file is reopened.
+ */
+class BackingUnavailableException(
+    message: String,
+    cause: Throwable? = null,
+) : IOException(message, cause), HasLocalizedError {
+
+    override fun getLocalizedError(context: LocalizedErrorContext) = LocalizedError(
+        throwable = this,
+        label = R.string.editor_backing_lost_banner_title.toCaString(),
+        description = R.string.editor_backing_lost_banner_message.toCaString(),
+    )
+}

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/ContentSource.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/ContentSource.kt
@@ -50,6 +50,12 @@ sealed class ContentSource {
          * after the next save's rebase - the display cap itself is applied unconditionally.
          */
         val hasLongLines: Boolean = false,
+        /**
+         * Set once the backing file becomes unreadable mid-session (deleted or read permission
+         * lost). Latches: the piece table can no longer read original bytes, so the document goes
+         * read-only and edits/saves are refused. Cleared only by a successful reopen/reload.
+         */
+        val isBackingLost: Boolean = false,
     ) : ContentSource() {
         override val name: String get() = path.name
 
@@ -75,6 +81,7 @@ sealed class ContentSource {
             if (staleBackups != other.staleBackups) return false
             if (isLikelyBinary != other.isLikelyBinary) return false
             if (hasLongLines != other.hasLongLines) return false
+            if (isBackingLost != other.isBackingLost) return false
 
             return true
         }
@@ -91,6 +98,7 @@ sealed class ContentSource {
             result = 31 * result + staleBackups.hashCode()
             result = 31 * result + isLikelyBinary.hashCode()
             result = 31 * result + hasLongLines.hashCode()
+            result = 31 * result + isBackingLost.hashCode()
             return result
         }
     }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/DocumentBuffer.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/DocumentBuffer.kt
@@ -8,6 +8,10 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.errors.PathPermissionDeniedException
+import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.common.files.errors.ServiceConnectionLostException
+import eu.darken.butler.common.files.saf.MissingUriPermissionException
 import eu.darken.butler.common.progress.Progress
 import eu.darken.butler.editor.R
 import eu.darken.butler.editor.core.engine.text.BlockIndex
@@ -33,10 +37,12 @@ import okio.BufferedSink
 import okio.Source
 import okio.buffer
 import okio.use
+import java.io.FileNotFoundException
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
 import java.nio.charset.Charset
 import java.nio.charset.CodingErrorAction
+import java.nio.file.NoSuchFileException
 import java.security.MessageDigest
 import java.util.LinkedList
 import kotlin.coroutines.coroutineContext
@@ -87,6 +93,13 @@ class DocumentBuffer @AssistedInject constructor(
 
     private val _canRedo = MutableStateFlow(false)
     val canRedo: StateFlow<Boolean> = _canRedo.asStateFlow()
+
+    // Latches once the backing file becomes unreadable mid-session (deleted / permission lost):
+    // original bytes can no longer be materialized, so the document goes read-only. Cleared only
+    // by a successful initialize().
+    private val _isBackingLost = MutableStateFlow(false)
+    val isBackingLost: StateFlow<Boolean> = _isBackingLost.asStateFlow()
+    private var backingLostCause: Throwable? = null
 
     private val bufferMutex = Mutex()
     private var pieceTable: PieceTable? = null
@@ -178,6 +191,10 @@ class DocumentBuffer @AssistedInject constructor(
                 )
             }
             saveError = null
+            // A fresh load is the only recovery from backing loss: reopening re-reads the file, so
+            // the read-only latch is cleared here (never on rebase, which reads before it succeeds)
+            backingLostCause = null
+            _isBackingLost.value = false
             lastKnownMeta = dataSource.getMeta()
 
             undoStack.clear()
@@ -435,21 +452,20 @@ class DocumentBuffer @AssistedInject constructor(
         endPosition: TextPosition,
         newText: String,
     ): Result<TextPosition> = bufferMutex.withLock {
+        val table = try {
+            table()
+        } catch (e: Exception) {
+            log(tag, ERROR) { "Failed to replace text from $startPosition to $endPosition - ${e.asLog()}" }
+            return@withLock Result.failure(e)
+        }
+        val checkpoint = table.checkpoint()
         try {
-            val table = table()
             val deletedText = table.read(startPosition.offset, endPosition.offset)
             if (deletedText.isNotEmpty()) {
                 table.delete(startPosition.offset, endPosition.offset)
             }
             if (newText.isNotEmpty()) {
-                try {
-                    table.insert(startPosition.offset, newText)
-                } catch (e: Exception) {
-                    if (deletedText.isNotEmpty()) {
-                        withContext(NonCancellable) { table.insert(startPosition.offset, deletedText) }
-                    }
-                    throw e
-                }
+                table.insert(startPosition.offset, newText)
             }
             if (deletedText.isNotEmpty()) {
                 commitNewEdit(
@@ -465,7 +481,11 @@ class DocumentBuffer @AssistedInject constructor(
             }
             Result.success(insertEndPosition(startPosition, newText))
         } catch (e: Exception) {
-            log(tag, ERROR) { "Failed to replace text from $startPosition to $endPosition - ${e.asLog()}" }
+            // Roll back the partial delete/insert. Restore is purely in-memory, so it holds even
+            // when the failure IS the backing file vanishing mid-splice (unlike re-inserting the
+            // deleted text, which would re-read the gone original and double-fault).
+            table.restore(checkpoint)
+            log(tag, ERROR) { "Failed to replace text from $startPosition to $endPosition, rolled back - ${e.asLog()}" }
             Result.failure(e)
         }
     }
@@ -593,19 +613,28 @@ class DocumentBuffer @AssistedInject constructor(
 
             breakUndoRunLocked()
             val ops = mutableListOf<EditOperation>()
-            for (replacement in sorted) {
-                val end = replacement.startOffset + replacement.oldText.length
-                val line = table.lineOfOffset(replacement.startOffset)
-                val column = (replacement.startOffset - table.lineStartOffset(line)).toInt()
-                table.delete(replacement.startOffset, end)
-                if (replacement.newText.isNotEmpty()) {
-                    table.insert(replacement.startOffset, replacement.newText)
+            // Snapshot before the first mutation: a mid-batch original read can fail (the backing
+            // file vanished), and applying N replacements is otherwise non-atomic - an earlier
+            // replacement would land with no undo entry. Roll back fully on any failure.
+            val checkpoint = table.checkpoint()
+            try {
+                for (replacement in sorted) {
+                    val end = replacement.startOffset + replacement.oldText.length
+                    val line = table.lineOfOffset(replacement.startOffset)
+                    val column = (replacement.startOffset - table.lineStartOffset(line)).toInt()
+                    table.delete(replacement.startOffset, end)
+                    if (replacement.newText.isNotEmpty()) {
+                        table.insert(replacement.startOffset, replacement.newText)
+                    }
+                    ops += EditOperation.Replace(
+                        TextPosition(replacement.startOffset, line, column),
+                        replacement.oldText,
+                        replacement.newText,
+                    )
                 }
-                ops += EditOperation.Replace(
-                    TextPosition(replacement.startOffset, line, column),
-                    replacement.oldText,
-                    replacement.newText,
-                )
+            } catch (e: Exception) {
+                table.restore(checkpoint)
+                throw e
             }
             commitNewEdit(ops)
             // The lone-entry guard keeps an oversized composite until the NEXT edit; report
@@ -626,6 +655,10 @@ class DocumentBuffer @AssistedInject constructor(
         return try {
             saveError?.let {
                 return Result.failure(IllegalStateException("Buffer requires reload after failed save", it))
+            }
+            // Also covers the release() flush path, which bypasses the engine's editability gate
+            if (_isBackingLost.value) {
+                return Result.failure(BackingUnavailableException("Backing file is no longer available"))
             }
             val table = pieceTable
                 ?: return Result.failure(IllegalStateException("Buffer not initialized"))
@@ -967,7 +1000,16 @@ class DocumentBuffer @AssistedInject constructor(
      */
     private suspend fun checkStaleness() {
         val known = lastKnownMeta ?: return
-        val current = dataSource.getMeta()
+        val current = try {
+            dataSource.getMeta()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Save/convert/stream reach here before touching original bytes; a vanished file must
+            // latch read-only here too, not only via the readOriginalBytes backstop.
+            if (e.isBackingUnavailable()) latchBackingLost(e)
+            throw e
+        }
         if (current.size != known.size) {
             throw ExternalModificationException(
                 "File size changed externally: ${known.size} -> ${current.size} bytes",
@@ -1015,6 +1057,9 @@ class DocumentBuffer @AssistedInject constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            // Proactive detection: the polled metadata read is where a deleted/denied file first
+            // shows up, before the user touches an original-byte range (e.g. typing at EOF).
+            if (e.isBackingUnavailable()) latchBackingLost(e)
             log(tag, VERBOSE) { "checkExternalChange: getMeta failed - $e" }
             return@withLock ExternalChangeProbe.Unknown
         }
@@ -1133,7 +1178,57 @@ class DocumentBuffer @AssistedInject constructor(
     }
 
     private suspend fun readOriginalBytes(physicalOffset: Long, byteLen: Int): ByteArray =
-        dataSource.openByteSource(physicalOffset).buffer().use { it.readByteArray(byteLen.toLong()) }
+        try {
+            dataSource.openByteSource(physicalOffset).buffer().use { it.readByteArray(byteLen.toLong()) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Backstop: an edit/read that needs original bytes hit a vanished/denied file. Latch
+            // read-only so subsequent edits are refused up front instead of failing one-by-one.
+            if (e.isBackingUnavailable()) latchBackingLost(e)
+            throw e
+        }
+
+    /**
+     * Classifies a read failure as "the backing file is gone / access lost" (vs a transient blip).
+     * Deliberately narrow: latching is sticky until reopen, so a transient read error on a
+     * still-present file must NOT lock the document read-only. Definitive signals only -
+     * [PathPermissionDeniedException] and the not-found family by type, plus the characteristic
+     * missing/unreadable messages the local & SAF layers wrap in a generic [ReadException]
+     * (local "Does not exist…", SAF cause "readable=false", raw "ENOENT"). A dropped root/ADB
+     * service ([ServiceConnectionLostException]) is transient and never latches, even when
+     * re-wrapped; a generic [ReadException] with no not-found signal stays recoverable.
+     */
+    private fun Throwable.isBackingUnavailable(): Boolean {
+        val chain = generateSequence(this) { it.cause }.take(16).toList()
+        if (chain.any { it is ServiceConnectionLostException }) return false
+        if (chain.any {
+                it is PathPermissionDeniedException ||
+                    it is MissingUriPermissionException ||
+                    it is FileNotFoundException ||
+                    it is NoSuchFileException
+            }
+        ) {
+            return true
+        }
+        return chain.any { link ->
+            link.message?.let { m ->
+                m.contains("does not exist", ignoreCase = true) ||
+                    m.contains("no such file", ignoreCase = true) ||
+                    m.contains("readable=false", ignoreCase = true) ||
+                    m.contains("ENOENT", ignoreCase = true)
+            } == true
+        }
+    }
+
+    /** Idempotently latches the read-only backing-lost state and publishes it on [contentSource]. */
+    private fun latchBackingLost(cause: Throwable) {
+        if (_isBackingLost.value) return
+        backingLostCause = cause
+        _isBackingLost.value = true
+        (_contentSource.value as? ContentSource.File)?.let { _contentSource.value = it.copy(isBackingLost = true) }
+        log(tag, WARN) { "Backing file became unavailable, document is now read-only - ${cause.asLog()}" }
+    }
 
     private suspend fun getTextForLineInternal(lineNumber: Long): Result<String> {
         if (lineNumber < 0 || lineNumber >= _totalLines.value) {

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/EditorEngine.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/EditorEngine.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.BufferedSink
+import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.coroutineContext
@@ -176,7 +177,12 @@ class EditorEngine @AssistedInject constructor(
      * Deliberately does NOT set [_error]: the read-only state is already visible in the UI and
      * a banner per swallowed keystroke would be noise.
      */
-    private fun EditorState.Loaded.editabilityError(): ReadOnlyFileException? {
+    private fun EditorState.Loaded.editabilityError(): IOException? {
+        // Read live: the backing file can vanish mid-session, long after this snapshot's canWrite
+        // was captured at open. Refusing edits here keeps the field and buffer from desyncing.
+        if (resources.textBuffer.isBackingLost.value) {
+            return BackingUnavailableException("Backing file is no longer available")
+        }
         val source = contentSource as? ContentSource.File ?: return null
         return when {
             source.isLikelyBinary -> ReadOnlyFileException("Binary file, editing is disabled: ${source.path}")
@@ -339,6 +345,10 @@ class EditorEngine @AssistedInject constructor(
     suspend fun saveFile(): Result<Unit> = stateMutex.withLock {
         return when (val currentState = _state.value) {
             is EditorState.Loaded -> {
+                currentState.editabilityError()?.let {
+                    log(tag, VERBOSE) { "saveFile rejected: ${it.message}" }
+                    return@withLock Result.failure(it)
+                }
                 try {
                     _progress.value = Progress.Data(
                         primary = R.string.editor_progress_saving.toCaString(),
@@ -383,6 +393,11 @@ class EditorEngine @AssistedInject constructor(
     suspend fun writeContentTo(sink: BufferedSink): Unit = stateMutex.withLock {
         when (val currentState = _state.value) {
             is EditorState.Loaded -> {
+                // Save-As of a read-only/binary file is allowed (it exports the original bytes),
+                // but not once the backing file is gone - its original ranges can't be read.
+                if (currentState.resources.textBuffer.isBackingLost.value) {
+                    throw BackingUnavailableException("Backing file is no longer available")
+                }
                 log(tag) { "Streaming current buffer content" }
                 val result = currentState.resources.textBuffer.writeContentTo(sink)
                 result.exceptionOrNull()?.let { e ->
@@ -607,8 +622,19 @@ class EditorEngine @AssistedInject constructor(
         val newText = matchDocumentLineEnding(text, buffer)
 
         // Resolve flat offsets from line/column - UI sends placeholder offset=0 with virtual scrolling.
-        val startOffset = buffer.findOffset(start.line, start.column)
-        val endOffset = buffer.findOffset(end.line, end.column)
+        // The field can diverge from the buffer (e.g. failed edits accumulate locally) and hand us a
+        // line past the document; dropping the edit beats an uncaught IndexOutOfBounds from findOffset.
+        val startOffset: Long
+        val endOffset: Long
+        try {
+            startOffset = buffer.findOffset(start.line, start.column)
+            endOffset = buffer.findOffset(end.line, end.column)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(tag, WARN) { "replaceText: position resolve failed, dropping edit - ${e.message}" }
+            return@withLock
+        }
         var lowPos: TextPosition
         var highPos: TextPosition
         if (startOffset <= endOffset) {
@@ -934,12 +960,21 @@ class EditorEngine @AssistedInject constructor(
         val correctedPosition = when (val currentState = _state.value) {
             is EditorState.Loaded -> {
                 val buffer = currentState.resources.textBuffer
-                val column = displayBoundedColumn(position.line, position.column, buffer)
-                TextPosition(
-                    offset = buffer.findOffset(position.line, column),
-                    line = position.line,
-                    column = column,
-                )
+                try {
+                    val column = displayBoundedColumn(position.line, position.column, buffer)
+                    TextPosition(
+                        offset = buffer.findOffset(position.line, column),
+                        line = position.line,
+                        column = column,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Stale line/column or an unreadable backing file: keep the current cursor
+                    // rather than surface an error for a tap that just can't be resolved.
+                    log(tag, VERBOSE) { "setCursorPosition: resolve failed, ignoring - ${e.message}" }
+                    return@withLock
+                }
             }
             else -> position
         }
@@ -951,20 +986,28 @@ class EditorEngine @AssistedInject constructor(
         textBuffer?.breakUndoRun()
         when (val currentState = _state.value) {
             is EditorState.Loaded -> {
-                // Recalculate actual offsets from line/column positions
-                // UI may send placeholder offset=0 with virtual scrolling
-                val correctedStart = TextPosition(
-                    offset = currentState.resources.textBuffer.findOffset(start.line, start.column),
-                    line = start.line,
-                    column = start.column
-                )
-                val correctedEnd = TextPosition(
-                    offset = currentState.resources.textBuffer.findOffset(end.line, end.column),
-                    line = end.line,
-                    column = end.column
-                )
-                _selectionRange.value = correctedStart to correctedEnd
-                _cursorPosition.value = correctedEnd
+                val buffer = currentState.resources.textBuffer
+                // Recalculate actual offsets from line/column positions (UI may send placeholder
+                // offset=0 with virtual scrolling). A stale position or unreadable backing must
+                // not crash selection - leave the current selection/cursor untouched.
+                val corrected = try {
+                    TextPosition(
+                        offset = buffer.findOffset(start.line, start.column),
+                        line = start.line,
+                        column = start.column,
+                    ) to TextPosition(
+                        offset = buffer.findOffset(end.line, end.column),
+                        line = end.line,
+                        column = end.column,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(tag, VERBOSE) { "setSelection: resolve failed, ignoring - ${e.message}" }
+                    return@withLock
+                }
+                _selectionRange.value = corrected.first to corrected.second
+                _cursorPosition.value = corrected.second
             }
             else -> {
                 // No file loaded, store as-is
@@ -983,37 +1026,45 @@ class EditorEngine @AssistedInject constructor(
         }
         val buffer = currentState.resources.textBuffer
         val rawPos = _cursorPosition.value
-        // Display-bound the starting point: from a hidden-region cursor, LEFT/WORD_LEFT would
-        // otherwise decrement invisibly inside the hidden suffix while RIGHT/END clamp
-        val boundedColumn = displayBoundedColumn(rawPos.line, rawPos.column, buffer)
-        val currentPos = if (boundedColumn == rawPos.column) {
-            rawPos
-        } else {
-            TextPosition(
-                offset = buffer.findOffset(rawPos.line, boundedColumn),
-                line = rawPos.line,
-                column = boundedColumn,
-            )
+        // Resolve the display-bounded start and the moved target together. findOffset and the
+        // line reads inside the move helpers can throw when the position is stale or the backing
+        // file is unreadable - a movement that can't be resolved is dropped, never crashed.
+        val currentPos: TextPosition
+        val newPos: TextPosition
+        try {
+            // Display-bound the starting point: from a hidden-region cursor, LEFT/WORD_LEFT would
+            // otherwise decrement invisibly inside the hidden suffix while RIGHT/END clamp
+            val boundedColumn = displayBoundedColumn(rawPos.line, rawPos.column, buffer)
+            currentPos = if (boundedColumn == rawPos.column) {
+                rawPos
+            } else {
+                TextPosition(
+                    offset = buffer.findOffset(rawPos.line, boundedColumn),
+                    line = rawPos.line,
+                    column = boundedColumn,
+                )
+            }
+            newPos = when (direction) {
+                CursorDirection.LEFT -> moveCursorLeft(currentPos, currentState)
+                CursorDirection.RIGHT -> moveCursorRight(currentPos, currentState)
+                CursorDirection.UP -> moveCursorUp(currentPos, currentState)
+                CursorDirection.DOWN -> moveCursorDown(currentPos, currentState)
+                CursorDirection.WORD_LEFT -> moveCursorWordLeft(currentPos, currentState)
+                CursorDirection.WORD_RIGHT -> moveCursorWordRight(currentPos, currentState)
+                CursorDirection.LINE_START -> moveCursorToLineStart(currentPos, currentState)
+                CursorDirection.LINE_END -> moveCursorToLineEnd(currentPos, currentState)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(tag, VERBOSE) { "moveCursor: resolve failed, ignoring - ${e.message}" }
+            return@withLock
         }
-        log(tag) { "moveCursor: currentPos=$currentPos" }
         buffer.breakUndoRun()
 
         // Set anchor if starting selection
         if (extendSelection && selectionAnchor == null) {
             selectionAnchor = currentPos
-            log(tag) { "moveCursor: Set selection anchor to $currentPos" }
-        }
-
-        // Calculate new position based on direction
-        val newPos = when (direction) {
-            CursorDirection.LEFT -> moveCursorLeft(currentPos, currentState)
-            CursorDirection.RIGHT -> moveCursorRight(currentPos, currentState)
-            CursorDirection.UP -> moveCursorUp(currentPos, currentState)
-            CursorDirection.DOWN -> moveCursorDown(currentPos, currentState)
-            CursorDirection.WORD_LEFT -> moveCursorWordLeft(currentPos, currentState)
-            CursorDirection.WORD_RIGHT -> moveCursorWordRight(currentPos, currentState)
-            CursorDirection.LINE_START -> moveCursorToLineStart(currentPos, currentState)
-            CursorDirection.LINE_END -> moveCursorToLineEnd(currentPos, currentState)
         }
 
         log(tag) { "moveCursor: newPos=$newPos (was $currentPos)" }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/text/PieceTable.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/text/PieceTable.kt
@@ -43,10 +43,40 @@ class PieceTable private constructor(
 
     internal fun pieceSnapshot(): List<Piece> = pieces.toList()
 
+    /**
+     * Immutable capture of the table's full mutable state for all-or-nothing batch edits.
+     * [Piece]s are immutable and the add buffer is append-only, so a shallow piece copy plus the
+     * add-buffer text is a complete, cheap snapshot.
+     */
+    internal class Checkpoint(
+        val pieces: List<Piece>,
+        val addBuffer: String,
+        val expectedCharLength: Long,
+    )
+
+    internal fun checkpoint(): Checkpoint = Checkpoint(
+        pieces = pieces.toList(),
+        addBuffer = addBuffer.toString(),
+        expectedCharLength = expectedCharLength,
+    )
+
+    /**
+     * Restores a prior [checkpoint], discarding every mutation since. Purely in-memory - it never
+     * reads the original document - so it is a reliable rollback even when the backing file is
+     * gone (unlike replaying inverse edits, which would re-read it).
+     */
+    internal fun restore(checkpoint: Checkpoint) {
+        pieces.clear()
+        pieces.addAll(checkpoint.pieces)
+        addBuffer = StringBuilder(checkpoint.addBuffer)
+        expectedCharLength = checkpoint.expectedCharLength
+        rebuildPrefix()
+        checkInvariants()
+    }
+
     suspend fun insert(offset: Long, text: String) {
         require(offset in 0..totalCharLength) { "Insert offset $offset not in [0, $totalCharLength]" }
         if (text.isEmpty()) return
-        expectedCharLength += text.length
 
         val endingPiece = pieceEndingAt(offset)
         val coalesced = endingPiece?.let { pieceIndex ->
@@ -64,11 +94,14 @@ class PieceTable private constructor(
         } ?: false
 
         if (!coalesced) {
+            // splitAt may read original bytes (charToByte) and throw if the backing file is gone;
+            // bookkeeping is bumped only after the throwing work so a failed insert is a no-op
             val insertAt = splitAt(offset)
             val addStart = addBuffer.length
             addBuffer.append(text)
             pieces.add(insertAt, makeAdded(addStart, text.length))
         }
+        expectedCharLength += text.length
         afterEdit()
     }
 
@@ -77,10 +110,13 @@ class PieceTable private constructor(
             "Delete range $start-$end not in [0, $totalCharLength]"
         }
         if (start == end) return
-        expectedCharLength -= end - start
 
+        // splitAt may read original bytes (charToByte) and throw if the backing file is gone.
+        // Splits are content-preserving, so a partial split (start done, end thrown) leaves the
+        // document identical; bookkeeping is decremented only once both splits succeed.
         val from = splitAt(start)
         val to = splitAt(end)
+        expectedCharLength -= end - start
         repeat(to - from) { pieces.removeAt(from) }
         afterEdit()
     }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
@@ -190,6 +190,8 @@ fun EditorWorkspacePage(
                         title = state.title,
                         subTitle = state.subTitle,
                         isModified = state.isModified,
+                        isReadOnly = state.isReadOnly,
+                        isBackingLost = state.isBackingLost,
                         progress = state.progress,
                         hasContent = state.hasContent,
                         canUndo = state.canUndo,
@@ -225,7 +227,7 @@ fun EditorWorkspacePage(
                 }
                 // Notices persist during scroll (Static) until dismissed; single stable bar, see EditorBannerGroup
                 FloatingBar(
-                    visible = state.error != null || state.showExternalChangeBanner ||
+                    visible = state.isBackingLost || state.error != null || state.showExternalChangeBanner ||
                         state.showBackupNotice || state.isBinary || state.showLongLinesNotice,
                     scrollBehavior = BarScrollBehavior.Static,
                     estimatedHeight = 56.dp,
@@ -234,13 +236,17 @@ fun EditorWorkspacePage(
                 ) {
                     EditorBannerGroup(
                         modifier = Modifier.heightIn(max = bannerMaxHeight),
-                        error = state.error,
+                        // The backing-lost banner already explains the vanished file; the raw
+                        // read error underneath it would just be a cryptic duplicate.
+                        error = state.error.takeUnless { state.isBackingLost },
+                        showBackingLost = state.isBackingLost,
                         showExternalChange = state.showExternalChangeBanner,
                         backupNames = state.staleBackups.map { it.name },
                         showBackupNotice = state.showBackupNotice,
                         isBinary = state.isBinary,
                         showLongLinesNotice = state.showLongLinesNotice,
                         onDismissError = { onPageAction(EditorPageAction.Error.Clear) },
+                        onCloseBackingLost = { onPageAction(EditorPageAction.Workspace.Close) },
                         onReloadFromDisk = { onPageAction(EditorPageAction.File.ReloadFromDisk) },
                         onDismissExternalChange = { onPageAction(EditorPageAction.File.DismissExternalChange) },
                         onDismissBackupNotice = { onPageAction(EditorPageAction.File.DismissBackupNotice) },

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspaceViewModel.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspaceViewModel.kt
@@ -39,7 +39,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -49,6 +51,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -150,7 +153,26 @@ class EditorWorkspaceViewModel @AssistedInject constructor(
     val pasteableClipboard = clipboardController.pasteableClipboard
     fun refreshClipboardState() = clipboardController.refreshClipboardState()
 
+    // Pulsed on every user edit; sampled to poll backing availability while actively typing.
+    private val editActivity = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    /**
+     * Append/EOF edits need no original bytes, so they can't trip the buffer's read backstop, and
+     * the resumed-page external-change poll is coarse (15s). Sampling edit activity checks the
+     * file every ~1.5s while typing, so a document whose backing file vanished flips read-only
+     * quickly instead of accumulating edits that can never be saved.
+     */
+    @OptIn(FlowPreview::class)
+    private fun observeEditActivityForAvailability() {
+        editActivity
+            .sample(1_500L)
+            .onEach { getWorkspace().checkExternalChange() }
+            .launchIn(vmScope)
+    }
+
     init {
+        observeEditActivityForAvailability()
+
         // Dismissed backup/long-lines notices belong to ONE path: any path change (open,
         // Save-As, scratch-to-file) re-arms the notices for the new document
         workspaceWithState
@@ -374,22 +396,27 @@ class EditorWorkspaceViewModel @AssistedInject constructor(
     }
 
     fun insertText(text: String) = launch {
+        editActivity.tryEmit(Unit)
         getWorkspace().insertText(text)
     }
 
     fun replaceText(start: TextPosition, end: TextPosition, text: String, caret: TextPosition) = launch {
+        editActivity.tryEmit(Unit)
         getWorkspace().replaceText(start, end, text, caret)
     }
 
     fun deleteSelection() = launch {
+        editActivity.tryEmit(Unit)
         getWorkspace().deleteSelection()
     }
 
     fun deleteAtCursor(count: Int) = launch {
+        editActivity.tryEmit(Unit)
         getWorkspace().deleteAtCursor(count)
     }
 
     fun deleteForward() = launch {
+        editActivity.tryEmit(Unit)
         getWorkspace().deleteForward()
     }
 
@@ -590,8 +617,11 @@ class EditorWorkspaceViewModel @AssistedInject constructor(
         val isLoading: Boolean get() = progress != null
         val hasFile: Boolean get() = contentSource is ContentSource.File
         val isBinary: Boolean get() = (contentSource as? ContentSource.File)?.isLikelyBinary == true
+
+        /** The backing file vanished/lost read access mid-session: read-only, save disabled. */
+        val isBackingLost: Boolean get() = (contentSource as? ContentSource.File)?.isBackingLost == true
         val isReadOnly: Boolean
-            get() = (contentSource as? ContentSource.File)?.canWrite == false || isBinary
+            get() = (contentSource as? ContentSource.File)?.canWrite == false || isBinary || isBackingLost
         val hasContent: Boolean get() = contentSource.hasContent
         val isFileReady: Boolean get() = contentSource is ContentSource.File && progress == null
         val hasSelection: Boolean get() = selectionRange != null

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorBackingLostBanner.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorBackingLostBanner.kt
@@ -1,0 +1,93 @@
+package eu.darken.butler.editor.ui.editor.elements
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.LinkOff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.editor.R
+
+/**
+ * Shown when the open file becomes unreadable mid-session (moved, deleted, or read permission
+ * lost). The document is served read-only from what is still in memory; edits and saves are
+ * refused because the original bytes can no longer be read. Offers to close the workspace.
+ */
+@Composable
+fun EditorBackingLostBanner(
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit,
+) {
+    Card(
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.TwoTone.LinkOff,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.editor_backing_lost_banner_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Text(
+                        text = stringResource(R.string.editor_backing_lost_banner_message),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onClose) {
+                    Text(stringResource(R.string.editor_action_close))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun EditorBackingLostBannerPreview() {
+    EditorBackingLostBanner(
+        onClose = {},
+    )
+}

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorBannerGroup.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorBannerGroup.kt
@@ -22,12 +22,14 @@ import eu.darken.butler.common.compose.PreviewWrapper
 fun EditorBannerGroup(
     modifier: Modifier = Modifier,
     error: Throwable? = null,
+    showBackingLost: Boolean = false,
     showExternalChange: Boolean = false,
     backupNames: List<String> = emptyList(),
     showBackupNotice: Boolean = false,
     isBinary: Boolean = false,
     showLongLinesNotice: Boolean = false,
     onDismissError: () -> Unit = {},
+    onCloseBackingLost: () -> Unit = {},
     onReloadFromDisk: () -> Unit = {},
     onDismissExternalChange: () -> Unit = {},
     onDismissBackupNotice: () -> Unit = {},
@@ -40,6 +42,13 @@ fun EditorBannerGroup(
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // Backing-lost is terminal for editing; surface it above the transient notices
+        if (showBackingLost) {
+            EditorBackingLostBanner(
+                onClose = onCloseBackingLost,
+            )
+        }
+
         if (showExternalChange) {
             EditorExternalChangeBanner(
                 onReload = onReloadFromDisk,
@@ -79,6 +88,7 @@ fun EditorBannerGroup(
 private fun EditorBannerGroupPreview() {
     EditorBannerGroup(
         error = RuntimeException("Failed to save file: Permission denied"),
+        showBackingLost = true,
         showExternalChange = true,
         backupNames = listOf("notes.txt.butler-save-bak-1a2b3c4d"),
         showBackupNotice = true,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorToolbarCard.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorToolbarCard.kt
@@ -58,6 +58,8 @@ fun EditorToolbarCard(
     title: CaString,
     subTitle: CaString,
     isModified: Boolean,
+    isReadOnly: Boolean = false,
+    isBackingLost: Boolean = false,
     progress: Progress.Data?,
     hasContent: Boolean,
     canUndo: Boolean,
@@ -264,12 +266,14 @@ fun EditorToolbarCard(
 
                         IconButton(
                             onClick = { onAction(EditorPageAction.File.Save) },
-                            enabled = isModified
+                            enabled = isModified && !isReadOnly
                         ) {
                             Icon(Icons.TwoTone.Save, contentDescription = stringResource(R.string.editor_action_save))
                         }
 
-                        if (hasContent || isModified) {
+                        // Save-As can export a read-only file elsewhere, but not a vanished one -
+                        // its original bytes can no longer be read.
+                        if ((hasContent || isModified) && !isBackingLost) {
                             IconButton(onClick = { onAction(EditorPageAction.File.SaveAs) }) {
                                 Icon(
                                     Icons.TwoTone.SaveAs,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/LazyTextEditor.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/LazyTextEditor.kt
@@ -433,6 +433,18 @@ private fun DualColumnEditorContent(
         }
     }
 
+    // When the document flips read-only mid-edit (e.g. the backing file vanished), the field's
+    // in-flight local text is now unappliable and would otherwise linger on screen while the
+    // engine stays behind. Hand authority back to the engine and rebuild from its content.
+    LaunchedEffect(readOnly) {
+        if (readOnly && isUserEditing) {
+            isUserEditing = false
+            authorityEcho = null
+            val caret = textFieldValue.selection.end.coerceIn(0, currentContent.length)
+            textFieldValue = TextFieldValue(text = currentContent, selection = TextRange(caret))
+        }
+    }
+
     val lineNumberWidth = if (showLineNumbers) {
         remember(totalLines) {
             (totalLines.toString().length * 8 + 16).dp

--- a/app-workspace-editor/src/main/res/values/strings.xml
+++ b/app-workspace-editor/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="editor_long_lines_banner_message">Very long lines are shortened for display; the full content is preserved and saved.</string>
     <string name="editor_line_truncated_marker">⋯ +%1$d</string>
 
+    <!-- Backing-file-lost notice -->
+    <string name="editor_backing_lost_banner_title">File no longer available</string>
+    <string name="editor_backing_lost_banner_message">It may have been moved or deleted. This view is read-only — reopen or close it.</string>
+
     <!-- External change notice -->
     <string name="editor_external_change_banner_title">File changed on disk</string>
     <string name="editor_external_change_banner_message">Another app modified this file.</string>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferBackingLostTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferBackingLostTest.kt
@@ -1,0 +1,179 @@
+package eu.darken.butler.editor.core.engine
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathPermissionDeniedException
+import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.common.files.errors.ServiceConnectionLostException
+import eu.darken.butler.common.files.saf.MissingUriPermissionException
+import eu.darken.butler.editor.core.sources.EditorDataSource
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import okio.Source
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.FileNotFoundException
+import java.nio.file.NoSuchFileException
+
+/**
+ * Verifies the buffer's reaction to a backing file that vanishes mid-session: it latches a
+ * read-only [DocumentBuffer.isBackingLost] state, still fails edits that need original bytes,
+ * and leaves the piece table consistent after a failed edit.
+ */
+class DocumentBufferBackingLostTest : BaseTest() {
+
+    private val workspaceId = Workspace.Id()
+    private val path: APath<*> = LocalPath.build("/tmp/mergetest.txt")
+
+    /** [EditorDataSource] that serves [text] until [failWith] is set, then throws on every read. */
+    private class FailableDataSource(
+        private val text: String,
+        private val path: APath<*>,
+    ) : EditorDataSource {
+        var failWith: (() -> Throwable)? = null
+        private val bytes = text.toByteArray(Charsets.UTF_8)
+        private val _contentSource = MutableStateFlow<ContentSource>(ContentSource.Memory(size = 0L))
+        override val contentSource: StateFlow<ContentSource> = _contentSource.asStateFlow()
+
+        override suspend fun open() {
+            _contentSource.value = ContentSource.File(
+                path = path,
+                size = bytes.size.toLong(),
+                lastModified = null,
+                canWrite = true,
+                detectedCharset = Charsets.UTF_8,
+            )
+        }
+
+        override suspend fun getSize(): Long = bytes.size.toLong()
+
+        override suspend fun getMeta(): EditorDataSource.Meta {
+            failWith?.let { throw it() }
+            return EditorDataSource.Meta(size = bytes.size.toLong(), modifiedAt = null)
+        }
+
+        override suspend fun openByteSource(offset: Long): Source {
+            failWith?.let { throw it() }
+            return Buffer().write(bytes).apply { skip(offset) }
+        }
+
+        override suspend fun commit(writer: suspend (EditorDataSource.CommitContext) -> Unit) =
+            throw UnsupportedOperationException("not needed for these tests")
+
+        override suspend fun close() {
+            _contentSource.value = ContentSource.Memory(size = 0L)
+        }
+    }
+
+    private suspend fun createBuffer(content: String, source: FailableDataSource): DocumentBuffer {
+        source.open()
+        val buffer = DocumentBuffer(
+            workspaceId = workspaceId,
+            dataSource = source,
+            maxUndoStackSize = 100,
+            maxUndoMemoryBytes = 10_485_760,
+            blockSize = 16,
+            assertions = true,
+        )
+        buffer.initialize().getOrThrow()
+        return buffer
+    }
+
+    @Test
+    fun `polled metadata failure latches read-only`() = runTest {
+        val source = FailableDataSource("first line\nsecond line\n", path)
+        val buffer = createBuffer("first line\nsecond line\n", source)
+        buffer.isBackingLost.value shouldBe false
+
+        source.failWith = { ReadException("Does not exist or can't be read :(", path) }
+        buffer.checkExternalChange() shouldBe DocumentBuffer.ExternalChangeProbe.Unknown
+
+        buffer.isBackingLost.value shouldBe true
+        // The read-only state is published on the content source for the UI
+        (buffer.contentSource.value as ContentSource.File).isBackingLost shouldBe true
+    }
+
+    @Test
+    fun `edit needing original bytes fails and latches read-only`() = runTest {
+        val source = FailableDataSource("first line\nsecond line\n", path)
+        val buffer = createBuffer("first line\nsecond line\n", source)
+
+        source.failWith = { FileNotFoundException("open failed: ENOENT (No such file or directory)") }
+        // Splitting the single original piece mid-content needs charToByte -> reads the gone file
+        val result = buffer.insertText(TextPosition(offset = 4L, line = 0, column = 4), text = "X")
+
+        result.isFailure shouldBe true
+        buffer.isBackingLost.value shouldBe true
+    }
+
+    @Test
+    fun `failed mid-document edit leaves the piece table consistent`() = runTest {
+        val source = FailableDataSource("hello world", path)
+        val buffer = createBuffer("hello world", source)
+        val originalLength = buffer.totalLength.value
+
+        source.failWith = { ReadException("gone", path) }
+        buffer.insertText(TextPosition(offset = 5L, line = 0, column = 5), text = "X").isFailure shouldBe true
+
+        // An append needs no original bytes, so it still succeeds - and its invariant check (the
+        // buffer runs with assertions on) would throw on any length drift left by the failed edit.
+        val append = buffer.insertText(
+            TextPosition(offset = originalLength, line = 0, column = originalLength.toInt()),
+            text = "!",
+        )
+        append.isSuccess shouldBe true
+        buffer.totalLength.value shouldBe originalLength + 1
+    }
+
+    @Test
+    fun `replaceMatches leaves content unchanged when the backing file vanishes`() = runTest {
+        val source = FailableDataSource("foo foo", path)
+        val buffer = createBuffer("foo foo", source)
+        // Warms the decode cache so replaceMatches' verify pass reads from memory; the mutation's
+        // charToByte still reads the file directly and trips the failure.
+        val original = buffer.getFullText().getOrThrow()
+
+        source.failWith = { FileNotFoundException("open failed: ENOENT (No such file or directory)") }
+        val result = buffer.replaceMatches(
+            listOf(
+                DocumentBuffer.MatchReplacement(startOffset = 0L, oldText = "foo", newText = "bar"),
+                DocumentBuffer.MatchReplacement(startOffset = 4L, oldText = "foo", newText = "bar"),
+            ),
+        )
+
+        result.isFailure shouldBe true
+        buffer.getFullText().getOrThrow() shouldBe original
+    }
+
+    @Test
+    fun `not-found and permission failures latch, transient service loss does not`() = runTest {
+        suspend fun latchesFor(failure: () -> Throwable): Boolean {
+            val source = FailableDataSource("alpha\nbeta\n", path)
+            val buffer = createBuffer("alpha\nbeta\n", source)
+            source.failWith = failure
+            buffer.checkExternalChange()
+            return buffer.isBackingLost.value
+        }
+
+        latchesFor { ReadException("Does not exist", path) } shouldBe true
+        latchesFor { FileNotFoundException("ENOENT") } shouldBe true
+        latchesFor { NoSuchFileException("/tmp/mergetest.txt") } shouldBe true
+        latchesFor {
+            PathPermissionDeniedException(path, "lookup", PathPermissionDeniedException.Reason.ACCESS_DENIED)
+        } shouldBe true
+        // SAF permission revocation: a ReadException subtype whose message has no not-found token
+        latchesFor { MissingUriPermissionException(path = path) } shouldBe true
+
+        // A dropped root/ADB service is transient - re-wrapping it in a ReadException must not latch
+        latchesFor { ServiceConnectionLostException() } shouldBe false
+        latchesFor { ReadException("read failed", path, cause = ServiceConnectionLostException()) } shouldBe false
+
+        // A generic read failure with no not-found signal must NOT lock the file read-only forever
+        latchesFor { ReadException("Couldn't open input stream", path) } shouldBe false
+    }
+}

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineReplaceTextTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineReplaceTextTest.kt
@@ -111,6 +111,18 @@ class EditorEngineReplaceTextTest : DocumentBufferTestBase() {
     }
 
     @Test
+    fun `out-of-range line from a diverged field is dropped, not thrown`() = runTest {
+        // Repro of the crash: the field diverged and asked for a line the buffer never had
+        // (findOffset(line=8, total=2) threw IndexOutOfBoundsException). It must be a no-op now.
+        val engine = createEngine("first line\nsecond line")
+
+        engine.replaceText(start = pos(8, 0), end = pos(8, 0), text = "\n", caret = pos(9, 0))
+
+        engine.fullContent() shouldBe "first line\nsecond line"
+        (engine.state.value as EditorState.Loaded).isModified shouldBe false
+    }
+
+    @Test
     fun `replace with newline adds a line`() = runTest {
         val engine = createEngine("abc")
 

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/text/PieceTableTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/text/PieceTableTest.kt
@@ -43,6 +43,45 @@ class PieceTableTest : BaseTest() {
         endsWithBreak shouldBe TextMetrics.endsWithBreak(text)
     }
 
+    /** [StringOriginalDocument] whose [charToByte] can be toggled to throw, mimicking a vanished file. */
+    private class ToggleFailOriginal(private val delegate: StringOriginalDocument) : OriginalDocument by delegate {
+        var fail = false
+        override suspend fun charToByte(charOffset: Long): Long {
+            if (fail) throw java.io.IOException("backing gone")
+            return delegate.charToByte(charOffset)
+        }
+    }
+
+    @Test
+    fun `checkpoint then restore round-trips a mutated table`() = runTest {
+        val table = stringTable("hello world")
+        val checkpoint = table.checkpoint()
+
+        table.insert(5, " brave new")
+        table.delete(0, 5)
+        table.readAll() shouldBe " brave new world"
+
+        table.restore(checkpoint)
+        table.shouldMatch("hello world")
+    }
+
+    @Test
+    fun `a mid-batch mutation failure restores fully via checkpoint`() = runTest {
+        val original = ToggleFailOriginal(StringOriginalDocument("aXaYaZa"))
+        val table = PieceTable.create(original, assertions = true)
+        val checkpoint = table.checkpoint()
+
+        // First replacement lands; the second reads the (now-gone) original and throws
+        table.delete(5, 6)
+        table.insert(5, "!")
+        original.fail = true
+        runCatching { table.delete(1, 2) }.isFailure shouldBe true
+
+        table.restore(checkpoint)
+        original.fail = false
+        table.shouldMatch("aXaYaZa")
+    }
+
     // ========== Insert splits ==========
 
     @Test


### PR DESCRIPTION
When an open file was moved, deleted, or lost read permission mid-session, the editor kept showing its cached content but every edit failed silently. The hidden text field and the piece-table buffer drifted apart until a keystroke resolved to a line that no longer existed and crashed with an `IndexOutOfBoundsException` (e.g. pressing Enter). Tapping to move the cursor also stopped working.

The editor now detects a vanished/unreadable backing file and switches the document to an explicit read-only state instead of drifting into a crash.

## Changes
- **Detection** — classify not-found / permission-loss read failures across local, SAF (including revoked Uri permission), and root/ADB. Fires proactively on the metadata poll and as a backstop on any original-byte read; transient read errors stay recoverable so a blip never locks a still-present file read-only.
- **Read-only state** — edits, Save, Save-As and line-ending conversion are refused; a "File no longer available" banner offers to close, the raw read error is suppressed, and the input field is handed back to the engine so unappliable local edits stop lingering on screen.
- **Crash fix** — cursor, selection and replace position resolution tolerate a stale line/column from a diverged field instead of throwing.
- **Data integrity** — single replaces and Find & Replace are fully transactional: a mid-edit read failure rolls the piece table back in-memory (never re-reading the gone original), and the piece table no longer drifts its length bookkeeping when a split fails.
- **Detection latency** — sustained typing samples availability every ~1.5s, so a vanished file goes read-only quickly rather than after the coarse 15s change poll.

## Testing
- New unit tests: backing-loss detection (proactive + backstop), classifier (not-found/permission latch; transient errors don't), transactional rollback for replace / replace-all, piece-table checkpoint/restore, and the stale-line replace no-op.
- Full `app-workspace-editor` unit suite green (806 tests); `lintVitalFossRelease` clean.
