### PR TITLE
General: Improve clipboard reliability and paste handling

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/SystemClipboardHelper.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/SystemClipboardHelper.kt
@@ -5,6 +5,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import androidx.core.text.HtmlCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
@@ -29,11 +30,16 @@ class SystemClipboardHelper @Inject constructor(
             var clipboardManager: ClipboardManager? = null
 
             Handler(Looper.getMainLooper()).postAtFrontOfQueue {
-                clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                lock.withLock { lockCondition.signal() }
+                lock.withLock {
+                    clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    lockCondition.signal()
+                }
             }
 
-            lock.withLock { lockCondition.await() }
+            lock.withLock {
+                // Predicate loop: guards against a lost wakeup if main signals before we await.
+                while (clipboardManager == null) lockCondition.await()
+            }
 
             clipboardManager!!
         }
@@ -44,16 +50,26 @@ class SystemClipboardHelper @Inject constructor(
         clipboard.setPrimaryClip(clip)
     }
 
+    /**
+     * Text representation of the primary clip. Prefers a plain-text item, then converts an HTML
+     * item via [HtmlCompat], and finally falls back to a URI item's literal string. A URI's
+     * *content* is never dereferenced here - that would be an unbounded, provider-controlled read.
+     */
     fun getClipboardText(): String? {
         val primaryClip = clipboard.primaryClip ?: return null
         if (primaryClip.itemCount == 0) return null
 
         val item = primaryClip.getItemAt(0)
-        return item.text?.toString()
+        item.text?.let { return it.toString() }
+        item.htmlText?.let { return HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY).toString() }
+        item.uri?.let { return it.toString() }
+        return null
     }
 
     fun hasClipboardContent(): Boolean {
-        return clipboard.hasPrimaryClip() && clipboard.primaryClipDescription?.hasMimeType("text/plain") == true
+        if (!clipboard.hasPrimaryClip()) return false
+        // "text/*" covers text/plain, text/html and text/uri-list.
+        return clipboard.primaryClipDescription?.hasMimeType("text/*") == true
     }
 
     companion object {

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
@@ -284,6 +284,7 @@ private fun LazyListScope.logSection(
                     text = logState.lines.joinToString("\n"),
                     style = MaterialTheme.typography.bodySmall.copy(fontSize = 11.sp, lineHeight = 14.sp),
                     fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/PasteFileReader.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/PasteFileReader.kt
@@ -21,7 +21,8 @@ import javax.inject.Inject
  * Streams with a hard byte cap (reported sizes are not trusted - a provider returning null or a
  * lying size must not bypass the limit), rejects binary content via null bytes AFTER honoring a
  * UTF-16 BOM (UTF-16 text legitimately contains 0x00), and decodes strictly as UTF-8 with a real
- * ISO-8859-1 fallback for legacy-encoded content.
+ * ISO-8859-1 fallback for legacy-encoded content. A control-character heuristic on the decoded
+ * text then rejects null-free binaries the Latin-1 fallback would otherwise pass through.
  */
 class PasteFileReader @Inject constructor(
     private val gatewaySwitch: GatewaySwitch,
@@ -59,10 +60,13 @@ class PasteFileReader @Inject constructor(
             return String(bytes, bom.bomSize, bytes.size - bom.bomSize, bom.charset)
         }
         val body = if (bom != null) bytes.copyOfRange(bom.bomSize, bytes.size) else bytes
+        // Null bytes are a hard binary signal.
         if (body.any { it == 0.toByte() }) {
             throw PasteBinaryException()
         }
-        return try {
+        // Decode UTF-8 strictly first so multibyte sequences aren't mistaken for raw C1 control
+        // bytes; only genuinely non-UTF-8 content falls back to ISO-8859-1.
+        val decoded = try {
             Charsets.UTF_8.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
                 .onUnmappableCharacter(CodingErrorAction.REPORT)
@@ -72,10 +76,38 @@ class PasteFileReader @Inject constructor(
             log(TAG, WARN) { "Strict UTF-8 decode failed, falling back to ISO-8859-1" }
             String(body, Charsets.ISO_8859_1)
         }
+        // Backstop against the ISO-8859-1 fallback (and null-free binaries) decoding to control-char
+        // garbage: run the check on the decoded text so C1 controls (0x80..0x9F) are also counted.
+        if (looksBinary(decoded)) {
+            throw PasteBinaryException()
+        }
+        return decoded
+    }
+
+    /**
+     * Heuristic binary guard for the decoded text: counts Unicode control characters (C0, DEL and
+     * C1 0x80..0x9F) that are not legitimate text controls (tab/LF/CR/FF and the ANSI ESC used in
+     * captured logs). Real text has essentially none; a high ratio means the ISO-8859-1 fallback
+     * decoded control-char garbage. The minimum-count guard keeps a lone stray control in a short
+     * snippet from tripping the ratio. High-byte-only binaries that decode to legible Latin-1 are
+     * an accepted miss for a paste convenience.
+     */
+    internal fun looksBinary(text: String): Boolean {
+        if (text.isEmpty()) return false
+        var suspicious = 0
+        for (c in text) {
+            if (c.isISOControl() && c !in ALLOWED_CONTROLS) suspicious++
+        }
+        return suspicious >= MIN_BINARY_CONTROL_COUNT &&
+            suspicious.toDouble() / text.length > BINARY_CONTROL_RATIO
     }
 
     companion object {
         const val MAX_PASTE_FILE_SIZE = 1024 * 1024L // 1 MB
+        private const val BINARY_CONTROL_RATIO = 0.10
+        private const val MIN_BINARY_CONTROL_COUNT = 4
+        /** Control chars that legitimately appear in text/logs (tab, LF, CR, FF, ANSI ESC). */
+        private val ALLOWED_CONTROLS = setOf('\t', '\n', '\r', '\u000C', '\u001B')
         private val TAG = logTag("Editor", "PasteFileReader")
     }
 }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorClipboardController.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorClipboardController.kt
@@ -7,6 +7,8 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.editor.core.EditorWorkspace
 import eu.darken.butler.editor.core.engine.ClipboardCapacityException
 import eu.darken.butler.editor.core.engine.ContentSource
@@ -154,7 +156,7 @@ class EditorClipboardController(
             is ClipboardClip.Paths -> {
                 val textFile = clip.paths.firstOrNull { isLikelyTextFile(it) }
                 if (textFile != null) {
-                    pasteFileContent(textFile)
+                    pasteFileContent(textFile.lookedUp)
                 } else {
                     log(tag, WARN) { "No text files found in clipboard paths" }
                 }
@@ -197,9 +199,18 @@ class EditorClipboardController(
         clipboardRepo.clear()
     }
 
-    private fun isLikelyTextFile(path: APath<*>): Boolean {
-        val ext = path.name.substringAfterLast('.', "").lowercase()
-        return ext in TEXT_EXTENSIONS
+    /**
+     * Cheap, no-I/O suggestion heuristic for the paste sheet. Requires regular-file metadata (so
+     * directories/symlinks never surface) and then accepts a known text extension, a known text
+     * filename/dotfile, or any extensionless regular file. It only decides what is *suggested* -
+     * an explicitly picked file is always attempted and [PasteFileReader] rejects real binaries.
+     */
+    private fun isLikelyTextFile(lookup: APathLookup<*>): Boolean {
+        if (lookup.fileType != FileType.FILE) return false
+        val name = lookup.name
+        if (name in KNOWN_TEXT_FILENAMES) return true
+        val ext = name.substringAfterLast('.', "").lowercase()
+        return ext.isEmpty() || ext in TEXT_EXTENSIONS
     }
 
     companion object {
@@ -220,6 +231,12 @@ class EditorClipboardController(
             "txt", "md", "json", "xml", "html", "css", "js", "kt", "java", "py", "sh",
             "yml", "yaml", "csv", "log", "conf", "ini", "properties", "gradle", "toml",
             "c", "cpp", "h", "hpp", "rs", "go", "rb", "php", "sql", "ts", "tsx", "jsx",
+        )
+
+        /** Common extensionless / dotfile text files the extension heuristic would otherwise miss. */
+        internal val KNOWN_TEXT_FILENAMES = setOf(
+            ".env", ".gitignore", ".gitattributes", ".editorconfig", ".bashrc", ".zshrc",
+            ".profile", "Makefile", "Dockerfile", "LICENSE", "README", "CHANGELOG",
         )
     }
 }

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/PasteFileReaderTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/PasteFileReaderTest.kt
@@ -72,6 +72,34 @@ class PasteFileReaderTest : BaseTest() {
         error.message shouldContain "binary"
     }
 
+    @Test
+    fun `null-free content with many control bytes is rejected as binary`() {
+        // The ISO-8859-1 fallback would otherwise decode this to control-char garbage.
+        val bytes = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x61, 0x62, 0x63)
+        shouldThrow<PasteBinaryException> { decoder.decodeBytes(bytes) }
+    }
+
+    @Test
+    fun `non-UTF-8 content with many C1 control bytes is rejected as binary`() {
+        // 0x80..0x83 are C1 controls; they fail strict UTF-8 and, via the ISO-8859-1 fallback,
+        // must be caught by the decoded-text heuristic rather than passed through.
+        val bytes = byteArrayOf(0x80.toByte(), 0x81.toByte(), 0x82.toByte(), 0x83.toByte(), 0x61, 0x62, 0x63)
+        shouldThrow<PasteBinaryException> { decoder.decodeBytes(bytes) }
+    }
+
+    @Test
+    fun `tabs newlines and carriage returns are not treated as binary`() {
+        val text = "line1\n\tindented\r\nline3\n"
+        decoder.decodeBytes(text.toByteArray(Charsets.UTF_8)) shouldBe text
+    }
+
+    @Test
+    fun `ANSI escape sequences in log text are not treated as binary`() {
+        // Captured terminal logs legitimately contain ESC (0x1B); they must paste, not be rejected.
+        val text = "\u001B[31mERROR\u001B[0m something failed\n\u001B[32mOK\u001B[0m"
+        decoder.decodeBytes(text.toByteArray(Charsets.UTF_8)) shouldBe text
+    }
+
     // ==================== read (streaming cap) ====================
 
     @Test

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorClipboardControllerTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorClipboardControllerTest.kt
@@ -2,6 +2,8 @@ package eu.darken.butler.editor.ui.editor
 
 import eu.darken.butler.common.SystemClipboardHelper
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.editor.core.EditorWorkspace
 import eu.darken.butler.editor.core.PasteFileReader
 import eu.darken.butler.editor.core.PasteTooLargeException
@@ -34,6 +36,13 @@ class EditorClipboardControllerTest : BaseTest() {
     private val workspaceId = Workspace.Id()
 
     private fun path(name: String) = LocalPath.build(File("/tmp/clip-test", name))
+
+    private fun fileLookup(name: String, fileType: FileType = FileType.FILE) = LocalPathLookup(
+        lookedUp = path(name),
+        fileType = fileType,
+        size = null,
+        modifiedAt = null,
+    )
 
     /** Mirrors ViewModel3's error handler: thrown controller errors surface here, not as crashes. */
     private val surfacedErrors = mutableListOf<Throwable>()
@@ -306,7 +315,7 @@ class EditorClipboardControllerTest : BaseTest() {
         val clip = ClipboardClip.Paths(
             origin = workspaceId,
             mode = ClipboardClip.Paths.Mode.COPY,
-            paths = listOf(path("archive.zip"), path("notes.txt")),
+            paths = listOf(fileLookup("archive.zip"), fileLookup("notes.txt")),
         )
 
         controller.pasteFromClipboard(clip)
@@ -339,7 +348,7 @@ class EditorClipboardControllerTest : BaseTest() {
         val clip = ClipboardClip.Paths(
             origin = workspaceId,
             mode = ClipboardClip.Paths.Mode.COPY,
-            paths = listOf(path("archive.zip")),
+            paths = listOf(fileLookup("archive.zip")),
         )
 
         controller.pasteFromClipboard(clip)
@@ -353,12 +362,12 @@ class EditorClipboardControllerTest : BaseTest() {
         val textClip = ClipboardClip.Paths(
             origin = workspaceId,
             mode = ClipboardClip.Paths.Mode.COPY,
-            paths = listOf(path("notes.md")),
+            paths = listOf(fileLookup("notes.md")),
         )
         val binaryClip = ClipboardClip.Paths(
             origin = workspaceId,
             mode = ClipboardClip.Paths.Mode.COPY,
-            paths = listOf(path("image.png")),
+            paths = listOf(fileLookup("image.png")),
         )
         val textEntry = ClipboardClip.Text(origin = workspaceId, content = "text")
         val controller = controller(repo = mockRepo(listOf(textClip, binaryClip, textEntry)))
@@ -367,5 +376,46 @@ class EditorClipboardControllerTest : BaseTest() {
 
         pasteable shouldHaveSize 1
         pasteable.single().paths.single().name shouldBe "notes.md"
+    }
+
+    @Test
+    fun `pasteable clipboard suggests extensionless and known-name text files but not directories`() = runTest {
+        val extensionless = ClipboardClip.Paths(
+            origin = workspaceId,
+            mode = ClipboardClip.Paths.Mode.COPY,
+            paths = listOf(fileLookup("changelog")),
+        )
+        val dotfile = ClipboardClip.Paths(
+            origin = workspaceId,
+            mode = ClipboardClip.Paths.Mode.COPY,
+            paths = listOf(fileLookup(".gitignore")),
+        )
+        val directory = ClipboardClip.Paths(
+            origin = workspaceId,
+            mode = ClipboardClip.Paths.Mode.COPY,
+            paths = listOf(fileLookup("logs", fileType = FileType.DIRECTORY)),
+        )
+        val controller = controller(repo = mockRepo(listOf(extensionless, dotfile, directory)))
+
+        val pasteable = controller.pasteableClipboard.first()
+
+        pasteable shouldHaveSize 2
+        pasteable.flatMap { it.paths }.map { it.name } shouldBe listOf("changelog", ".gitignore")
+    }
+
+    @Test
+    fun `pasting a paths clip skips directories`() = runTest {
+        val workspace = mockWorkspace()
+        val controller = controller(workspace)
+        val clip = ClipboardClip.Paths(
+            origin = workspaceId,
+            mode = ClipboardClip.Paths.Mode.COPY,
+            paths = listOf(fileLookup("subdir", fileType = FileType.DIRECTORY), fileLookup("notes.txt")),
+        )
+
+        controller.pasteFromClipboard(clip)
+        runCurrent()
+
+        coVerify { workspace.readFileContent(match { it.name == "notes.txt" }) }
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -661,7 +661,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                     origin = getWorkspace().id,
                     paths = selected
                         .filterIsInstance<ExplorerItem.Lookup>()
-                        .map { it.lookup.lookedUp },
+                        .map { it.lookup },
                 )
                 clipboardRepo.add(clip)
                 clearSelection()
@@ -675,7 +675,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                     origin = getWorkspace().id,
                     paths = selected
                         .filterIsInstance<ExplorerItem.Lookup>()
-                        .map { it.lookup.lookedUp },
+                        .map { it.lookup },
                 )
                 clipboardRepo.add(clip)
                 clearSelection()
@@ -969,7 +969,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 val clip = ClipboardClip.Paths(
                     mode = ClipboardClip.Paths.Mode.COPY,
                     origin = getWorkspace().id,
-                    paths = listOf(action.item.lookup.lookedUp),
+                    paths = listOf(action.item.lookup),
                 )
                 clipboardRepo.add(clip)
             }
@@ -977,7 +977,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 val clip = ClipboardClip.Paths(
                     mode = ClipboardClip.Paths.Mode.CUT,
                     origin = getWorkspace().id,
-                    paths = listOf(action.item.lookup.lookedUp),
+                    paths = listOf(action.item.lookup),
                 )
                 clipboardRepo.add(clip)
             }
@@ -1310,12 +1310,12 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 if (currentLocation is ExplorerLocation.Directory) {
                     val command = when (clip.mode) {
                         ClipboardClip.Paths.Mode.COPY -> ExplorerCommand.Copy(
-                            sources = clip.paths.toSet(),
+                            sources = clip.paths.map { it.lookedUp }.toSet(),
                             destination = currentLocation.path,
                             intent = Operation.Metadata.Intent.PASTE_COPY,
                         )
                         ClipboardClip.Paths.Mode.CUT -> ExplorerCommand.Move(
-                            sources = clip.paths.toSet(),
+                            sources = clip.paths.map { it.lookedUp }.toSet(),
                             destination = currentLocation.path,
                             intent = Operation.Metadata.Intent.PASTE_MOVE,
                         )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
@@ -409,6 +409,13 @@ object MockDataProvider {
 
     // MARK: - Clipboard State Factories
 
+    private fun mockFileLookup(path: String): LocalPathLookup = LocalPathLookup(
+        lookedUp = LocalPath.build(path),
+        fileType = FileType.FILE,
+        size = null,
+        modifiedAt = null,
+    )
+
     fun createMockClipboardCopy(
         files: List<String> = listOf("photo1.jpg", "photo2.jpg", "photo3.jpg"),
         basePath: String = "/storage/emulated/0/Pictures",
@@ -417,7 +424,7 @@ object MockDataProvider {
         return ClipboardClip.Paths(
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.COPY,
-            paths = files.map { LocalPath.build("$basePath/$it") },
+            paths = files.map { mockFileLookup("$basePath/$it") },
             clippedAt = MockTimes.minutesAgo(minutesAgo),
         )
     }
@@ -430,7 +437,7 @@ object MockDataProvider {
         return ClipboardClip.Paths(
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.CUT,
-            paths = files.map { LocalPath.build("$basePath/$it") },
+            paths = files.map { mockFileLookup("$basePath/$it") },
             clippedAt = MockTimes.minutesAgo(minutesAgo),
         )
     }

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
@@ -746,7 +746,7 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
                         ClipboardClip.Paths(
                             origin = id,
                             mode = ClipboardClip.Paths.Mode.COPY,
-                            paths = action.results.map { it.path }
+                            paths = action.results.map { it.lookup }
                         )
                     )
                 }
@@ -757,7 +757,7 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
                         ClipboardClip.Paths(
                             origin = id,
                             mode = ClipboardClip.Paths.Mode.CUT,
-                            paths = action.results.map { it.path }
+                            paths = action.results.map { it.lookup }
                         )
                     )
                 }
@@ -1104,7 +1104,7 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
                     return@launch
                 }
 
-                val commonParent = clip.paths.commonParent()
+                val commonParent = clip.paths.map { it.lookedUp }.commonParent()
                 if (commonParent == null) {
                     log(TAG, WARN) { "Cannot open in Explorer - paths have no common parent" }
                     return@launch

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchBar.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchBar.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -121,6 +122,7 @@ fun SearchBar(
                 textStyle = MaterialTheme.typography.bodyMedium.copy(
                     color = colors.onSurface
                 ),
+                cursorBrush = SolidColor(colors.primary),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                 keyboardActions = KeyboardActions(onSearch = {
                     keyboardController?.hide()

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/clipboard/ClipboardClip.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/clipboard/ClipboardClip.kt
@@ -4,6 +4,7 @@ import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
@@ -23,7 +24,7 @@ sealed interface ClipboardClip {
         override val clippedAt: Instant = Clock.System.now(),
         override val origin: Workspace.Id,
         val mode: Mode,
-        val paths: List<APath<*>>,
+        val paths: List<APathLookup<*>>,
     ) : ClipboardClip {
         override val title: CaString
             get() = caString {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/clipboard/ClipboardRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/clipboard/ClipboardRepo.kt
@@ -4,7 +4,6 @@ import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
-import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
@@ -34,13 +33,6 @@ class ClipboardRepo @Inject constructor(
         log(TAG, INFO) { "Removing entry with id $id" }
         _state.value = _state.value.copy(
             entries = _state.value.entries.filter { it.id != id }
-        )
-    }
-
-    suspend fun prune(id: Workspace.Id) = lock.withLock {
-        log(TAG, INFO) { "Pruning entries for workspace $id" }
-        _state.value = _state.value.copy(
-            entries = _state.value.entries.filter { it.origin != id }
         )
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/ClipboardPreviewMocks.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/ClipboardPreviewMocks.kt
@@ -1,0 +1,13 @@
+package eu.darken.butler.workspace.ui.clipboard
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+
+/** Builds a lightweight file [LocalPathLookup] for Compose previews of clipboard entries. */
+internal fun mockFileLookup(path: String): LocalPathLookup = LocalPathLookup(
+    lookedUp = LocalPath.build(path),
+    fileType = FileType.FILE,
+    size = null,
+    modifiedAt = null,
+)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardBar.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
-import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.ui.clipboard.mockFileLookup
 import eu.darken.butler.common.ui.SwipeToDismissItem
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
@@ -223,9 +223,9 @@ fun ClipboardBarPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.COPY,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Pictures/photo1.jpg"),
-                LocalPath.build("/storage/emulated/0/Pictures/photo2.jpg"),
-                LocalPath.build("/storage/emulated/0/Pictures/photo3.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo2.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo3.jpg"),
             ),
             clippedAt = Clock.System.now() - 5.minutes,
         ),
@@ -233,7 +233,7 @@ fun ClipboardBarPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.CUT,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
             ),
             clippedAt = Clock.System.now() - 2.minutes,
         ),
@@ -257,7 +257,7 @@ fun ClipboardBarSingleItemPreview() {
         origin = Workspace.Id(Uuid.random()),
         mode = ClipboardClip.Paths.Mode.COPY,
         paths = listOf(
-            LocalPath.build("/storage/emulated/0/Documents/important_document.pdf"),
+            mockFileLookup("/storage/emulated/0/Documents/important_document.pdf"),
         ),
         clippedAt = Clock.System.now() - 2.minutes,
     )
@@ -287,9 +287,9 @@ fun ClipboardBarExpandedPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.COPY,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Pictures/photo1.jpg"),
-                LocalPath.build("/storage/emulated/0/Pictures/photo2.jpg"),
-                LocalPath.build("/storage/emulated/0/Pictures/photo3.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo2.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo3.jpg"),
             ),
             clippedAt = Clock.System.now() - 5.minutes,
         ),
@@ -297,7 +297,7 @@ fun ClipboardBarExpandedPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.CUT,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
             ),
             clippedAt = Clock.System.now() - 2.minutes,
         ),
@@ -305,7 +305,7 @@ fun ClipboardBarExpandedPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.COPY,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Downloads/app.apk"),
+                mockFileLookup("/storage/emulated/0/Downloads/app.apk"),
             ),
             clippedAt = Clock.System.now() - 1.minutes,
         ),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardEntryRow.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardEntryRow.kt
@@ -32,7 +32,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.asComposable
-import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.ui.clipboard.mockFileLookup
 import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
@@ -353,9 +353,9 @@ private fun ClipboardEntryRowCollapsedPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.COPY,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Pictures/photo1.jpg"),
-                LocalPath.build("/storage/emulated/0/Pictures/photo2.jpg"),
-                LocalPath.build("/storage/emulated/0/Pictures/photo3.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo2.jpg"),
+                mockFileLookup("/storage/emulated/0/Pictures/photo3.jpg"),
             ),
             clippedAt = Clock.System.now() - 5.minutes,
         ),
@@ -375,7 +375,7 @@ private fun ClipboardEntryRowExpandedPreview() {
             origin = Workspace.Id(Uuid.random()),
             mode = ClipboardClip.Paths.Mode.CUT,
             paths = listOf(
-                LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
             ),
             clippedAt = Clock.System.now() - 2.minutes,
         ),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/details/ClipboardInfoBottomSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/details/ClipboardInfoBottomSheet.kt
@@ -55,8 +55,10 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.asComposable
-import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.ui.clipboard.mockFileLookup
 import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
@@ -358,7 +360,7 @@ private fun ClipboardOverviewSection(
 
 @Composable
 private fun ClipboardFilesSection(
-    paths: List<APath<*>>,
+    paths: List<APathLookup<*>>,
     onCopyPath: ((String) -> Unit)? = null,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
@@ -790,13 +792,9 @@ private fun ClipboardActionsSection(
     }
 }
 
-private fun getPathIcon(path: APath<*>): ImageVector {
-    // Simple heuristic - in a real implementation, you'd use file type detection
-    return if (path.name.contains('.')) {
-        Icons.AutoMirrored.TwoTone.InsertDriveFile
-    } else {
-        Icons.TwoTone.FolderOpen
-    }
+private fun getPathIcon(path: APathLookup<*>): ImageVector = when (path.fileType) {
+    FileType.DIRECTORY -> Icons.TwoTone.FolderOpen
+    else -> Icons.AutoMirrored.TwoTone.InsertDriveFile
 }
 
 @Preview2
@@ -807,9 +805,9 @@ private fun ClipboardInfoBottomSheetPreview() {
         origin = Workspace.Id(Uuid.random()),
         mode = ClipboardClip.Paths.Mode.COPY,
         paths = listOf(
-            LocalPath.build("/storage/emulated/0/Pictures/photo1.jpg"),
-            LocalPath.build("/storage/emulated/0/Pictures/photo2.jpg"),
-            LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+            mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
+            mockFileLookup("/storage/emulated/0/Pictures/photo2.jpg"),
+            mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
         ),
         clippedAt = Clock.System.now() - 5.minutes,
     )
@@ -834,7 +832,7 @@ private fun ClipboardInfoSingleFilePreview() {
         origin = Workspace.Id(Uuid.random()),
         mode = ClipboardClip.Paths.Mode.CUT,
         paths = listOf(
-            LocalPath.build("/storage/emulated/0/Documents/important_document.pdf"),
+            mockFileLookup("/storage/emulated/0/Documents/important_document.pdf"),
         ),
         clippedAt = Clock.System.now() - 2.minutes,
     )

--- a/app/src/main/java/eu/darken/butler/common/debug/logviewer/ui/FloatingLogPanelViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/common/debug/logviewer/ui/FloatingLogPanelViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.butler.common.debug.logviewer.ui
 
 import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import androidx.core.content.FileProvider
@@ -9,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.R
 import eu.darken.butler.common.BuildConfigWrap
+import eu.darken.butler.common.SystemClipboardHelper
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.DebugSettings
@@ -42,6 +42,7 @@ class FloatingLogPanelViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val debugSettings: DebugSettings,
     private val recorder: LogHistoryRecorder,
+    private val clipboardHelper: SystemClipboardHelper,
 ) : ViewModel3(dispatcherProvider, tag = TAG) {
 
     private val lifecycleStarted = MutableStateFlow(false)
@@ -188,11 +189,8 @@ class FloatingLogPanelViewModel @Inject constructor(
         val visible = state.value.lines
         val truncatedBy = (visible.size - COPY_LINE_CAP).coerceAtLeast(0)
         val text = visible.takeLast(COPY_LINE_CAP).joinToString("\n") { it.render() }
-        withContext(dispatcherProvider.Main) {
-            val clipboard = context.getSystemService(ClipboardManager::class.java)
-            clipboard?.setPrimaryClip(ClipData.newPlainText(CLIP_LABEL, text))
-            events.emit(Event.Copied(truncatedBy = truncatedBy))
-        }
+        clipboardHelper.copyToClipboard(text)
+        events.emit(Event.Copied(truncatedBy = truncatedBy))
     }
 
     fun shareAll() = launch {
@@ -268,7 +266,6 @@ class FloatingLogPanelViewModel @Inject constructor(
         private val TAG = logTag("Debug", "LogView", "Floating", "ViewModel")
         private const val SNAPSHOT_THROTTLE_MS = 250L
         private const val SHARING_STOP_TIMEOUT_MS = 5_000L
-        private const val CLIP_LABEL = "Butler log"
         private const val SHARE_DIR = "logview_share"
         private const val EXPORT_MAX_AGE_MS = 60L * 60L * 1000L
         const val COPY_LINE_CAP = 1000

--- a/app/src/test/java/eu/darken/butler/common/debug/logviewer/ui/FloatingLogPanelViewModelTest.kt
+++ b/app/src/test/java/eu/darken/butler/common/debug/logviewer/ui/FloatingLogPanelViewModelTest.kt
@@ -1,19 +1,17 @@
 package eu.darken.butler.common.debug.logviewer.ui
 
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
+import eu.darken.butler.common.SystemClipboardHelper
 import eu.darken.butler.common.datastore.DataStoreValue
 import eu.darken.butler.common.debug.DebugSettings
 import eu.darken.butler.common.debug.logging.Logging
 import eu.darken.butler.common.debug.logviewer.core.LogHistoryRecorder
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -32,6 +30,7 @@ class FloatingLogPanelViewModelTest : BaseTest() {
     private lateinit var debugValue: DataStoreValue<Boolean>
     private lateinit var debugSettings: DebugSettings
     private val context: Context = mockk(relaxed = true)
+    private val clipboardHelper: SystemClipboardHelper = mockk(relaxed = true)
 
     @BeforeEach
     fun setup() {
@@ -60,6 +59,7 @@ class FloatingLogPanelViewModelTest : BaseTest() {
         context = context,
         debugSettings = debugSettings,
         recorder = recorder,
+        clipboardHelper = clipboardHelper,
     )
 
     private fun emit(message: String, priority: Logging.Priority = Logging.Priority.DEBUG) =
@@ -171,25 +171,16 @@ class FloatingLogPanelViewModelTest : BaseTest() {
 
     @Test
     fun `copyAll truncates to the cap and reports it`() = runTest {
-        // ClipData.newPlainText is an android.jar stub that throws on the JVM, and the relaxed
-        // Context mock returns a bare Object for the erased getSystemService(Class) generic.
-        mockkStatic(ClipData::class)
-        try {
-            every { ClipData.newPlainText(any(), any()) } returns mockk()
-            every { context.getSystemService(ClipboardManager::class.java) } returns mockk(relaxed = true)
+        val vm = createViewModel()
+        val total = FloatingLogPanelViewModel.COPY_LINE_CAP + 5
+        repeat(total) { emit("line $it") }
+        vm.state.first { it.lines.size == total }
 
-            val vm = createViewModel()
-            val total = FloatingLogPanelViewModel.COPY_LINE_CAP + 5
-            repeat(total) { emit("line $it") }
-            vm.state.first { it.lines.size == total }
+        vm.copyAll()
 
-            vm.copyAll()
-
-            val event = vm.events.first() as FloatingLogPanelViewModel.Event.Copied
-            event.truncatedBy shouldBe 5
-        } finally {
-            unmockkStatic(ClipData::class)
-        }
+        val event = vm.events.first() as FloatingLogPanelViewModel.Event.Copied
+        event.truncatedBy shouldBe 5
+        coVerify { clipboardHelper.copyToClipboard(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Hardens clipboard handling across the app and fixes several latent bugs found while auditing how the Android system clipboard, the in-app workspace clipboard, and the editor interact.

- **Removed dead clipboard cleanup code** that was never wired up and would have silently dropped clips when a tab closed — the workspace clipboard is intentionally shared across tabs, so a copy in one tab stays pasteable elsewhere.
- **Unified system-clipboard access**: the debug log panel's "copy all" now goes through the shared clipboard helper instead of a separate raw path, and reports success only after the copy actually happens.
- **Richer paste**: pasting from the system clipboard now understands HTML and URI clips, not just plain text, and the paste affordance is offered for any text content. Also fixes a rare initialization race that could hang a clipboard copy started off the main thread.
- **Smarter, safer file paste in the editor**: file clips now retain their file-type info, so paste suggestions skip directories and include extensionless/known text files (`.env`, `.gitignore`, `Makefile`, …) instead of a fixed extension list. A control-character check on the decoded content prevents pasting binary files as garbage.

## Implementation notes

- `ClipboardClip.Paths` now carries `APathLookup` instead of raw `APath` to preserve `fileType`; producers (Explorer, Searcher) and consumers were updated accordingly, and `.lookedUp` is used where a raw path is needed.
- `PasteFileReader` runs its binary heuristic on the decoded text so C1 controls (0x80–0x9F) are counted, decoding UTF-8 first and whitelisting tab/LF/CR/FF/ESC.
- `SystemClipboardHelper` off-main initialization now uses a predicate loop to avoid a lost-wakeup hang.

## Testing

- Editor clipboard controller and paste-file reader unit tests, including new coverage for directories, extensionless/known filenames, ANSI-log text, and binary rejection (C0/C1).
- Debug log panel copy test.
- FOSS debug compilation across the affected modules.
