### PR TITLE
Select multiple items by dragging after a long press

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
@@ -126,7 +126,10 @@ private fun <K : Any> Modifier.dragSelect(
                 edgePx = edgePx,
                 maxSpeedPx = maxSpeedPx,
                 // A finger resting at the edge keeps extending the range while the content moves.
-                onScrolled = { position -> session.moveTo(target.keyAt(position)) },
+                onScrolled = { position ->
+                    session.moveTo(target.keyAt(position))
+                    session.isActive
+                },
             )
             session.start()
             try {
@@ -204,13 +207,16 @@ private class DragSelectSession<K : Any>(
  * Scrolls the content while the pointer rests near a viewport edge, advancing by frame delta so the
  * speed is refresh-rate independent. Stops as soon as the content bound is reached and is re-armed
  * by the next drag event.
+ *
+ * [onScrolled] reports whether the session is still live: a finger resting at the edge produces no
+ * pointer events, so the frame loop is the only place that would notice the session ending.
  */
 private class DragSelectAutoScroller(
     private val scope: CoroutineScope,
     private val target: DragSelectTarget,
     private val edgePx: Float,
     private val maxSpeedPx: Float,
-    private val onScrolled: (Offset) -> Unit,
+    private val onScrolled: (Offset) -> Boolean,
 ) {
 
     private var job: Job? = null
@@ -232,7 +238,7 @@ private class DragSelectAutoScroller(
                 val speed = speedFor(pointer)
                 if (speed == 0f) break
                 if (target.scrollableState.scrollBy(speed * seconds) == 0f) break
-                onScrolled(pointer)
+                if (!onScrolled(pointer)) break
             }
         }
     }

--- a/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
@@ -1,0 +1,305 @@
+package eu.darken.butler.common.compose.dragselect
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/** How close to a viewport edge the pointer has to get before the content starts scrolling. */
+private val AutoScrollEdge = 56.dp
+
+/** Auto-scroll speed at the very edge of the viewport, scaled down with the distance to it. */
+private val AutoScrollMaxSpeed = 900.dp
+
+/**
+ * Long-press-then-drag multi selection for a vertical [LazyListState] container.
+ *
+ * Apply to the lazy container itself, next to its `state`. The long press claims the gesture only
+ * when it lands on a key from [orderedKeys] that [enabled] accepts - any other press is left
+ * completely untouched, so item long clicks, platform drags and long-press-then-scroll keep
+ * working as before.
+ *
+ * @param orderedKeys the selectable keys in display order; re-read on every update, so the data may
+ *        re-sort mid-drag.
+ * @param currentSelection the selection at the moment the drag starts; it is never deselected,
+ *        the drag only adds the range between the anchor and the pointer.
+ * @param onSelectionChange invoked with the full new selection, only when it actually changes.
+ * @param enabled decides per pressed key whether drag-select owns this long press.
+ */
+@Composable
+fun <K : Any> Modifier.listDragSelect(
+    state: LazyListState,
+    orderedKeys: () -> List<K>,
+    currentSelection: () -> Set<K>,
+    onSelectionChange: (Set<K>) -> Unit,
+    enabled: (K) -> Boolean = { true },
+): Modifier {
+    val target = remember(state) { LazyListDragSelectTarget(state) }
+    return dragSelect(target, orderedKeys, currentSelection, onSelectionChange, enabled)
+}
+
+/** [listDragSelect] for a vertical [LazyGridState] container; the range follows the display order. */
+@Composable
+fun <K : Any> Modifier.gridDragSelect(
+    state: LazyGridState,
+    orderedKeys: () -> List<K>,
+    currentSelection: () -> Set<K>,
+    onSelectionChange: (Set<K>) -> Unit,
+    enabled: (K) -> Boolean = { true },
+): Modifier {
+    val target = remember(state) { LazyGridDragSelectTarget(state) }
+    return dragSelect(target, orderedKeys, currentSelection, onSelectionChange, enabled)
+}
+
+/**
+ * Claim-before-consume gesture: nothing is consumed until the long press has resolved to a key the
+ * caller accepts. `detectDragGesturesAfterLongPress` would consume every post-long-press movement
+ * even when the session declines, which silently breaks scrolling and competing gestures.
+ *
+ * Once claimed, the drag events are consumed on the initial pass - the lazy container's own
+ * scrollable and the item's press sit below this modifier and see the consumption, so neither the
+ * list scrolls nor the item click fires while the range is being dragged.
+ */
+@Composable
+private fun <K : Any> Modifier.dragSelect(
+    target: DragSelectTarget,
+    orderedKeys: () -> List<K>,
+    currentSelection: () -> Set<K>,
+    onSelectionChange: (Set<K>) -> Unit,
+    enabled: (K) -> Boolean,
+): Modifier {
+    val currentOrderedKeys by rememberUpdatedState(orderedKeys)
+    val currentSelectionProvider by rememberUpdatedState(currentSelection)
+    val currentOnSelectionChange by rememberUpdatedState(onSelectionChange)
+    val currentEnabled by rememberUpdatedState(enabled)
+    val haptics = LocalHapticFeedback.current
+    val scope = rememberCoroutineScope()
+
+    return this.pointerInput(target) {
+        val edgePx = AutoScrollEdge.toPx()
+        val maxSpeedPx = AutoScrollMaxSpeed.toPx()
+        awaitEachGesture {
+            // The pane focus handler consumes the down on the initial pass, so an unconsumed down
+            // would never arrive here.
+            val down = awaitFirstDown(requireUnconsumed = false)
+            val longPress = awaitLongPressOrCancellation(down.id) ?: return@awaitEachGesture
+            val pressedKey = target.keyAt(longPress.position)
+            val anchor = currentOrderedKeys()
+                .firstOrNull { it == pressedKey }
+                ?.takeIf { currentEnabled(it) }
+                ?: return@awaitEachGesture
+
+            val session = DragSelectSession(
+                anchor = anchor,
+                base = currentSelectionProvider(),
+                orderedKeys = { currentOrderedKeys() },
+                onSelectionChange = { currentOnSelectionChange(it) },
+                onEndpointChanged = { haptics.performHapticFeedback(HapticFeedbackType.SegmentTick) },
+            )
+            val autoScroller = DragSelectAutoScroller(
+                scope = scope,
+                target = target,
+                edgePx = edgePx,
+                maxSpeedPx = maxSpeedPx,
+                // A finger resting at the edge keeps extending the range while the content moves.
+                onScrolled = { position -> session.moveTo(target.keyAt(position)) },
+            )
+            session.start()
+            try {
+                while (session.isActive) {
+                    val event = awaitPointerEvent(PointerEventPass.Initial)
+                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                    change.consume()
+                    if (!change.pressed) break
+                    session.moveTo(target.keyAt(change.position))
+                    autoScroller.update(change.position)
+                }
+            } finally {
+                autoScroller.stop()
+                session.end()
+                haptics.performHapticFeedback(HapticFeedbackType.GestureEnd)
+            }
+        }
+    }
+}
+
+/**
+ * Applied selection = selection at drag start ∪ the contiguous range between anchor and endpoint.
+ * Both ends are held as keys and re-resolved against a fresh key list on every update, so the data
+ * may re-sort or shrink while the finger is down.
+ */
+private class DragSelectSession<K : Any>(
+    private val anchor: K,
+    private val base: Set<K>,
+    private val orderedKeys: () -> List<K>,
+    private val onSelectionChange: (Set<K>) -> Unit,
+    private val onEndpointChanged: () -> Unit,
+) {
+
+    private var endpoint: K = anchor
+    private var applied: Set<K> = base
+
+    var isActive: Boolean = true
+        private set
+
+    fun start() = moveTo(anchor)
+
+    /** [pressedKey] is the raw key under the pointer; anything not selectable keeps the last endpoint. */
+    fun moveTo(pressedKey: Any?) {
+        if (!isActive) return
+        val keys = orderedKeys()
+        val anchorIndex = keys.indexOf(anchor)
+        // The anchor vanished from the listing - end the session, keep what it applied so far.
+        if (anchorIndex == -1) {
+            isActive = false
+            return
+        }
+        keys.firstOrNull { it == pressedKey }?.let { next ->
+            if (next != endpoint) {
+                endpoint = next
+                onEndpointChanged()
+            }
+        }
+        val endpointIndex = keys.indexOf(endpoint)
+        if (endpointIndex == -1) return
+        val range = keys.subList(min(anchorIndex, endpointIndex), max(anchorIndex, endpointIndex) + 1)
+        // Union, never subtraction: keys the caller had selected before the drag - including ones
+        // hidden by a filter and thus absent from the listing - ride along untouched.
+        val next = base + range
+        if (next == applied) return
+        applied = next
+        onSelectionChange(next)
+    }
+
+    fun end() {
+        isActive = false
+    }
+}
+
+/**
+ * Scrolls the content while the pointer rests near a viewport edge, advancing by frame delta so the
+ * speed is refresh-rate independent. Stops as soon as the content bound is reached and is re-armed
+ * by the next drag event.
+ */
+private class DragSelectAutoScroller(
+    private val scope: CoroutineScope,
+    private val target: DragSelectTarget,
+    private val edgePx: Float,
+    private val maxSpeedPx: Float,
+    private val onScrolled: (Offset) -> Unit,
+) {
+
+    private var job: Job? = null
+    private var pointer: Offset = Offset.Unspecified
+
+    fun update(pointer: Offset) {
+        this.pointer = pointer
+        if (speedFor(pointer) == 0f) {
+            stop()
+            return
+        }
+        if (job?.isActive == true) return
+        job = scope.launch {
+            var previousFrame = withFrameNanos { it }
+            while (true) {
+                val frame = withFrameNanos { it }
+                val seconds = (frame - previousFrame) / 1_000_000_000f
+                previousFrame = frame
+                val speed = speedFor(pointer)
+                if (speed == 0f) break
+                if (target.scrollableState.scrollBy(speed * seconds) == 0f) break
+                onScrolled(pointer)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    private fun speedFor(pointer: Offset): Float {
+        if (pointer == Offset.Unspecified) return 0f
+        val viewport = target.viewportMainAxisSize.toFloat()
+        if (viewport <= 0f) return 0f
+        val toStart = pointer.y
+        val toEnd = viewport - pointer.y
+        return when {
+            toStart < edgePx -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
+            toEnd < edgePx -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)
+            else -> 0f
+        }
+    }
+}
+
+/** The lazy container the session drives: hit-testing, viewport extent and scrolling. */
+internal interface DragSelectTarget {
+    val scrollableState: ScrollableState
+
+    /** Main-axis extent of the viewport in pixels, content padding included. */
+    val viewportMainAxisSize: Int
+
+    /** The key of the item under [position], which is relative to the container's top left. */
+    fun keyAt(position: Offset): Any?
+}
+
+/**
+ * Item offsets are relative to the scrolled content, the pointer is relative to the container -
+ * `viewportStartOffset` is the difference (negative by the amount of leading content padding).
+ */
+internal class LazyListDragSelectTarget(private val state: LazyListState) : DragSelectTarget {
+
+    override val scrollableState: ScrollableState get() = state
+
+    override val viewportMainAxisSize: Int get() = state.layoutInfo.viewportSize.height
+
+    override fun keyAt(position: Offset): Any? {
+        val layoutInfo = state.layoutInfo
+        val mainAxis = position.y + layoutInfo.viewportStartOffset
+        return layoutInfo.visibleItemsInfo
+            .firstOrNull { mainAxis >= it.offset && mainAxis < it.offset + it.size }
+            ?.key
+    }
+}
+
+internal class LazyGridDragSelectTarget(private val state: LazyGridState) : DragSelectTarget {
+
+    override val scrollableState: ScrollableState get() = state
+
+    override val viewportMainAxisSize: Int get() = state.layoutInfo.viewportSize.height
+
+    override fun keyAt(position: Offset): Any? {
+        val layoutInfo = state.layoutInfo
+        val point = IntOffset(
+            x = position.x.roundToInt(),
+            y = (position.y + layoutInfo.viewportStartOffset).roundToInt(),
+        )
+        return layoutInfo.visibleItemsInfo
+            .firstOrNull { IntRect(it.offset, it.size).contains(point) }
+            ?.key
+    }
+}

--- a/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
@@ -18,7 +20,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
@@ -62,7 +66,13 @@ fun <K : Any> Modifier.listDragSelect(
     return dragSelect(target, orderedKeys, currentSelection, onSelectionChange, enabled)
 }
 
-/** [listDragSelect] for a vertical [LazyGridState] container; the range follows the display order. */
+/**
+ * [listDragSelect] for a vertical [LazyGridState] container; the range follows the display order.
+ *
+ * @param contentPadding the grid's own content padding; its leading (start) inset is subtracted from
+ *        the pointer x before hit-testing, because grid item offsets are content-relative on the
+ *        cross axis while LazyGridLayoutInfo never exposes the horizontal padding.
+ */
 @Composable
 fun <K : Any> Modifier.gridDragSelect(
     state: LazyGridState,
@@ -70,8 +80,13 @@ fun <K : Any> Modifier.gridDragSelect(
     currentSelection: () -> Set<K>,
     onSelectionChange: (Set<K>) -> Unit,
     enabled: (K) -> Boolean = { true },
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ): Modifier {
-    val target = remember(state) { LazyGridDragSelectTarget(state) }
+    val layoutDirection = LocalLayoutDirection.current
+    val startPaddingPx = with(LocalDensity.current) {
+        contentPadding.calculateStartPadding(layoutDirection).roundToPx()
+    }
+    val target = remember(state, startPaddingPx) { LazyGridDragSelectTarget(state, startPaddingPx) }
     return dragSelect(target, orderedKeys, currentSelection, onSelectionChange, enabled)
 }
 
@@ -292,7 +307,10 @@ internal class LazyListDragSelectTarget(private val state: LazyListState) : Drag
     }
 }
 
-internal class LazyGridDragSelectTarget(private val state: LazyGridState) : DragSelectTarget {
+internal class LazyGridDragSelectTarget(
+    private val state: LazyGridState,
+    private val startPaddingPx: Int = 0,
+) : DragSelectTarget {
 
     override val scrollableState: ScrollableState get() = state
 
@@ -300,8 +318,9 @@ internal class LazyGridDragSelectTarget(private val state: LazyGridState) : Drag
 
     override fun keyAt(position: Offset): Any? {
         val layoutInfo = state.layoutInfo
+        // Item cross-axis offsets exclude the leading content padding, so undo it on the pointer.
         val point = IntOffset(
-            x = position.x.roundToInt(),
+            x = (position.x - startPaddingPx).roundToInt(),
             y = (position.y + layoutInfo.viewportStartOffset).roundToInt(),
         )
         return layoutInfo.visibleItemsInfo

--- a/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectGridTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectGridTest.kt
@@ -1,0 +1,212 @@
+package eu.darken.butler.common.compose.dragselect
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.TouchInjectionScope
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * A 3-column grid of 40dp cells in a 480dp viewport: index 0..2 sit in the top auto-scroll edge
+ * zone ([AutoScrollEdge], 56dp), every index these tests touch is below it.
+ */
+class DragSelectGridTest : ComposeTest() {
+
+    private val keys = (0..11).map { "item$it" }
+
+    @Test
+    fun `a long press without movement selects the anchor`() {
+        val harness = GridHarness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 4)
+
+        harness.selection.value shouldBe setOf("item4")
+    }
+
+    @Test
+    fun `a drag across a row boundary selects the whole index range`() {
+        val harness = GridHarness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 4, 5, 6, 7)
+
+        harness.selection.value shouldBe setOf("item4", "item5", "item6", "item7")
+    }
+
+    @Test
+    fun `retreating across a row boundary drops the items left behind`() {
+        val harness = GridHarness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 3, 6, 8, 4)
+
+        harness.selection.value shouldBe setOf("item3", "item4")
+    }
+
+    @Test
+    fun `a pre-existing selection survives the drag`() {
+        val harness = GridHarness(keys, initialSelection = setOf("item11"))
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 4, 5, 4)
+
+        harness.selection.value shouldBe setOf("item4", "item11")
+    }
+
+    @Test
+    fun `a declined anchor changes nothing`() {
+        val harness = GridHarness(keys, enabled = { false })
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 4, 5, 6)
+
+        harness.selection.value shouldBe emptySet()
+        harness.longClicks shouldBe listOf("item4")
+    }
+
+    @Test
+    fun `content padding is accounted for when resolving the pressed item`() {
+        val harness = GridHarness(keys, contentPadding = PaddingValues(top = 60.dp))
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 4, 7)
+
+        harness.selection.value shouldBe setOf("item4", "item5", "item6", "item7")
+    }
+
+    @Test
+    fun `a gap between cells keeps the last endpoint`() {
+        // The horizontal spacing between two cells belongs to no item at all.
+        val harness = GridHarness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.onNodeWithTag(GRID_TAG).performTouchInput {
+            down(harness.itemCenter(this, 4))
+            advanceEventTime(LONG_PRESS_MS)
+            moveTo(harness.itemCenter(this, 5))
+            advanceEventTime(16)
+            moveTo(harness.gapAfter(this, 5))
+            advanceEventTime(16)
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        harness.selection.value shouldBe setOf("item4", "item5")
+    }
+}
+
+private const val GRID_TAG = "dragselect-grid"
+private const val LONG_PRESS_MS = 1000L
+private const val COLUMNS = 3
+private val CELL_HEIGHT = 40.dp
+private val CELL_SPACING = 8.dp
+private val VIEWPORT_HEIGHT = 480.dp
+
+private class GridHarness(
+    val allKeys: List<String>,
+    selectableKeys: List<String> = allKeys,
+    initialSelection: Set<String> = emptySet(),
+    val enabled: (String) -> Boolean = { true },
+    val contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    val selectableKeys: MutableState<List<String>> = mutableStateOf(selectableKeys)
+    val selection: MutableState<Set<String>> = mutableStateOf(initialSelection)
+    val longClicks = mutableListOf<String>()
+    lateinit var gridState: LazyGridState
+
+    fun itemCenter(scope: TouchInjectionScope, index: Int): Offset = with(scope) {
+        val columnWidth = width.toFloat() / COLUMNS
+        val rowHeight = CELL_HEIGHT.toPx() + CELL_SPACING.toPx()
+        Offset(
+            x = (index % COLUMNS) * columnWidth + columnWidth / 2,
+            y = contentPadding.calculateTopPadding().toPx() + (index / COLUMNS) * rowHeight + CELL_HEIGHT.toPx() / 2,
+        )
+    }
+
+    /** The spacing strip to the right of [index], which is part of no cell. */
+    fun gapAfter(scope: TouchInjectionScope, index: Int): Offset = with(scope) {
+        val columnWidth = width.toFloat() / COLUMNS
+        itemCenter(scope, index).copy(x = (index % COLUMNS + 1) * columnWidth - CELL_SPACING.toPx() / 2)
+    }
+}
+
+@Composable
+private fun GridHarnessContent(harness: GridHarness) {
+    val state = rememberLazyGridState()
+    harness.gridState = state
+    val selectable = harness.selectableKeys
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(COLUMNS),
+        state = state,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(VIEWPORT_HEIGHT)
+            .testTag(GRID_TAG)
+            .gridDragSelect(
+                state = state,
+                orderedKeys = { selectable.value },
+                currentSelection = { harness.selection.value },
+                onSelectionChange = { harness.selection.value = it },
+                enabled = harness.enabled,
+            ),
+        contentPadding = harness.contentPadding,
+        verticalArrangement = Arrangement.spacedBy(CELL_SPACING),
+        horizontalArrangement = Arrangement.spacedBy(CELL_SPACING),
+    ) {
+        items(harness.allKeys, key = { it }) { key ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(CELL_HEIGHT)
+                    .combinedClickable(
+                        onClick = {},
+                        onLongClick = { harness.longClicks += key },
+                    ),
+            )
+        }
+    }
+}
+
+private fun ComposeContentTestRule.setHarness(harness: GridHarness) {
+    setContent {
+        PreviewWrapper {
+            GridHarnessContent(harness)
+        }
+    }
+    waitForIdle()
+}
+
+private fun ComposeContentTestRule.longPressDrag(harness: GridHarness, vararg indices: Int) {
+    onNodeWithTag(GRID_TAG).performTouchInput {
+        down(harness.itemCenter(this, indices.first()))
+        advanceEventTime(LONG_PRESS_MS)
+        indices.drop(1).forEach { index ->
+            moveTo(harness.itemCenter(this, index))
+            advanceEventTime(16)
+        }
+        up()
+    }
+    waitForIdle()
+}

--- a/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectGridTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectGridTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -21,6 +23,7 @@ import androidx.compose.ui.test.TouchInjectionScope
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.PreviewWrapper
 import io.kotest.matchers.shouldBe
@@ -97,6 +100,17 @@ class DragSelectGridTest : ComposeTest() {
     }
 
     @Test
+    fun `horizontal content padding is accounted for in the trailing column`() {
+        val harness = GridHarness(keys, contentPadding = PaddingValues(start = 48.dp, top = 60.dp))
+        composeTestRule.setHarness(harness)
+
+        // item5 sits in the last column; without undoing the leading inset the press misses it.
+        composeTestRule.longPressDrag(harness, 5)
+
+        harness.selection.value shouldBe setOf("item5")
+    }
+
+    @Test
     fun `a gap between cells keeps the last endpoint`() {
         // The horizontal spacing between two cells belongs to no item at all.
         val harness = GridHarness(keys)
@@ -137,18 +151,34 @@ private class GridHarness(
     lateinit var gridState: LazyGridState
 
     fun itemCenter(scope: TouchInjectionScope, index: Int): Offset = with(scope) {
-        val columnWidth = width.toFloat() / COLUMNS
         val rowHeight = CELL_HEIGHT.toPx() + CELL_SPACING.toPx()
+        val cellLeft = (index % COLUMNS) * (slotWidth(scope) + CELL_SPACING.toPx())
         Offset(
-            x = (index % COLUMNS) * columnWidth + columnWidth / 2,
+            x = startPaddingPx(scope) + cellLeft + slotWidth(scope) / 2,
             y = contentPadding.calculateTopPadding().toPx() + (index / COLUMNS) * rowHeight + CELL_HEIGHT.toPx() / 2,
         )
     }
 
     /** The spacing strip to the right of [index], which is part of no cell. */
     fun gapAfter(scope: TouchInjectionScope, index: Int): Offset = with(scope) {
-        val columnWidth = width.toFloat() / COLUMNS
-        itemCenter(scope, index).copy(x = (index % COLUMNS + 1) * columnWidth - CELL_SPACING.toPx() / 2)
+        val cellLeft = (index % COLUMNS) * (slotWidth(scope) + CELL_SPACING.toPx())
+        itemCenter(scope, index).copy(
+            x = startPaddingPx(scope) + cellLeft + slotWidth(scope) + CELL_SPACING.toPx() / 2,
+        )
+    }
+
+    /** Width of one column slot, matching GridCells.Fixed inside the padded content area. */
+    private fun slotWidth(scope: TouchInjectionScope): Float = with(scope) {
+        val content = width.toFloat() - startPaddingPx(scope) - endPaddingPx(scope)
+        (content - CELL_SPACING.toPx() * (COLUMNS - 1)) / COLUMNS
+    }
+
+    private fun startPaddingPx(scope: TouchInjectionScope): Float = with(scope) {
+        contentPadding.calculateStartPadding(LayoutDirection.Ltr).toPx()
+    }
+
+    private fun endPaddingPx(scope: TouchInjectionScope): Float = with(scope) {
+        contentPadding.calculateEndPadding(LayoutDirection.Ltr).toPx()
     }
 }
 
@@ -170,6 +200,7 @@ private fun GridHarnessContent(harness: GridHarness) {
                 currentSelection = { harness.selection.value },
                 onSelectionChange = { harness.selection.value = it },
                 enabled = harness.enabled,
+                contentPadding = harness.contentPadding,
             ),
         contentPadding = harness.contentPadding,
         verticalArrangement = Arrangement.spacedBy(CELL_SPACING),

--- a/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectListTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectListTest.kt
@@ -1,0 +1,352 @@
+package eu.darken.butler.common.compose.dragselect
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.TouchInjectionScope
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * Item geometry is chosen so every index these tests touch sits outside the auto-scroll edge zone
+ * ([AutoScrollEdge], 56dp): index 0 is inside it, indices 1..10 are not.
+ */
+class DragSelectListTest : ComposeTest() {
+
+    private val keys = (0..9).map { "item$it" }
+
+    /** Long enough to overflow the viewport, so scrolling is observable. */
+    private val scrollableKeys = (0..19).map { "item$it" }
+
+    @Test
+    fun `a long press without movement selects the anchor`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 2)
+
+        harness.selection.value shouldBe setOf("item2")
+    }
+
+    @Test
+    fun `a long press and drag selects the whole range`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2, 3)
+
+        harness.selection.value shouldBe setOf("item1", "item2", "item3")
+    }
+
+    @Test
+    fun `retreating drops the items left behind but keeps the anchor`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2, 3, 4, 2)
+
+        harness.selection.value shouldBe setOf("item1", "item2")
+    }
+
+    @Test
+    fun `a pre-existing selection survives the drag and the retreat`() {
+        val harness = Harness(keys, initialSelection = setOf("item8"))
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2, 3, 1)
+
+        harness.selection.value shouldBe setOf("item1", "item8")
+    }
+
+    @Test
+    fun `a selection hidden from the listing is never dropped`() {
+        // Filtering keeps items selected that the list doesn't show - they must ride along.
+        val harness = Harness(keys, initialSelection = setOf("hidden"))
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2, 1)
+
+        harness.selection.value shouldBe setOf("item1", "hidden")
+    }
+
+    @Test
+    fun `a non-selectable item between anchor and pointer is spanned, not selected`() {
+        val harness = Harness(keys, selectableKeys = keys - "item2")
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2, 3)
+
+        harness.selection.value shouldBe setOf("item1", "item3")
+    }
+
+    @Test
+    fun `a declined anchor changes nothing`() {
+        val harness = Harness(keys, enabled = { false })
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2, 3)
+
+        harness.selection.value shouldBe emptySet()
+        harness.selectionChanges shouldBe 0
+    }
+
+    @Test
+    fun `content padding is accounted for when resolving the pressed item`() {
+        val harness = Harness(keys, contentPadding = PaddingValues(top = 60.dp))
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 1, 2)
+
+        harness.selection.value shouldBe setOf("item1", "item2")
+    }
+
+    @Test
+    fun `a declined gesture still fires the item long click`() {
+        val harness = Harness(keys, enabled = { false })
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 4, 3, 2)
+
+        harness.longClicks shouldBe listOf("item4")
+        harness.selection.value shouldBe emptySet()
+    }
+
+    @Test
+    fun `a declined gesture leaves the drag to the list`() {
+        // Items without a long click, or the tap detector's own post-long-press consumption would
+        // swallow the movement before the list ever sees it.
+        val harness = Harness(scrollableKeys, enabled = { false }, itemsAreClickable = false)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 8, 6, 4, 2)
+
+        harness.selection.value shouldBe emptySet()
+        (harness.listState.firstVisibleItemIndex > 0) shouldBe true
+    }
+
+    @Test
+    fun `a claimed gesture selects once and never fires the item click`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 2)
+
+        harness.longClicks shouldBe listOf("item2")
+        harness.clicks shouldBe emptyList()
+        harness.selectionChanges shouldBe 1
+        harness.selection.value shouldBe setOf("item2")
+    }
+
+    @Test
+    fun `a claimed gesture does not scroll the list`() {
+        val harness = Harness(scrollableKeys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.longPressDrag(harness, 8, 6, 4, 2)
+
+        harness.selection.value shouldBe setOf("item2", "item3", "item4", "item5", "item6", "item7", "item8")
+        harness.listState.firstVisibleItemIndex shouldBe 0
+        harness.listState.firstVisibleItemScrollOffset shouldBe 0
+    }
+
+    @Test
+    fun `a tap still clicks the item`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            down(Offset(centerX, harness.itemCenterY(this, 3)))
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        harness.clicks shouldBe listOf("item3")
+        harness.selection.value shouldBe emptySet()
+    }
+
+    @Test
+    fun `the range follows a listing that re-sorts mid-drag`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        // Events are only dispatched when the injection block returns, so a mid-drag data change
+        // has to happen between two blocks of the same (still unreleased) gesture.
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            down(Offset(centerX, harness.itemCenterY(this, 1)))
+            advanceEventTime(LONG_PRESS_MS)
+            moveTo(Offset(centerX, harness.itemCenterY(this, 3)))
+        }
+        composeTestRule.waitForIdle()
+        harness.selection.value shouldBe setOf("item1", "item2", "item3")
+
+        // Same anchor and endpoint keys, different display order between them.
+        harness.selectableKeys.value = listOf("item1", "item9", "item3") +
+            (keys - setOf("item1", "item3", "item9"))
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            advanceEventTime(16)
+            moveTo(Offset(centerX, harness.itemCenterY(this, 3) + 1f))
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        harness.selection.value shouldBe setOf("item1", "item9", "item3")
+    }
+
+    @Test
+    fun `an anchor that vanishes mid-drag ends the session and keeps the selection`() {
+        val harness = Harness(keys)
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            down(Offset(centerX, harness.itemCenterY(this, 1)))
+            advanceEventTime(LONG_PRESS_MS)
+            moveTo(Offset(centerX, harness.itemCenterY(this, 2)))
+        }
+        composeTestRule.waitForIdle()
+        harness.selection.value shouldBe setOf("item1", "item2")
+
+        harness.selectableKeys.value = keys - "item1"
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            advanceEventTime(16)
+            moveTo(Offset(centerX, harness.itemCenterY(this, 5)))
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        harness.selection.value shouldBe setOf("item1", "item2")
+    }
+
+    @Test
+    fun `holding at the bottom edge scrolls and extends past the initial viewport`() {
+        val harness = Harness(scrollableKeys)
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            down(Offset(centerX, harness.itemCenterY(this, 1)))
+            advanceEventTime(LONG_PRESS_MS)
+            moveTo(Offset(centerX, height - 1f))
+        }
+        repeat(60) { composeTestRule.mainClock.advanceTimeByFrame() }
+
+        // Everything from the anchor to the very last item, well past the initial viewport.
+        harness.selection.value shouldBe (scrollableKeys - "item0").toSet()
+        // The loop stops itself at the content bound instead of spinning.
+        val settled = harness.selectionChanges
+        repeat(20) { composeTestRule.mainClock.advanceTimeByFrame() }
+        harness.selectionChanges shouldBe settled
+
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput { up() }
+        composeTestRule.mainClock.autoAdvance = true
+    }
+}
+
+private const val LIST_TAG = "dragselect-list"
+private const val LONG_PRESS_MS = 1000L
+private val ITEM_HEIGHT = 40.dp
+private val VIEWPORT_HEIGHT = 480.dp
+
+private class Harness(
+    val allKeys: List<String>,
+    selectableKeys: List<String> = allKeys,
+    initialSelection: Set<String> = emptySet(),
+    val enabled: (String) -> Boolean = { true },
+    val contentPadding: PaddingValues = PaddingValues(0.dp),
+    val itemsAreClickable: Boolean = true,
+) {
+    val selectableKeys: MutableState<List<String>> = mutableStateOf(selectableKeys)
+    val selection: MutableState<Set<String>> = mutableStateOf(initialSelection)
+    val clicks = mutableListOf<String>()
+    val longClicks = mutableListOf<String>()
+    var selectionChanges = 0
+    lateinit var listState: LazyListState
+
+    fun itemCenterY(scope: TouchInjectionScope, index: Int): Float = with(scope) {
+        contentPadding.calculateTopPadding().toPx() + index * ITEM_HEIGHT.toPx() + ITEM_HEIGHT.toPx() / 2
+    }
+}
+
+@Composable
+private fun HarnessContent(harness: Harness) {
+    val state = rememberLazyListState()
+    harness.listState = state
+    val selectable = harness.selectableKeys
+    LazyColumn(
+        state = state,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(VIEWPORT_HEIGHT)
+            .testTag(LIST_TAG)
+            .listDragSelect(
+                state = state,
+                orderedKeys = { selectable.value },
+                currentSelection = { harness.selection.value },
+                onSelectionChange = {
+                    harness.selectionChanges++
+                    harness.selection.value = it
+                },
+                enabled = harness.enabled,
+            ),
+        contentPadding = harness.contentPadding,
+    ) {
+        items(harness.allKeys, key = { it }) { key ->
+            val clickModifier = if (harness.itemsAreClickable) {
+                Modifier.combinedClickable(
+                    onClick = { harness.clicks += key },
+                    onLongClick = { harness.longClicks += key },
+                )
+            } else {
+                Modifier
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(ITEM_HEIGHT)
+                    .then(clickModifier),
+            )
+        }
+    }
+}
+
+private fun ComposeContentTestRule.setHarness(harness: Harness) {
+    setContent {
+        PreviewWrapper {
+            HarnessContent(harness)
+        }
+    }
+    waitForIdle()
+}
+
+/** Presses the first of [indices], holds past the long press timeout, then drags across the rest. */
+private fun ComposeContentTestRule.longPressDrag(harness: Harness, vararg indices: Int) {
+    onNodeWithTag(LIST_TAG).performTouchInput {
+        down(Offset(centerX, harness.itemCenterY(this, indices.first())))
+        advanceEventTime(LONG_PRESS_MS)
+        indices.drop(1).forEach { index ->
+            moveTo(Offset(centerX, harness.itemCenterY(this, index)))
+            advanceEventTime(16)
+        }
+        up()
+    }
+    waitForIdle()
+}

--- a/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectListTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectListTest.kt
@@ -259,6 +259,36 @@ class DragSelectListTest : ComposeTest() {
         composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput { up() }
         composeTestRule.mainClock.autoAdvance = true
     }
+
+    @Test
+    fun `an anchor that vanishes mid-scroll stops the auto scroll`() {
+        // A finger resting at the edge sends no further pointer events, so only the frame loop can
+        // notice that the session ended - otherwise it scrolls on to the content bound.
+        val harness = Harness(scrollableKeys)
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setHarness(harness)
+
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput {
+            down(Offset(centerX, harness.itemCenterY(this, 1)))
+            advanceEventTime(LONG_PRESS_MS)
+            moveTo(Offset(centerX, height - 1f))
+        }
+        repeat(5) { composeTestRule.mainClock.advanceTimeByFrame() }
+        (harness.listState.firstVisibleItemIndex > 0) shouldBe true
+
+        harness.selectableKeys.value = scrollableKeys - "item1"
+        // One more frame for the in-flight scroll that started before the anchor vanished.
+        composeTestRule.mainClock.advanceTimeByFrame()
+        val stoppedAt = harness.listState.firstVisibleItemIndex
+        val settled = harness.selectionChanges
+        repeat(30) { composeTestRule.mainClock.advanceTimeByFrame() }
+
+        harness.listState.firstVisibleItemIndex shouldBe stoppedAt
+        harness.selectionChanges shouldBe settled
+
+        composeTestRule.onNodeWithTag(LIST_TAG).performTouchInput { up() }
+        composeTestRule.mainClock.autoAdvance = true
+    }
 }
 
 private const val LIST_TAG = "dragselect-list"

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppsWorkspace.kt
@@ -268,6 +268,10 @@ class AppsWorkspace @AssistedInject constructor(
         appsEngine.selectApps(installIds)
     }
 
+    suspend fun setSelection(installIds: Set<InstallId>) {
+        appsEngine.setSelection(installIds)
+    }
+
     suspend fun refresh() {
         appsEngine.refresh(showIndicator = true)
     }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppsWorkspace.kt
@@ -256,6 +256,10 @@ class AppsWorkspace @AssistedInject constructor(
         appsEngine.selectApp(installId, selected)
     }
 
+    suspend fun toggleSelection(installId: InstallId) {
+        appsEngine.toggleSelection(installId)
+    }
+
     suspend fun clearSelection() {
         appsEngine.clearSelection()
     }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModel.kt
@@ -147,9 +147,9 @@ class AppDetailsWorkspaceViewModel @AssistedInject constructor(
         componentsController.onItemClick(entry)
     }
 
-    fun onComponentLongPressed(entry: ComponentEntry) {
-        log(tag) { "onComponentLongPressed(${entry.key})" }
-        componentsController.onItemLongClick(entry)
+    fun onComponentSelectionChanged(keys: Set<String>) {
+        log(tag) { "onComponentSelectionChanged(${keys.size} keys)" }
+        componentsController.setSelection(keys)
     }
 
     fun clearComponentSelection() {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/components/AppComponentsController.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/components/AppComponentsController.kt
@@ -183,6 +183,12 @@ class AppComponentsController(
         }
     }
 
+    /** Replaces the multi-selection wholesale, e.g. with the range a drag has swept over. */
+    fun setSelection(keys: Set<String>) {
+        log(tag) { "setSelection(${keys.size} keys)" }
+        selectedKeys.value = keys
+    }
+
     fun clearSelection() {
         log(tag) { "clearSelection()" }
         selectedKeys.value = emptySet()
@@ -197,5 +203,4 @@ class AppComponentsController(
         }
     }
 
-    fun onItemLongClick(entry: ComponentEntry) = toggleSelection(entry)
 }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/engine/AppsEngine.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/engine/AppsEngine.kt
@@ -208,6 +208,13 @@ class AppsEngine @AssistedInject constructor(
         _selectedAppIds.update { it + installIds }
     }
 
+    // Replaces the whole selection, ids pass through unfiltered: what a drag no longer covers is
+    // deselected, while selections hidden by the current search/tag filter ride along in the caller's set.
+    suspend fun setSelection(installIds: Set<InstallId>) = withContext(dispatcherProvider.Default) {
+        log(tag) { "Setting selection to ${installIds.size} apps" }
+        _selectedAppIds.value = installIds
+    }
+
     suspend fun refresh(showIndicator: Boolean = false) = withContext(dispatcherProvider.IO) {
         if (!showIndicator) {
             log(tag) { "Refreshing package data (silent)" }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/engine/AppsEngine.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/engine/AppsEngine.kt
@@ -191,6 +191,13 @@ class AppsEngine @AssistedInject constructor(
         log(tag) { "App selection updated: ${newSelection.size} selected" }
     }
 
+    suspend fun toggleSelection(installId: InstallId) = withContext(dispatcherProvider.Default) {
+        val newSelection = _selectedAppIds.updateAndGet {
+            if (installId in it) it - installId else it + installId
+        }
+        log(tag) { "App selection toggled: ${newSelection.size} selected" }
+    }
+
     suspend fun clearSelection() = withContext(dispatcherProvider.Default) {
         log(tag) { "Clearing selection" }
         _selectedAppIds.value = emptySet()

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsPageAction.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsPageAction.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.apps.ui.apps
 import androidx.compose.ui.text.input.TextFieldValue
 import eu.darken.butler.apps.core.engine.AppItem
 import eu.darken.butler.apps.ui.apps.elements.AppsActionBarItem
+import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.workspace.contracts.apps.AppTag
 import eu.darken.butler.workspace.contracts.apps.SortSettings
 import eu.darken.butler.workspace.contracts.apps.TagFilterConfig
@@ -45,7 +46,6 @@ sealed interface AppsPageAction {
     sealed interface Apps : AppsPageAction {
         data object Refresh : Apps
         data class Click(val app: AppItem) : Apps
-        data class LongClick(val app: AppItem) : Apps
     }
 
     /**
@@ -53,6 +53,9 @@ sealed interface AppsPageAction {
      */
     sealed interface Selection : AppsPageAction {
         data object Clear : Selection
+
+        /** Replace the selection, e.g. with the range a drag has swept over */
+        data class SetSelection(val installIds: Set<InstallId>) : Selection
         data object SelectUserApps : Selection
         data object SelectSystemApps : Selection
     }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
@@ -85,18 +85,77 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
     private val searchQueryFlow = MutableStateFlow(TextFieldValue(""))
     private val dialogStateFlow = MutableStateFlow<AppsDialogState>(AppsDialogState.None)
 
+    private sealed interface SelectionOp {
+        data class SetSelection(val installIds: Set<InstallId>) : SelectionOp
+        data class Toggle(val installId: InstallId) : SelectionOp
+        data object Clear : SelectionOp
+        data object SelectAll : SelectionOp
+        data object SelectUserApps : SelectionOp
+        data object SelectSystemApps : SelectionOp
+    }
+
     /**
-     * Selection ranges from a drag arrive faster than the round trip through the workspace, and a
-     * launch-per-event coroutine that hops dispatchers can land them out of order - a stale, larger
-     * range would then overwrite a retreat. A conflated channel with a single sequential collector
-     * may drop intermediate ranges, but never the last one.
+     * Every selection mutation, no matter which gesture produced it, is applied by this one
+     * sequential worker. A launch-per-event coroutine that hops dispatchers can land them out of
+     * order - a stale, larger drag range would then overwrite the retreat that followed it, or
+     * reinstate a selection the user just cleared.
      */
-    private val selectionRequests = Channel<Set<InstallId>>(Channel.CONFLATED)
+    private val selectionOpsLock = Any()
+    private val selectionOps = ArrayDeque<SelectionOp>()
+    private val selectionOpsSignal = Channel<Unit>(Channel.CONFLATED)
 
     init {
-        selectionRequests.receiveAsFlow()
-            .onEach { getWorkspace().setSelection(it) }
+        selectionOpsSignal.receiveAsFlow()
+            .onEach {
+                while (true) {
+                    val op = synchronized(selectionOpsLock) { selectionOps.removeFirstOrNull() } ?: break
+                    applySelectionOp(op)
+                }
+            }
             .launchInViewModel()
+    }
+
+    /**
+     * Queued synchronously so the caller's order is the applied order. Only a trailing
+     * [SelectionOp.SetSelection] that a newer one overtook is dropped - a drag may skip intermediate
+     * ranges, but never the last one, and no other op is ever discarded.
+     */
+    private fun submitSelectionOp(op: SelectionOp) {
+        synchronized(selectionOpsLock) {
+            if (op is SelectionOp.SetSelection && selectionOps.lastOrNull() is SelectionOp.SetSelection) {
+                selectionOps.removeLast()
+            }
+            selectionOps.addLast(op)
+        }
+        selectionOpsSignal.trySend(Unit)
+    }
+
+    private suspend fun applySelectionOp(op: SelectionOp) {
+        val workspace = getWorkspace()
+        when (op) {
+            is SelectionOp.SetSelection -> workspace.setSelection(op.installIds)
+
+            is SelectionOp.Toggle -> {
+                val readyState = workspaceReadyState.filterNotNull().first()
+                workspace.selectApp(op.installId, op.installId !in readyState.selectedAppIds)
+            }
+
+            SelectionOp.Clear -> workspace.clearSelection()
+
+            SelectionOp.SelectAll -> workspace.selectAll()
+
+            SelectionOp.SelectUserApps -> {
+                val ids = getReadyState().apps.filter { !it.isSystemApp }.map { it.pkg.installId }.toSet()
+                log(tag) { "Selecting ${ids.size} user apps" }
+                workspace.selectApps(ids)
+            }
+
+            SelectionOp.SelectSystemApps -> {
+                val ids = getReadyState().apps.filter { it.isSystemApp }.map { it.pkg.installId }.toSet()
+                log(tag) { "Selecting ${ids.size} system apps" }
+                workspace.selectApps(ids)
+            }
+        }
     }
 
     sealed interface State {
@@ -224,14 +283,12 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
 
     private fun onSetSelection(installIds: Set<InstallId>) {
         log(tag) { "onSetSelection(): ${installIds.size} apps" }
-        selectionRequests.trySend(installIds)
+        submitSelectionOp(SelectionOp.SetSelection(installIds))
     }
 
-    private suspend fun toggleAppSelection(installId: InstallId) {
-        val workspace = getWorkspace()
-        val readyState = workspaceReadyState.filterNotNull().first()
-        val isSelected = installId in readyState.selectedAppIds
-        workspace.selectApp(installId, !isSelected)
+    private fun toggleAppSelection(installId: InstallId) {
+        log(tag) { "toggleAppSelection($installId)" }
+        submitSelectionOp(SelectionOp.Toggle(installId))
     }
 
     fun onSearchQueryChanged(query: TextFieldValue) = launch {
@@ -264,26 +321,24 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
         appsSettings.defaultSortSettings.value(sortSettings)
     }
 
-    fun onClearSelection() = launch {
+    fun onClearSelection() {
         log(tag) { "Clearing selection" }
-        getWorkspace().clearSelection()
+        submitSelectionOp(SelectionOp.Clear)
     }
 
-    fun onSelectAll() = launch {
+    fun onSelectAll() {
         log(tag) { "Selecting all" }
-        getWorkspace().selectAll()
+        submitSelectionOp(SelectionOp.SelectAll)
     }
 
-    fun onSelectUserApps() = launch {
-        val ids = getReadyState().apps.filter { !it.isSystemApp }.map { it.pkg.installId }.toSet()
-        log(tag) { "Selecting ${ids.size} user apps" }
-        getWorkspace().selectApps(ids)
+    fun onSelectUserApps() {
+        log(tag) { "Selecting user apps" }
+        submitSelectionOp(SelectionOp.SelectUserApps)
     }
 
-    fun onSelectSystemApps() = launch {
-        val ids = getReadyState().apps.filter { it.isSystemApp }.map { it.pkg.installId }.toSet()
-        log(tag) { "Selecting ${ids.size} system apps" }
-        getWorkspace().selectApps(ids)
+    fun onSelectSystemApps() {
+        log(tag) { "Selecting system apps" }
+        submitSelectionOp(SelectionOp.SelectSystemApps)
     }
 
     fun onRefresh() = launch {
@@ -548,7 +603,7 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
                             callerWorkspaceId = id,
                         ),
                     )
-                    getWorkspace().clearSelection()
+                    onClearSelection()
                 } else {
                     log(tag, WARN) { "No APK source paths available for export" }
                 }
@@ -585,7 +640,7 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
                     }
                 )
 
-                getWorkspace().clearSelection()
+                onClearSelection()
             }
 
             is AppsActionBarItem.OpenInTab -> launch {
@@ -593,7 +648,7 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
                 action.apps.forEach { app ->
                     openAppDetailsInTab(app)
                 }
-                getWorkspace().clearSelection()
+                onClearSelection()
             }
 
             is AppsActionBarItem.BrowsePath -> launch {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
@@ -135,10 +135,7 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
         when (op) {
             is SelectionOp.SetSelection -> workspace.setSelection(op.installIds)
 
-            is SelectionOp.Toggle -> {
-                val readyState = workspaceReadyState.filterNotNull().first()
-                workspace.selectApp(op.installId, op.installId !in readyState.selectedAppIds)
-            }
+            is SelectionOp.Toggle -> workspace.toggleSelection(op.installId)
 
             SelectionOp.Clear -> workspace.clearSelection()
 

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
@@ -43,6 +43,7 @@ import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.createAndFocus
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -52,6 +53,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 
 @HiltViewModel(assistedFactory = AppsWorkspaceViewModel.Factory::class)
 class AppsWorkspaceViewModel @AssistedInject constructor(
@@ -81,6 +84,20 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
 
     private val searchQueryFlow = MutableStateFlow(TextFieldValue(""))
     private val dialogStateFlow = MutableStateFlow<AppsDialogState>(AppsDialogState.None)
+
+    /**
+     * Selection ranges from a drag arrive faster than the round trip through the workspace, and a
+     * launch-per-event coroutine that hops dispatchers can land them out of order - a stale, larger
+     * range would then overwrite a retreat. A conflated channel with a single sequential collector
+     * may drop intermediate ranges, but never the last one.
+     */
+    private val selectionRequests = Channel<Set<InstallId>>(Channel.CONFLATED)
+
+    init {
+        selectionRequests.receiveAsFlow()
+            .onEach { getWorkspace().setSelection(it) }
+            .launchInViewModel()
+    }
 
     sealed interface State {
         data object Initializing : State
@@ -205,14 +222,9 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
-    private fun onAppLongClick(item: AppItem) = launch {
-        log(tag) { "onAppLongClick(${item.packageName})" }
-        // Once a selection exists the long press belongs to the drag gesture, taps do the selecting.
-        if (workspaceReadyState.filterNotNull().first().isMultiSelectMode) {
-            log(tag, DEBUG) { "onAppLongClick() ignored, selection is active" }
-            return@launch
-        }
-        toggleAppSelection(item.pkg.installId)
+    private fun onSetSelection(installIds: Set<InstallId>) {
+        log(tag) { "onSetSelection(): ${installIds.size} apps" }
+        selectionRequests.trySend(installIds)
     }
 
     private suspend fun toggleAppSelection(installId: InstallId) {
@@ -440,10 +452,10 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
             // App interactions
             is AppsPageAction.Apps.Refresh -> onRefresh()
             is AppsPageAction.Apps.Click -> handleAppClick(action.app)
-            is AppsPageAction.Apps.LongClick -> onAppLongClick(action.app)
 
             // Selection
             is AppsPageAction.Selection.Clear -> onClearSelection()
+            is AppsPageAction.Selection.SetSelection -> onSetSelection(action.installIds)
             is AppsPageAction.Selection.SelectUserApps -> onSelectUserApps()
             is AppsPageAction.Selection.SelectSystemApps -> onSelectSystemApps()
 

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsReadyContent.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsReadyContent.kt
@@ -144,6 +144,7 @@ internal fun AppsReadyContent(
                             orderedKeys = { state.apps.map { app -> app.pkg.installId } },
                             currentSelection = { state.selectedAppIds },
                             onSelectionChange = { onPageAction(AppsPageAction.Selection.SetSelection(it)) },
+                            contentPadding = gridContentPadding,
                         ),
                     contentPadding = gridContentPadding,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsReadyContent.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsReadyContent.kt
@@ -24,6 +24,8 @@ import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.dragselect.gridDragSelect
+import eu.darken.butler.common.compose.dragselect.listDragSelect
 import eu.darken.butler.workspace.contracts.apps.AppsViewStyle
 import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.common.WorkspacePullToRefreshBox
@@ -79,7 +81,13 @@ internal fun AppsReadyContent(
                     modifier = Modifier
                         .fillMaxSize()
                         .nestedScroll(topBarStackState.nestedScrollConnection)
-                        .nestedScroll(bottomBarStackState.nestedScrollConnection),
+                        .nestedScroll(bottomBarStackState.nestedScrollConnection)
+                        .listDragSelect(
+                            state = listState,
+                            orderedKeys = { state.apps.map { app -> app.pkg.installId } },
+                            currentSelection = { state.selectedAppIds },
+                            onSelectionChange = { onPageAction(AppsPageAction.Selection.SetSelection(it)) },
+                        ),
                     contentPadding = listContentPadding,
                 ) {
                     when {
@@ -104,12 +112,10 @@ internal fun AppsReadyContent(
                                     item = appItem,
                                     isSelected = appItem.pkg.installId in state.selectedAppIds,
                                     onClick = { onPageAction(AppsPageAction.Apps.Click(appItem)) },
-                                    onLongClick = {
-                                        // Synchronous gate, the ViewModel guard reads state across a suspension point.
-                                        if (!state.isMultiSelectMode) {
-                                            onPageAction(AppsPageAction.Apps.LongClick(appItem))
-                                        }
-                                    },
+                                    // The long press belongs to the drag selection, which owns the
+                                    // whole gesture; kept non-null so releasing it can't fall
+                                    // through to onClick and so the press still gives haptic feedback.
+                                    onLongClick = {},
                                     showSelection = state.isMultiSelectMode,
                                 )
                             }
@@ -132,7 +138,13 @@ internal fun AppsReadyContent(
                     modifier = Modifier
                         .fillMaxSize()
                         .nestedScroll(topBarStackState.nestedScrollConnection)
-                        .nestedScroll(bottomBarStackState.nestedScrollConnection),
+                        .nestedScroll(bottomBarStackState.nestedScrollConnection)
+                        .gridDragSelect(
+                            state = gridState,
+                            orderedKeys = { state.apps.map { app -> app.pkg.installId } },
+                            currentSelection = { state.selectedAppIds },
+                            onSelectionChange = { onPageAction(AppsPageAction.Selection.SetSelection(it)) },
+                        ),
                     contentPadding = gridContentPadding,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -159,12 +171,10 @@ internal fun AppsReadyContent(
                                     item = appItem,
                                     isSelected = appItem.pkg.installId in state.selectedAppIds,
                                     onClick = { onPageAction(AppsPageAction.Apps.Click(appItem)) },
-                                    onLongClick = {
-                                        // Synchronous gate, the ViewModel guard reads state across a suspension point.
-                                        if (!state.isMultiSelectMode) {
-                                            onPageAction(AppsPageAction.Apps.LongClick(appItem))
-                                        }
-                                    },
+                                    // The long press belongs to the drag selection, which owns the
+                                    // whole gesture; kept non-null so releasing it can't fall
+                                    // through to onClick and so the press still gives haptic feedback.
+                                    onLongClick = {},
                                     showSelection = state.isMultiSelectMode,
                                 )
                             }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
@@ -49,6 +49,7 @@ import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.dragselect.listDragSelect
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.navigation.NavigationEventHandler
@@ -80,7 +81,7 @@ sealed interface AppDetailsPageAction {
     data class ExportApk(val app: AppInfo) : AppDetailsPageAction
     data class ShareApk(val app: AppInfo) : AppDetailsPageAction
     data class SelectComponent(val entry: ComponentEntry) : AppDetailsPageAction
-    data class LongPressComponent(val entry: ComponentEntry) : AppDetailsPageAction
+    data class SetComponentSelection(val keys: Set<String>) : AppDetailsPageAction
     data class ComponentAction(val item: ComponentsActionBarItem) : AppDetailsPageAction
     data object ClearComponentSelection : AppDetailsPageAction
     data class SetComponentEnabled(val entry: ComponentEntry, val enabled: Boolean) : AppDetailsPageAction
@@ -129,7 +130,7 @@ fun AppDetailsWorkspacePageHost(
                     is AppDetailsPageAction.ExportApk -> vm.onExportApk(action.app)
                     is AppDetailsPageAction.ShareApk -> vm.onShareApk(action.app)
                     is AppDetailsPageAction.SelectComponent -> vm.onComponentSelected(action.entry)
-                    is AppDetailsPageAction.LongPressComponent -> vm.onComponentLongPressed(action.entry)
+                    is AppDetailsPageAction.SetComponentSelection -> vm.onComponentSelectionChanged(action.keys)
                     is AppDetailsPageAction.ComponentAction -> vm.onComponentAction(action.item)
                     is AppDetailsPageAction.ClearComponentSelection -> vm.clearComponentSelection()
                     is AppDetailsPageAction.SetComponentEnabled -> vm.onSetComponentEnabled(action.entry, action.enabled)
@@ -256,12 +257,21 @@ fun AppDetailsWorkspacePage(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
     ) {
+        val activeListState = if (showComponents) componentsListState else overviewListState
         LazyColumn(
-            state = if (showComponents) componentsListState else overviewListState,
+            state = activeListState,
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(topBarStackState.nestedScrollConnection)
-                .nestedScroll(bottomBarStackState.nestedScrollConnection),
+                .nestedScroll(bottomBarStackState.nestedScrollConnection)
+                .listDragSelect(
+                    state = activeListState,
+                    // Group headers are not entries, the range simply spans them.
+                    orderedKeys = { filteredComponents.all.map { entry -> entry.key } },
+                    currentSelection = { selectedComponentKeys },
+                    onSelectionChange = { onPageAction(AppDetailsPageAction.SetComponentSelection(it)) },
+                    enabled = { showComponents },
+                ),
             contentPadding = contentPadding,
             // Cards on the overview are spaced apart; the flat component list stays dense.
             verticalArrangement = Arrangement.spacedBy(if (showComponents) 0.dp else 8.dp),
@@ -274,7 +284,10 @@ fun AppDetailsWorkspacePage(
                         query = query,
                         onComponentClick = { onPageAction(AppDetailsPageAction.SelectComponent(it)) },
                         selectedKeys = selectedComponentKeys,
-                        onComponentLongClick = { onPageAction(AppDetailsPageAction.LongPressComponent(it)) },
+                        // The long press belongs to the drag selection, which owns the whole
+                        // gesture; kept non-null so releasing it can't fall through to onClick and
+                        // so the press still gives haptic feedback.
+                        onComponentLongClick = {},
                     )
                 } else {
                     overviewItems(

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceComponentConfirmTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceComponentConfirmTest.kt
@@ -83,12 +83,12 @@ class AppDetailsWorkspaceComponentConfirmTest : BaseTest() {
     @Test
     fun `a selection change retires the pending confirm request`() {
         val vm = createVM()
-        vm.onComponentLongPressed(activity)
+        vm.onComponentSelectionChanged(setOf(activity.key))
 
         vm.onComponentAction(ComponentsActionBarItem.Disable(listOf(activity)))
         vm.componentConfirm.value!!.entries.map { it.key } shouldBe listOf(activity.key)
 
-        vm.onComponentLongPressed(service)
+        vm.onComponentSelectionChanged(setOf(service.key))
 
         vm.componentConfirm.value shouldBe null
     }
@@ -96,12 +96,12 @@ class AppDetailsWorkspaceComponentConfirmTest : BaseTest() {
     @Test
     fun `confirming a stale request applies nothing`() {
         val vm = createVM()
-        vm.onComponentLongPressed(activity)
+        vm.onComponentSelectionChanged(setOf(activity.key))
         vm.onComponentAction(ComponentsActionBarItem.Disable(listOf(activity)))
         val stale = vm.componentConfirm.value!!
 
         // The dialog's own callback still holds the captured request after the selection moved on.
-        vm.onComponentLongPressed(service)
+        vm.onComponentSelectionChanged(setOf(service.key))
         vm.onComponentConfirm(stale)
 
         coVerify(exactly = 0) { workspace.setComponentsEnabled(any(), any()) }
@@ -110,7 +110,7 @@ class AppDetailsWorkspaceComponentConfirmTest : BaseTest() {
     @Test
     fun `confirming an unchanged selection applies the live entries`() {
         val vm = createVM()
-        vm.onComponentLongPressed(activity)
+        vm.onComponentSelectionChanged(setOf(activity.key))
         vm.onComponentAction(ComponentsActionBarItem.Disable(listOf(activity)))
 
         vm.onComponentConfirm(vm.componentConfirm.value!!)

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/components/AppComponentsControllerTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/components/AppComponentsControllerTest.kt
@@ -334,7 +334,7 @@ class AppComponentsControllerTest : BaseTest() {
     }
 
     @Test
-    fun `a long press enters multi-selection instead of opening the sheet`() = runTest {
+    fun `a dragged selection does not open the sheet`() = runTest {
         val loader = mockk<AppComponentsLoader>()
         coEvery { loader.load(any()) } returns data
         coEvery { loader.resolveEnabledStates(any()) } returns emptyMap()
@@ -344,7 +344,7 @@ class AppComponentsControllerTest : BaseTest() {
         controller.onComponentsRouteActive(true)
         runCurrent()
 
-        controller.onItemLongClick(activity)
+        controller.setSelection(setOf(activity.key))
         runCurrent()
 
         controller.selectedComponents.value shouldBe listOf(activity)
@@ -368,7 +368,7 @@ class AppComponentsControllerTest : BaseTest() {
         controller.selectedComponents.value shouldBe emptyList()
 
         controller.dismiss()
-        controller.onItemLongClick(activity)
+        controller.setSelection(setOf(activity.key))
         controller.onItemClick(service)
         runCurrent()
         controller.selectedComponents.value shouldBe listOf(activity, service)
@@ -389,7 +389,7 @@ class AppComponentsControllerTest : BaseTest() {
 
         controller.onAppChanged(appInfo())
         controller.onComponentsRouteActive(true)
-        controller.onItemLongClick(activity)
+        controller.setSelection(setOf(activity.key))
         runCurrent()
         controller.selectedComponents.value shouldBe listOf(activity)
 
@@ -408,7 +408,7 @@ class AppComponentsControllerTest : BaseTest() {
 
         controller.onAppChanged(appInfo())
         controller.onComponentsRouteActive(true)
-        controller.onItemLongClick(activity)
+        controller.setSelection(setOf(activity.key))
         runCurrent()
 
         controller.onComponentsRouteActive(false)
@@ -429,7 +429,7 @@ class AppComponentsControllerTest : BaseTest() {
 
         controller.onAppChanged(appInfo())
         controller.onComponentsRouteActive(true)
-        controller.onItemLongClick(activity)
+        controller.setSelection(setOf(activity.key))
         runCurrent()
 
         controller.selectedComponents.value.single().enabledState shouldBe ComponentEnabledState.ENABLED

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsDragSelectionOrderTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsDragSelectionOrderTest.kt
@@ -92,6 +92,7 @@ class AppsDragSelectionOrderTest : BaseTest() {
         val applied = mutableListOf<String>()
         val completions = Channel<Unit>(Channel.UNLIMITED)
         val workspace = mockk<AppsWorkspace>(relaxed = true)
+        // A populated Ready state puts the click into multi-select mode so it routes to a toggle.
         every { workspace.state } returns flowOf(
             AppsWorkspace.State.Ready(
                 apps = apps,
@@ -104,10 +105,10 @@ class AppsDragSelectionOrderTest : BaseTest() {
             completions.receive()
             applied += "set(${requested.size})"
         }
-        coEvery { workspace.selectApp(any(), any()) } coAnswers {
-            val selected = secondArg<Boolean>()
+        // The toggle resolves atomically against the engine's selection, so it takes no boolean.
+        coEvery { workspace.toggleSelection(any()) } coAnswers {
             completions.receive()
-            applied += "toggle(${firstArg<InstallId>()}=$selected)"
+            applied += "toggle(${firstArg<InstallId>()})"
         }
         val vm = createVM(workspace)
 
@@ -119,7 +120,7 @@ class AppsDragSelectionOrderTest : BaseTest() {
 
         repeat(3) { completions.send(Unit) }
 
-        applied shouldBe listOf("set(2)", "set(4)", "toggle(${ids[1]}=true)")
+        applied shouldBe listOf("set(2)", "set(4)", "toggle(${ids[1]})")
     }
 
     private fun createVM(workspace: AppsWorkspace): AppsWorkspaceViewModel {

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsDragSelectionOrderTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsDragSelectionOrderTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.butler.apps.ui.apps
+
+import eu.darken.butler.apps.core.AppsWorkspace
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.pkgs.features.InstallId
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * A drag produces selection ranges far faster than the round trip through the workspace. They have
+ * to be applied in order, or an expanding range that was overtaken lands after the retreat that
+ * followed it and re-selects what the user just gave back.
+ */
+class AppsDragSelectionOrderTest : BaseTest() {
+
+    private val ids = listOf(
+        AppsMockDataProvider.Presets.chromeItem,
+        AppsMockDataProvider.Presets.settingsItem,
+        AppsMockDataProvider.Presets.notesItem,
+        AppsMockDataProvider.Presets.disabledAppItem,
+    ).map { it.pkg.installId }
+
+    @Test
+    fun `a burst of ranges ends on the last one, never on an overtaken larger range`() = runTest {
+        val applied = mutableListOf<Set<InstallId>>()
+        // Each token lets exactly one in-flight update complete, so the burst arrives while the
+        // workspace is still busy with the first one.
+        val completions = Channel<Unit>(Channel.UNLIMITED)
+        val workspace = mockk<AppsWorkspace>(relaxed = true)
+        coEvery { workspace.setSelection(any()) } coAnswers {
+            val requested = firstArg<Set<InstallId>>()
+            completions.receive()
+            applied += requested
+        }
+        val vm = createVM(workspace)
+
+        val first = setOf(ids[0], ids[1])
+        val expanded = setOf(ids[0], ids[1], ids[2], ids[3])
+        val retreated = setOf(ids[0])
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(first))
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(expanded))
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(retreated))
+
+        completions.send(Unit)
+        completions.send(Unit)
+
+        // The overtaken middle range may be dropped, the last one never is.
+        applied shouldBe listOf(first, retreated)
+    }
+
+    private fun createVM(workspace: AppsWorkspace): AppsWorkspaceViewModel {
+        val id = Workspace.Id()
+        return AppsWorkspaceViewModel(
+            id = id,
+            context = mockk(relaxed = true),
+            dispatchers = TestDispatcherProvider(),
+            workspaceProvider = mockk<WorkspaceProvider> { every { retrieve(id) } returns flowOf(workspace) },
+            workspaceRemote = mockk<WorkspaceRemote>(relaxed = true),
+            appsSettings = mockk(relaxed = true),
+            appSizeCache = mockk(relaxed = true),
+        )
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsDragSelectionOrderTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsDragSelectionOrderTest.kt
@@ -24,12 +24,13 @@ import testhelpers.coroutine.TestDispatcherProvider
  */
 class AppsDragSelectionOrderTest : BaseTest() {
 
-    private val ids = listOf(
+    private val apps = listOf(
         AppsMockDataProvider.Presets.chromeItem,
         AppsMockDataProvider.Presets.settingsItem,
         AppsMockDataProvider.Presets.notesItem,
         AppsMockDataProvider.Presets.disabledAppItem,
-    ).map { it.pkg.installId }
+    )
+    private val ids = apps.map { it.pkg.installId }
 
     @Test
     fun `a burst of ranges ends on the last one, never on an overtaken larger range`() = runTest {
@@ -57,6 +58,68 @@ class AppsDragSelectionOrderTest : BaseTest() {
 
         // The overtaken middle range may be dropped, the last one never is.
         applied shouldBe listOf(first, retreated)
+    }
+
+    @Test
+    fun `a clear that follows a range is never overtaken by it`() = runTest {
+        val applied = mutableListOf<String>()
+        val completions = Channel<Unit>(Channel.UNLIMITED)
+        val workspace = mockk<AppsWorkspace>(relaxed = true)
+        coEvery { workspace.setSelection(any()) } coAnswers {
+            val requested = firstArg<Set<InstallId>>()
+            completions.receive()
+            applied += "set(${requested.size})"
+        }
+        coEvery { workspace.clearSelection() } coAnswers {
+            completions.receive()
+            applied += "clear"
+        }
+        val vm = createVM(workspace)
+
+        // The second range is still queued when the clear arrives - it must not land after it and
+        // bring the selection the user just gave back.
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(setOf(ids[0], ids[1])))
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(ids.toSet()))
+        vm.onPageAction(AppsPageAction.Selection.Clear)
+
+        repeat(3) { completions.send(Unit) }
+
+        applied shouldBe listOf("set(2)", "set(4)", "clear")
+    }
+
+    @Test
+    fun `a tap queued behind a burst of ranges lands after them`() = runTest {
+        val applied = mutableListOf<String>()
+        val completions = Channel<Unit>(Channel.UNLIMITED)
+        val workspace = mockk<AppsWorkspace>(relaxed = true)
+        every { workspace.state } returns flowOf(
+            AppsWorkspace.State.Ready(
+                apps = apps,
+                filteredApps = apps,
+                selectedAppIds = setOf(ids[0]),
+            )
+        )
+        coEvery { workspace.setSelection(any()) } coAnswers {
+            val requested = firstArg<Set<InstallId>>()
+            completions.receive()
+            applied += "set(${requested.size})"
+        }
+        coEvery { workspace.selectApp(any(), any()) } coAnswers {
+            val selected = secondArg<Boolean>()
+            completions.receive()
+            applied += "toggle(${firstArg<InstallId>()}=$selected)"
+        }
+        val vm = createVM(workspace)
+
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(setOf(ids[0], ids[1])))
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(setOf(ids[0], ids[1], ids[2])))
+        vm.onPageAction(AppsPageAction.Selection.SetSelection(ids.toSet()))
+        // A tap while the selection is active toggles - it must not be discarded by the burst.
+        vm.onPageAction(AppsPageAction.Apps.Click(apps[1]))
+
+        repeat(3) { completions.send(Unit) }
+
+        applied shouldBe listOf("set(2)", "set(4)", "toggle(${ids[1]}=true)")
     }
 
     private fun createVM(workspace: AppsWorkspace): AppsWorkspaceViewModel {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -651,6 +651,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
     fun toggleItemSelection(item: ExplorerItem) = selection.toggle(item)
 
+    fun setSelection(items: Set<ExplorerItem>) = selection.set(items)
+
     fun onItemClick(item: ExplorerItem) = selection.onItemClick(item)
 
     fun onItemLongClick(item: ExplorerItem) = selection.onItemLongClick(item)

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -1596,7 +1596,20 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         log(tag) { "onTrashDropConfirmed(${payload.items.size} items)" }
         // Atomic claim of the dialog: a second invocation (double tap) finds it already gone.
         if (!dialogs.dismissIfCurrent(TrashDropConfirmation(payload))) return
-        onDeleteConfirmed(payload.items.map { it.path }.toSet(), forcePermDelete = false)
+        launch {
+            val paths = payload.items.map { it.path }.toSet()
+            if (paths.isEmpty()) return@launch
+            getWorkspace().execute(
+                ExplorerCommand.Delete(
+                    targets = paths,
+                    options = ExplorerCommand.Delete.Options(forcePermDelete = false),
+                )
+            )
+            clearSelection()
+            // Trash is a virtual location; BrowsingEngine's incremental FS updates key on
+            // parent == current.path and don't cover it, so re-list explicitly.
+            navigation.refresh()
+        }
     }
 
     fun onDropConfirmed(payload: WorkspaceDragPayload, destination: APath<*>, move: Boolean) = launch {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -76,6 +76,7 @@ import eu.darken.butler.explorer.ui.explorer.dialogs.RenameResult
 import eu.darken.butler.explorer.ui.explorer.dialogs.SortOptionsResult
 import eu.darken.butler.explorer.ui.explorer.dialogs.SortScope
 import eu.darken.butler.explorer.ui.explorer.dnd.validateDropDestination
+import eu.darken.butler.explorer.ui.explorer.dnd.validateTrashDrop
 import eu.darken.butler.explorer.ui.explorer.util.ExplorerSelectionState
 import eu.darken.butler.explorer.ui.explorer.util.ItemInfoCalculator
 import eu.darken.butler.explorer.ui.picker.ExplorerPickerHelper
@@ -1579,12 +1580,21 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
     /** Items dragged in from another workspace landed on this one, ask what to do with them. */
     fun onDragDropped(payload: WorkspaceDragPayload) = launch {
         log(tag) { "onDragDropped(${payload.items.size} items from ${payload.sourceWorkspaceId})" }
+        if (validateTrashDrop(getState(), id, payload)) {
+            dialogs.show(TrashDropConfirmation(payload))
+            return@launch
+        }
         val destination = validateDropDestination(getState(), id, payload)
         if (destination == null) {
             log(tag) { "onDragDropped(): Drop is not valid here, ignoring" }
             return@launch
         }
         dialogs.show(DropConfirmation(payload, destination))
+    }
+
+    fun onTrashDropConfirmed(payload: WorkspaceDragPayload) {
+        log(tag) { "onTrashDropConfirmed(${payload.items.size} items)" }
+        onDeleteConfirmed(payload.items.map { it.path }.toSet(), forcePermDelete = false)
     }
 
     fun onDropConfirmed(payload: WorkspaceDragPayload, destination: APath<*>, move: Boolean) = launch {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -1594,6 +1594,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
     fun onTrashDropConfirmed(payload: WorkspaceDragPayload) {
         log(tag) { "onTrashDropConfirmed(${payload.items.size} items)" }
+        // Atomic claim of the dialog: a second invocation (double tap) finds it already gone.
+        if (!dialogs.dismissIfCurrent(TrashDropConfirmation(payload))) return
         onDeleteConfirmed(payload.items.map { it.path }.toSet(), forcePermDelete = false)
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogHost.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogHost.kt
@@ -164,6 +164,14 @@ fun ExplorerDialogHost(
             )
         }
 
+        is ExplorerDialogState.TrashDropConfirmation -> {
+            TrashDropConfirmationDialog(
+                payload = dialogState.payload,
+                onDismiss = { vm?.dismissDialog() },
+                onConfirm = { vm?.onTrashDropConfirmed(dialogState.payload) },
+            )
+        }
+
         is ExplorerDialogState.ClipboardInfo -> {
             ClipboardInfoBottomSheet(
                 clip = dialogState.clip,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogState.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogState.kt
@@ -84,6 +84,11 @@ sealed interface ExplorerDialogState {
         val destination: APath<*>,
     ) : ExplorerDialogState
 
+    /** Items dropped from another workspace onto the Trash view, waiting to confirm the move to trash. */
+    data class TrashDropConfirmation(
+        val payload: WorkspaceDragPayload,
+    ) : ExplorerDialogState
+
     data class ClipboardInfo(val clip: ClipboardClip) : ExplorerDialogState
 
     data class CreateFileFromText(val clip: ClipboardClip.Text) : ExplorerDialogState

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/TrashDropConfirmationDialog.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/TrashDropConfirmationDialog.kt
@@ -1,0 +1,73 @@
+package eu.darken.butler.explorer.ui.explorer.dialogs
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.explorer.R
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
+import eu.darken.butler.common.R as CommonR
+
+@Composable
+fun TrashDropConfirmationDialog(
+    payload: WorkspaceDragPayload,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val itemCount = payload.items.size
+
+    PaneBoundAlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.explorer_trash_drop_confirmation_title)) },
+        text = {
+            Text(
+                pluralStringResource(
+                    R.plurals.explorer_trash_drop_confirmation_message,
+                    itemCount,
+                    itemCount,
+                )
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.explorer_file_action_move_to_trash))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TrashDropConfirmationDialogPreview() {
+    TrashDropConfirmationDialog(
+        payload = WorkspaceDragPayload(
+            sourceWorkspaceId = Workspace.Id(),
+            items = listOf(
+                WorkspaceDragPayload.Item(
+                    path = LocalPath.build("/storage/emulated/0/DCIM/photo.jpg"),
+                    kind = WorkspaceDragPayload.Kind.FILE_OTHER,
+                ),
+                WorkspaceDragPayload.Item(
+                    path = LocalPath.build("/storage/emulated/0/DCIM/raw"),
+                    kind = WorkspaceDragPayload.Kind.DIRECTORY,
+                ),
+            ),
+            allowMove = true,
+        ),
+        onDismiss = {},
+        onConfirm = {},
+    )
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidator.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidator.kt
@@ -28,3 +28,21 @@ fun validateDropDestination(
     if (!validateDropPaths(payload.items, directory.path)) return null
     return directory.path
 }
+
+/**
+ * Gate for accepting a [payload] dropped onto the root Trash view. Trashing removes the items from
+ * their source, so it is only offered when the source allows a move. Returns true when this
+ * workspace's Trash root can take the drop.
+ */
+fun validateTrashDrop(
+    state: ExplorerWorkspaceViewModel.State,
+    workspaceId: Workspace.Id,
+    payload: WorkspaceDragPayload,
+): Boolean {
+    if (state.pickerConfig != null) return false
+    if (payload.sourceWorkspaceId == workspaceId) return false
+    if (state.currentLocation !is ExplorerLocation.Trash.Root) return false
+    if (!payload.allowMove) return false
+    if (payload.items.isEmpty()) return false
+    return true
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelect.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelect.kt
@@ -1,0 +1,48 @@
+package eu.darken.butler.explorer.ui.explorer.dragselect
+
+import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+
+/**
+ * The items a drag may sweep over, in display order. Sourced from the picker-aware eligibility set
+ * instead of a generic "is selectable" test, so e.g. a file picker can't drag-select directories.
+ */
+fun explorerDragSelectKeys(state: ExplorerWorkspaceViewModel.State): List<String> {
+    val selectable = state.selectionState.selectableItems
+    return state.items.orEmpty()
+        .filter { it in selectable && it !in state.disabledItems }
+        .map { it.id }
+}
+
+/**
+ * Whether drag-select owns the long press on [anchorId], or a cross-pane drag does.
+ *
+ * The payload factory is evaluated for the pressed item rather than merely tested for presence: it
+ * returns null for pickers and for items that can't be dragged at all (storage volumes, trash
+ * roots), and those presses would otherwise end up owned by neither gesture.
+ */
+fun explorerDragSelectClaims(
+    state: ExplorerWorkspaceViewModel.State,
+    anchorId: String,
+    dragPayloadFactory: ((ExplorerItem) -> WorkspaceDragPayload?)?,
+): Boolean {
+    if (state.pickerConfig?.selection?.isMultiSelect == false) return false
+    if (!state.selectionState.isSelectionMode) return true
+    val anchor = state.items?.firstOrNull { it.id == anchorId } ?: return true
+    return dragPayloadFactory?.invoke(anchor) == null
+}
+
+/**
+ * Resolves dragged ids back to items. Selected items the current filter hides are kept out of the
+ * listing but stay selected, so ids that don't resolve against [ExplorerWorkspaceViewModel.State.items]
+ * are looked up in the live selection - resolving only against the listing would silently drop them.
+ */
+fun explorerDragSelectItems(
+    state: ExplorerWorkspaceViewModel.State,
+    ids: Set<String>,
+): Set<ExplorerItem> {
+    val visible = state.items.orEmpty().associateBy { it.id }
+    val selected = state.selectionState.selectedItems.associateBy { it.id }
+    return ids.mapNotNullTo(mutableSetOf()) { visible[it] ?: selected[it] }
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelect.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelect.kt
@@ -21,6 +21,9 @@ fun explorerDragSelectKeys(state: ExplorerWorkspaceViewModel.State): List<String
  * The payload factory is evaluated for the pressed item rather than merely tested for presence: it
  * returns null for pickers and for items that can't be dragged at all (storage volumes, trash
  * roots), and those presses would otherwise end up owned by neither gesture.
+ *
+ * In selection mode an unselected anchor is always claimed by drag-select, so long-pressing it
+ * extends the selection; only an already selected anchor may fall through to the cross-pane drag.
  */
 fun explorerDragSelectClaims(
     state: ExplorerWorkspaceViewModel.State,
@@ -30,6 +33,7 @@ fun explorerDragSelectClaims(
     if (state.pickerConfig?.selection?.isMultiSelect == false) return false
     if (!state.selectionState.isSelectionMode) return true
     val anchor = state.items?.firstOrNull { it.id == anchorId } ?: return true
+    if (anchor !in state.selectionState.selectedItems) return true
     return dragPayloadFactory?.invoke(anchor) == null
 }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
@@ -79,6 +79,7 @@ internal fun ExplorerGridContent(
             currentSelection = { state.selectionState.selectedItems.mapTo(mutableSetOf()) { it.id } },
             onSelectionChange = { ids -> vm?.setSelection(explorerDragSelectItems(state, ids)) },
             enabled = { id -> explorerDragSelectClaims(state, id, dragPayloadFactory) },
+            contentPadding = contentPadding,
         ),
         verticalArrangement = Arrangement.spacedBy(2.dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
@@ -24,8 +24,12 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.dragselect.gridDragSelect
 import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.ui.explorer.dragselect.explorerDragSelectClaims
+import eu.darken.butler.explorer.ui.explorer.dragselect.explorerDragSelectItems
+import eu.darken.butler.explorer.ui.explorer.dragselect.explorerDragSelectKeys
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
 import eu.darken.butler.explorer.ui.explorer.items.ExplorerItemRenderer
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
@@ -69,7 +73,13 @@ internal fun ExplorerGridContent(
     LazyVerticalGrid(
         state = effectiveGridState,
         columns = GridCells.Adaptive(minSize = 120.dp),
-        modifier = modifier,
+        modifier = modifier.gridDragSelect(
+            state = effectiveGridState,
+            orderedKeys = { explorerDragSelectKeys(state) },
+            currentSelection = { state.selectionState.selectedItems.mapTo(mutableSetOf()) { it.id } },
+            onSelectionChange = { ids -> vm?.setSelection(explorerDragSelectItems(state, ids)) },
+            enabled = { id -> explorerDragSelectClaims(state, id, dragPayloadFactory) },
+        ),
         verticalArrangement = Arrangement.spacedBy(2.dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),
         contentPadding = contentPadding,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
@@ -18,7 +18,11 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.dragselect.listDragSelect
 import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.ui.explorer.dragselect.explorerDragSelectClaims
+import eu.darken.butler.explorer.ui.explorer.dragselect.explorerDragSelectItems
+import eu.darken.butler.explorer.ui.explorer.dragselect.explorerDragSelectKeys
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
 import eu.darken.butler.explorer.ui.explorer.items.ExplorerItemRenderer
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
@@ -42,9 +46,16 @@ internal fun ExplorerListContent(
     // Skeletons must never attach to the persisted scroll state: restore readiness would fire
     // against placeholder content and the recorder would persist the resulting clamp.
     val skeletonListState = rememberLazyListState()
+    val effectiveListState = if (state.items == null) skeletonListState else listState
     LazyColumn(
-        state = if (state.items == null) skeletonListState else listState,
-        modifier = modifier,
+        state = effectiveListState,
+        modifier = modifier.listDragSelect(
+            state = effectiveListState,
+            orderedKeys = { explorerDragSelectKeys(state) },
+            currentSelection = { state.selectionState.selectedItems.mapTo(mutableSetOf()) { it.id } },
+            onSelectionChange = { ids -> vm?.setSelection(explorerDragSelectItems(state, ids)) },
+            enabled = { id -> explorerDragSelectClaims(state, id, dragPayloadFactory) },
+        ),
         verticalArrangement = Arrangement.spacedBy(4.dp),
         contentPadding = contentPadding,
     ) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
@@ -41,6 +41,7 @@ import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
 import eu.darken.butler.workspace.ui.dnd.dropTargetHighlight
 import eu.darken.butler.workspace.ui.dnd.workspaceDragPayload
@@ -99,6 +100,10 @@ internal fun ExplorerReadyContent(
     val isDragHovered = remember { mutableStateOf(false) }
     val currentState by rememberUpdatedState(state)
     val currentVm by rememberUpdatedState(vm)
+    // Same focus request AdaptiveWorkspaceLayout wires to WorkspaceScreenAction.Focus(info.id),
+    // republished by WorkspacePane. Focusing the target pane before the drop opens the confirmation
+    // dialog in an already-focused pane, so its first tap confirms instead of only focusing.
+    val currentFocusRequest by rememberUpdatedState(LocalWorkspaceFocusRequest.current)
     val dropTarget = remember {
         object : DragAndDropTarget {
             override fun onEntered(event: DragAndDropEvent) {
@@ -116,6 +121,7 @@ internal fun ExplorerReadyContent(
             override fun onDrop(event: DragAndDropEvent): Boolean {
                 isDragHovered.value = false
                 val payload = event.workspaceDragPayload() ?: return false
+                currentFocusRequest?.invoke()
                 currentVm?.onDragDropped(payload)
                 return true
             }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
@@ -36,6 +36,7 @@ import eu.darken.butler.explorer.core.engine.BrowsingAbortedException
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
 import eu.darken.butler.explorer.ui.explorer.dnd.validateDropDestination
+import eu.darken.butler.explorer.ui.explorer.dnd.validateTrashDrop
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
 import eu.darken.butler.workspace.core.Workspace
@@ -127,7 +128,10 @@ internal fun ExplorerReadyContent(
             .dragAndDropTarget(
                 shouldStartDragAndDrop = { event ->
                     val payload = event.workspaceDragPayload()
-                    payload != null && validateDropDestination(currentState, workspaceId, payload) != null
+                    payload != null && (
+                        validateDropDestination(currentState, workspaceId, payload) != null ||
+                            validateTrashDrop(currentState, workspaceId, payload)
+                        )
                 },
                 target = dropTarget,
             )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
@@ -59,8 +59,8 @@ fun ExplorerItemRenderer(
         Modifier
     }
 
-    // The long-press that already selects also arms the drag - the pointer is still down when it
-    // fires, which is what the platform needs to pick up the drag. A null payload means no drag.
+    // The long press arms the drag while the pointer is still down, which is what the platform needs
+    // to pick up the drag. A null payload means no drag.
     val dragSource = dragPayloadFactory?.let { factory -> rememberWorkspaceDragSource { factory(item) } }
 
     Box(modifier = focusModifier.then(dragSource?.modifier ?: Modifier)) {
@@ -73,7 +73,9 @@ fun ExplorerItemRenderer(
             showSelection = showSelection,
             onItemClick = onItemClick,
             onItemLongClick = {
-                dragSource?.startDrag()
+                // The first long press belongs to drag-select; the cross-pane drag starts from a
+                // long press made while a selection already exists.
+                if (state.selectionState.isSelectionMode) dragSource?.startDrag()
                 onItemLongClick(it)
             },
             onNavigate = onNavigate,
@@ -155,8 +157,9 @@ private fun ItemContent(
             val storageShowSelection = state.selectionState.selectedItems.isNotEmpty() &&
                 item in state.selectionState.selectableItems
             val decorations = decorationsFor(item, state)
-            // Once a selection exists, only taps change it - the long press is the drag gesture.
-            val onLongClick = { if (!state.selectionState.isSelectionMode) onToggleSelection(item) }
+            // Same entry point as every other item type: it guards against a live selection instead
+            // of the composed one, so it can't race the drag session's own selection update.
+            val onLongClick = { onItemLongClick(item) }
             when (viewStyle) {
                 is ExplorerViewStyle.List -> StorageRow(
                     item = item,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
@@ -73,9 +73,11 @@ fun ExplorerItemRenderer(
             showSelection = showSelection,
             onItemClick = onItemClick,
             onItemLongClick = {
-                // The first long press belongs to drag-select; the cross-pane drag starts from a
-                // long press made while a selection already exists.
-                if (state.selectionState.isSelectionMode) dragSource?.startDrag()
+                // The cross-pane drag starts only from an already selected item; long-pressing an
+                // unselected item in selection mode extends the selection instead.
+                if (state.selectionState.isSelectionMode && it in state.selectionState.selectedItems) {
+                    dragSource?.startDrag()
+                }
                 onItemLongClick(it)
             },
             onNavigate = onNavigate,

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -427,6 +427,13 @@
         <item quantity="other">Copy %1$d items to \"%2$s\"?</item>
     </plurals>
 
+    <!-- Trash drop dialog (items dragged onto the Trash view) -->
+    <string name="explorer_trash_drop_confirmation_title">Move to trash?</string>
+    <plurals name="explorer_trash_drop_confirmation_message">
+        <item quantity="one">Move %1$d item to trash?</item>
+        <item quantity="other">Move %1$d items to trash?</item>
+    </plurals>
+
     <string name="explorer_operation_move_title">Move operation</string>
     <string name="explorer_operation_move_description_single">Move \"%1$s\" from \"%2$s\" to \"%3$s\".</string>
     <plurals name="explorer_operation_move_description">

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidatorTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidatorTest.kt
@@ -98,7 +98,7 @@ class ExplorerDropValidatorTest : BaseTest() {
 
     @Test
     fun `a nested trash view refuses drops`() {
-        val state = state(location = mockk<ExplorerLocation.Trash.Nested>())
+        val state = state(location = mockk<ExplorerLocation.Trash.Nested>(relaxed = true))
 
         validateTrashDrop(state, workspaceId, payload()) shouldBe false
     }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidatorTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidatorTest.kt
@@ -89,4 +89,66 @@ class ExplorerDropValidatorTest : BaseTest() {
         validateDropDestination(state(), workspaceId, fromSameFolder) shouldBe null
     }
 
+    @Test
+    fun `the trash root takes a movable drop from another workspace`() {
+        val state = state(location = ExplorerLocation.Trash.Root())
+
+        validateTrashDrop(state, workspaceId, payload()) shouldBe true
+    }
+
+    @Test
+    fun `a nested trash view refuses drops`() {
+        val state = state(location = mockk<ExplorerLocation.Trash.Nested>())
+
+        validateTrashDrop(state, workspaceId, payload()) shouldBe false
+    }
+
+    @Test
+    fun `a trash drop from the same workspace is refused`() {
+        val state = state(location = ExplorerLocation.Trash.Root())
+
+        validateTrashDrop(state, workspaceId, payload(sourceWorkspaceId = workspaceId)) shouldBe false
+    }
+
+    @Test
+    fun `a trash drop of copy-only items is refused`() {
+        val state = state(location = ExplorerLocation.Trash.Root())
+        val copyOnly = WorkspaceDragPayload(
+            sourceWorkspaceId = sourceWorkspaceId,
+            items = listOf(
+                WorkspaceDragPayload.Item(
+                    path = LocalPath.build("/storage/emulated/0/DCIM/photo.jpg"),
+                    kind = WorkspaceDragPayload.Kind.FILE_OTHER,
+                ),
+            ),
+            allowMove = false,
+        )
+
+        validateTrashDrop(state, workspaceId, copyOnly) shouldBe false
+    }
+
+    @Test
+    fun `picker mode refuses trash drops`() {
+        val state = state(location = ExplorerLocation.Trash.Root(), pickerConfig = mockk<PickerConfig>())
+
+        validateTrashDrop(state, workspaceId, payload()) shouldBe false
+    }
+
+    @Test
+    fun `a trash drop without items is refused`() {
+        val state = state(location = ExplorerLocation.Trash.Root())
+        val empty = WorkspaceDragPayload(
+            sourceWorkspaceId = sourceWorkspaceId,
+            items = emptyList(),
+            allowMove = true,
+        )
+
+        validateTrashDrop(state, workspaceId, empty) shouldBe false
+    }
+
+    @Test
+    fun `a normal directory refuses trash drops`() {
+        validateTrashDrop(state(), workspaceId, payload()) shouldBe false
+    }
+
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelectTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelectTest.kt
@@ -1,0 +1,160 @@
+package eu.darken.butler.explorer.ui.explorer.dragselect
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.core.engine.ExplorerLocation
+import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
+import eu.darken.butler.explorer.ui.explorer.dnd.ExplorerDragPayloadFactory
+import eu.darken.butler.explorer.ui.explorer.util.ExplorerSelectionState
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.contracts.explorer.PickerConfig
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ExplorerDragSelectTest : BaseTest() {
+
+    private val workspaceId = Workspace.Id()
+    private val directoryPath = LocalPath.build("/storage/emulated/0/DCIM")
+
+    private fun pickerConfig(selection: PickerConfig.Selection) = PickerConfig(
+        callerWorkspaceId = Workspace.Id(),
+        selection = selection,
+    )
+
+    private fun file(name: String) = ExplorerItem.RegularFile(
+        lookup = LocalPathLookup(
+            lookedUp = directoryPath.child(name),
+            fileType = FileType.FILE,
+            size = 1L,
+            modifiedAt = null,
+        ),
+        mimeType = MimeInfo("image/jpeg"),
+    )
+
+    private fun state(
+        items: List<ExplorerItem>? = emptyList(),
+        selectable: Set<ExplorerItem> = items.orEmpty().toSet(),
+        selected: Set<ExplorerItem> = emptySet(),
+        disabled: Set<ExplorerItem> = emptySet(),
+        pickerConfig: PickerConfig? = null,
+    ) = ExplorerWorkspaceViewModel.State(
+        currentLocation = ExplorerLocation.Directory(
+            info = ExplorerLocation.Directory.Info(isWritable = true),
+            path = directoryPath,
+        ),
+        items = items,
+        selectionState = ExplorerSelectionState(selectableItems = selectable, selectedItems = selected),
+        disabledItems = disabled,
+        pickerConfig = pickerConfig,
+    )
+
+    /** The very factory the page hands down in a multi-pane layout. */
+    private fun payloadFactory(
+        state: ExplorerWorkspaceViewModel.State,
+    ): (ExplorerItem) -> WorkspaceDragPayload? = { pressed ->
+        ExplorerDragPayloadFactory.build(state, workspaceId, pressed)
+    }
+
+    @Test
+    fun `keys are the eligible items in display order`() {
+        val first = file("a.jpg")
+        val second = file("b.jpg")
+        val notSelectable = file("c.jpg")
+        val disabled = file("d.jpg")
+        val state = state(
+            items = listOf(first, notSelectable, second, disabled),
+            selectable = setOf(first, second, disabled),
+            disabled = setOf(disabled),
+        )
+
+        explorerDragSelectKeys(state) shouldContainExactly listOf(first.id, second.id)
+    }
+
+    @Test
+    fun `there are no keys while the listing is still loading`() {
+        explorerDragSelectKeys(state(items = null)) shouldContainExactly emptyList()
+    }
+
+    @Test
+    fun `a single-select picker never claims the long press`() {
+        val item = file("a.jpg")
+        val picker = pickerConfig(PickerConfig.Selection.FileSingle)
+
+        explorerDragSelectClaims(state(items = listOf(item), pickerConfig = picker), item.id, null) shouldBe false
+    }
+
+    @Test
+    fun `a multi-select picker claims the long press`() {
+        val item = file("a.jpg")
+        val picker = pickerConfig(PickerConfig.Selection.FileMulti)
+
+        explorerDragSelectClaims(state(items = listOf(item), pickerConfig = picker), item.id, null) shouldBe true
+    }
+
+    @Test
+    fun `without an active selection drag-select claims even in a multi-pane layout`() {
+        val item = file("a.jpg")
+        val state = state(items = listOf(item))
+
+        explorerDragSelectClaims(state, item.id, payloadFactory(state)) shouldBe true
+    }
+
+    @Test
+    fun `a draggable item in selection mode leaves the long press to the platform drag`() {
+        val item = file("a.jpg")
+        val state = state(items = listOf(item), selected = setOf(item))
+
+        explorerDragSelectClaims(state, item.id, payloadFactory(state)) shouldBe false
+    }
+
+    @Test
+    fun `an item the payload factory refuses is still claimed in selection mode`() {
+        // Storage volumes and other non-lookup items never produce a payload - without evaluating
+        // the factory they would end up owned by neither gesture.
+        val selected = file("a.jpg")
+        val peek = ExplorerItem.Peek(directoryPath.child("peeked.jpg"))
+        val state = state(items = listOf(selected, peek), selected = setOf(selected))
+
+        explorerDragSelectClaims(state, peek.id, payloadFactory(state)) shouldBe true
+    }
+
+    @Test
+    fun `a single pane has no payload factory and always claims`() {
+        val item = file("a.jpg")
+        val state = state(items = listOf(item), selected = setOf(item))
+
+        explorerDragSelectClaims(state, item.id, null) shouldBe true
+    }
+
+    @Test
+    fun `ids resolve against the listing`() {
+        val first = file("a.jpg")
+        val second = file("b.jpg")
+        val state = state(items = listOf(first, second))
+
+        explorerDragSelectItems(state, setOf(first.id, second.id)) shouldBe setOf(first, second)
+    }
+
+    @Test
+    fun `a selected item the filter hides survives the resolution`() {
+        val visible = file("a.jpg")
+        val hidden = file("hidden.jpg")
+        val state = state(items = listOf(visible), selected = setOf(hidden))
+
+        explorerDragSelectItems(state, setOf(visible.id, hidden.id)) shouldBe setOf(visible, hidden)
+    }
+
+    @Test
+    fun `ids that resolve to nothing are dropped`() {
+        val visible = file("a.jpg")
+        val state = state(items = listOf(visible))
+
+        explorerDragSelectItems(state, setOf(visible.id, "gone")) shouldBe setOf(visible)
+    }
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelectTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelectTest.kt
@@ -114,6 +114,17 @@ class ExplorerDragSelectTest : BaseTest() {
     }
 
     @Test
+    fun `an unselected draggable item is claimed while another item is selected`() {
+        // Long-pressing an unselected item in selection mode extends the selection, it must never
+        // start the cross-pane drag even though its payload factory would produce a payload.
+        val selected = file("a.jpg")
+        val anchor = file("b.jpg")
+        val state = state(items = listOf(selected, anchor), selected = setOf(selected))
+
+        explorerDragSelectClaims(state, anchor.id, payloadFactory(state)) shouldBe true
+    }
+
+    @Test
     fun `an item the payload factory refuses is still claimed in selection mode`() {
         // Storage volumes and other non-lookup items never produce a payload - without evaluating
         // the factory they would end up owned by neither gesture.

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRendererDragTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRendererDragTest.kt
@@ -14,9 +14,10 @@ import testhelpers.ComposeTest
 
 /**
  * The first long press belongs to drag-select, so it must not start a platform drag; only a long
- * press made while a selection already exists arms one. Whether the press changes the selection is
- * decided by the selection controller, which every item type - storage volumes included - is routed
- * to instead of toggling from the composition's own (stale within the frame) selection state.
+ * press on an already-selected item arms one - pressing an unselected item in selection mode extends
+ * the selection instead. Whether the press changes the selection is decided by the selection
+ * controller, which every item type - storage volumes included - is routed to instead of toggling
+ * from the composition's own (stale within the frame) selection state.
  */
 class ExplorerItemRendererDragTest : ComposeTest() {
 
@@ -29,8 +30,8 @@ class ExplorerItemRendererDragTest : ComposeTest() {
     private var longClicks = 0
 
     @Test
-    fun `long pressing a row arms the drag while a selection exists`() {
-        renderItem(item = file, selectedItems = setOf(otherFile))
+    fun `long pressing an already-selected row arms the drag`() {
+        renderItem(item = file, selectedItems = setOf(file, otherFile))
 
         composeTestRule.onNodeWithText(FILE_NAME).performTouchInput { longClick() }
 
@@ -38,6 +39,21 @@ class ExplorerItemRendererDragTest : ComposeTest() {
         // the untouched selection can't be a silently missed gesture.
         composeTestRule.runOnIdle {
             payloadRequests shouldBe 1
+            longClicks shouldBe 1
+            toggles shouldBe 0
+        }
+    }
+
+    @Test
+    fun `long pressing an unselected row does not arm the drag even while a selection exists`() {
+        renderItem(item = file, selectedItems = setOf(otherFile))
+
+        composeTestRule.onNodeWithText(FILE_NAME).performTouchInput { longClick() }
+
+        // An unselected item in selection mode is claimed by drag-select to extend the selection,
+        // never by the cross-pane drag.
+        composeTestRule.runOnIdle {
+            payloadRequests shouldBe 0
             longClicks shouldBe 1
             toggles shouldBe 0
         }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRendererDragTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRendererDragTest.kt
@@ -13,9 +13,10 @@ import org.junit.Test
 import testhelpers.ComposeTest
 
 /**
- * Once a selection exists the long press belongs to the drag gesture and may no longer change the
- * selection. Rows route the press to the selection controller (guarded there), storage volumes
- * toggle directly from here.
+ * The first long press belongs to drag-select, so it must not start a platform drag; only a long
+ * press made while a selection already exists arms one. Whether the press changes the selection is
+ * decided by the selection controller, which every item type - storage volumes included - is routed
+ * to instead of toggling from the composition's own (stale within the frame) selection state.
  */
 class ExplorerItemRendererDragTest : ComposeTest() {
 
@@ -25,9 +26,10 @@ class ExplorerItemRendererDragTest : ComposeTest() {
 
     private var payloadRequests = 0
     private var toggles = 0
+    private var longClicks = 0
 
     @Test
-    fun `long pressing a row arms the drag without toggling the selection`() {
+    fun `long pressing a row arms the drag while a selection exists`() {
         renderItem(item = file, selectedItems = setOf(otherFile))
 
         composeTestRule.onNodeWithText(FILE_NAME).performTouchInput { longClick() }
@@ -36,26 +38,46 @@ class ExplorerItemRendererDragTest : ComposeTest() {
         // the untouched selection can't be a silently missed gesture.
         composeTestRule.runOnIdle {
             payloadRequests shouldBe 1
+            longClicks shouldBe 1
             toggles shouldBe 0
         }
     }
 
     @Test
-    fun `long pressing a storage volume toggles only while nothing is selected`() {
+    fun `long pressing a row does not arm the drag while nothing is selected`() {
+        renderItem(item = file, selectedItems = emptySet())
+
+        composeTestRule.onNodeWithText(FILE_NAME).performTouchInput { longClick() }
+
+        composeTestRule.runOnIdle {
+            payloadRequests shouldBe 0
+            longClicks shouldBe 1
+            toggles shouldBe 0
+        }
+    }
+
+    @Test
+    fun `long pressing a storage volume goes through the selection controller`() {
         renderItem(item = storage, selectedItems = emptySet())
 
         composeTestRule.onNodeWithText(STORAGE_NAME).performTouchInput { longClick() }
 
-        composeTestRule.runOnIdle { toggles shouldBe 1 }
+        composeTestRule.runOnIdle {
+            longClicks shouldBe 1
+            toggles shouldBe 0
+        }
     }
 
     @Test
-    fun `long pressing a storage volume does nothing while a selection exists`() {
+    fun `long pressing a storage volume while a selection exists changes nothing here either`() {
         renderItem(item = storage, selectedItems = setOf(otherFile))
 
         composeTestRule.onNodeWithText(STORAGE_NAME).performTouchInput { longClick() }
 
-        composeTestRule.runOnIdle { toggles shouldBe 0 }
+        composeTestRule.runOnIdle {
+            longClicks shouldBe 1
+            toggles shouldBe 0
+        }
     }
 
     private fun renderItem(item: ExplorerItem, selectedItems: Set<ExplorerItem>) {
@@ -72,7 +94,7 @@ class ExplorerItemRendererDragTest : ComposeTest() {
                     ),
                     isFocused = false,
                     onItemClick = {},
-                    onItemLongClick = {},
+                    onItemLongClick = { longClicks++ },
                     onNavigate = {},
                     onToggleSelection = { toggles++ },
                     // A null payload keeps the platform drag out of Robolectric, the factory call

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -405,8 +405,14 @@ fun SearcherWorkspacePage(
                                 onSelectionChange = { onPageAction(SearcherPageAction.Results.SetSelection(it)) },
                                 // Every result is draggable - SearcherDragPayloadFactory has no
                                 // per-item null case - so the pane/selection test is exact and no
-                                // press ends up owned by neither gesture.
-                                enabled = { !dragsToOtherPanes || !currentState.selectionState.isSelectionMode },
+                                // press ends up owned by neither gesture. In selection mode an
+                                // unselected item is still claimed by drag-select, only already
+                                // selected items fall through to the cross-pane drag.
+                                enabled = { key ->
+                                    !dragsToOtherPanes ||
+                                        !currentState.selectionState.isSelectionMode ||
+                                        key !in currentState.selectionState.selectedResultIds
+                                },
                             ),
                         verticalArrangement = Arrangement.spacedBy(
                             when (style.density) {
@@ -481,10 +487,12 @@ fun SearcherWorkspacePage(
                                                 }
                                             },
                                             onLongPress = {
-                                                // The first long press belongs to drag-select; the
-                                                // cross-pane drag starts from a long press made
-                                                // while a selection already exists.
-                                                if (currentState.selectionState.isSelectionMode) {
+                                                // The cross-pane drag starts only from an already
+                                                // selected item; long-pressing an unselected item
+                                                // in selection mode extends the selection instead.
+                                                if (currentState.selectionState.isSelectionMode &&
+                                                    item.searchItem.resultKey in currentState.selectionState.selectedResultIds
+                                                ) {
                                                     dragSource?.startDrag()
                                                 }
                                                 wrappedOnEnterSelectionMode(item.searchItem)
@@ -549,7 +557,12 @@ fun SearcherWorkspacePage(
                                 orderedKeys = { currentState.resultKeys() },
                                 currentSelection = { currentState.selectionState.selectedResultIds },
                                 onSelectionChange = { onPageAction(SearcherPageAction.Results.SetSelection(it)) },
-                                enabled = { !dragsToOtherPanes || !currentState.selectionState.isSelectionMode },
+                                enabled = { key ->
+                                    !dragsToOtherPanes ||
+                                        !currentState.selectionState.isSelectionMode ||
+                                        key !in currentState.selectionState.selectedResultIds
+                                },
+                                contentPadding = contentPaddingValues,
                             ),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -607,9 +620,11 @@ fun SearcherWorkspacePage(
                                         }
                                     },
                                     onLongPress = {
-                                        // See the list branch: only a long press with a selection
-                                        // already active arms the cross-pane drag.
-                                        if (currentState.selectionState.isSelectionMode) {
+                                        // See the list branch: only a long press on an already
+                                        // selected item arms the cross-pane drag.
+                                        if (currentState.selectionState.isSelectionMode &&
+                                            item.searchItem.resultKey in currentState.selectionState.selectedResultIds
+                                        ) {
                                             dragSource?.startDrag()
                                         }
                                         wrappedOnEnterSelectionMode(item.searchItem)

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -39,6 +39,8 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.OnValueChange
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.dragselect.gridDragSelect
+import eu.darken.butler.common.compose.dragselect.listDragSelect
 import eu.darken.butler.common.keyboard.KeyboardShortcut
 import eu.darken.butler.common.keyboard.keyboardShortcuts
 import eu.darken.butler.common.navigation.NavigationEventHandler
@@ -395,7 +397,17 @@ fun SearcherWorkspacePage(
                         modifier = Modifier
                             .fillMaxSize()
                             .nestedScroll(topBarStackState.nestedScrollConnection)
-                            .nestedScroll(bottomBarStackState.nestedScrollConnection),
+                            .nestedScroll(bottomBarStackState.nestedScrollConnection)
+                            .listDragSelect(
+                                state = listState,
+                                orderedKeys = { currentState.resultKeys() },
+                                currentSelection = { currentState.selectionState.selectedResultIds },
+                                onSelectionChange = { onPageAction(SearcherPageAction.Results.SetSelection(it)) },
+                                // Every result is draggable - SearcherDragPayloadFactory has no
+                                // per-item null case - so the pane/selection test is exact and no
+                                // press ends up owned by neither gesture.
+                                enabled = { !dragsToOtherPanes || !currentState.selectionState.isSelectionMode },
+                            ),
                         verticalArrangement = Arrangement.spacedBy(
                             when (style.density) {
                                 SearcherViewStyle.List.Density.COMPACT -> 4.dp
@@ -469,7 +481,12 @@ fun SearcherWorkspacePage(
                                                 }
                                             },
                                             onLongPress = {
-                                                dragSource?.startDrag()
+                                                // The first long press belongs to drag-select; the
+                                                // cross-pane drag starts from a long press made
+                                                // while a selection already exists.
+                                                if (currentState.selectionState.isSelectionMode) {
+                                                    dragSource?.startDrag()
+                                                }
                                                 wrappedOnEnterSelectionMode(item.searchItem)
                                             },
                                         )
@@ -526,7 +543,14 @@ fun SearcherWorkspacePage(
                         modifier = Modifier
                             .fillMaxSize()
                             .nestedScroll(topBarStackState.nestedScrollConnection)
-                            .nestedScroll(bottomBarStackState.nestedScrollConnection),
+                            .nestedScroll(bottomBarStackState.nestedScrollConnection)
+                            .gridDragSelect(
+                                state = gridState,
+                                orderedKeys = { currentState.resultKeys() },
+                                currentSelection = { currentState.selectionState.selectedResultIds },
+                                onSelectionChange = { onPageAction(SearcherPageAction.Results.SetSelection(it)) },
+                                enabled = { !dragsToOtherPanes || !currentState.selectionState.isSelectionMode },
+                            ),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = contentPaddingValues
@@ -583,7 +607,11 @@ fun SearcherWorkspacePage(
                                         }
                                     },
                                     onLongPress = {
-                                        dragSource?.startDrag()
+                                        // See the list branch: only a long press with a selection
+                                        // already active arms the cross-pane drag.
+                                        if (currentState.selectionState.isSelectionMode) {
+                                            dragSource?.startDrag()
+                                        }
                                         wrappedOnEnterSelectionMode(item.searchItem)
                                     },
                                     previewsSettled = previewsSettled,
@@ -763,6 +791,14 @@ fun SearcherWorkspacePage(
 
     // Dialogs and sheets live in the page host's overlay slot, see SearcherWorkspaceOverlays
 }
+
+/**
+ * The keys a drag may sweep over, in display order. Errors and placeholder cards are not results
+ * and therefore not selectable; the range simply spans them.
+ */
+private fun SearcherWorkspaceViewModel.State.Ready.resultKeys(): List<String> = listItems
+    .filterIsInstance<SearchListItem.Result>()
+    .map { it.searchItem.resultKey }
 
 @Composable
 fun SearcherWorkspacePageHost(

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
@@ -754,6 +754,11 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
         selectionState.update { it.toggleSelection(result) }
     }
 
+    private fun setSelection(resultIds: Set<String>) {
+        log(TAG) { "Setting selection to ${resultIds.size} results" }
+        selectionState.update { it.setSelection(resultIds) }
+    }
+
     private fun selectAll() {
         log(TAG) { "Selecting all results" }
         selectionState.update { it.selectAll() }
@@ -1357,6 +1362,7 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
             }
             is SearcherPageAction.Results.EnterSelectionMode -> enterSelectionMode(action.item)
             is SearcherPageAction.Results.ToggleSelection -> toggleSelection(action.item)
+            is SearcherPageAction.Results.SetSelection -> setSelection(action.resultIds)
             is SearcherPageAction.Results.ExitSelectionMode -> deselectAll()
             is SearcherPageAction.Results.HideQuickActions -> hideQuickActions()
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherPageAction.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherPageAction.kt
@@ -195,6 +195,11 @@ sealed interface SearcherPageAction {
         data class ToggleSelection(val item: SearchItem) : Results
 
         /**
+         * Replace the selection, e.g. with the range a drag has swept over
+         */
+        data class SetSelection(val resultIds: Set<String>) : Results
+
+        /**
          * Exit selection mode
          */
         data object ExitSelectionMode : Results

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherSelectionState.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherSelectionState.kt
@@ -28,6 +28,9 @@ data class SearcherSelectionState(
         return copy(selectedResultIds = newSelectedIds)
     }
 
+    /** Replaces the selection wholesale; ids of results the current search no longer lists survive. */
+    fun setSelection(ids: Set<String>): SearcherSelectionState = copy(selectedResultIds = ids)
+
     fun selectAll(): SearcherSelectionState {
         return copy(selectedResultIds = selectableResults.map { it.resultKey }.toSet())
     }


### PR DESCRIPTION
## What changed

Adds long-press-and-drag multi-selection to the file, search, apps, and app-component lists and grids: press and hold an item, then keep your finger down and drag over more items to select a range (like Google Photos). Dragging to the top or bottom edge auto-scrolls the list. While a selection is active, dragging over an unselected item adds it to the selection; the existing cross-pane drag to copy/move now starts from an already-selected item.

Also adds two drag-and-drop improvements: you can drop items onto the Trash view to move them to trash (with a confirmation dialog, recoverable), and dropping items onto another pane now focuses that pane so the copy/move/trash dialog can be confirmed with a single tap instead of two.

## Technical Context

- New reusable `Modifier.listDragSelect`/`gridDragSelect` in app-common: a custom claim-before-consume long-press-drag detector (avoids `detectDragGesturesAfterLongPress`, which consumes movement even when the gesture is declined and would break scrolling/DnD), key-based range selection re-resolved against live ordering on each update, and frame-delta edge auto-scroll bounded at the content edge.
- Grid hit-testing subtracts the leading horizontal content padding, which `LazyGridLayoutInfo` does not expose (affected presses in the last grid column; caught in review).
- Apps selection mutations run through a single sequential actor with an atomic engine-level toggle, fixing ordering and stale-read races that rapid drag updates exposed.
- Trash drop reuses the existing move-to-trash (`Delete(forcePermDelete=false)`) and re-lists the trash view explicitly, because the Trash root is a virtual location that `BrowsingEngine`'s incremental filesystem updates (keyed on parent == current path) do not cover.
- Closest review attention: the gesture arbitration between drag-select and cross-pane DnD (`ExplorerItemRenderer` / `SearcherWorkspacePage` long-click gating plus `explorerDragSelectClaims`), and the drop-to-trash validator (`ExplorerDropValidator.validateTrashDrop`).
