### PR TITLE
Explorer: Fix pasted snippet overwriting an existing file

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperation.kt
@@ -91,14 +91,18 @@ class CreateTextFileOperation @AssistedInject constructor(
 
             result as CreateAction.State.Completed<*, *>
 
-            // Write content to the file
-            log(tag) { "Writing ${command.content.length} characters to file" }
-            gatewaySwitch.openOutputStream(command.path, append = false).use { outputStream ->
+            // A rename resolution for a name conflict moves the file we created, writing to
+            // command.path would truncate the very file the rename was meant to preserve.
+            val createdPath = (result.created as APathLookup<*>).lookedUp
+
+            log(tag) { "Writing ${command.content.length} characters to $createdPath" }
+            gatewaySwitch.openOutputStream(createdPath, append = false).use { outputStream ->
                 outputStream.write(command.content.toByteArray(Charsets.UTF_8))
             }
 
-            // Lookup the created file for tracking
-            val lookup = gatewaySwitch.lookup(command.path, LookupOptions())
+            // Re-lookup, result.created predates the content. BASE so the item enters the listing
+            // with a size instead of showing "?" until the next refresh.
+            val lookup = gatewaySwitch.lookup(createdPath, LookupOptions.BASE)
 
             // Track filesystem changes
             @Suppress("UNCHECKED_CAST")

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -1718,7 +1718,11 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
                 if (completed.error == null) {
                     log(tag, INFO) { "Created text file: $filename with ${clip.content.length} characters" }
-                    revealItems(listOf(filePath))
+                    // Resolving a name conflict by renaming lands the file somewhere other than filePath.
+                    val createdPath = completed.report?.affectedPaths
+                        ?.firstOrNull { it.change == Operation.Report.PathChange.Change.ADDED }
+                        ?.path
+                    revealItems(listOfNotNull(createdPath))
                     clipboardRepo.remove(clip.id)
                 }
             } catch (e: Exception) {

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
@@ -1,0 +1,145 @@
+package eu.darken.butler.explorer.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.actions.CreateAction
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemEvent
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.ByteArrayOutputStream
+import kotlin.time.Instant
+
+class CreateTextFileOperationTest : BaseTest() {
+
+    private val directory = LocalPath.build("/test/dir")
+    private val requestedPath = directory.child("snippet.txt")
+    private val renamedPath = directory.child("snippet-2.txt")
+    private val content = "Hello World!"
+
+    private fun lookupOf(path: APath<*>, size: Long?) = LocalPathLookup(
+        lookedUp = path as LocalPath,
+        fileType = FileType.FILE,
+        size = size,
+        modifiedAt = Instant.DISTANT_PAST,
+    )
+
+    /**
+     * @param createdAs where [CreateAction] says the file actually landed, which is not the
+     * requested path once the user resolves a name conflict by renaming.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun setup(
+        gatewaySwitch: GatewaySwitch,
+        createdAs: APath<*>,
+        writtenTo: MutableList<APath<*>>,
+        sink: ByteArrayOutputStream,
+        lookupOptions: MutableList<LookupOptions>,
+    ) {
+        coEvery { gatewaySwitch.useRes(any<suspend (Any) -> Any?>()) } coAnswers {
+            firstArg<suspend (Any) -> Any?>().invoke(gatewaySwitch)
+        }
+        coEvery { gatewaySwitch.create(any(), any(), any()) } returns flowOf(
+            CreateAction.State.Completed(lookupOf(createdAs, size = 0L) as APathLookup<APath<*>>)
+        )
+        val writeTarget = slot<APath<*>>()
+        coEvery { gatewaySwitch.openOutputStream(capture(writeTarget), any()) } answers {
+            writtenTo.add(writeTarget.captured)
+            sink
+        }
+        val options = slot<LookupOptions>()
+        coEvery { gatewaySwitch.lookup(any(), capture(options)) } answers {
+            lookupOptions.add(options.captured)
+            lookupOf(firstArg(), size = sink.size().toLong()) as APathLookup<APath<*>>
+        }
+    }
+
+    private fun operation(gatewaySwitch: GatewaySwitch, hinter: FileSystemHinter) = CreateTextFileOperation(
+        workspaceId = Workspace.Id(),
+        command = ExplorerCommand.CreateTextFile(path = requestedPath, content = content),
+        issueHandler = mockk<IssueHandler>(),
+        gatewaySwitch = gatewaySwitch,
+        fileSystemHinter = hinter,
+    )
+
+    @Test
+    fun `the created file is reported with a size, not an unknown one`(): Unit = runTest {
+        val hinter = FileSystemHinter()
+        val events = mutableListOf<FileSystemEvent>()
+        hinter.events.onEach { events.add(it) }.launchIn(backgroundScope)
+        runCurrent()
+
+        val gatewaySwitch = mockk<GatewaySwitch>()
+        val writtenTo = mutableListOf<APath<*>>()
+        val lookupOptions = mutableListOf<LookupOptions>()
+        val sink = ByteArrayOutputStream()
+        setup(gatewaySwitch, createdAs = requestedPath, writtenTo, sink, lookupOptions)
+
+        val completed = operation(gatewaySwitch, hinter)
+            .perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
+            .last() as ExplorerOperation.State.Completed
+        runCurrent()
+
+        completed.error shouldBe null
+        writtenTo shouldBe listOf(requestedPath)
+        sink.toString(Charsets.UTF_8.name()) shouldBe content
+
+        // The lookup that feeds the listing has to carry the size, or the row renders "?" until
+        // the directory is re-entered.
+        lookupOptions.last().fetchSize shouldBe true
+        val added = events.single().shouldBeInstanceOf<FileSystemEvent.Added>().paths.single()
+        added.lookedUp shouldBe requestedPath
+        added.size shouldNotBe null
+    }
+
+    @Test
+    fun `renaming past a name conflict writes to the new file, not the existing one`(): Unit = runTest {
+        val hinter = FileSystemHinter()
+        val events = mutableListOf<FileSystemEvent>()
+        hinter.events.onEach { events.add(it) }.launchIn(backgroundScope)
+        runCurrent()
+
+        val gatewaySwitch = mockk<GatewaySwitch>()
+        val writtenTo = mutableListOf<APath<*>>()
+        val lookupOptions = mutableListOf<LookupOptions>()
+        val sink = ByteArrayOutputStream()
+        setup(gatewaySwitch, createdAs = renamedPath, writtenTo, sink, lookupOptions)
+
+        val completed = operation(gatewaySwitch, hinter)
+            .perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
+            .last() as ExplorerOperation.State.Completed
+        runCurrent()
+
+        completed.error shouldBe null
+        // Writing to the requested path would truncate the file the rename was meant to preserve.
+        writtenTo shouldBe listOf(renamedPath)
+        sink.toString(Charsets.UTF_8.name()) shouldBe content
+
+        // Reporting the requested path leaves the renamed file out of the listing until a refresh.
+        completed.report.affectedPaths.single().let {
+            it.path shouldBe renamedPath
+            it.change shouldBe Operation.Report.PathChange.Change.ADDED
+        }
+        events.single().shouldBeInstanceOf<FileSystemEvent.Added>().paths.single().lookedUp shouldBe renamedPath
+    }
+}


### PR DESCRIPTION
## What changed

Pasting a text snippet from the clipboard into a directory that already holds a file of the same name, then resolving the conflict by picking a different name, wrote the snippet over the existing file instead of into the new one. The existing file's contents were destroyed, the newly named file was left empty, and it stayed out of the listing until the directory was refreshed.

Snippets pasted without a name conflict showed "?" instead of their size until the directory was re-entered.

## Technical Context

- Root cause of the overwrite: `GenericPathCreate` resolves a `RenameSource` conflict by advancing its own internal target, and returns where the file actually landed in `CreateAction.State.Completed.created`. `CreateTextFileOperation` discarded that result and kept using `command.path`, so `openOutputStream(append = false)` (which is `TRUNCATE_EXISTING`) hit the pre-existing file, and the hint, report and reveal all named the wrong path. `CreateOperation` already consumed `result.created` correctly; this operation was the only deviation.
- Root cause of the "?": the tracking lookup used a bare `LookupOptions()`. Every fetch flag on that class defaults to false, so the lookup handed to `FileSystemHinter` carried a null size and the row rendered `?`. The re-lookup now uses `LookupOptions.BASE` and runs *after* the content is written, because `result.created` is captured before the bytes exist and would report 0.
- `LookupOptions`' KDoc claims "Basic metadata (fileType, size, modifiedAt) is always fetched (cheap)", which is not true of the defaults. Left alone here to keep the diff scoped; other callers affected by the same trap are being fixed separately.
- Worth a close look: `CreateTextFileOperationTest` drives the operation with a mocked `GatewaySwitch` whose `create` reports a path different from the requested one, which is how the rename case is exercised without a real filesystem. Both tests were confirmed to fail against the pre-fix code before being committed.
