### PR TITLE
General: Fix the test report workflow looking for artifacts that are never built

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -16,78 +16,19 @@ jobs:
   report:
     runs-on: ubuntu-22.04
     if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        # Must match the artifacts uploaded by the test-modules matrix in code-checks.yml
+        variant: [ Debug ]
+        flavor: [ test,testFoss,testGplay ]
     steps:
-      - name: Test Report - FOSS Debug
+      - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0
         if: always()
         with:
-          name: 'Unit Tests - testFoss Debug'
-          artifact: test-results-testFoss-Debug
-          path: '**/*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          list-suites: 'failed'
-          list-tests: 'failed'
-          max-annotations: 10
-
-      - name: Test Report - FOSS Beta
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0
-        if: always()
-        with:
-          name: 'Unit Tests - testFoss Beta'
-          artifact: test-results-testFoss-Beta
-          path: '**/*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          list-suites: 'failed'
-          list-tests: 'failed'
-          max-annotations: 10
-
-      - name: Test Report - FOSS Release
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0
-        if: always()
-        with:
-          name: 'Unit Tests - testFoss Release'
-          artifact: test-results-testFoss-Release
-          path: '**/*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          list-suites: 'failed'
-          list-tests: 'failed'
-          max-annotations: 10
-
-      - name: Test Report - GPlay Debug
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0
-        if: always()
-        with:
-          name: 'Unit Tests - testGplay Debug'
-          artifact: test-results-testGplay-Debug
-          path: '**/*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          list-suites: 'failed'
-          list-tests: 'failed'
-          max-annotations: 10
-
-      - name: Test Report - GPlay Beta
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0
-        if: always()
-        with:
-          name: 'Unit Tests - testGplay Beta'
-          artifact: test-results-testGplay-Beta
-          path: '**/*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          list-suites: 'failed'
-          list-tests: 'failed'
-          max-annotations: 10
-
-      - name: Test Report - GPlay Release
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0
-        if: always()
-        with:
-          name: 'Unit Tests - testGplay Release'
-          artifact: test-results-testGplay-Release
+          name: 'Unit Tests - ${{ matrix.flavor }} ${{ matrix.variant }}'
+          artifact: test-results-${{ matrix.flavor }}-${{ matrix.variant }}
           path: '**/*.xml'
           reporter: java-junit
           fail-on-error: false


### PR DESCRIPTION
## What changed

No user-facing behavior change. The "Test Reports" CI workflow now finds the unit test result artifacts it is supposed to publish, so test reports appear again instead of the workflow failing on every push.

## Technical Context

- Root cause: the workflow had six hardcoded `dorny/test-reporter` steps for `test-results-{testFoss,testGplay}-{Debug,Beta,Release}`, but the producing `test-modules` matrix in `code-checks.yml` only builds `variant: [Debug]` across `flavor: [test,testFoss,testGplay]`. Four of the six artifacts have never existed, and `fail-on-empty` defaults to true, so the workflow failed even on fully green runs.
- There was no reporter step for `test-results-test-Debug` at all, which is the artifact carrying the module tests (`:app-common-shell`, `:app-common-io`, ...). That is why the recent `FlowCmdShellTest` failure on main produced no report.
- The fix mirrors the producer's matrix rather than listing names, so the artifact name is built from the same `test-results-<flavor>-<variant>` expression on both sides. A future change to the producer matrix still has to be mirrored here; the comment flags it but nothing enforces it.
- `fail-on-empty` stays at its default so genuine producer/consumer drift keeps failing loudly. Runs where the producer never started (for example the recent GitHub spending-limit blocks) upload no artifacts and will still fail this workflow.