### PR TITLE
General: Move releases onto a dispatched workflow and harden tagged releases

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,378 @@
+name: Release prepare
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_kind:
+        description: 'How to bump the version (ignored if version_override is set)'
+        type: choice
+        options: [build, patch, minor, major]
+        default: build
+      version_type:
+        description: 'Channel for the new version (keep-current preserves current type)'
+        type: choice
+        options: [keep-current, rc, beta]
+        default: keep-current
+      version_override:
+        description: 'Explicit version, e.g. 1.8.0-rc0 (overrides bump_kind/version_type)'
+        type: string
+        default: ''
+      expected_current:
+        description: 'Safety check: fail if current version does not match (e.g. 1.7.1-rc0)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'When true: compute and validate only. When false: commit, tag, push.'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-prepare-main
+  cancel-in-progress: false
+
+jobs:
+  compute-and-validate:
+    name: Compute and validate
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      checks: read
+    outputs:
+      new_name: ${{ steps.plan.outputs.new_name }}
+      new_code: ${{ steps.plan.outputs.new_code }}
+      current_name: ${{ steps.plan.outputs.current_name }}
+      validated_sha: ${{ steps.validated.outputs.sha }}
+    env:
+      INPUT_BUMP_KIND: ${{ inputs.bump_kind }}
+      INPUT_VERSION_TYPE: ${{ inputs.version_type }}
+      INPUT_VERSION_OVERRIDE: ${{ inputs.version_override }}
+      INPUT_EXPECTED_CURRENT: ${{ inputs.expected_current }}
+    steps:
+      - name: Guard ref must be main
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Must dispatch from main, got ${GITHUB_REF}"
+            exit 1
+          fi
+
+      - name: Record validated commit
+        id: validated
+        run: |
+          set -euo pipefail
+          echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Validating and releasing commit ${GITHUB_SHA}"
+
+      - name: Pre-flight main health check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POLL_ATTEMPTS: "20"
+          POLL_INTERVAL_SECONDS: "30"
+        run: |
+          set -euo pipefail
+          REPO="${GITHUB_REPOSITORY}"
+          SHA="${GITHUB_SHA}"
+
+          # Fetch required check contexts from the main branch ruleset. A failure to
+          # read the ruleset is fatal: treating it as "no required checks" would let a
+          # transient API error authorize a release off an unvalidated main.
+          if ! RULES=$(gh api "/repos/${REPO}/rules/branches/main"); then
+            echo "::error::Could not read the branch ruleset for ${REPO}. Refusing to release without a health gate."
+            exit 1
+          fi
+
+          REQUIRED=$(echo "$RULES" \
+            | jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[] | .context] | unique')
+
+          if [[ "$REQUIRED" == "[]" || -z "$REQUIRED" ]]; then
+            echo "::error::The main branch ruleset declares no required status checks. Refusing to release without a health gate."
+            exit 1
+          fi
+
+          # GitHub check-run names are job names, not workflow names. Ignore this
+          # release workflow's own jobs so a manual release run cannot gate itself.
+          RELEASE_WORKFLOW_CHECKS='["Compute and validate","Push and dispatch"]'
+          IGNORED_REQUIRED=$(echo "$REQUIRED" | jq --argjson ignored "$RELEASE_WORKFLOW_CHECKS" \
+            '[.[] | select(. as $name | ($ignored | index($name)))]')
+          if [[ "$IGNORED_REQUIRED" != "[]" ]]; then
+            echo "Ignoring Release prepare self-checks: $(echo "$IGNORED_REQUIRED" | jq -r 'join(", ")')"
+          fi
+          REQUIRED=$(echo "$REQUIRED" | jq --argjson ignored "$RELEASE_WORKFLOW_CHECKS" \
+            'map(select(. as $name | ($ignored | index($name) | not)))')
+
+          if [[ "$REQUIRED" == "[]" || -z "$REQUIRED" ]]; then
+            echo "::error::Every required check is a Release prepare self-check. Refusing to release without an external health gate."
+            exit 1
+          fi
+
+          echo "Required checks: $(echo "$REQUIRED" | jq -r 'join(", ")')"
+
+          # Only these conclusions count as "this check is content with the commit".
+          # Anything else - failure, cancelled, timed_out, action_required,
+          # startup_failure, stale - blocks the release.
+          PASSING_CONCLUSIONS='["success","neutral","skipped"]'
+
+          attempt=1
+          while true; do
+            RUNS=$(gh api "/repos/${REPO}/commits/${SHA}/check-runs?per_page=100" \
+              --jq '.check_runs | group_by(.name) | map(sort_by(.started_at) | last | {name: .name, status: .status, conclusion: (.conclusion // "pending")})')
+
+            FAILED=()
+            PENDING=()
+
+            while IFS= read -r check_name; do
+              result=$(echo "$RUNS" | jq -r --arg name "$check_name" \
+                'map(select(.name == $name)) | if length == 0 then "not_found" else last | "\(.status)|\(.conclusion)" end')
+
+              if [[ "$result" == "not_found" ]]; then
+                PENDING+=("$check_name (not yet started)")
+                continue
+              fi
+
+              IFS='|' read -r status conclusion <<< "$result"
+
+              if [[ "$status" != "completed" ]]; then
+                PENDING+=("$check_name ($status)")
+              elif ! echo "$PASSING_CONCLUSIONS" | jq -e --arg c "$conclusion" 'index($c)' >/dev/null; then
+                FAILED+=("$check_name: $conclusion")
+              fi
+            done < <(echo "$REQUIRED" | jq -r '.[]')
+
+            # A definitive failure will not improve by waiting.
+            if [[ ${#FAILED[@]} -gt 0 ]]; then
+              for item in "${FAILED[@]}"; do
+                echo "::error::Required check failed on main: $item"
+              done
+              echo ""
+              echo "Fix the failing checks on main before dispatching a release."
+              exit 1
+            fi
+
+            if [[ ${#PENDING[@]} -eq 0 ]]; then
+              break
+            fi
+
+            if [[ "$attempt" -ge "$POLL_ATTEMPTS" ]]; then
+              {
+                echo "### Required checks never settled"
+                echo ""
+                for item in "${PENDING[@]}"; do
+                  echo "- $item"
+                done
+              } >> "${GITHUB_STEP_SUMMARY}"
+              for item in "${PENDING[@]}"; do
+                echo "::error::Required check still unfinished after waiting: $item"
+              done
+              echo ""
+              echo "Wait for CI on main to finish, then dispatch the release again."
+              exit 1
+            fi
+
+            echo "Waiting on ${#PENDING[@]} unfinished required check(s), attempt ${attempt}/${POLL_ATTEMPTS}:"
+            for item in "${PENDING[@]}"; do
+              echo "  - $item"
+            done
+            attempt=$((attempt + 1))
+            sleep "${POLL_INTERVAL_SECONDS}"
+          done
+
+          echo "Pre-flight OK: every required check passed on ${SHA}."
+
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute and validate
+        id: plan
+        run: |
+          set -euo pipefail
+          args=("--mode=plan")
+          if [[ -n "${INPUT_VERSION_OVERRIDE}" ]]; then
+            args+=("--version-override=${INPUT_VERSION_OVERRIDE}")
+          else
+            args+=("--bump-kind=${INPUT_BUMP_KIND}")
+            args+=("--version-type=${INPUT_VERSION_TYPE}")
+          fi
+          if [[ -n "${INPUT_EXPECTED_CURRENT}" ]]; then
+            args+=("--expected-current=${INPUT_EXPECTED_CURRENT}")
+          fi
+          ./tools/release/bump.sh "${args[@]}" | tee plan.txt
+          {
+            grep -E '^current_name=' plan.txt
+            grep -E '^new_name=' plan.txt
+            grep -E '^new_code=' plan.txt
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Tag collision check (local + remote)
+        env:
+          NEW_NAME: ${{ steps.plan.outputs.new_name }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify "refs/tags/v${NEW_NAME}" >/dev/null 2>&1; then
+            echo "::error::Local tag v${NEW_NAME} already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${NEW_NAME}" >/dev/null; then
+            echo "::error::Remote tag v${NEW_NAME} already exists"
+            exit 1
+          fi
+
+      - name: Write step summary
+        env:
+          CURRENT_NAME: ${{ steps.plan.outputs.current_name }}
+          NEW_NAME: ${{ steps.plan.outputs.new_name }}
+          NEW_CODE: ${{ steps.plan.outputs.new_code }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Release plan"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Current | \`${CURRENT_NAME}\` |"
+            echo "| New | \`${NEW_NAME}\` (code ${NEW_CODE}) |"
+            echo "| Tag | \`v${NEW_NAME}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
+            echo ""
+            echo "### bump.sh output"
+            echo ""
+            echo '```'
+            cat plan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  push-and-dispatch:
+    name: Push and dispatch
+    needs: compute-and-validate
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    env:
+      INPUT_BUMP_KIND: ${{ inputs.bump_kind }}
+      INPUT_VERSION_TYPE: ${{ inputs.version_type }}
+      INPUT_VERSION_OVERRIDE: ${{ inputs.version_override }}
+      NEW_NAME: ${{ needs.compute-and-validate.outputs.new_name }}
+      NEW_CODE: ${{ needs.compute-and-validate.outputs.new_code }}
+      CURRENT_NAME_AT_PLAN: ${{ needs.compute-and-validate.outputs.current_name }}
+      VALIDATED_SHA: ${{ needs.compute-and-validate.outputs.validated_sha }}
+    steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 #v3.1.1
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve bot identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          user_id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          echo "user_name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+          echo "user_email=${user_id}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout validated commit with credentials
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          ref: ${{ needs.compute-and-validate.outputs.validated_sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Verify main still points at the validated commit
+        run: |
+          set -euo pipefail
+          if [[ -z "${VALIDATED_SHA}" ]]; then
+            echo "::error::No validated SHA was handed over from the validation job"
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD)" != "${VALIDATED_SHA}" ]]; then
+            echo "::error::Checked-out HEAD is not the validated commit ${VALIDATED_SHA}"
+            exit 1
+          fi
+          git fetch --quiet origin main
+          remote_sha=$(git rev-parse refs/remotes/origin/main)
+          if [[ "${remote_sha}" != "${VALIDATED_SHA}" ]]; then
+            echo "::error::main moved from ${VALIDATED_SHA} to ${remote_sha} after validation."
+            echo "The new commit has not been through the pre-flight gate. Re-run the release."
+            exit 1
+          fi
+
+      - name: Verify state still matches plan from Job 1
+        run: |
+          set -euo pipefail
+          ./tools/release/bump.sh --mode=check --expected-current="${CURRENT_NAME_AT_PLAN}"
+
+      - name: Re-check tag collision (state may have moved between jobs)
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify "refs/tags/v${NEW_NAME}" >/dev/null 2>&1; then
+            echo "::error::Tag v${NEW_NAME} now exists (state moved between jobs)"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${NEW_NAME}" >/dev/null; then
+            echo "::error::Remote tag v${NEW_NAME} now exists (state moved between jobs)"
+            exit 1
+          fi
+
+      - name: Apply bump
+        run: |
+          set -euo pipefail
+          args=("--mode=write" "--expected-current=${CURRENT_NAME_AT_PLAN}")
+          if [[ -n "${INPUT_VERSION_OVERRIDE}" ]]; then
+            args+=("--version-override=${INPUT_VERSION_OVERRIDE}")
+          else
+            args+=("--bump-kind=${INPUT_BUMP_KIND}")
+            args+=("--version-type=${INPUT_VERSION_TYPE}")
+          fi
+          ./tools/release/bump.sh "${args[@]}"
+
+      - name: Verify post-write state
+        run: |
+          set -euo pipefail
+          ./tools/release/bump.sh --mode=check --expected-current="${NEW_NAME}"
+
+      - name: Configure git identity
+        env:
+          BOT_USER_NAME: ${{ steps.bot.outputs.user_name }}
+          BOT_USER_EMAIL: ${{ steps.bot.outputs.user_email }}
+        run: |
+          git config user.name "${BOT_USER_NAME}"
+          git config user.email "${BOT_USER_EMAIL}"
+
+      - name: Commit and tag
+        run: |
+          set -euo pipefail
+          git add version.properties VERSION
+          git commit -m "Release: ${NEW_NAME}"
+          git tag -a "v${NEW_NAME}" -m "Release v${NEW_NAME}"
+
+      - name: Atomic push (commit + tag)
+        run: |
+          set -euo pipefail
+          git push --atomic origin "HEAD:refs/heads/main" "refs/tags/v${NEW_NAME}"
+
+      - name: Write step summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Released"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Tag | \`v${NEW_NAME}\` |"
+            echo "| Version code | \`${NEW_CODE}\` |"
+            echo "| Bump commit | on \`main\` |"
+            echo ""
+            echo "The App-token push triggers [Tagged releases](../../actions/workflows/release-tag.yml) automatically."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,22 +7,74 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Build only, skip release/upload'
+        description: 'Dry run (build only, no release/upload)'
         type: boolean
         default: true
 
 permissions:
   contents: read
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
+  validate-tag:
+    name: Validate tag
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+      - name: Validate tag against version files
+        run: bash tools/release/bump.sh --mode=check --expected-tag="${{ github.ref_name }}"
+
   release-github:
     name: Create GitHub release
+    needs: validate-tag
+    if: always() && (needs.validate-tag.result == 'success' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: write
       actions: write
     runs-on: ubuntu-22.04
     environment: foss-production
     steps:
+      - name: Guard against publishing from a non-tag ref
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run) && !startsWith(github.ref, 'refs/tags/v')"
+        run: |
+          echo "Refusing to build/publish a release from non-tag ref: ${{ github.ref }}" >&2
+          echo "Non-dry runs must target a 'v*' tag; immutable releases cannot be undone." >&2
+          exit 1
+
+      # Make reruns safe under immutable releases: if a published release with the
+      # APK already exists, skip build+release so the rerun is green. A stale draft
+      # from a prior failed run is deleted so notes/assets aren't duplicated. A
+      # published-but-empty release is immutable and unrepairable — fail loudly.
+      - name: Reconcile existing release
+        id: existing_release
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          published=false
+          if json=$(gh release view "${{ github.ref_name }}" \
+              --repo "${{ github.repository }}" \
+              --json isDraft,assets 2>/dev/null); then
+            if echo "$json" | jq -e '.isDraft == false and ([.assets[].name | select(endswith(".apk"))] | length > 0)' >/dev/null; then
+              published=true
+              echo "Release ${{ github.ref_name }} already published with an APK asset; skipping build and release." >&2
+            elif echo "$json" | jq -e '.isDraft == true' >/dev/null; then
+              echo "Removing stale draft release ${{ github.ref_name }} from a prior failed run." >&2
+              gh release delete "${{ github.ref_name }}" --repo "${{ github.repository }}" --yes || true
+            else
+              echo "::error::Release ${{ github.ref_name }} is published but has no APK asset and is immutable. It cannot be repaired — cut a new tag." >&2
+              exit 1
+            fi
+          fi
+          echo "published=$published" >> "$GITHUB_OUTPUT"
+
       - name: Decode Keystore
         env:
           ENCODED_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
@@ -43,7 +95,7 @@ jobs:
         uses: ./.github/actions/common-setup
 
       - name: Assemble beta APK
-        if: contains(github.ref_name, '-beta')
+        if: "contains(github.ref_name, '-beta') && steps.existing_release.outputs.published != 'true'"
         run: ./gradlew assembleFossBeta
         env:
           VERSION: ${{ github.ref }}
@@ -52,7 +104,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Assemble production APK
-        if: "!contains(github.ref_name, '-beta')"
+        if: "!contains(github.ref_name, '-beta') && steps.existing_release.outputs.published != 'true'"
         run: ./gradlew assembleFossRelease
         env:
           VERSION: ${{ github.ref }}
@@ -60,29 +112,47 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
-      - name: Create pre-release
-        if: contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
+      # Immutable releases become read-only the moment they are published, so assets
+      # must be attached while the release is still a draft. Create as draft here, then
+      # publish in the "Publish GitHub release" step once the APK is uploaded.
+      - name: Create pre-release (draft)
+        if: "contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.existing_release.outputs.published != 'true'"
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 #v3.0.2
         with:
+          draft: true
           prerelease: true
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/beta/*.apk
+          fail_on_unmatched_files: true
+          files: app/build/outputs/apk/foss/beta/eu.darken.butler-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create release
-        if: "!contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
+      - name: Create release (draft)
+        if: "!contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.existing_release.outputs.published != 'true'"
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 #v3.0.2
         with:
+          draft: true
           prerelease: false
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/release/*.apk
+          fail_on_unmatched_files: true
+          files: app/build/outputs/apk/foss/release/eu.darken.butler-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish GitHub release
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.existing_release.outputs.published != 'true'"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.ref_name }}" == *-beta* ]]; then
+            gh release edit "${{ github.ref_name }}" --draft=false --prerelease
+          else
+            gh release edit "${{ github.ref_name }}" --draft=false --latest
+          fi
 
       - name: Trigger GitHub Pages deployment
         if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
@@ -92,6 +162,8 @@ jobs:
 
   release-gplay:
     name: Create Google Play release
+    needs: validate-tag
+    if: always() && (needs.validate-tag.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     environment: gplay-production
     env:
@@ -137,7 +209,7 @@ jobs:
         run: bundle exec fastlane --version
 
       - name: Assemble beta and upload to Google Play
-        if: contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        if: "contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
         run: bundle exec fastlane beta
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}


### PR DESCRIPTION
## What changed

Butler releases are now cut by dispatching a workflow instead of running a script by hand. You pick a bump kind (or an explicit version) and whether it is a dry run; the workflow works out the new version, commits the bump, and pushes it together with the `v*` tag, which starts the existing tagged-release build.

It refuses to release from a main that is not demonstrably green, and it will not release a commit other than the one it checked.

Three defects in the tagged-release workflow are fixed at the same time. Dispatching it from `main` with dry run turned off previously built the production APK, created a release named `main`, and uploaded to Play production, because every "is this a beta" test looks at the ref name. A pushed tag was never checked against the committed version number. And because published releases are immutable, a run that failed partway left a release that could neither be repaired nor cleanly re-run.

## Technical Context

- `release-prepare.yml` is ported from sdmaid-se, including the fail-closed pre-flight and commit pinning added there in d4rken-org/sdmaid-se#2716. The pre-flight reads required contexts from the branch ruleset, so it only works because the Main ruleset now exists on this repo; with no ruleset it fails closed rather than releasing blind.
- The App token is not a convenience. `GITHUB_TOKEN` pushes do not trigger workflows, so a tag pushed with it would never start `release-tag.yml`. It is also the actor that the branch and tag rulesets grant bypass to.
- Draft-then-publish in `release-tag.yml` is the part worth close review. Immutable releases are read-only from the moment they are published, so assets have to be attached while the release is still a draft. The reconcile step ahead of it decides between three states: complete release (skip), stale draft (delete and rebuild), published-but-empty (fail, since it cannot be repaired).
- Asset globs are `eu.darken.butler-*.apk`, matching the `androidComponents { onVariants { ... outputFileName } }` rename in `app/build.gradle.kts` (`{packageName}-v{versionName}-{versionCode}-{FLAVOR-BUILDTYPE}.apk`). Paired with `fail_on_unmatched_files: true` so a future rename fails the release rather than publishing an empty one.
- Deliberately not downgraded: `ruby/setup-ruby` stays at Butler's v1.316.0 rather than sdmaid-se's v1.292.0, and `actions/checkout` is pinned to Butler's v7.0.0 throughout.
- `GPLAY_SERVICE_ACCOUNT_KEY_JSON_BASE64` is referenced by the Play job but is not present in this repo's secrets or in any of its three environments, so it has to resolve at org level for a Play upload to work. Same for `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY`, which the new workflow needs.