### PR TITLE
General: Add a security page and clean up the website navigation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+---
+layout: plain
+permalink: /security
+title: "Security"
+---
+
+# Security
+
+## Verifying APK authenticity
+
+You can verify a downloaded or installed APK against the fingerprints below using
+[`apksigner`](https://developer.android.com/tools/apksigner) or
+[AppVerifier](https://github.com/soupslurpr/AppVerifier):
+
+```bash
+apksigner verify --print-certs eu.darken.butler-*.apk
+```
+
+### FOSS build (GitHub Releases)
+
+```
+SHA-256: D6:CC:28:FA:61:EF:3E:6D:C3:2E:2B:62:92:8B:C4:54:26:10:B7:36:9A:EF:EF:A5:DE:1C:30:56:28:65:63:70
+SHA-1:   0E:68:0E:B2:55:F8:9C:3F:53:54:6D:49:34:5C:C2:B1:A4:82:5E:CE
+MD5:     62:22:0A:6D:77:B4:DF:89:D1:5E:7A:35:73:C3:4C:0A
+```

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,11 @@ title: "Butler"
 description: "The file explorer for Android."
 author: "by Matthias Urhahn"
 
+header_pages:
+  - CHANGELOG.md
+  - PRIVACY_POLICY.md
+  - SECURITY.md
+
 include:
   - PRIVACY_POLICY.md
 exclude:
@@ -28,5 +33,6 @@ exclude:
   - app-common-io
   - app-common-adb
   - motd
+  - docs
   - tooling
   - CONTRIBUTING.md


### PR DESCRIPTION
## What changed

The website now has a Security page at `/security` listing the signing fingerprints for the FOSS build, so anyone downloading an APK from GitHub releases can verify it with `apksigner` or AppVerifier before installing.

The site navigation is also fixed. It was showing an internal development note, "Editor input architecture — refactor", alongside Changelog and Privacy Policy. That page is no longer published, and the navigation is now Changelog, Privacy Policy, Security.

## Technical Context

- GitHub Pages enables `jekyll-optional-front-matter` and `jekyll-titles-from-headings` by default, so `docs/editor-input-architecture-refactor.md` became a page despite having no front matter, and its first heading became its title. Minima lists every page that has a title, which is how it reached the navigation bar. Excluding `docs` removes the page entirely rather than just hiding it from the nav.
- `header_pages` is set explicitly so the nav can't pick up stray markdown again, and so the order is deterministic instead of depending on path sorting.
- `SECURITY.md` follows the SD Maid SE page, but adds front matter with `permalink: /security` and `layout: plain` to match the existing `/changelog` and `/privacy` pages. SD Maid SE's equivalent serves at `/SECURITY.html`.
- No Google Play fingerprints yet. Play re-signs uploads with its own app signing key, so the local `production-gplay-upload` keystore is not what installed APKs carry, and the real value is only available from the Play Console. Verified against SD Maid SE, where the published Play fingerprint matches no local keystore while its published FOSS fingerprint matches `production-foss` exactly.
- The custom domain was configured separately in the repository's Pages settings. `butler.darken.eu` is already serving over HTTPS; the committed `CNAME` file is not what sets it, because workflow-built Pages sites ignore that file.