### PR TITLE
Editor: Fix a flaky workspace lifecycle test

### DIFF
--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceLifecycleTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceLifecycleTest.kt
@@ -224,8 +224,8 @@ class EditorWorkspaceLifecycleTest : BaseTest() {
         )
         try {
             workspace.awaitFile("doc.txt")
-
-            workspace.info.value.isPausable shouldBe true
+            // The content-source collector runs asynchronously, so wait for it to have seen the file
+            withTimeout(10_000) { workspace.info.first { it.isPausable } }
         } finally {
             workspace.release()
         }


### PR DESCRIPTION
## What changed

No user-facing behavior change. `EditorWorkspaceLifecycleTest > a file-backed tab can be paused` failed intermittently in CI; this makes it deterministic. No production code is touched.

## Technical Context

- Root cause is a race between two flows. `awaitFile()` waits on the workspace `state` flow, but `isPausable` is carried by `info`, which is updated separately when `publishContentSource()` runs its `_info.update {}` (`EditorWorkspace.kt:196`). `_info` is deliberately seeded with `isPausable = false` (`:130`) so per-path open dedup can see the tab before the engine finishes loading. When the state flow won the race, the test's immediate `info.value` read observed that seed and asserted `false` against `true`.
- The fix awaits `info` until `isPausable` flips, which is the idiom already used by `a file whose backing was lost must not be paused` a few tests below, including its comment about the content-source collector being asynchronous. The await still fails the test (by timeout) if `isPausable` never becomes true, so the assertion is preserved.
- This flake is independent of #48. It reproduced on `main` at `b18dd4283` (run 32508518663) with identical test code, and the subsequent green `main` run only touched two workflow YAML files, so it won the race rather than fixing anything.