### PR TITLE
General: Document sensitive permissions in the privacy policy

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -20,17 +20,42 @@ Send a [quick mail](mailto:support@darken.eu) if you have questions.
 
 Details about senstive permissions can be found below.
 
-In general, Butler only processes data locally, on your device. Two edge cases exist:
+In general, Butler only processes data locally, on your device. Two features create files that describe what Butler
+did in detail, and that you can choose to share:
 
 * If you record a [debug log](#debug-log), the resulting file will contain a detailed log of Butlers actions.
-* If you enable [automatic error reports](#automatic-error-reports) and an error occurs, the resulting bug report may
-  contain information about what Butler did shortly before the error occured.
+* If Butler crashes, a [crash report](#crash-reports) is written to your device and may contain information about what
+  Butler did shortly before the error occured.
 
 ### Query installed apps
 
 Butler has multiple features that require the `QUERY_ALL_PACKAGES` permission.
 The
 `QUERY_ALL_PACKAGES` permission allows Butler to retrieve the inventory of installed apps, i.e. know which apps you currently have installed on your device. To display icons and extra information when browsing directories related to an app.
+
+### All files access
+
+Butler is a file manager, so browsing and managing the files on your device is its core function. Android restricts
+apps to their own directories and to media files unless they hold the `MANAGE_EXTERNAL_STORAGE` permission, which
+Android presents as "All files access". Without it Butler cannot show or modify most of your storage.
+
+You grant this permission yourself in the system settings, and you can revoke it there at any time. Butler reads and
+writes files only where you direct it to. File names and file contents are not transmitted anywhere.
+
+### Usage access
+
+The `PACKAGE_USAGE_STATS` permission, which Android presents as "Usage access", allows Butler to see which apps are
+currently running. Butler uses this to show app related information, for example when displaying installed apps.
+
+This permission is optional. If it is not granted, Butler skips the features that depend on it.
+
+### Install apps
+
+The `REQUEST_INSTALL_PACKAGES` permission allows Butler to hand an APK file you selected to the system's package
+installer, so that installing an app you found in your storage works from within Butler.
+
+Butler does not install anything on its own. The system installer is what performs the installation, and it asks for
+your confirmation.
 
 ## Message of the day
 
@@ -63,3 +88,15 @@ This feature creates a log file that contains verbose output of what the app is 
 It is manually triggered by the user through an option in the app settings.
 The recorded log file can be shared through compatible apps (e.g. your email app) using the system's share dialog.
 As this log file may contain sensitive information (e.g. details about files or your installed applications) it should only be shared with trusted parties.
+
+## Crash reports
+
+If Butler crashes, it writes a crash report into its own private storage on your device. The report contains the error
+details and information about what Butler was doing shortly before the crash.
+
+Crash reports are never sent anywhere automatically. Butler does not include any crash reporting or analytics service.
+Reports stay on your device until you open them via "Bug reports" in the app settings and share them yourself using the
+system's share dialog.
+
+As a crash report may contain sensitive information (e.g. details about files or your installed applications) it should
+only be shared with trusted parties.


### PR DESCRIPTION
## What changed

The privacy policy now explains the sensitive permissions Butler declares. Previously only "Query installed apps" was covered, so someone reading the policy could not find out why the app asks for All files access, Usage access, or the ability to hand an APK to the system installer.

It also no longer claims that crash data can be sent off the device. The old text offered "automatic error reports" as an opt-in that transmits a bug report, which Butler has never been able to do. The new "Crash reports" section describes what actually happens: reports are written to the device and only leave it if you share them yourself.

## Technical Context

- The manifest declares 14 permissions; the policy documented one. Added sections for `MANAGE_EXTERNAL_STORAGE`, `PACKAGE_USAGE_STATS` and `REQUEST_INSTALL_PACKAGES`, which are the ones Play treats as sensitive or gates behind a declaration form. The routine ones (`INTERNET`, `POST_NOTIFICATIONS`, `FOREGROUND_SERVICE*`, the legacy storage pair) are left out deliberately to keep the sensitive disclosures readable.
- Each description is derived from the actual call site rather than from the permission name: usage access is used by `PkgOps.getRunningPackages()` as the non-root, non-ADB path, and the `REQUEST_INSTALL_PACKAGES` wording follows the existing manifest comment about being authorized as an install source.
- The removed error-reporting claim was inherited from SD Maid SE's policy, which carries the same dangling `#automatic-error-reports` link. It was inaccurate here: there is no Crashlytics/Bugsnag/Sentry/ACRA dependency, and `app-workspace-bugreport` contains no network code. `App.kt` installs an uncaught exception handler that calls `bugReportRepo.captureCrashBlocking(...)`, and `BugReportStorage` writes to `context.filesDir`, with sharing going through the `bugreports_share` FileProvider cache path on user action.
- `WRITE_SECURE_SETTINGS` is deliberately not documented here. It is declared in the manifest, but `SystemSettingsProvider` has no callers and no `Settings.Secure` key is read or written anywhere, so there is no behaviour to describe. `BROADCAST_CLOSE_SYSTEM_DIALOGS` is in the same state; the `ACTION_CLOSE_SYSTEM_DIALOGS` intent is never sent. Both are protected permissions that a normal app is never granted, and both are being looked at separately.