### PR TITLE
IO: Recover from a privileged host left over from an older app installation

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/butler/common/adb/service/AdbHostOptions.kt
+++ b/app-common-adb/src/main/java/eu/darken/butler/common/adb/service/AdbHostOptions.kt
@@ -8,5 +8,14 @@ import kotlinx.parcelize.Parcelize
 data class AdbHostOptions(
     val isDebug: Boolean = BuildConfigWrap.DEBUG,
     val isTrace: Boolean = false,
-    val recorderPath: String? = null
+    val recorderPath: String? = null,
+    /**
+     * Encoded `IpcContract.HostIdentity` of the app installation that launched the host. Shizuku has
+     * no init arguments, so this rides along with the initial options push; the host keeps the FIRST
+     * one it ever receives, which makes it a launch stamp rather than a settable value.
+     *
+     * APPEND new fields, never insert: this crosses the binder as a parcelable, so field order is the
+     * wire format.
+     */
+    val hostIdentity: String? = null,
 ) : Parcelable

--- a/app-common-adb/src/main/java/eu/darken/butler/common/adb/service/internal/AdbHostLauncher.kt
+++ b/app-common-adb/src/main/java/eu/darken/butler/common/adb/service/internal/AdbHostLauncher.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
@@ -68,6 +69,12 @@ class AdbHostLauncher(
         // connect-watchdog below waits for.
         val ready = CompletableDeferred<Unit>()
 
+        // Attempt-scoped answer to "is this generation's host actually gone?", handed to whoever
+        // wants to bind a replacement. The teardown below is bounded and partly detached, so a
+        // finished producer coroutine says nothing about the server having processed the removal.
+        // Always completed by that teardown (see its finally), so awaiting it can't hang a caller.
+        val disconnectConfirmed = CompletableDeferred<Boolean>()
+
         val service = serviceFactory.create(
             hostClass = hostClass,
             options = options,
@@ -85,7 +92,7 @@ class AdbHostLauncher(
                             options = options,
                         )
                         log(TAG) { "onServiceConnected(...) -> $userConnection" }
-                        send(ConnectionWrapper(userConnection, baseConnection))
+                        send(ConnectionWrapper(userConnection, baseConnection, disconnectConfirmed))
                         ready.complete(Unit)
                     } catch (e: CancellationException) {
                         throw e
@@ -156,51 +163,73 @@ class AdbHostLauncher(
             // only in awaitClose) so a throw before awaitClose can't leak the Shizuku binding, and
             // unbind is best-effort so a DeadObjectException can't mask the cancellation.
             withContext(NonCancellable) {
-                // Bounded settle so a merely-slow (not wedged) bind() still gets its unbind here.
-                withTimeoutOrNull(BIND_SETTLE_TIMEOUT_MS) { bindJob.join() }
-                if (bindState.compareAndSet(BindState.BINDING, BindState.TEARDOWN)) {
-                    // bind() has not returned yet: nothing to unbind now, the late-unbind path
-                    // above owns the eventual cleanup.
-                } else if (bindState.get() == BindState.BOUND) {
-                    log(TAG) { "Unbinding Shizuku user service…" }
-                    // unbindUserService() is a synchronous binder transaction against the same server
-                    // that may already be wedged, and runCatching bounds nothing - it only catches a
-                    // throw. Collection of a callbackFlow awaits its producer, so an unbounded wedge
-                    // in this finally pins every collector even though the watchdog above already
-                    // close()d the channel: the eternal setup spinner, moved into teardown. Detached
-                    // + bounded, the same trade bind() makes above.
-                    //
-                    // That trade is not free, and not merely "the unbind finishes later": once we stop
-                    // waiting, an outstanding unbind can outlive this generation, and Shizuku keys its
-                    // remove=true unbind on the service args rather than on our callback - so a late
-                    // one can remove a service a NEWER generation just bound. The late-unbind path
-                    // above already carries that race; a teardown that never returns is worse. The
-                    // detached call may also never run at all, if it was still queued when we gave up.
-                    runCatching {
-                        val unbound = appScope.runDetachedWithTimeout(dispatcherProvider.IO, unbindTimeoutMs) {
-                            runCatching { service.unbind() }
-                                .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
-                            Unit
+                // Stays false unless this teardown can prove the host is gone. An unbind we stopped
+                // waiting for, an unbind we never got to start and the late-unbind path above all
+                // leave a removal in flight, and a replacement bound while it is in flight can be
+                // what that removal hits. Completed in the finally, so nobody awaiting it can hang.
+                var confirmed = false
+                try {
+                    // Bounded settle so a merely-slow (not wedged) bind() still gets its unbind here.
+                    withTimeoutOrNull(BIND_SETTLE_TIMEOUT_MS) { bindJob.join() }
+                    if (bindState.compareAndSet(BindState.BINDING, BindState.TEARDOWN)) {
+                        // bind() has not returned yet: nothing to unbind now, the late-unbind path
+                        // above owns the eventual cleanup.
+                    } else if (bindState.get() == BindState.BOUND) {
+                        log(TAG) { "Unbinding Shizuku user service…" }
+                        // unbindUserService() is a synchronous binder transaction against the same
+                        // server that may already be wedged, and runCatching bounds nothing - it only
+                        // catches a throw. Collection of a callbackFlow awaits its producer, so an
+                        // unbounded wedge in this finally pins every collector even though the watchdog
+                        // above already close()d the channel: the eternal setup spinner, moved into
+                        // teardown. Detached + bounded, the same trade bind() makes above.
+                        //
+                        // That trade is not free, and not merely "the unbind finishes later": once we
+                        // stop waiting, an outstanding unbind can outlive this generation, and Shizuku
+                        // keys its remove=true unbind on the service args rather than on our callback -
+                        // so a late one can remove a service a NEWER generation just bound. The
+                        // late-unbind path above already carries that race; a teardown that never
+                        // returns is worse. The detached call may also never run at all, if it was
+                        // still queued when we gave up. What we can do is report it: `confirmed` is
+                        // what keeps a caller from binding that newer generation into the race.
+                        var unbindReturned = false
+                        runCatching {
+                            val unbound = appScope.runDetachedWithTimeout(dispatcherProvider.IO, unbindTimeoutMs) {
+                                runCatching { service.unbind() }
+                                    .onFailure { log(TAG, WARN) { "unbindUserService() failed: ${it.asLog()}" } }
+                                Unit
+                            }
+                            if (unbound == null) {
+                                log(TAG, WARN) { "unbindUserService() did not return within ${unbindTimeoutMs}ms" }
+                            } else {
+                                // Returned, a thrown failure included: the server answered instead of
+                                // leaving the transaction in flight.
+                                unbindReturned = true
+                            }
+                        }.onFailure {
+                            // Mainly @AppScope already cancelled (shutdown): await() then throws a
+                            // CancellationException that withTimeoutOrNull does not convert. It would
+                            // not corrupt what collectors see (the watchdog's close() already latched
+                            // the cause), but it would abandon the rest of this teardown - the
+                            // disconnect wait below - and surface as an unhandled producer failure.
+                            // Teardown is best-effort, and not being able to start the unbind is no
+                            // reason to skip the rest of it.
+                            log(TAG, WARN) { "Detached unbind could not run: ${it.asLog()}" }
                         }
-                        if (unbound == null) {
-                            log(TAG, WARN) { "unbindUserService() did not return within ${unbindTimeoutMs}ms" }
-                        }
-                    }.onFailure {
-                        // Mainly @AppScope already cancelled (shutdown): await() then throws a
-                        // CancellationException that withTimeoutOrNull does not convert. It would not
-                        // corrupt what collectors see (the watchdog's close() already latched the
-                        // cause), but it would abandon the rest of this teardown - the disconnect wait
-                        // below - and surface as an unhandled producer failure. Teardown is
-                        // best-effort, and not being able to start the unbind is no reason to skip
-                        // the rest of it.
-                        log(TAG, WARN) { "Detached unbind could not run: ${it.asLog()}" }
+                        // Bounded wait for the actual disconnect; without it, quick flow restarts can
+                        // cause DeadObjectExceptions from our Shizuku service binder. Still worth doing
+                        // after a timed-out unbind: the server may have processed the removal while the
+                        // synchronous transaction was still waiting on its reply.
+                        val disconnected = withTimeoutOrNull(DISCONNECT_TIMEOUT_MS) {
+                            service.awaitDisconnect()
+                        } != null
+                        // Both halves, because they answer different halves of the question: the unbind
+                        // returning means the server took the removal, the disconnect arriving means it
+                        // carried it out.
+                        confirmed = unbindReturned && disconnected
+                        log(TAG) { "Shizuku user service unbind teardown finished (confirmed=$confirmed)" }
                     }
-                    // Bounded wait for the actual disconnect; without it, quick flow restarts can
-                    // cause DeadObjectExceptions from our Shizuku service binder. Still worth doing
-                    // after a timed-out unbind: the server may have processed the removal while the
-                    // synchronous transaction was still waiting on its reply.
-                    withTimeoutOrNull(DISCONNECT_TIMEOUT_MS) { service.awaitDisconnect() }
-                    log(TAG) { "Shizuku user service unbind teardown finished." }
+                } finally {
+                    disconnectConfirmed.complete(confirmed)
                 }
             }
         }
@@ -220,6 +249,14 @@ class AdbHostLauncher(
     data class ConnectionWrapper<Service : IInterface, Host : AdbConnection>(
         val service: Service,
         val host: Host,
+        /**
+         * Scoped to THIS connection attempt: completes with true only once its teardown both got its
+         * `unbind()` back within the timeout and saw the service actually disconnect. False means a
+         * removal may still be in flight, and since Shizuku keys `remove=true` on the service args, a
+         * replacement bound now could be the one that removal hits. Anyone rebinding after a teardown
+         * has to wait for this and honour it.
+         */
+        val disconnectConfirmed: Deferred<Boolean>,
     )
 
     companion object {

--- a/app-common-io/src/main/aidl/eu/darken/butler/common/pkgs/pkgops/ipc/PkgOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/butler/common/pkgs/pkgops/ipc/PkgOpsConnection.aidl
@@ -34,7 +34,7 @@ interface PkgOpsConnection {
     // Appended, never inserted, and never removed mid-interface: this is non-stable AIDL, so
     // transaction codes come from declaration order. Adding or deleting a method mid-interface
     // renumbers every later one, and a root/Shizuku host that survived an in-place app update would
-    // then dispatch the wrong transaction. Any such change must bump IpcContract.VERSION so the
-    // handshake in checkBase() rejects a mismatched host instead of misdispatching.
+    // then dispatch the wrong transaction. Such a host is caught by the identity handshake in
+    // checkBase() (see IpcContract), but appending keeps it from being a problem in the first place.
     void setComponentEnabledSetting(String packageName, String className, int newState, int flags);
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbHost.kt
@@ -95,7 +95,12 @@ class AdbHost(
         keepAliveToken.close()
     }
 
-    override fun getUserConnection(): IBinder = serviceHost.get()
+    override fun getUserConnection(): IBinder = serviceHost.get().also {
+        // Shizuku has no init arguments, so the identity rides along with the initial options push,
+        // which the client's handshake does before asking for this connection. Only the first stamp
+        // sticks, so a newer client binding to this (possibly stale) host cannot overwrite it.
+        it.identityStamp.stamp(currentOptions.value.hostIdentity)
+    }
 
     override fun updateHostOptions(options: AdbHostOptions) {
         log(TAG) { "updateHostOptions(): $options" }

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.ipc.IpcContract
+import eu.darken.butler.common.ipc.IpcContractMismatchException
 import eu.darken.butler.common.ipc.IpcHostAttempt
 import eu.darken.butler.common.ipc.gateOnHostIdentity
 import eu.darken.butler.common.debug.logging.logTag
@@ -130,7 +131,14 @@ class AdbServiceClient @Inject constructor(
     // another full budget. On a device where Shizuku's user service never comes up (the MediaTek/
     // HyperOS defect) that turns one 15s stall into up to five for every concurrent probe. The
     // caller that started the generation always got the real error; this gives it to the others too.
-    isRetryableStartupFailure = { !it.isAdbConnectTimeout() },
+    //
+    // An identity mismatch is excluded for a different reason: the gate has already decided whether
+    // rebinding is safe (it reconnects only when the stale host's teardown was confirmed), and a
+    // fresh source collection started here would bypass that decision — binding a replacement that
+    // the still-in-flight `remove=true` unbind can take out.
+    isRetryableStartupFailure = {
+        !it.isAdbConnectTimeout() && it !is IpcContractMismatchException
+    },
     // A cached generation may predate an in-place app update, and the keep-alive above makes that
     // window longer than elsewhere. Compared against the identity captured when the connection was
     // gated, so this stays local: the validator runs on every acquire, and another checkBase()

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.ipc.IpcContract
+import eu.darken.butler.common.ipc.IpcHostAttempt
 import eu.darken.butler.common.ipc.gateOnHostIdentity
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.local.ipc.FileOpsClient
@@ -58,7 +59,7 @@ class AdbServiceClient @Inject constructor(
     // slow host-disconnect IPC during keep-alive expiry would otherwise starve Dispatchers.Default —
     // the same pool the UI's vmScope uses — wedging the dashboard. Mirrors ShellOps/PkgOps.
     coroutineScope + dispatcherProvider.IO,
-    callbackFlow {
+    callbackFlow<IpcHostAttempt<AdbServiceConnection>> {
         log(TAG) { "Instantiating ADB launcher..." }
 
         if (adbSettings.useAdb.value() != true) throw AdbUnavailableException("ADB is not enabled")
@@ -76,7 +77,9 @@ class AdbServiceClient @Inject constructor(
             .createServiceHostConnection(optionsInitial)
             .onEach { wrapper ->
                 lastInternal.value = wrapper.host
-                send(wrapper.service)
+                // The teardown signal rides along: Shizuku's unbind is detached and bounded, so the
+                // identity gate must not rebind on a mismatch until this generation is really gone.
+                send(IpcHostAttempt(wrapper.service, wrapper.disconnectConfirmed))
             }
             .launchIn(this)
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
@@ -1,5 +1,7 @@
 package eu.darken.butler.common.adb.service
 
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.adb.AdbServiceConnection
 import eu.darken.butler.common.adb.AdbSettings
 import eu.darken.butler.common.adb.AdbUnavailableException
@@ -14,7 +16,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.ipc.IpcContract
-import eu.darken.butler.common.ipc.IpcContractMismatchException
+import eu.darken.butler.common.ipc.gateOnHostIdentity
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.local.ipc.FileOpsClient
 import eu.darken.butler.common.flow.setupCommonEventHandlers
@@ -30,7 +32,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -42,6 +43,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class AdbServiceClient @Inject constructor(
+    @ApplicationContext context: Context,
     serviceLauncher: AdbHostLauncher,
     @AppScope coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
@@ -65,6 +67,8 @@ class AdbServiceClient @Inject constructor(
             isDebug = debugSettings.isDebugMode.value(),
             isTrace = debugSettings.isTraceMode.value(),
             recorderPath = debugSettings.recorderPath.value(),
+            // Shizuku has no init args, so this initial push doubles as the host's launch arguments.
+            hostIdentity = IpcContract.current(context).encode(),
         )
 
         val lastInternal = MutableStateFlow<AdbConnection?>(null)
@@ -86,6 +90,7 @@ class AdbServiceClient @Inject constructor(
                 isDebug = isDebug,
                 isTrace = isTrace,
                 recorderPath = recorderPath,
+                // No identity: it is a launch stamp, and this push happens after the host was stamped.
             )
             log(TAG) { "Updating debug settings: $optionsDynamic" }
             lastConnection.updateHostOptions(optionsDynamic)
@@ -98,20 +103,18 @@ class AdbServiceClient @Inject constructor(
             log(TAG) { "awaitClose() CLOSING" }
         }
     }
-        .map {
-            val reply = it.checkBase()
-            if (!IpcContract.isCompatible(reply)) {
-                // A host from a different app revision: its AIDL transaction codes need not line up
-                // with ours, so refuse before any module client can issue a call against it.
-                log(TAG, WARN) { "Incompatible host, expected ipc-version ${IpcContract.VERSION}, got: $reply" }
-                throw IpcContractMismatchException("Host does not speak ipc-version ${IpcContract.VERSION}")
-            }
+        .gateOnHostIdentity(
+            tag = TAG,
+            expected = { IpcContract.current(context) },
+            checkBase = { it.checkBase() },
+        ) { ipc, identity ->
             Connection(
-                ipc = it,
+                ipc = ipc,
+                hostIdentity = identity,
                 clientModules = listOf(
-                    fileOpsClientFactory.create(it.fileOps),
-                    pkgOpsClientFactory.create(it.pkgOps),
-                    shellOpsClientFactory.create(it.shellOps),
+                    fileOpsClientFactory.create(ipc.fileOps),
+                    pkgOpsClientFactory.create(ipc.pkgOps),
+                    shellOpsClientFactory.create(ipc.shellOps),
                 )
             )
         },
@@ -125,10 +128,17 @@ class AdbServiceClient @Inject constructor(
     // HyperOS defect) that turns one 15s stall into up to five for every concurrent probe. The
     // caller that started the generation always got the real error; this gives it to the others too.
     isRetryableStartupFailure = { !it.isAdbConnectTimeout() },
+    // A cached generation may predate an in-place app update, and the keep-alive above makes that
+    // window longer than elsewhere. Compared against the identity captured when the connection was
+    // gated, so this stays local: the validator runs on every acquire, and another checkBase()
+    // round-trip would run `id` in the host each time.
+    isReusable = { it.hostIdentity == IpcContract.current(context) },
 ) {
 
     data class Connection(
         val ipc: AdbServiceConnection,
+        /** Identity of the app installation that launched the host, verified when it was handed out. */
+        val hostIdentity: IpcContract.HostIdentity,
         val clientModules: List<IpcClientModule>
     )
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
@@ -126,19 +126,7 @@ class AdbServiceClient @Inject constructor(
     // ADB teardown hangs were a silent-failure support pain point (#2453); surface its lifecycle
     // breadcrumbs at DEBUG even outside trace mode.
     verboseLifecycle = true,
-    // A connect timeout means the Shizuku handshake burned its entire budget without an answer, so
-    // the default "the starter owns this failure, retry fresh" is a bad trade here: each retry is
-    // another full budget. On a device where Shizuku's user service never comes up (the MediaTek/
-    // HyperOS defect) that turns one 15s stall into up to five for every concurrent probe. The
-    // caller that started the generation always got the real error; this gives it to the others too.
-    //
-    // An identity mismatch is excluded for a different reason: the gate has already decided whether
-    // rebinding is safe (it reconnects only when the stale host's teardown was confirmed), and a
-    // fresh source collection started here would bypass that decision — binding a replacement that
-    // the still-in-flight `remove=true` unbind can take out.
-    isRetryableStartupFailure = {
-        !it.isAdbConnectTimeout() && it !is IpcContractMismatchException
-    },
+    isRetryableStartupFailure = RETRYABLE_STARTUP_FAILURE,
     // A cached generation may predate an in-place app update, and the keep-alive above makes that
     // window longer than elsewhere. Compared against the identity captured when the connection was
     // gated, so this stays local: the validator runs on every acquire, and another checkBase()
@@ -161,6 +149,23 @@ class AdbServiceClient @Inject constructor(
         // purpose: a uid-2000 host should not linger in the background for long. Teardown still happens
         // (and is prompt/safe); this only delays its start.
         private val ADB_HOST_KEEPALIVE: Duration = 30.seconds
+
+        // A connect timeout means the Shizuku handshake burned its entire budget without an answer, so
+        // the default "the starter owns this failure, retry fresh" is a bad trade here: each retry is
+        // another full budget. On a device where Shizuku's user service never comes up (the MediaTek/
+        // HyperOS defect) that turns one 15s stall into up to five for every concurrent probe. The
+        // caller that started the generation always got the real error; this gives it to the others too.
+        //
+        // An identity mismatch is excluded for a different reason: the gate has already decided whether
+        // rebinding is safe (it reconnects only when the stale host's teardown was confirmed), and a
+        // fresh source collection started here would bypass that decision — binding a replacement that
+        // the still-in-flight `remove=true` unbind can take out.
+        //
+        // Shared with the regression test that covers the mismatch case, so a change here can't quietly
+        // leave the test guarding a stale copy.
+        internal val RETRYABLE_STARTUP_FAILURE: (Throwable) -> Boolean = {
+            !it.isAdbConnectTimeout() && it !is IpcContractMismatchException
+        }
 
         fun AdbHostLauncher.createServiceHostConnection(
             options: AdbHostOptions,

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceHost.kt
@@ -7,7 +7,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.adb.AdbServiceConnection
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
-import eu.darken.butler.common.ipc.IpcContract
+import eu.darken.butler.common.ipc.IpcHostIdentityStamp
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.local.ipc.FileOpsConnection
 import eu.darken.butler.common.files.local.ipc.FileOpsHost
@@ -34,10 +34,13 @@ class AdbServiceHost @Inject constructor(
         log(TAG, INFO) { "init()" }
     }
 
+    /** Identity of the app installation that launched this host, set once at process start. */
+    val identityStamp = IpcHostIdentityStamp()
+
     override fun checkBase(): String {
         val sb = StringBuilder()
         // Must stay the FIRST line: the client gates the whole connection on it.
-        sb.append("${IpcContract.marker()}\n")
+        sb.append("${identityStamp.asReplyLine()}\n")
         sb.append("Our pkg: ${context.packageName}\n")
         val ids = runBlocking { FlowCmd("id").execute() }
         sb.append("Shell ids are: ${ids.merged}\n")

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
@@ -174,12 +174,16 @@ class ShizukuManager @Inject constructor(
         }
         try {
             log(TAG, VERBOSE) { "getServiceState(): Requesting service client (CACHE MISS)" }
-            val alive = serviceClient.get().use { IpcContract.isCompatible(it.item.ipc.checkBase()) }
+            val alive = serviceClient.get().use {
+                // The round-trip is the liveness proof; the identity in its reply must still be the
+                // one the connection was gated on (the client rejects anything else).
+                IpcContract.decode(it.item.ipc.checkBase()) == it.item.hostIdentity
+            }
             if (alive) {
                 ShizukuServiceState.Available
             } else {
                 // Connected, but the host handed back nothing usable.
-                log(TAG, WARN) { "getServiceState(): checkBase() reply was missing or incompatible" }
+                log(TAG, WARN) { "getServiceState(): checkBase() reply was missing or from another host" }
                 ShizukuServiceState.Failed
             }
         } catch (e: CancellationException) {

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcContract.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcContract.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.ipc
 
 import android.content.Context
 import androidx.core.content.pm.PackageInfoCompat
+import kotlinx.coroutines.Deferred
 
 /** Tag every identity frame starts with, so a host predating it can't be mistaken for a stamped one. */
 private const val PREFIX = "ipc-host-identity:"
@@ -115,12 +116,19 @@ object IpcContract {
  * i.e. it survived an in-place app update. Thrown before any module client is handed out, so no
  * caller can issue a transaction against a host that would misdispatch it or run stale code.
  *
- * The service clients recover from this on the fresh-connection path: the stale host is torn down,
- * its unbind is awaited, and the connection is retried exactly once. A second mismatch (the host is
- * still there, e.g. Shizuku handed back the same running user service) propagates to the caller.
+ * The service clients recover from this on the fresh-connection path: the stale host is torn down
+ * and, if that teardown is known to have finished, the connection is retried exactly once. A second
+ * mismatch (the host is still there, e.g. Shizuku handed back the same running user service)
+ * propagates to the caller, as does a mismatch whose teardown could not be confirmed.
  */
 class IpcContractMismatchException(
     message: String,
+    /**
+     * Teardown signal of the host generation that mismatched, carried along so the recovery in
+     * [gateOnHostIdentity] can decide whether rebinding is safe. Null when the launcher's teardown
+     * needs no confirmation; see [IpcHostAttempt].
+     */
+    internal val disconnectConfirmed: Deferred<Boolean>? = null,
 ) : IllegalStateException(message)
 
 private const val ESCAPE = '\\'

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcContract.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcContract.kt
@@ -1,69 +1,170 @@
 package eu.darken.butler.common.ipc
 
+import android.content.Context
+import androidx.core.content.pm.PackageInfoCompat
+
+/** Tag every identity frame starts with, so a host predating it can't be mistaken for a stamped one. */
+private const val PREFIX = "ipc-host-identity:"
+private const val HEADER = "$PREFIX "
+
 /**
  * Wire contract between the app and its privileged hosts (root, and ADB via Shizuku).
  *
  * The host runs out of our own APK but in a separate process, and that process can outlive an
  * in-place app update. The AIDL interfaces it exposes are *non-stable* AIDL, so transaction codes
  * are assigned by declaration order: a host built from a different revision than the client can
- * answer the wrong method for a given code instead of failing. [VERSION] plus the marker exchanged
- * through `checkBase()` turns that silent misdispatch into a detectable mismatch.
+ * answer the wrong method for a given code instead of failing. The host also runs the *code* of the
+ * APK it was launched from, so a survivor is stale in behaviour, not just in AIDL shape.
  *
- * Bump [VERSION] whenever the shape of anything reachable across that process boundary changes:
- * - `RootServiceConnection`, `AdbServiceConnection` and the interfaces they hand out
- *   (`FileOpsConnection`, `PkgOpsConnection`, `ShellOpsConnection`) plus their callbacks
- *   (e.g. `FileOperationCallback`).
- * - Any parcelable crossing that boundary, including `@Parcelize` classes. Reordering or retyping a
- *   field changes the wire format without touching a single `.aidl` file, so the compiler cannot
- *   catch it.
- *
- * A forgotten bump degrades to the old behaviour (possible misdispatch), so err towards bumping.
+ * The signal for that is a [HostIdentity]: the CLIENT reads its own package identity and passes it
+ * into the host's launch arguments, the host keeps it for the lifetime of its process and echoes it
+ * back as the first line of `checkBase()`. A host launched by an older app echoes that older app's
+ * identity, which is the staleness signal. Nothing here is derived from a build-time constant (that
+ * would break reproducible builds), and nothing is read by the host itself: the root host's Dagger
+ * graph is built on `ActivityThread.getSystemContext()`, which identifies the `android` package
+ * rather than ours, so a host-side lookup would mismatch permanently.
  */
 object IpcContract {
 
     /**
-     * 2: dropped clearCacheAsUser/clearCache/trimCaches from PkgOpsConnection, which renumbered
-     * every transaction below them.
+     * Identifies the app installation that launched a host process. Compared field by field, so a
+     * mismatch can say what actually differed.
+     *
+     * [lastUpdateTime] is the discriminator that carries the check: it changes on a same-version
+     * reinstall, which is exactly the case where the version fields would agree. The others are kept
+     * because they make the mismatch log diagnosable.
      */
-    const val VERSION = 2
+    data class HostIdentity(
+        val versionCode: Long,
+        val versionName: String,
+        val lastUpdateTime: Long,
+        val packageCodePath: String,
+    ) {
+        /**
+         * A single line, field-tagged so a decoder can tell which field disagreed, and escaped so a
+         * versionName carrying a delimiter or a newline cannot corrupt the frame or forge fields.
+         */
+        fun encode(): String = listOf(
+            KEY_VERSION_CODE to versionCode.toString(),
+            KEY_VERSION_NAME to versionName,
+            KEY_LAST_UPDATE_TIME to lastUpdateTime.toString(),
+            KEY_PACKAGE_CODE_PATH to packageCodePath,
+        ).joinToString(separator = FIELD_SEPARATOR, prefix = "$PREFIX ") { (key, value) ->
+            "$key$KEY_VALUE_SEPARATOR${value.escape()}"
+        }
+    }
 
-    private const val MARKER_PREFIX = "ipc-version:"
-
-    /** First line of every `checkBase()` reply. */
-    fun marker(): String = "$MARKER_PREFIX $VERSION"
+    /** Stand-in for a `null` versionName, so the encoding has no optional fields. */
+    const val VERSION_NAME_UNKNOWN = "<unknown>"
 
     /**
-     * A reply is only compatible when its very first line is our marker and carries exactly our
-     * version. Anything else - a null reply, a host too old to emit a marker at all, a malformed or
-     * out-of-range number, or a reply carrying more than one marker - counts as incompatible.
+     * First line emitted by a host that never received an identity. Decodes to null on purpose. A
+     * host predating this handshake emits its own older marker instead, which decodes to null too.
      */
-    fun isCompatible(checkBaseReply: String?): Boolean {
-        if (checkBaseReply == null) return false
+    const val UNSTAMPED = "$PREFIX <unstamped>"
 
-        val lines = checkBaseReply.lineSequence().toList()
-        if (lines.count { it.trimStart().startsWith(MARKER_PREFIX) } != 1) return false
+    /** Our own identity. CLIENT-side only, see the object's docs for why the host must not call it. */
+    fun current(context: Context): HostIdentity {
+        @Suppress("DEPRECATION")
+        val pkgInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+        return HostIdentity(
+            versionCode = PackageInfoCompat.getLongVersionCode(pkgInfo),
+            versionName = pkgInfo.versionName ?: VERSION_NAME_UNKNOWN,
+            lastUpdateTime = pkgInfo.lastUpdateTime,
+            packageCodePath = context.packageCodePath,
+        )
+    }
 
-        val first = lines.firstOrNull()?.trim() ?: return false
-        if (!first.startsWith(MARKER_PREFIX)) return false
+    /**
+     * Parses ONLY the first line of a `checkBase()` reply, everything below it is free-form
+     * diagnostics.
+     *
+     * Returns null for anything that isn't exactly one well-formed frame: a null reply, a host too
+     * old to emit one, a bad escape, an unknown/duplicate/missing field, a non-numeric number, or
+     * trailing data.
+     */
+    fun decode(reply: String?): HostIdentity? {
+        if (reply == null) return null
 
-        // toIntOrNull() covers both "not a number" and values that overflow Int
-        val version = first.removePrefix(MARKER_PREFIX).trim().toIntOrNull() ?: return false
-        return version == VERSION
+        val line = reply.lineSequence().firstOrNull() ?: return null
+        if (!line.startsWith(HEADER)) return null
+
+        val fields = mutableMapOf<String, String>()
+        line.substring(HEADER.length).split(FIELD_SEPARATOR).forEach { entry ->
+            val split = entry.indexOf(KEY_VALUE_SEPARATOR)
+            // <= 0 also rejects an empty key, and with it a trailing separator or stray padding
+            if (split <= 0) return null
+            val key = entry.substring(0, split)
+            if (!KEYS.contains(key)) return null
+            val value = entry.substring(split + 1).unescape() ?: return null
+            if (fields.put(key, value) != null) return null
+        }
+        if (fields.size != KEYS.size) return null
+
+        return HostIdentity(
+            versionCode = fields.getValue(KEY_VERSION_CODE).toLongOrNull() ?: return null,
+            versionName = fields.getValue(KEY_VERSION_NAME),
+            lastUpdateTime = fields.getValue(KEY_LAST_UPDATE_TIME).toLongOrNull() ?: return null,
+            packageCodePath = fields.getValue(KEY_PACKAGE_CODE_PATH),
+        )
     }
 }
 
 /**
- * The connected host speaks a different [IpcContract.VERSION] than we do, i.e. it survived an
- * in-place app update. Thrown before any module client is handed out, so no caller can issue a
- * transaction against a host that would misdispatch it.
+ * The connected host was launched by a different installation of the app than the one talking to it,
+ * i.e. it survived an in-place app update. Thrown before any module client is handed out, so no
+ * caller can issue a transaction against a host that would misdispatch it or run stale code.
  *
- * Recovery is not automatic and the stale host is left running. `RootManager` invalidates its cached
- * state when the root binder changes, so restarting the root host is enough there. The Shizuku path
- * has no equivalent signal: restarting Butler's Shizuku user service need not change the base
- * Shizuku binder that clears `ShizukuManager`'s cache, so ADB access can keep reporting unavailable
- * until Butler itself is restarted. Tearing down and relaunching the host on mismatch is deliberately
- * left to a follow-up.
+ * The service clients recover from this on the fresh-connection path: the stale host is torn down,
+ * its unbind is awaited, and the connection is retried exactly once. A second mismatch (the host is
+ * still there, e.g. Shizuku handed back the same running user service) propagates to the caller.
  */
 class IpcContractMismatchException(
     message: String,
 ) : IllegalStateException(message)
+
+private const val ESCAPE = '\\'
+private const val FIELD_SEPARATOR = ";"
+private const val KEY_VALUE_SEPARATOR = '='
+private const val KEY_VERSION_CODE = "versionCode"
+private const val KEY_VERSION_NAME = "versionName"
+private const val KEY_LAST_UPDATE_TIME = "lastUpdateTime"
+private const val KEY_PACKAGE_CODE_PATH = "packageCodePath"
+private val KEYS = setOf(KEY_VERSION_CODE, KEY_VERSION_NAME, KEY_LAST_UPDATE_TIME, KEY_PACKAGE_CODE_PATH)
+
+private fun String.escape(): String = buildString(length) {
+    this@escape.forEach {
+        when (it) {
+            ESCAPE -> append("$ESCAPE$ESCAPE")
+            ';' -> append("${ESCAPE}s")
+            '=' -> append("${ESCAPE}e")
+            '\n' -> append("${ESCAPE}n")
+            '\r' -> append("${ESCAPE}r")
+            else -> append(it)
+        }
+    }
+}
+
+private fun String.unescape(): String? {
+    val out = StringBuilder(length)
+    var i = 0
+    while (i < length) {
+        val current = this[i]
+        if (current != ESCAPE) {
+            out.append(current)
+            i++
+            continue
+        }
+        if (i + 1 == length) return null
+        when (this[i + 1]) {
+            ESCAPE -> out.append(ESCAPE)
+            's' -> out.append(';')
+            'e' -> out.append('=')
+            'n' -> out.append('\n')
+            'r' -> out.append('\r')
+            else -> return null
+        }
+        i += 2
+    }
+    return out.toString()
+}

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcHostIdentityGate.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcHostIdentityGate.kt
@@ -2,20 +2,42 @@ package eu.darken.butler.common.ipc
 
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retryWhen
+
+/**
+ * One host generation on its way into [gateOnHostIdentity].
+ *
+ * @param ipc the freshly connected host
+ * @param disconnectConfirmed this generation's teardown signal, completing with true only if that
+ * teardown is known to have finished (see AdbHostLauncher.ConnectionWrapper). Null when the launcher
+ * has nothing to confirm because its teardown is fully structured, i.e. finishes before the producer
+ * coroutine does — the root path.
+ */
+internal data class IpcHostAttempt<IPC : Any>(
+    val ipc: IPC,
+    val disconnectConfirmed: Deferred<Boolean>? = null,
+)
 
 /**
  * Gates a freshly established host connection on the identity the host echoes back, and recovers
  * once if it doesn't match. Shared by [eu.darken.butler.common.root.service.RootServiceClient] and
  * [eu.darken.butler.common.adb.service.AdbServiceClient], whose handshakes only differ in types.
  *
- * A mismatch throws, which cancels the upstream connection flow: that runs the launcher's teardown
- * (root session close / Shizuku unbind plus the bounded await for the actual disconnect) to
- * completion before this operator re-collects, so the reconnect can't race its own predecessor's
- * unbind. Awaiting matters for the Shizuku path in particular, where a late `remove=true` unbind is
- * keyed on the service args and would otherwise remove the newer generation (see AdbHostLauncher).
+ * A mismatch throws, which cancels the upstream connection flow and runs the launcher's teardown
+ * before this operator can re-collect. On the root path that settles it: the teardown (IPC receiver
+ * release, session close) is structured, so the producer coroutine finishing means the host is gone,
+ * and [IpcHostAttempt.disconnectConfirmed] is null.
+ *
+ * Shizuku is not like that. Its `unbindUserService()` is a synchronous binder transaction that can
+ * wedge, so AdbHostLauncher runs it detached under a timeout and gives up waiting when that expires:
+ * the producer can finish with the unbind still in flight. Since Shizuku keys a `remove=true` unbind
+ * on the service args rather than on our callback, rebinding then risks the late unbind removing the
+ * REPLACEMENT — recovery killing what it just recovered. So this reconnects only when the launcher
+ * confirms the teardown finished; otherwise the mismatch propagates and the caller sees the host as
+ * unavailable, which is the better of the two outcomes.
  *
  * Exactly one retry, no loop: the case worth recovering from is a stale host that goes away when
  * torn down. If the second attempt lands on the same host again (Shizuku handing back a still-running
@@ -25,15 +47,15 @@ import kotlinx.coroutines.flow.retryWhen
  * @param checkBase the host round-trip whose first line carries the echo
  * @param onAccepted builds the connection handed downstream, given the host and its verified identity
  */
-internal fun <IPC : Any, CONNECTION : Any> Flow<IPC>.gateOnHostIdentity(
+internal fun <IPC : Any, CONNECTION : Any> Flow<IpcHostAttempt<IPC>>.gateOnHostIdentity(
     tag: String,
     expected: () -> IpcContract.HostIdentity,
     checkBase: (IPC) -> String?,
     onAccepted: (IPC, IpcContract.HostIdentity) -> CONNECTION,
 ): Flow<CONNECTION> = this
-    .map { ipc ->
+    .map { host ->
         val ours = expected()
-        val reply = checkBase(ipc)
+        val reply = checkBase(host.ipc)
         val theirs = IpcContract.decode(reply)
         if (theirs != ours) {
             // A host from a different app installation: it runs that installation's code and its AIDL
@@ -44,12 +66,26 @@ internal fun <IPC : Any, CONNECTION : Any> Flow<IPC>.gateOnHostIdentity(
                     "expected: $ours\n" +
                     "reported: ${theirs ?: "<undecodable> (first line: ${reply?.lineSequence()?.firstOrNull()})"}"
             }
-            throw IpcContractMismatchException("Host was launched by a different app installation")
+            throw IpcContractMismatchException(
+                message = "Host was launched by a different app installation",
+                disconnectConfirmed = host.disconnectConfirmed,
+            )
         }
-        onAccepted(ipc, ours)
+        onAccepted(host.ipc, ours)
     }
     .retryWhen { cause, attempt ->
         if (cause !is IpcContractMismatchException || attempt > 0) return@retryWhen false
-        log(tag, WARN) { "Stale host was torn down, reconnecting once…" }
-        true
+        // The teardown has already run by the time we get here (collection awaits the upstream
+        // producer); this asks whether it actually finished. It is that teardown which completes the
+        // signal, so awaiting it doesn't add a wait.
+        val confirmed = cause.disconnectConfirmed?.await() ?: true
+        if (confirmed) {
+            log(tag, WARN) { "Stale host was torn down, reconnecting once…" }
+        } else {
+            log(tag, ERROR) {
+                "Stale host teardown was not confirmed, not reconnecting: a replacement bound now " +
+                    "could be removed by the unbind that is still in flight."
+            }
+        }
+        confirmed
     }

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcHostIdentityGate.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcHostIdentityGate.kt
@@ -1,0 +1,55 @@
+package eu.darken.butler.common.ipc
+
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retryWhen
+
+/**
+ * Gates a freshly established host connection on the identity the host echoes back, and recovers
+ * once if it doesn't match. Shared by [eu.darken.butler.common.root.service.RootServiceClient] and
+ * [eu.darken.butler.common.adb.service.AdbServiceClient], whose handshakes only differ in types.
+ *
+ * A mismatch throws, which cancels the upstream connection flow: that runs the launcher's teardown
+ * (root session close / Shizuku unbind plus the bounded await for the actual disconnect) to
+ * completion before this operator re-collects, so the reconnect can't race its own predecessor's
+ * unbind. Awaiting matters for the Shizuku path in particular, where a late `remove=true` unbind is
+ * keyed on the service args and would otherwise remove the newer generation (see AdbHostLauncher).
+ *
+ * Exactly one retry, no loop: the case worth recovering from is a stale host that goes away when
+ * torn down. If the second attempt lands on the same host again (Shizuku handing back a still-running
+ * user service), the mismatch is real and belongs to the caller.
+ *
+ * @param expected our own identity, re-read per attempt
+ * @param checkBase the host round-trip whose first line carries the echo
+ * @param onAccepted builds the connection handed downstream, given the host and its verified identity
+ */
+internal fun <IPC : Any, CONNECTION : Any> Flow<IPC>.gateOnHostIdentity(
+    tag: String,
+    expected: () -> IpcContract.HostIdentity,
+    checkBase: (IPC) -> String?,
+    onAccepted: (IPC, IpcContract.HostIdentity) -> CONNECTION,
+): Flow<CONNECTION> = this
+    .map { ipc ->
+        val ours = expected()
+        val reply = checkBase(ipc)
+        val theirs = IpcContract.decode(reply)
+        if (theirs != ours) {
+            // A host from a different app installation: it runs that installation's code and its AIDL
+            // transaction codes need not line up with ours, so refuse before any module client can
+            // issue a call against it.
+            log(tag, WARN) {
+                "Host identity mismatch!\n" +
+                    "expected: $ours\n" +
+                    "reported: ${theirs ?: "<undecodable> (first line: ${reply?.lineSequence()?.firstOrNull()})"}"
+            }
+            throw IpcContractMismatchException("Host was launched by a different app installation")
+        }
+        onAccepted(ipc, ours)
+    }
+    .retryWhen { cause, attempt ->
+        if (cause !is IpcContractMismatchException || attempt > 0) return@retryWhen false
+        log(tag, WARN) { "Stale host was torn down, reconnecting once…" }
+        true
+    }

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcHostIdentityStamp.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcHostIdentityStamp.kt
@@ -1,0 +1,25 @@
+package eu.darken.butler.common.ipc
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * HOST-side holder for the encoded [IpcContract.HostIdentity] the launching client stamped into this
+ * process, echoed back as the first line of `checkBase()`.
+ *
+ * The first non-null stamp wins and nothing can change it afterwards. That is what makes it a launch
+ * stamp: a newer client that binds to a host left over from an older installation (Shizuku hands back
+ * the still-running user service and pushes its options into it) must not be able to overwrite the
+ * older identity, or the mismatch it is meant to reveal would disappear. Hosts old enough to have no
+ * stamping code at all cannot be re-stamped either — they answer with their own older marker.
+ */
+class IpcHostIdentityStamp {
+
+    private val stamped = AtomicReference<String?>(null)
+
+    fun stamp(encodedIdentity: String?) {
+        if (encodedIdentity != null) stamped.compareAndSet(null, encodedIdentity)
+    }
+
+    /** First line of the `checkBase()` reply. [IpcContract.UNSTAMPED] decodes to null, i.e. mismatch. */
+    fun asReplyLine(): String = stamped.get() ?: IpcContract.UNSTAMPED
+}

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/RootManager.kt
@@ -79,7 +79,11 @@ class RootManager @Inject constructor(
             cachedState?.let { return@withContext it }
 
             val newState = try {
-                serviceClient.get().use { IpcContract.isCompatible(it.item.ipc.checkBase()) }
+                serviceClient.get().use {
+                    // The round-trip is the liveness proof; the identity in its reply must still be
+                    // the one the connection was gated on (the client rejects anything else).
+                    IpcContract.decode(it.item.ipc.checkBase()) == it.item.hostIdentity
+                }
             } catch (e: CancellationException) {
                 throw e // don't cache a cancelled probe as "not rooted"
             } catch (e: Exception) {

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootHost.kt
@@ -48,9 +48,12 @@ class RootHost(_args: List<String>) : HasSharedResource<Any>, BaseRootHost("$TAG
 
     override suspend fun onExecute() {
         log(iTag) { "Starting IPC connection via $rootIpcFactory" }
+        // Stamped from our launch args, never read from this process: the Dagger graph above is built
+        // on the system context, which identifies the "android" package rather than ours.
+        val userBinder = serviceHost.get().also { it.identityStamp.stamp(initOptions.hostIdentity) }
         val ipc = rootIpcFactory.create(
             initArgs = initOptions,
-            userProvidedBinder = serviceHost.get(),
+            userProvidedBinder = userBinder,
         )
         log(iTag) { "IPC created: $ipc" }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceClient.kt
@@ -1,5 +1,7 @@
 package eu.darken.butler.common.root.service
 
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.datastore.value
@@ -8,7 +10,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.ipc.IpcContract
-import eu.darken.butler.common.ipc.IpcContractMismatchException
+import eu.darken.butler.common.ipc.gateOnHostIdentity
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.local.ipc.FileOpsClient
 import eu.darken.butler.common.flow.setupCommonEventHandlers
@@ -29,7 +31,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -39,6 +40,7 @@ import javax.inject.Singleton
 
 @Singleton
 class RootServiceClient @Inject constructor(
+    @ApplicationContext context: Context,
     @AppScope coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
     private val rootHostLauncher: RootHostLauncher,
@@ -65,7 +67,10 @@ class RootServiceClient @Inject constructor(
 
         val lastInternal = MutableStateFlow<RootConnection?>(null)
         rootHostLauncher
-            .createHostConnection(options = initialOptions)
+            .createHostConnection(
+                options = initialOptions,
+                hostIdentity = IpcContract.current(context).encode(),
+            )
             .onEach { wrapper ->
                 lastInternal.value = wrapper.host
                 send(wrapper.service)
@@ -94,30 +99,34 @@ class RootServiceClient @Inject constructor(
             log(TAG) { "awaitClose() CLOSING" }
         }
     }
-        .map {
-            val reply = it.checkBase()
-            if (!IpcContract.isCompatible(reply)) {
-                // A host from a different app revision: its AIDL transaction codes need not line up
-                // with ours, so refuse before any module client can issue a call against it.
-                log(TAG, WARN) { "Incompatible host, expected ipc-version ${IpcContract.VERSION}, got: $reply" }
-                throw IpcContractMismatchException("Host does not speak ipc-version ${IpcContract.VERSION}")
-            }
+        .gateOnHostIdentity(
+            tag = TAG,
+            expected = { IpcContract.current(context) },
+            checkBase = { it.checkBase() },
+        ) { ipc, identity ->
             Connection(
-                ipc = it,
+                ipc = ipc,
+                hostIdentity = identity,
                 clientModules = listOf(
-                    fileOpsClientFactory.create(it.fileOps),
-                    pkgOpsClientFactory.create(it.pkgOps),
-                    shellOpsClientFactory.create(it.shellOps),
+                    fileOpsClientFactory.create(ipc.fileOps),
+                    pkgOpsClientFactory.create(ipc.pkgOps),
+                    shellOpsClientFactory.create(ipc.shellOps),
                 )
             )
         },
     // Root teardown hangs were a silent-failure support pain point (#2453); surface its lifecycle
     // breadcrumbs at DEBUG even outside trace mode.
     verboseLifecycle = true,
+    // A cached generation may predate an in-place app update. Compared against the identity captured
+    // when the connection was gated, so this stays local: the validator runs on every acquire, and
+    // another checkBase() round-trip would run `id` in the host each time.
+    isReusable = { it.hostIdentity == IpcContract.current(context) },
 ) {
 
     data class Connection(
         val ipc: RootServiceConnection,
+        /** Identity of the app installation that launched the host, verified when it was handed out. */
+        val hostIdentity: IpcContract.HostIdentity,
         val clientModules: List<IpcClientModule>
     )
 
@@ -130,12 +139,14 @@ class RootServiceClient @Inject constructor(
              */
             useMountMaster: Boolean = false,
             options: RootHostOptions,
+            hostIdentity: String,
         ) = this
             .createConnection(
                 serviceClass = RootServiceConnection::class,
                 hostClass = RootHost::class,
                 useMountMaster = useMountMaster,
                 options = options,
+                hostIdentity = hostIdentity,
             )
             .onStart { log(TAG) { "Initiating connection to host." } }
             .onEach { log(TAG) { "Connection available: $it" } }

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceClient.kt
@@ -10,6 +10,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.ipc.IpcContract
+import eu.darken.butler.common.ipc.IpcHostAttempt
 import eu.darken.butler.common.ipc.gateOnHostIdentity
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.local.ipc.FileOpsClient
@@ -55,7 +56,7 @@ class RootServiceClient @Inject constructor(
     // slow host-disconnect IPC during teardown would otherwise starve Dispatchers.Default — the same
     // pool the UI's vmScope uses — wedging the dashboard. Mirrors ShellOps/PkgOps.
     parentScope = coroutineScope + dispatcherProvider.IO,
-    source = callbackFlow {
+    source = callbackFlow<IpcHostAttempt<RootServiceConnection>> {
         log(TAG) { "Instantiating Root launcher..." }
         if (rootSettings.useRoot.value() != true) throw RootUnavailableException("Root is not enabled")
 
@@ -73,7 +74,9 @@ class RootServiceClient @Inject constructor(
             )
             .onEach { wrapper ->
                 lastInternal.value = wrapper.host
-                send(wrapper.service)
+                // No teardown signal: RootHostLauncher tears down inside the producer coroutine, so
+                // the identity gate's re-collection already happens after the host is gone.
+                send(IpcHostAttempt(wrapper.service))
             }
             .launchIn(this)
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceHost.kt
@@ -5,7 +5,7 @@ import androidx.annotation.Keep
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.debug.logging.log
-import eu.darken.butler.common.ipc.IpcContract
+import eu.darken.butler.common.ipc.IpcHostIdentityStamp
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.local.ipc.FileOpsConnection
 import eu.darken.butler.common.files.local.ipc.FileOpsHost
@@ -28,10 +28,13 @@ class RootServiceHost @Inject constructor(
     private val shellOpsHost: Lazy<ShellOpsHost>,
 ) : RootServiceConnection.Stub() {
 
+    /** Identity of the app installation that launched this host, set once at process start. */
+    val identityStamp = IpcHostIdentityStamp()
+
     override fun checkBase(): String {
         val sb = StringBuilder()
         // Must stay the FIRST line: the client gates the whole connection on it.
-        sb.append("${IpcContract.marker()}\n")
+        sb.append("${identityStamp.asReplyLine()}\n")
         sb.append("Our pkg: ${context.packageName}\n")
         val ids = runBlocking { FlowCmd("id").execute() }
         sb.append("Shell ids are: ${ids.merged}\n")

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcContractTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcContractTest.kt
@@ -1,55 +1,135 @@
 package eu.darken.butler.common.ipc
 
+import eu.darken.butler.common.ipc.IpcContract.HostIdentity
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class IpcContractTest : BaseTest() {
 
+    private val identity = HostIdentity(
+        versionCode = 12345,
+        versionName = "1.2.3-beta",
+        lastUpdateTime = 1755800000000,
+        packageCodePath = "/data/app/~~aB1/eu.darken.butler-Xy2/base.apk",
+    )
+
+    /** What a host actually answers: the identity frame plus free-form diagnostics below it. */
     private fun reply(firstLine: String) = "$firstLine\nOur pkg: eu.darken.butler\nShell ids are: uid=0"
 
     @Test
-    fun `our own marker is accepted`() {
-        IpcContract.isCompatible(reply(IpcContract.marker())) shouldBe true
+    fun `encoding round-trips`() {
+        IpcContract.decode(reply(identity.encode())) shouldBe identity
     }
 
     @Test
-    fun `a host too old to emit a marker is rejected`() {
-        // Exactly what a pre-handshake host answers: a plain diagnostic string.
-        IpcContract.isCompatible("Our pkg: eu.darken.butler\nShell ids are: uid=0") shouldBe false
+    fun `the frame is a single line`() {
+        identity.encode().lines() shouldBe listOf(identity.encode())
     }
 
     @Test
-    fun `a null reply is rejected`() {
-        IpcContract.isCompatible(null) shouldBe false
+    fun `a differing versionCode is rejected`() {
+        IpcContract.decode(reply(identity.copy(versionCode = 12346).encode())) shouldNotBe identity
     }
 
     @Test
-    fun `a different version is rejected`() {
-        IpcContract.isCompatible(reply("ipc-version: ${IpcContract.VERSION + 1}")) shouldBe false
-        IpcContract.isCompatible(reply("ipc-version: ${IpcContract.VERSION - 1}")) shouldBe false
+    fun `a differing versionName is rejected`() {
+        IpcContract.decode(reply(identity.copy(versionName = "1.2.4").encode())) shouldNotBe identity
     }
 
     @Test
-    fun `a malformed or out-of-range version is rejected`() {
-        IpcContract.isCompatible(reply("ipc-version: banana")) shouldBe false
-        IpcContract.isCompatible(reply("ipc-version:")) shouldBe false
-        // Overflows Int, so toIntOrNull() yields null rather than wrapping
-        IpcContract.isCompatible(reply("ipc-version: 99999999999999999999")) shouldBe false
+    fun `a differing lastUpdateTime alone is rejected`() {
+        // The same-version reinstall: every other field agrees, this is the only discriminator.
+        val reinstalled = identity.copy(lastUpdateTime = identity.lastUpdateTime + 1)
+        IpcContract.decode(reply(reinstalled.encode())) shouldNotBe identity
     }
 
     @Test
-    fun `the marker only counts on the first line`() {
-        IpcContract.isCompatible("Our pkg: eu.darken.butler\n${IpcContract.marker()}") shouldBe false
+    fun `a differing packageCodePath is rejected`() {
+        val moved = identity.copy(packageCodePath = "/data/app/~~cD3/eu.darken.butler-Zz9/base.apk")
+        IpcContract.decode(reply(moved.encode())) shouldNotBe identity
     }
 
     @Test
-    fun `more than one marker is rejected`() {
-        IpcContract.isCompatible("${IpcContract.marker()}\n${IpcContract.marker()}") shouldBe false
+    fun `a host too old to emit an identity is rejected`() {
+        // A pre-identity host answers with a plain diagnostic string, or with the older version marker.
+        IpcContract.decode("Our pkg: eu.darken.butler\nShell ids are: uid=0") shouldBe null
+        IpcContract.decode(reply("ipc-version: 2")) shouldBe null
     }
 
     @Test
-    fun `an empty reply is rejected`() {
-        IpcContract.isCompatible("") shouldBe false
+    fun `a null or empty reply is rejected`() {
+        IpcContract.decode(null) shouldBe null
+        IpcContract.decode("") shouldBe null
+    }
+
+    @Test
+    fun `an unstamped host is rejected`() {
+        IpcContract.decode(reply(IpcContract.UNSTAMPED)) shouldBe null
+    }
+
+    @Test
+    fun `the identity only counts on the first line`() {
+        IpcContract.decode("Our pkg: eu.darken.butler\n${identity.encode()}") shouldBe null
+    }
+
+    @Test
+    fun `a truncated frame is rejected`() {
+        val encoded = identity.encode()
+        // Cut mid-frame (dangling separator) and cut a whole field off the end (missing field)
+        IpcContract.decode(encoded.substringBefore("versionName")) shouldBe null
+        IpcContract.decode(encoded.substringBeforeLast(";")) shouldBe null
+        IpcContract.decode("ipc-host-identity:") shouldBe null
+        IpcContract.decode("ipc-host-identity: ") shouldBe null
+    }
+
+    @Test
+    fun `a duplicated field is rejected`() {
+        IpcContract.decode("${identity.encode()};versionCode=12345") shouldBe null
+    }
+
+    @Test
+    fun `an unknown field is rejected`() {
+        IpcContract.decode("${identity.encode()};buildType=debug") shouldBe null
+    }
+
+    @Test
+    fun `trailing data is rejected`() {
+        IpcContract.decode("${identity.encode()};") shouldBe null
+        IpcContract.decode("${identity.encode()};garbage") shouldBe null
+        // Padding lands inside the last field's value, which is a mismatch rather than a parse error
+        IpcContract.decode("${identity.encode()} ") shouldNotBe identity
+    }
+
+    @Test
+    fun `a non-numeric or out-of-range number is rejected`() {
+        IpcContract.decode(identity.encode().replace("versionCode=12345", "versionCode=banana")) shouldBe null
+        IpcContract.decode(identity.encode().replace("versionCode=12345", "versionCode=")) shouldBe null
+        // Overflows Long, so toLongOrNull() yields null rather than wrapping
+        val huge = "versionCode=99999999999999999999999"
+        IpcContract.decode(identity.encode().replace("versionCode=12345", huge)) shouldBe null
+    }
+
+    @Test
+    fun `a bad escape is rejected`() {
+        IpcContract.decode(identity.encode().replace("versionName=1.2.3-beta", "versionName=1\\x2")) shouldBe null
+        IpcContract.decode(identity.encode().replace("versionName=1.2.3-beta", "versionName=1.2\\")) shouldBe null
+    }
+
+    @Test
+    fun `a null versionName round-trips as the sentinel`() {
+        val unnamed = identity.copy(versionName = IpcContract.VERSION_NAME_UNKNOWN)
+        IpcContract.decode(reply(unnamed.encode())) shouldBe unnamed
+        IpcContract.decode(reply(unnamed.encode())) shouldNotBe identity
+    }
+
+    @Test
+    fun `a versionName carrying delimiters or newlines cannot corrupt the frame`() {
+        val hostile = identity.copy(versionName = "1.0;versionCode=666=\\\nsecond line\rthird")
+        val encoded = hostile.encode()
+
+        encoded.lines() shouldBe listOf(encoded)
+        IpcContract.decode(reply(encoded)) shouldBe hostile
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateAdbTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateAdbTest.kt
@@ -2,8 +2,8 @@ package eu.darken.butler.common.ipc
 
 import android.os.IBinder
 import android.os.IInterface
-import eu.darken.butler.common.adb.isAdbConnectTimeout
 import eu.darken.butler.common.adb.service.AdbHostOptions
+import eu.darken.butler.common.adb.service.AdbServiceClient
 import eu.darken.butler.common.adb.service.internal.AdbConnection
 import eu.darken.butler.common.adb.service.internal.AdbHostLauncher
 import eu.darken.butler.common.adb.service.internal.ShizukuUserService
@@ -262,8 +262,8 @@ class IpcHostIdentityGateAdbTest : BaseTest() {
             // A single reply, so any rebind lands on the same stale host again.
             source = hostLauncher.gated(stale.encode(), unbindTimeoutMs = 250L),
             stopTimeout = Duration.ZERO,
-            // The predicate AdbServiceClient installs.
-            isRetryableStartupFailure = { !it.isAdbConnectTimeout() && it !is IpcContractMismatchException },
+            // The very value AdbServiceClient installs, not a copy of it.
+            isRetryableStartupFailure = AdbServiceClient.RETRYABLE_STARTUP_FAILURE,
         )
         var pump: Thread? = null
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateAdbTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateAdbTest.kt
@@ -2,11 +2,15 @@ package eu.darken.butler.common.ipc
 
 import android.os.IBinder
 import android.os.IInterface
+import eu.darken.butler.common.adb.isAdbConnectTimeout
 import eu.darken.butler.common.adb.service.AdbHostOptions
 import eu.darken.butler.common.adb.service.internal.AdbConnection
 import eu.darken.butler.common.adb.service.internal.AdbHostLauncher
 import eu.darken.butler.common.adb.service.internal.ShizukuUserService
 import eu.darken.butler.common.adb.service.internal.ShizukuUserServiceFactory
+import eu.darken.butler.common.debug.Bugs
+import eu.darken.butler.common.debug.logging.Logging
+import eu.darken.butler.common.sharedresource.SharedResource
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
@@ -19,6 +23,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -30,6 +35,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KClass
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -206,4 +212,92 @@ class IpcHostIdentityGateAdbTest : BaseTest() {
             realScope.cancel()
         }
     }
+
+    /**
+     * The gate refusing to rebind only settles the gate's own retry. [SharedResource] has a second
+     * one: a caller that latched onto a generation which died before producing a value gets that
+     * generation detached and a FRESH source collection started — the rebind the gate just declined,
+     * with the stale unbind still in flight. Wired with the predicate AdbServiceClient passes, so
+     * this covers the layer the gate-only tests above cannot see.
+     */
+    @Test fun `a mismatch is not rebound by the shared resource retry either`() = runTest(timeout = 10.seconds) {
+        val unbindEntered = CompletableDeferred<Unit>()
+        val unbindWedge = CountDownLatch(1)
+        val service = object : ShizukuUserService {
+            override fun bind() {
+                binds.incrementAndGet()
+            }
+
+            override fun unbind() {
+                unbindEntered.complete(Unit)
+                unbindWedge.await() // blocks the thread, unaffected by coroutine cancellation
+            }
+
+            override suspend fun awaitDisconnect() {}
+        }
+        val realScope = CoroutineScope(SupervisorJob())
+        val hostLauncher = launcher(service, realScope)
+
+        // Only a REUSING get() logs this, and it is trace-gated. Without waiting for it, the second
+        // caller could arrive after generation 1 already died and pass vacuously on a fresh one.
+        val reuserLatched = CompletableDeferred<Unit>()
+        val capture = object : Logging.Logger {
+            override fun log(
+                priority: Logging.Priority,
+                tag: String,
+                message: String,
+                metaData: Map<String, Any>?,
+            ) {
+                if (tag == "$SR_TAG:SR" && message.contains("Source job already exists")) {
+                    reuserLatched.complete(Unit)
+                }
+            }
+        }
+        Bugs.isTrace = true
+        Logging.install(capture)
+
+        val sharedResource = SharedResource(
+            tag = SR_TAG,
+            parentScope = realScope + Dispatchers.IO,
+            // A single reply, so any rebind lands on the same stale host again.
+            source = hostLauncher.gated(stale.encode(), unbindTimeoutMs = 250L),
+            stopTimeout = Duration.ZERO,
+            // The predicate AdbServiceClient installs.
+            isRetryableStartupFailure = { !it.isAdbConnectTimeout() && it !is IpcContractMismatchException },
+        )
+        var pump: Thread? = null
+
+        try {
+            withContext(Dispatchers.Default) {
+                val creator = realScope.async(Dispatchers.IO) { runCatching { sharedResource.get() } }
+                // Generation 1 is installed and its source is running, but nothing has answered its
+                // connect callback yet, so it cannot have produced a value.
+                awaitBinds(1)
+
+                val reuser = realScope.async(Dispatchers.IO) { runCatching { sharedResource.get() } }
+                awaitOrFail("the second caller to latch onto generation 1") { reuserLatched.await() }
+
+                // Only now let the host connect, mismatch, and wedge its unbind.
+                pump = startConnectPump()
+                awaitOrFail("unbind() to be entered") { unbindEntered.await() }
+
+                awaitOrFail("the starting caller to be released") { creator.await() }
+                    .exceptionOrNull().shouldBeInstanceOf<IpcContractMismatchException>()
+                // The waiter must inherit the mismatch instead of retrying onto a fresh generation.
+                awaitOrFail("the reusing caller to be released") { reuser.await() }
+                    .exceptionOrNull().shouldBeInstanceOf<IpcContractMismatchException>()
+            }
+
+            // The whole point: no second generation for the in-flight unbind to remove.
+            binds.get() shouldBe 1
+        } finally {
+            unbindWedge.countDown()
+            pump?.interrupt()
+            realScope.cancel()
+            Logging.remove(capture)
+            Bugs.isTrace = false
+        }
+    }
 }
+
+private const val SR_TAG = "gate-shared-resource"

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateAdbTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateAdbTest.kt
@@ -1,0 +1,209 @@
+package eu.darken.butler.common.ipc
+
+import android.os.IBinder
+import android.os.IInterface
+import eu.darken.butler.common.adb.service.AdbHostOptions
+import eu.darken.butler.common.adb.service.internal.AdbConnection
+import eu.darken.butler.common.adb.service.internal.AdbHostLauncher
+import eu.darken.butler.common.adb.service.internal.ShizukuUserService
+import eu.darken.butler.common.adb.service.internal.ShizukuUserServiceFactory
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.reflect.KClass
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The identity gate on top of the REAL [AdbHostLauncher], because that is where the gate's recovery
+ * and Shizuku's teardown have to line up: the launcher's unbind is detached under a timeout, so its
+ * producer coroutine can finish with the removal still in flight, and rebinding then risks the late
+ * `remove=true` unbind taking out the replacement instead. Shizuku is replaced via the launcher's
+ * seam (AdbHostLauncherSeam.kt).
+ */
+class IpcHostIdentityGateAdbTest : BaseTest() {
+
+    private val ours = IpcContract.HostIdentity(
+        versionCode = 12345,
+        versionName = "1.2.3",
+        lastUpdateTime = 1755800000000,
+        packageCodePath = "/data/app/~~aB1/eu.darken.butler-Xy2/base.apk",
+    )
+
+    /** A host left over from the previous installation: same version, earlier install timestamp. */
+    private val stale = ours.copy(lastUpdateTime = ours.lastUpdateTime - 5000)
+
+    private val binds = AtomicInteger()
+    private val checks = AtomicInteger()
+    private val connectCallbacks = LinkedBlockingQueue<(IBinder?) -> Unit>()
+    private val binder = mockk<IBinder>()
+
+    private inner class FakeFactory(private val service: ShizukuUserService) : ShizukuUserServiceFactory {
+
+        override fun apiVersion(): Int = 11
+
+        override fun <Host : AdbConnection> create(
+            hostClass: KClass<Host>,
+            options: AdbHostOptions,
+            onConnected: (IBinder?) -> Unit,
+            onDisconnected: () -> Unit,
+        ): ShizukuUserService {
+            connectCallbacks.put(onConnected)
+            return service
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <Service : IInterface, Host : AdbConnection> handshake(
+            binder: IBinder?,
+            serviceClass: KClass<Service>,
+            options: AdbHostOptions,
+        ): Pair<Service, Host> = (mockk<AdbConnection>() as Service) to (mockk<AdbConnection>() as Host)
+    }
+
+    /**
+     * Stands in for Shizuku firing onServiceConnected, for however many generations get bound — which
+     * is the thing under test, so it can't be a fixed number of hand-fired callbacks.
+     */
+    private fun startConnectPump(): Thread = Thread {
+        try {
+            while (!Thread.currentThread().isInterrupted) {
+                connectCallbacks.poll(100, TimeUnit.MILLISECONDS)?.invoke(binder)
+            }
+        } catch (_: InterruptedException) {
+            // Shutting down
+        }
+    }.apply {
+        isDaemon = true
+        start()
+    }
+
+    /**
+     * Bounded await, [withTimeoutOrNull] plus an explicit failure. Never `withTimeout` here: its
+     * `TimeoutCancellationException` unwinds a test body as a cancellation rather than a failure, so a
+     * regression that re-introduces a hang would be reported as a pass.
+     */
+    private suspend fun <T> awaitOrFail(what: String, block: suspend () -> T): T =
+        withTimeoutOrNull(5 * 1000L) { block() } ?: throw AssertionError("Timed out waiting for $what")
+
+    /** bind() runs detached from the flow, so its count is only stable once it has caught up. */
+    private suspend fun awaitBinds(expected: Int) = awaitOrFail("$expected bind(s)") {
+        while (binds.get() < expected) delay(10)
+    }
+
+    /** The launcher under the gate, answering [replies] in order, one per host generation. */
+    private fun AdbHostLauncher.gated(vararg replies: String, unbindTimeoutMs: Long) = createConnection(
+        serviceClass = AdbConnection::class,
+        hostClass = AdbConnection::class,
+        // Explicit values: AdbHostOptions()'s isDebug default triggers BuildConfigWrap's static init,
+        // which isn't available on a plain JVM.
+        options = AdbHostOptions(isDebug = false, isTrace = false, recorderPath = null),
+        unbindTimeoutMs = unbindTimeoutMs,
+    )
+        .map { IpcHostAttempt(it.service, it.disconnectConfirmed) }
+        .gateOnHostIdentity(
+            tag = "test",
+            expected = { ours },
+            checkBase = { replies[minOf(checks.getAndIncrement(), replies.lastIndex)] },
+            onAccepted = { _, identity -> "connection#${identity.lastUpdateTime}" },
+        )
+
+    private fun launcher(service: ShizukuUserService, scope: CoroutineScope) = AdbHostLauncher(
+        serviceFactory = FakeFactory(service),
+        appScope = scope,
+        // Real dispatchers: the wedge below blocks an actual thread, virtual time can't model that.
+        dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+    )
+
+    @Test fun `a mismatch does not rebind while the stale unbind is still in flight`() = runTest(
+        timeout = 10.seconds,
+    ) {
+        val unbindEntered = CompletableDeferred<Unit>()
+        val unbindWedge = CountDownLatch(1)
+        val service = object : ShizukuUserService {
+            override fun bind() {
+                binds.incrementAndGet()
+            }
+
+            override fun unbind() {
+                unbindEntered.complete(Unit)
+                unbindWedge.await() // blocks the thread, unaffected by coroutine cancellation
+            }
+
+            override suspend fun awaitDisconnect() {}
+        }
+        val realScope = CoroutineScope(SupervisorJob())
+        val hostLauncher = launcher(service, realScope)
+        val pump = startConnectPump()
+
+        try {
+            val result = realScope.async(Dispatchers.Default) {
+                runCatching { hostLauncher.gated(stale.encode(), ours.encode(), unbindTimeoutMs = 250L).first() }
+            }
+
+            withContext(Dispatchers.Default) {
+                awaitOrFail("unbind() to be entered") { unbindEntered.await() }
+
+                // Teardown gives up on the wedged unbind, and an unconfirmed teardown is not a base to
+                // rebind on: the mismatch reaches the caller instead.
+                val error = awaitOrFail("the collector to be released") { result.await() }.exceptionOrNull()
+                error.shouldBeInstanceOf<IpcContractMismatchException>()
+            }
+
+            // The whole point: no second generation for the in-flight unbind to remove.
+            binds.get() shouldBe 1
+        } finally {
+            unbindWedge.countDown()
+            pump.interrupt()
+            realScope.cancel()
+        }
+    }
+
+    @Test fun `a mismatch rebinds once the teardown is confirmed`() = runTest(timeout = 10.seconds) {
+        val service = object : ShizukuUserService {
+            override fun bind() {
+                binds.incrementAndGet()
+            }
+
+            override fun unbind() {}
+
+            override suspend fun awaitDisconnect() {}
+        }
+        val realScope = CoroutineScope(SupervisorJob())
+        val hostLauncher = launcher(service, realScope)
+        val pump = startConnectPump()
+
+        try {
+            val result = realScope.async(Dispatchers.Default) {
+                runCatching { hostLauncher.gated(stale.encode(), ours.encode(), unbindTimeoutMs = 250L).first() }
+            }
+
+            withContext(Dispatchers.Default) {
+                val connection = awaitOrFail("the replacement connection") { result.await() }.getOrThrow()
+                connection shouldBe "connection#${ours.lastUpdateTime}"
+
+                awaitBinds(2)
+            }
+        } finally {
+            pump.interrupt()
+            realScope.cancel()
+        }
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.common.ipc
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -15,10 +16,12 @@ import testhelpers.BaseTest
 
 /**
  * Covers what the service clients do with the identity a host echoes back: the fresh-connection gate,
- * its single bounded reconnect, and that the stale host's teardown is finished before the reconnect.
+ * its single bounded reconnect, and that a reconnect only happens once the stale host is known to be
+ * gone.
  *
  * The upstream here stands in for RootHostLauncher/AdbHostLauncher: one host per collection, with the
- * bind/unbind/await-disconnect breadcrumbs those launchers emit in their teardown.
+ * bind/unbind/await-disconnect breadcrumbs those launchers emit in their teardown. The real ADB
+ * launcher's teardown feeding that signal is covered in IpcHostIdentityGateAdbTest.
  */
 class IpcHostIdentityGateTest : BaseTest() {
 
@@ -35,22 +38,33 @@ class IpcHostIdentityGateTest : BaseTest() {
     private val events = mutableListOf<String>()
     private var launches = 0
 
-    /** Emits one "host" (its index) per collection and tears it down like the real launchers do. */
-    private fun hosts(): Flow<Int> = callbackFlow {
+    /**
+     * Emits one "host" (its index) per collection and tears it down like the real launchers do.
+     *
+     * [disconnectConfirmed] picks the launcher being stood in for: null is the root path, which has
+     * no teardown signal, true/false are an ADB teardown that did or didn't finish — completed in the
+     * teardown itself, exactly like AdbHostLauncher does.
+     */
+    private fun hosts(disconnectConfirmed: Boolean? = null): Flow<IpcHostAttempt<Int>> = callbackFlow {
         val host = launches++
+        val teardown = CompletableDeferred<Boolean>()
         events += "bind#$host"
-        send(host)
+        send(IpcHostAttempt(host, teardown.takeIf { disconnectConfirmed != null }))
         try {
             awaitClose { }
         } finally {
             withContext(NonCancellable) {
                 events += "unbind#$host"
                 events += "awaitDisconnect#$host"
+                disconnectConfirmed?.let { teardown.complete(it) }
             }
         }
     }
 
-    private fun gate(vararg replies: String?) = hosts().gateOnHostIdentity(
+    private fun gate(
+        vararg replies: String?,
+        disconnectConfirmed: Boolean? = null,
+    ) = hosts(disconnectConfirmed).gateOnHostIdentity(
         tag = "test",
         expected = { ours },
         checkBase = { host -> replies[minOf(host, replies.size - 1)] },
@@ -83,6 +97,25 @@ class IpcHostIdentityGateTest : BaseTest() {
             "connection#1(${ours.lastUpdateTime})"
 
         launches shouldBe 2
+    }
+
+    @Test fun `a confirmed teardown lets the replacement bind`() = runTest {
+        gate(stale.encode(), ours.encode(), disconnectConfirmed = true).first() shouldBe
+            "connection#1(${ours.lastUpdateTime})"
+
+        launches shouldBe 2
+    }
+
+    @Test fun `a teardown that could not be confirmed is not replaced`() = runTest {
+        // The stale host may still be on its way out (a Shizuku unbind we stopped waiting for), and a
+        // replacement bound now could be what that removal hits. Reporting unavailable is the lesser
+        // failure, so the mismatch propagates instead.
+        shouldThrow<IpcContractMismatchException> {
+            gate(stale.encode(), ours.encode(), disconnectConfirmed = false).first()
+        }
+
+        launches shouldBe 1
+        events shouldContainInOrder listOf("bind#0", "unbind#0")
     }
 
     @Test fun `an unrelated failure is not retried`() = runTest {

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/IpcHostIdentityGateTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.butler.common.ipc
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Covers what the service clients do with the identity a host echoes back: the fresh-connection gate,
+ * its single bounded reconnect, and that the stale host's teardown is finished before the reconnect.
+ *
+ * The upstream here stands in for RootHostLauncher/AdbHostLauncher: one host per collection, with the
+ * bind/unbind/await-disconnect breadcrumbs those launchers emit in their teardown.
+ */
+class IpcHostIdentityGateTest : BaseTest() {
+
+    private val ours = IpcContract.HostIdentity(
+        versionCode = 12345,
+        versionName = "1.2.3",
+        lastUpdateTime = 1755800000000,
+        packageCodePath = "/data/app/~~aB1/eu.darken.butler-Xy2/base.apk",
+    )
+
+    /** A host left over from the previous installation: same version, earlier install timestamp. */
+    private val stale = ours.copy(lastUpdateTime = ours.lastUpdateTime - 5000)
+
+    private val events = mutableListOf<String>()
+    private var launches = 0
+
+    /** Emits one "host" (its index) per collection and tears it down like the real launchers do. */
+    private fun hosts(): Flow<Int> = callbackFlow {
+        val host = launches++
+        events += "bind#$host"
+        send(host)
+        try {
+            awaitClose { }
+        } finally {
+            withContext(NonCancellable) {
+                events += "unbind#$host"
+                events += "awaitDisconnect#$host"
+            }
+        }
+    }
+
+    private fun gate(vararg replies: String?) = hosts().gateOnHostIdentity(
+        tag = "test",
+        expected = { ours },
+        checkBase = { host -> replies[minOf(host, replies.size - 1)] },
+        onAccepted = { host, identity -> "connection#$host(${identity.lastUpdateTime})" },
+    )
+
+    @Test fun `a matching identity is handed straight through`() = runTest {
+        gate(ours.encode()).first() shouldBe "connection#0(${ours.lastUpdateTime})"
+        launches shouldBe 1
+    }
+
+    @Test fun `a stale host is torn down and replaced, once`() = runTest {
+        gate(stale.encode(), ours.encode()).first() shouldBe "connection#1(${ours.lastUpdateTime})"
+
+        launches shouldBe 2
+        // The stale host must be gone before the replacement binds: Shizuku keys its late unbind on
+        // the service args, so an unbind still in flight can remove the newer generation.
+        events shouldContainInOrder listOf("bind#0", "unbind#0", "awaitDisconnect#0", "bind#1")
+    }
+
+    @Test fun `a host that stays stale fails without looping`() = runTest {
+        shouldThrow<IpcContractMismatchException> { gate(stale.encode()).first() }
+
+        launches shouldBe 2
+        events shouldContainInOrder listOf("unbind#0", "bind#1", "unbind#1")
+    }
+
+    @Test fun `a host too old to answer with an identity is a mismatch`() = runTest {
+        gate("ipc-version: 2\nOur pkg: eu.darken.butler", ours.encode()).first() shouldBe
+            "connection#1(${ours.lastUpdateTime})"
+
+        launches shouldBe 2
+    }
+
+    @Test fun `an unrelated failure is not retried`() = runTest {
+        val boom = IllegalStateException("host went away")
+        val flow = hosts().gateOnHostIdentity<Int, String>(
+            tag = "test",
+            expected = { ours },
+            checkBase = { throw boom },
+            onAccepted = { _, _ -> "unreachable" },
+        )
+
+        shouldThrow<IllegalStateException> { flow.first() } shouldBe boom
+        launches shouldBe 1
+    }
+}

--- a/app-common-root/src/main/java/eu/darken/butler/common/root/service/internal/RootHostInitArgs.kt
+++ b/app-common-root/src/main/java/eu/darken/butler/common/root/service/internal/RootHostInitArgs.kt
@@ -10,5 +10,13 @@ data class RootHostInitArgs(
     val waitForDebugger: Boolean = false,
     val isDebug: Boolean = false,
     val isTrace: Boolean = false,
-    val recorderPath: String? = null
+    val recorderPath: String? = null,
+    /**
+     * Encoded `IpcContract.HostIdentity` of the app installation launching this host, echoed back by
+     * the host's `checkBase()` so a host that survived an in-place app update can be detected.
+     *
+     * APPEND new fields, never insert: this is marshalled through a raw [android.os.Parcel], so field
+     * order is the wire format.
+     */
+    val hostIdentity: String? = null,
 ) : Parcelable

--- a/app-common-root/src/main/java/eu/darken/butler/common/root/service/internal/RootHostLauncher.kt
+++ b/app-common-root/src/main/java/eu/darken/butler/common/root/service/internal/RootHostLauncher.kt
@@ -55,6 +55,8 @@ class RootHostLauncher(
         hostClass: KClass<Host>,
         useMountMaster: Boolean = false,
         options: RootHostOptions,
+        /** Encoded `IpcContract.HostIdentity` of the launching app installation, stamped into the host. */
+        hostIdentity: String,
     ): Flow<ConnectionWrapper<Service>> = callbackFlow {
         val iTag = "$TAG:${Uuid.random().toString().takeLast(4)}"
         log(iTag, INFO) { "createConnection($serviceClass, $hostClass, $useMountMaster, $options)" }
@@ -110,7 +112,7 @@ class RootHostLauncher(
                 }
             }
 
-            val command = commandFactory.create(hostClass, pairingCode, options)
+            val command = commandFactory.create(hostClass, pairingCode, options, hostIdentity)
 
             // Attempt 1: direct exec. Blocks until the root host process exits (success path, with
             // onConnect having fired meanwhile) or fails fast on a broken pipe / unsupported exec.

--- a/app-common-root/src/main/java/eu/darken/butler/common/root/service/internal/RootHostLauncherSeam.kt
+++ b/app-common-root/src/main/java/eu/darken/butler/common/root/service/internal/RootHostLauncherSeam.kt
@@ -60,11 +60,15 @@ interface RootLaunchCommandFactory {
      * (which touches [Debug] and the package name) plus [RootHostCmdBuilder] (which touches Parcel /
      * reflection), none of which run on a plain JVM — hence the seam. The args are captured ONCE here
      * so the direct-exec and relocation attempts use identical init args (matching pre-seam behaviour).
+     *
+     * [hostIdentity] is the caller's encoded `IpcContract.HostIdentity`, stamped into the host at
+     * launch so it can be echoed back and compared later.
      */
     fun <Host : BaseRootHost> create(
         hostClass: KClass<Host>,
         pairingCode: String,
         options: RootHostOptions,
+        hostIdentity: String,
     ): RootLaunchCommand
 }
 
@@ -105,6 +109,7 @@ internal class DefaultRootLaunchCommandFactory(
         hostClass: KClass<Host>,
         pairingCode: String,
         options: RootHostOptions,
+        hostIdentity: String,
     ): RootLaunchCommand {
         // Captured once per connection — both launch attempts reuse these.
         val initArgs = RootHostInitArgs(
@@ -114,6 +119,7 @@ internal class DefaultRootLaunchCommandFactory(
             isDebug = options.isDebug,
             isTrace = options.isTrace,
             recorderPath = options.recorderPath,
+            hostIdentity = hostIdentity,
         )
         val cmdBuilder = RootHostCmdBuilder(context, hostClass)
         return object : RootLaunchCommand {

--- a/app-common-root/src/test/java/eu/darken/butler/common/root/service/internal/RootHostLauncherTest.kt
+++ b/app-common-root/src/test/java/eu/darken/butler/common/root/service/internal/RootHostLauncherTest.kt
@@ -83,13 +83,16 @@ class RootHostLauncherTest {
 
     private class FakeCommandFactory : RootLaunchCommandFactory {
         val relocations = mutableListOf<Boolean>()
+        val identities = mutableListOf<String>()
         override fun <Host : BaseRootHost> create(
             hostClass: kotlin.reflect.KClass<Host>,
             pairingCode: String,
             options: RootHostOptions,
+            hostIdentity: String,
         ): RootLaunchCommand = object : RootLaunchCommand {
             override fun build(withRelocation: Boolean): FlowCmd {
                 relocations += withRelocation
+                identities += hostIdentity
                 return FlowCmd("launch relocate=$withRelocation")
             }
         }
@@ -105,6 +108,7 @@ class RootHostLauncherTest {
         serviceClass = RootConnection::class,
         hostClass = BaseRootHost::class,
         options = RootHostOptions(),
+        hostIdentity = HOST_IDENTITY,
     )
 
     @Test fun `session open failure still releases the receiver`() = runTest {
@@ -208,10 +212,14 @@ class RootHostLauncherTest {
         job.cancelAndJoin()
 
         cmds.relocations shouldBe listOf(false) // connected -> relocation retry skipped
+        cmds.identities shouldBe listOf(HOST_IDENTITY) // our identity is stamped into the launch args
         emitted shouldHaveSize 1 // factory-routed callback sent the connection into the flow
     }
 
     companion object {
+        /** Stand-in for the launching app's encoded `IpcContract.HostIdentity`, opaque to the launcher. */
+        private const val HOST_IDENTITY = "ipc-host-identity: test"
+
         private fun ok(cmd: FlowCmd) = FlowCmd.Result(cmd, FlowProcess.ExitCode.OK, emptyList(), emptyList())
     }
 }

--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
@@ -65,7 +65,9 @@ class RootSetupModule @Inject constructor(
                 @Suppress("USELESS_CAST")
                 baseState.copy(
                     ourService = try {
-                        IpcContract.isCompatible(connection.ipc.checkBase())
+                        // The round-trip is the liveness proof; the identity in its reply must still
+                        // be the one the connection was gated on.
+                        IpcContract.decode(connection.ipc.checkBase()) == connection.hostIdentity
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -74,9 +76,8 @@ class RootSetupModule @Inject constructor(
                     },
                 ) as SetupModule.State
             }
-            // The service client now rejects a host that speaks a different IpcContract.VERSION, so
-            // obtaining the binder itself can fail. Report "no service" rather than erroring the
-            // whole setup flow.
+            // The service client rejects a host left over from an older app installation, so obtaining
+            // the binder itself can fail. Report "no service" rather than erroring the whole setup flow.
             .catch { e ->
                 log(TAG, WARN) { "Root service unavailable: $e" }
                 emit(baseState as SetupModule.State)

--- a/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
@@ -38,6 +38,13 @@ class RootSetupModuleTest : BaseTest() {
     private lateinit var scope: CoroutineScope
     private var probeCount = 0
 
+    private val hostIdentity = IpcContract.HostIdentity(
+        versionCode = 12345,
+        versionName = "1.2.3",
+        lastUpdateTime = 1755800000000,
+        packageCodePath = "/data/app/~~aB1/eu.darken.butler-Xy2/base.apk",
+    )
+
     @BeforeEach
     fun setup() {
         probeCount = 0
@@ -50,7 +57,8 @@ class RootSetupModuleTest : BaseTest() {
         coEvery { rootManager.isInstalled() } returns true
         every { rootManager.binder } returns flowOf(connection)
         every { connection.ipc } returns ipc
-        every { ipc.checkBase() } answers { probeCount++; "${IpcContract.marker()}\nok" }
+        every { connection.hostIdentity } returns hostIdentity
+        every { ipc.checkBase() } answers { probeCount++; "${hostIdentity.encode()}\nok" }
     }
 
     @AfterEach
@@ -123,23 +131,25 @@ class RootSetupModuleTest : BaseTest() {
         runBlocking { collector.cancelAndJoin() }
     }
 
-    @Test fun `a host without a version marker is not reported as our service`() {
+    @Test fun `a host without an identity is not reported as our service`() {
         // Pre-handshake hosts answer with a plain diagnostic string. Its transaction codes need not
         // match ours, so the setup card must not show as complete.
         every { ipc.checkBase() } answers { probeCount++; "Our pkg: eu.darken.butler" }
         val mod = module()
 
-        val collector = mod.state.test(tag = "no-marker", scope = scope)
+        val collector = mod.state.test(tag = "no-identity", scope = scope)
         collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
 
         collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>().ourService shouldBe false
     }
 
-    @Test fun `a host with a mismatched version is not reported as our service`() {
-        every { ipc.checkBase() } answers { probeCount++; "ipc-version: ${IpcContract.VERSION + 1}\nok" }
+    @Test fun `a host from another installation is not reported as our service`() {
+        // Same app version, reinstalled: only lastUpdateTime gives the leftover host away.
+        val leftover = hostIdentity.copy(lastUpdateTime = hostIdentity.lastUpdateTime - 5000)
+        every { ipc.checkBase() } answers { probeCount++; "${leftover.encode()}\nok" }
         val mod = module()
 
-        val collector = mod.state.test(tag = "bad-version", scope = scope)
+        val collector = mod.state.test(tag = "stale-host", scope = scope)
         collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
 
         collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>().ourService shouldBe false


### PR DESCRIPTION
## What changed

When Butler's root or Shizuku helper process belongs to an older installation of the app, Butler now notices and replaces it instead of talking to it. Previously it could issue calls against a helper running different code, where the same request number can mean a different operation.

No visible behaviour change in normal use.

## Technical Context

- Replaces the hand-bumped `IpcContract.VERSION` from #51, which was the wrong granularity and required discipline it could not enforce. The host classes ship in the app's own APK and the root host is launched with `CLASSPATH=$packageCodePath exec app_process … <hostClass>`, so an update changes host *behaviour*, not just AIDL shape. A constant, or the AIDL fingerprint originally sketched as the follow-up, tracks interface shape only and misses host logic changes and `@Parcelize` field reordering.
- Identity is derived at runtime from the installed package (`versionCode`, `versionName`, `lastUpdateTime`, `packageCodePath`), so nothing is baked into the APK and reproducible builds are unaffected. `lastUpdateTime` is the discriminator: it changes on same-version reinstalls, which is the case that actually produces stale hosts during development.
- **The client stamps, the host echoes.** The identity goes into `RootHostInitArgs` / `AdbHostOptions` at launch and comes back on the first line of `checkBase()`. The host deliberately does not read its own metadata: `RootHost` builds its graph with `systemContext`, which identifies the `android` package, so a host-side read would mismatch permanently. Stamping also removes any PackageManager use in the host and makes "captured at process start" structural.
- **Recovery is asymmetric on purpose, and this is the part worth reviewing.** Root teardown is structured, so the gate reconnects once unconditionally. Shizuku's `unbindUserService(remove=true)` is a synchronous binder call that can wedge past its timeout, and removal is keyed on the service args, so rebinding early risks the late unbind removing the *replacement*. `AdbHostLauncher` therefore reports a `disconnectConfirmed` signal and the gate reconnects only when teardown is confirmed; otherwise the mismatch propagates and the host reads as unavailable, which is the better failure.
- `AdbServiceClient` also excludes `IpcContractMismatchException` from `isRetryableStartupFailure`, because `SharedResource` runs its own fresh-generation retry for a concurrent waiter and would otherwise route around that decision entirely. The predicate is a single shared value used by both the client and its regression test, so reverting it makes the test fail rather than leaving it green.
- Verified on a rooted Pixel 7a with Shizuku: both paths stamp and echo the identity correctly. Worth stating plainly — reinstalling over live hosts did **not** reproduce the stale case, because package replacement killed both helpers before the new client connected. This mechanism is defensive rather than routinely exercised; it is not established as dead code across other Shizuku versions, root managers or vendor ROMs, but ordinary in-place installs do not appear to trigger it.