### PR TITLE
General: Fix Android Studio variant conflict on Google Play builds

### DIFF
--- a/.claude/rules/development-commands.md
+++ b/.claude/rules/development-commands.md
@@ -15,8 +15,8 @@
 # Build debug version (FOSS flavor) - main app
 ./gradlew :app:compileFossDebugKotlin --no-daemon
 
-# Build specific modules (use compileDebugKotlin, not compileFossDebugKotlin for modules)
-./gradlew :app-workspace:compileDebugKotlin --no-daemon
+# Build specific modules (every module carries the foss/gplay dimension)
+./gradlew :app-workspace:compileFossDebugKotlin --no-daemon
 
 # Build release version
 ./gradlew :app:bundleFossRelease

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -6,7 +6,7 @@ paths: ["**/src/test*/**", "**/src/androidTest/**", "**/*Test.kt", "app-common-t
 
 ## Test Commands
 
-Standard Gradle invocations (`testDebugUnitTest`, `--tests "<fqcn>"`, `connectedAndroidTest`). Flavored modules need the flavor in the task name — see the Compose section below.
+Standard Gradle invocations (`testFossDebugUnitTest`, `--tests "<fqcn>"`, `connectedAndroidTest`). Every module carries the `version` flavor dimension, so unit test tasks always include the flavor — there is no flavor-free `testDebugUnitTest`.
 
 ## What to Test
 
@@ -53,9 +53,8 @@ class MyComponentTest : ComposeTest() {
 **Running Compose tests:**
 
 ```bash
-# Module without flavors
-./gradlew :app-workspace:testDebugUnitTest --tests "*.MyComponentTest"
+./gradlew :app-workspace:testFossDebugUnitTest --tests "*.MyComponentTest"
 
-# Module with flavors (app-common)
-./gradlew :app-common:testFossDebugUnitTest --tests "*.MyComponentTest"
+# The gplay side of the same module
+./gradlew :app-workspace:testGplayDebugUnitTest --tests "*.MyComponentTest"
 ```

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -56,7 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         variant: [ Debug ]
-        flavor: [ test,testFoss,testGplay ]
+        # Every module carries the `version` dimension, so there is no flavor-free
+        # `testDebugUnitTest` task left to run; these two cover the whole tree.
+        flavor: [ testFoss,testGplay ]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Assemble beta APK
         if: "contains(github.ref_name, '-beta') && steps.existing_release.outputs.published != 'true'"
-        run: ./gradlew assembleFossBeta
+        run: ./gradlew :app:assembleFossBeta
         env:
           VERSION: ${{ github.ref }}
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Assemble production APK
         if: "!contains(github.ref_name, '-beta') && steps.existing_release.outputs.published != 'true'"
-        run: ./gradlew assembleFossRelease
+        run: ./gradlew :app:assembleFossRelease
         env:
           VERSION: ${{ github.ref }}
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Must match the artifacts uploaded by the test-modules matrix in code-checks.yml
         variant: [ Debug ]
-        flavor: [ test,testFoss,testGplay ]
+        flavor: [ testFoss,testGplay ]
     steps:
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 #v3.0.0

--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -15,18 +15,7 @@ apply(plugin = "org.jetbrains.kotlinx.kover")
 android {
     namespace = "${projectConfig.packageName}.common"
 
-    setupLibraryDefaults(projectConfig, ownsVersionFlavor = true)
-
-    flavorDimensions.add("version")
-    productFlavors {
-        create("foss") {
-            dimension = "version"
-            isDefault = true
-        }
-        create("gplay") {
-            dimension = "version"
-        }
-    }
+    setupLibraryDefaults(projectConfig)
 
     setupModuleBuildTypes()
 
@@ -72,9 +61,6 @@ dependencies {
     addCoil()
     addLottie()
     addRoomDb()
-
-    "gplayImplementation"(libs.billing.core)
-    "gplayImplementation"(libs.billing.ktx)
 }
 
 // Kover's verify rules can't filter per-rule (only the report can), so to gate ONLY the

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/text/PieceStorageBenchmark.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/text/PieceStorageBenchmark.kt
@@ -15,7 +15,7 @@ import kotlin.time.measureTime
  * The `manual-benchmark` tag is excluded from the module's normal `Test` tasks, so this class is
  * absent from the test plan (not reported as skipped). Run it manually with:
  *
- * `./gradlew :app-workspace-editor:testDebugUnitTest -PrunEditorBenchmarks --tests "*PieceStorageBenchmark*"`
+ * `./gradlew :app-workspace-editor:testFossDebugUnitTest -PrunEditorBenchmarks --tests "*PieceStorageBenchmark*"`
  *
  * Decision rule: consider a piece tree only if per-edit latency at >= 10k pieces exceeds ~1ms
  * or UI jank is otherwise plausible. Storage is internal to PieceTable, so a later swap needs

--- a/buildSrc/src/main/java/ProjectExtensions.kt
+++ b/buildSrc/src/main/java/ProjectExtensions.kt
@@ -23,12 +23,8 @@ fun Project.setupRoomSchemas() {
     }
 }
 
-/**
- * @param ownsVersionFlavor set this for the module that DECLARES the `version` flavor dimension.
- */
 fun LibraryExtension.setupLibraryDefaults(
     projectConfig: ProjectConfig,
-    ownsVersionFlavor: Boolean = false,
 ) {
     if (projectConfig.compileSdkPreview != null) {
         compileSdkPreview = projectConfig.compileSdkPreview
@@ -39,16 +35,21 @@ fun LibraryExtension.setupLibraryDefaults(
     defaultConfig {
         minSdk = projectConfig.minSdk
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
 
-        // Modules without the `version` dimension need this fallback to resolve flavored
-        // dependencies (app-common) against foss.
-        // The module that OWNS the dimension must NOT apply it: the strategy also overrides that
-        // module's OWN requested flavor attribute, so its gplay variants would request
-        // version=foss and compile against the foss classes.jar. That jar is not the Kotlin
-        // friend-path jar of the gplay variant, so every `internal` member of the module becomes
-        // inaccessible to its own gplay unit tests ("it is internal in ...").
-        if (!ownsVersionFlavor) {
-            missingDimensionStrategy("version", "foss")
+    // Every library carries the `version` dimension, even the ones with no flavor-specific source,
+    // so the attribute propagates down from :app and each module resolves to a single variant.
+    // The alternative (pinning consumers with missingDimensionStrategy) makes :app-common resolve
+    // as gplay on :app's direct edge and as foss on every transitive one. Android Studio selects
+    // one variant per module, so it cannot represent that and reports a variant selection conflict.
+    flavorDimensions.add("version")
+    productFlavors {
+        create("foss") {
+            dimension = "version"
+            isDefault = true
+        }
+        create("gplay") {
+            dimension = "version"
         }
     }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Selecting a Google Play build variant in Android Studio reported "variant selection conflicts found". Every library module now carries the foss/gplay flavor dimension, so the IDE resolves a single variant per module and the warning goes away. Command-line builds were already correct and are unaffected.

## Technical Context

- Root cause: `:app-common` was the only module declaring the `version` dimension, and `setupLibraryDefaults` pinned every other library to foss via `missingDimensionStrategy`. That made `:app-common` resolve as gplay on `:app`'s direct edge and as foss on all 18 transitive edges. Gradle resolves that per-configuration and built fine, but Android Studio selects one variant per module and cannot represent two.
- The `ownsVersionFlavor` parameter and the Kotlin friend-path caveat it carried are both gone. That hazard existed only because `missingDimensionStrategy` overrode the owning module's own flavor attribute; with no strategy left, it cannot occur.
- Alternative considered and rejected: moving the one genuinely flavored resource (`app_name_upgrade_postfix`) into `:app`'s existing flavor source sets, which would have let `app-common` stay flavor-free. Keeping it as a flavored source-set resource in `app-common` was the deliberate choice.
- Renaming the library test tasks forced three follow-on fixes worth reviewing together: the unit test matrix drops its flavor-free `test` entry (no longer resolves to any task), `test-reports.yml` drops the matching entry so it stops requesting an artifact that is no longer produced (that consumer matrix exists specifically to mirror the producer, per f260c7aa, so changing one side alone re-breaks it), and `release-tag.yml` scopes its assemble tasks to `:app` — unqualified `assembleFossBeta` used to match only `:app` but now matches all 20 modules.
- Trade-off: 17 modules have no flavor-specific source but now build and test twice. Measured configuration cost is +238ms with the configuration cache disabled, and effectively zero with it enabled (it is on by default here).
- Not yet confirmed: the fix targets an IDE-model defect, and every check run against it so far has been command-line Gradle, which built this variant successfully before the change too. A Studio sync selecting `gplayBeta` is what actually validates the premise.
