### PR TITLE
General: Label pull requests automatically by the modules they touch

### DIFF
--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -1,4 +1,4 @@
-# Commit Message Guidelines
+# Commit & Pull Request Guidelines
 
 ## Format
 
@@ -15,10 +15,17 @@
 - **Explorer**: File browsing, navigation, file operations
 - **Searcher**: File search functionality
 - **Editor**: Text editing
+- **Viewer**: File preview and viewing
+- **Apps**: App management workspace
 - **Templates**: Workspace template management
+- **History**: Operation history
+- **Saver**: Save/pick target selection
+- **Developer**: Developer tools workspace
+- **Bugreport**: Bug report workspace
 - **Workspace**: Core workspace framework, tab management
 - **IO**: File I/O, path system, gateway operations
 - **General**: Cross-cutting concerns, architecture, build system
+- **Release**: Version bumps and release plumbing
 - **Fix**: Bug fixes that don't fit a specific module
 
 ## Title Guidelines
@@ -41,3 +48,35 @@ when rendering the breadcrumb bar overlay.
 
 Closes #42
 ```
+
+## Pull Request Titles
+
+PR titles use the same module prefixes as commits. Title rules (user-facing language, no internal
+names) are enforced by the devtools PR skill. The PR body format ("What changed" + "Technical
+Context", no Validation section) is defined in the global instructions, not here.
+
+## Pull Request Labels
+
+Component and platform/scope labels are applied automatically by `.github/workflows/pr-labeler.yml`
+from the paths a PR touches (mapping in `.github/labeler.yml`). Do not apply those by hand. If a
+label is wrong or missing, the glob is wrong, so fix `labeler.yml` instead.
+
+The labels below are the ones a human or the PR skill still has to set. Run `gh label list` to see
+what exists, and do not invent new labels.
+
+- **Type labels**: `bug` for fixes, `enhancement` for new features/improvements, `Chore` for
+  refactors/tests/cleanup, `documentation` for docs-only changes. Every PR gets exactly one.
+- **Device-specific labels**: `Device specific` plus the relevant ROM label (`ROM: OneUI`,
+  `ROM: LOS`, `ROM: MIUI`, `ROM: HyperOS`, `ROM: ColorOS`, `ROM: OxygenOS`, `ROM: AOSP`, …) when
+  fixing manufacturer/ROM-specific behavior.
+- **API level labels** (`api: 26 A8.0 (Oreo)` through `api: 37 A17 (Cinnamon Bun)`): apply when the
+  change targets behavior specific to certain Android versions, e.g. a scoped-storage or SAF
+  restriction that only exists from a given release on.
+- **Scope labels the globs cannot see**: `General UI/UX` and `F-Droid`, which describe work spread
+  across modules rather than confined to a directory the mapping matches.
+
+The type label is the only mandatory one. Skip anything from the other three groups that doesn't
+clearly fit, no extra label is better than a wrong one.
+
+Component labels are only added, never removed, by the workflow (`sync-labels: false`), so a label
+you add by hand survives later pushes.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,138 @@
+# Path-based PR labels, applied by .github/workflows/pr-labeler.yml
+#
+# Only labels that follow objectively from the changed paths belong here.
+# Type labels (bug/enhancement/Chore/documentation), device/ROM labels and
+# api-level labels are not derivable from a diff and stay manual.
+#
+# Under pull_request_target this file is read from the base branch, so edits
+# only take effect once they are merged into main.
+
+"c: Explorer":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-explorer/**"
+
+"c: Searcher":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-searcher/**"
+
+"c: Editor":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-editor/**"
+
+"c: Viewer":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-viewer/**"
+
+"c: Apps":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-apps/**"
+
+"c: Templates":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-templates/**"
+
+"c: History":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-history/**"
+
+"c: Saver":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-saver/**"
+
+"c: Developer":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-developer/**"
+
+"c: Bugreport":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace-bugreport/**"
+
+"c: Workspace":
+  - changed-files:
+      - any-glob-to-any-file: "app-workspace/**"
+
+"c: IO":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app-common-io/**"
+          - "app-common-shell/**"
+
+"c: PKGS":
+  - changed-files:
+      - any-glob-to-any-file: "app-common-pkgs/**"
+
+"c: Documents":
+  - changed-files:
+      - any-glob-to-any-file: "app-provider-documents/**"
+
+"c: Setup":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*/src/*/java/eu/darken/butler/setup/**"
+          - "*/src/*/java/eu/darken/butler/workspace/core/setup/**"
+          - "app/src/*/java/eu/darken/butler/main/ui/onboarding/**"
+
+Root:
+  - changed-files:
+      - any-glob-to-any-file: "app-common-root/**"
+
+ADB:
+  - changed-files:
+      - any-glob-to-any-file: "app-common-adb/**"
+
+SAF:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app-common-io/src/*/java/eu/darken/butler/common/files/saf/**"
+          - "app-common-io/src/*/java/eu/darken/butler/common/files/SAFPath*"
+          - "app-common-io/src/*/java/eu/darken/butler/common/storage/saf/**"
+          - "app-common-io/schemas/*SAFLocationDatabase/**"
+
+MOTD:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "motd/**"
+          - "app/src/*/java/eu/darken/butler/main/core/motd/**"
+          - "app/src/*/java/eu/darken/butler/main/ui/motd/**"
+
+# Locale-shaped qualifiers only. The character classes matter: values-?? would
+# also match API and density qualifiers such as values-v4, and letters-only
+# keeps values-night, values-sw600dp and values-car out. Butler has no
+# translated resources yet, these match once Crowdin pulls land.
+Translation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/res/values-[a-z][a-z]/strings.xml"
+          - "**/res/values-[a-z][a-z]-r[A-Z][A-Z]/strings.xml"
+          - "**/res/values-b+*/strings.xml"
+  # Store listing changes, but only when they touch a locale other than the
+  # en-US source. Both globs must match a changed file for this rule to fire.
+  - changed-files:
+      - all-globs-to-any-file:
+          - "fastlane/metadata/android/**"
+          - "!fastlane/metadata/android/en-US/**"
+
+FOSS:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*/src/foss/**"
+          - "*/src/testFoss/**"
+          - "motd/foss/**"
+
+"Google Play":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*/src/gplay/**"
+          - "*/src/testGplay/**"
+          - "motd/gplay/**"
+
+"Build process":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.gradle"
+          - "**/*.gradle.kts"
+          - "gradle/**"
+          - "gradlew"
+          - "gradlew.bat"
+          - "buildSrc/**"
+          - ".github/**"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,38 @@
+name: PR labeler
+
+# Applies component and platform/scope labels based on the paths a PR touches.
+# The mapping lives in .github/labeler.yml.
+#
+# pull_request_target is required so PRs from forks and from dependabot get a
+# token that can write labels. It is safe here because this workflow never
+# checks out or executes the PR's code, it only reads the changed file list
+# through the API. Do not add a checkout step.
+#
+# Two consequences of pull_request_target: the config is read from the base
+# branch, so changes to labeler.yml only apply after they land on main, and
+# this workflow will not label the PR that introduces it.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 #v7.0.0
+        with:
+          # Labels are pre-created in the repository, so issues:write is not needed.
+          # sync-labels stays off so manually added labels are never stripped.
+          sync-labels: false


### PR DESCRIPTION
## What changed

No user-facing behavior change.

Pull requests now get component and platform labels applied automatically from the files they touch, and the repository has a label taxonomy to apply them from. 54 labels were created, modelled on sd-maid-se so both projects share colours and descriptions: component labels for each workspace and infrastructure module, `Chore` alongside the existing type labels, the platform/scope set (Root, ADB, SAF, FOSS, Google Play, F-Droid, Translation, Build process, General UI/UX, MOTD), `Device specific` with 15 ROM labels, and api levels 26 through 37.

## Technical Context

* Only labels that follow objectively from a diff are automated. Type labels (`bug`/`enhancement`/`Chore`/`documentation`), ROM labels and api-level labels cannot be derived from changed paths and stay manual, documented in `commit-guidelines.md`. Branch-prefix inference for type labels was considered and rejected: branch naming isn't enforced, and a wrong `enhancement` on a bugfix is worse than no label.
* The workflow runs on `pull_request_target` because fork and dependabot PRs get a read-only token under `pull_request` and cannot write labels. This is safe only because the workflow never checks out or executes PR code, it just reads the changed file list through the API. Do not add a checkout step. `issues: write` is deliberately omitted, it would only be needed to create labels that don't exist yet, and all 23 referenced labels are pre-created.
* Two `pull_request_target` consequences: the config is read from the base branch, so `labeler.yml` edits only take effect after merging, and this PR will not label itself. First real verification is the next PR opened after this lands.
* Worth close review are the globs in `.github/labeler.yml`. Each was checked against minimatch and the actual tree: `app-workspace/**` does not leak into `app-workspace-explorer/**`, `values-[a-z][a-z]` keeps `values-v4`/`values-night`/`values-car` out of `Translation`, and the `!fastlane/metadata/android/en-US/**` negation inside `all-globs-to-any-file` fires only when a non-en-US locale is touched. The `Translation` locale globs match nothing today, which is expected since there are no translated resources yet.
* `sync-labels` is off, so a ROM or api-level label applied by hand is never stripped by a later push.
* The module prefix list in `commit-guidelines.md` was stale: Viewer, Apps, History, Saver, Developer, Bugreport and Release were already in use in commit titles but undocumented. Corrected here because the component labels mirror that list.
