### PR TITLE
Release: Refresh the default Play Store release notes

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,9 +1,8 @@
-Hey 👋
-Butler is actively developed and not feature complete yet, I'm adding new stuff all the time!
-Got ideas? Let me know 😊
+Butler 🤵 is actively developed and getting frequent updates.
+I'm adding new stuff all the time! Got ideas? Let me know 😊
 
-🐛 Bug fixes, 🚀 performance boosts, maybe even ✨ new features.
+This update may contain bug fixes 🐛, performance boosts 🚀, and even new features ✨.
+A detailed list of changes can be found here: https://butler.darken.eu/changelog
 
-Changelog: https://butler.darken.eu/changelog
-
-FYI: It’s just me here, thanks for understanding if replies take a bit. ¯\_(ツ)_/¯
+Questions? Just mail me!
+Note: It’s just me here, sometimes replies might take a bit. Sorry for that!


### PR DESCRIPTION
## What changed

The default release notes shown on the Play Store listing have new wording. They no longer say Butler isn't feature complete, they point at the online changelog with a full sentence rather than a bare link label, and the note about slow replies is written plainly instead of ending in a shrug.

## Technical Context

- Only `fastlane/metadata/android/en-US/changelogs/default.txt` changes; en-US is the only locale with a changelog directory, so there is nothing to fan out to.
- The text is 390 characters, inside Play's 500 character release-notes limit.