### PR TITLE
Upgrade: Remove upgrade-screen strings left behind by the redesigns

### DIFF
--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -12,14 +12,9 @@
     <string name="upgrade_screen_preamble">Butler has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
 
     <string name="upgrade_screen_how_title">Options</string>
-    <string name="upgrade_screen_how_body">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription starts with a free 14-day trial, after which you\'ll be charged once per year. Trial and subscription are cancellable at any time.\nSame features, just different pricing models.</string>
-    <string name="upgrade_screen_how_body_no_trial">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription is charged once per year and is cancellable at any time.\nSame features, just different pricing models.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
-    <string name="upgrade_screen_subscription_action_hint">The subscription costs %s per year.</string>
     <string name="upgrade_screen_iap_action">One-time purchase</string>
-    <string name="upgrade_screen_iap_action_hint">The one-time purchase costs %s.</string>
-    <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
     <string name="upgrade_screen_restore_banner_title">Already bought Pro?</string>
     <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. Restore your purchase to unlock it again.</string>


### PR DESCRIPTION
**What changed**
No user-facing behavior change. Removes five unused text resources from the Google Play flavor.

**Technical Context**
- `upgrade_screen_iap_action_hint` and `upgrade_screen_subscription_action_hint` were orphaned by 9f367c232, which recast the offers as title-and-price rows. The price is part of the offer heading now, so a separate cost line would just repeat it.
- `upgrade_screen_how_body` and `upgrade_screen_how_body_no_trial` were orphaned by 2401c8a99, which rebuilt the screen around ownership state and offers. `upgrade_screen_offers_body` and the per-offer bodies cover that text now.
- `upgrade_screen_thanks_toast` was never referenced by any gplay code path, neither here nor in the SD Maid code this screen was forked from. Removing it takes away nothing users ever saw.
- The FOSS flavor declares its own separate copies of `upgrade_screen_how_body` and `upgrade_screen_thanks_toast` with different text, and both are still live there. Only the gplay copies are deleted, so FOSS is unaffected.
