### PR TITLE
General: Stop the shared resource churn tests flaking on a benign teardown race

### DIFF
--- a/app-common/src/test/java/eu/darken/butler/common/sharedresource/SharedResourceTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/sharedresource/SharedResourceTest.kt
@@ -835,7 +835,9 @@ class SharedResourceTest : BaseTest() {
                 var r = sr.get()
                 var guard = 0
                 // A transient get() may reuse the not-yet-detached (dead) gen-1; retry until gen-2.
-                while (r.item == 1 && guard++ < 1000) {
+                // Gen-1's async self-teardown may force-close the freshly handed-out lease between
+                // get() and the item read, making `item` throw — treat that as dead-gen-1 reuse too.
+                while (runCatching { r.item }.getOrNull() != 2 && guard++ < 1000) {
                     r.close()
                     r = sr.get()
                 }
@@ -915,7 +917,9 @@ class SharedResourceTest : BaseTest() {
             val r2 = withTimeout(5_000) {
                 var r = sr.get()
                 var guard = 0
-                while (r.item == 1 && guard++ < 2000) {
+                // Tolerate `item` throwing when gen-1's self-teardown force-closes a fresh lease
+                // mid-read (see the sibling supersede test's churn loop).
+                while (runCatching { r.item }.getOrNull() != 2 && guard++ < 2000) {
                     r.close()
                     r = sr.get()
                 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Two generation-churn tests in `SharedResourceTest` could intermittently fail CI (last seen on the testGplay unit-test job) because their retry loops didn't tolerate a benign, designed teardown race. Both loops now retry through it.

## Technical Context

- Root cause: when gen-1 dies spontaneously, its async onCompletion cleanup force-closes every lease, including one `get()` just handed out. The `isClosed` re-check inside `get()` and the caller's later `.item` read are not atomic, so `Resource.item` can throw `CancellationException("Resource was cancelled!")` in that window. CI stack trace (run 32723097381, attempt 1) matches this exactly: thrown at Resource.kt:11 from the loop condition, item value 1 (dead gen-1 reuse).
- This is test tolerance, not a product fix: force-closing a dead generation's leases is documented, intended behavior, and `get()` itself already retries the same race when it lands a moment earlier.
- The failing test's sibling (`a superseded generation's self-teardown never clobbers the live generation`) has the identical loop and latent race, so both were changed.
- `runCatching` around a non-suspending getter cannot swallow the surrounding `withTimeout` cancellation, and the loops still require value 2 (re-asserted after the loop), so the change can't mask the regressions these tests guard.