### PR TITLE
Explorer: Stop the favorites tests flaking on a stale-cache race

### DIFF
--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/favorites/ExplorerFavoritesRepoTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/favorites/ExplorerFavoritesRepoTest.kt
@@ -150,6 +150,7 @@ class ExplorerFavoritesRepoTest : BaseTest() {
 
         val path = LocalPath.build("/will-be-removed")
         repo.add(path)
+        repo.favoritePaths.first { it.isNotEmpty() }
         repo.isFavorite(path) shouldBe true
 
         repo.remove(path)
@@ -179,6 +180,7 @@ class ExplorerFavoritesRepoTest : BaseTest() {
 
         val path = LocalPath.build("/toggle-target")
         repo.toggle(path) shouldBe ExplorerFavoritesRepo.ToggleResult.Added(path)
+        repo.favoritePaths.first { it.isNotEmpty() }
         repo.isFavorite(path) shouldBe true
     }
 
@@ -194,6 +196,7 @@ class ExplorerFavoritesRepoTest : BaseTest() {
         repo.toggle(path) shouldBe ExplorerFavoritesRepo.ToggleResult.Removed(
             ExplorerFavoritesRepo.RemovedFavorite(path, 1)
         )
+        repo.favoritePaths.first { it.size == 1 }
         repo.isFavorite(path) shouldBe false
     }
 


### PR DESCRIPTION
## What changed

No user-facing behavior change. Deflakes the Explorer favorites test suite that intermittently failed CI on main.

## Technical Context

- `isFavorite()` reads a hot in-memory cache that is filled asynchronously from persisted storage. A mutation call returning only guarantees the storage commit, not that the cache has caught up.
- Three assertions ran immediately after an add/toggle without awaiting that propagation, so a slow CI runner could still observe the previous list. This is a different race than the one addressed in #59.
- The fix awaits the cache flow reaching the expected state before each `isFavorite` assertion, the same pattern the other tests in the file already use.
