### PR TITLE
Workspace: Stop losing tab changes when a session save fails

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/debug/Bugs.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/Bugs.kt
@@ -23,7 +23,12 @@ object Bugs {
         }
     }
 
+    // Written from App's settings observer, read from arbitrary flow-collection threads that gate
+    // their logging on them.
+    @Volatile
     var isDebug = false
+
+    @Volatile
     var isTrace = false
 
     var processTag: String = "Default"

--- a/app-common/src/main/java/eu/darken/butler/common/flow/FlowExtensions.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/flow/FlowExtensions.kt
@@ -74,13 +74,49 @@ fun <T> Flow<T>.takeUntilAfter(predicate: suspend (T) -> Boolean) = transformWhi
     !fullfilled // We keep emitting until condition is fullfilled = true
 }
 
-fun <T> Flow<T>.setupCommonEventHandlers(tag: String, enabled: Boolean = true, identifier: () -> String) = this
-    .onStart { log(tag, VERBOSE) { "${identifier()}.onStart()" } }
-    .onEach { log(tag, VERBOSE) { "${identifier()}.onEach(): $it" } }
-    .onCompletion { log(tag, VERBOSE) { "${identifier()}.onCompletion()" } }
+/**
+ * Renders a flow emission for a log line.
+ *
+ * Only self-describing scalars are printed by value. Everything else degrades to its type name
+ * (plus element count for collections/maps), because these lines reach two places a raw
+ * `toString()` must not: logcat, and the bug-report file a user attaches to an issue. An Explorer
+ * state emission, for example, carries the whole directory listing.
+ *
+ * Numbers are excluded from by-value printing on purpose: this helper cannot tell a list size from
+ * an account id or a PIN, and it is applied to every flow in the app. A call site that knows its
+ * number is safe should log it itself.
+ *
+ *     true                    -> "true"
+ *     Type.EXPLORER           -> "EXPLORER"
+ *     42                      -> "Int"
+ *     Directory(items=[...])  -> "Directory"
+ *     listOf(a, b, c)         -> "ArrayList(3)"
+ */
+private fun Any?.asFlowLogValue(): String = when (this) {
+    null -> "null"
+    is Boolean -> toString()
+    // name, not toString(): an enum may override toString() to render a user-facing value.
+    is Enum<*> -> name
+    is Collection<*> -> "${this::class.simpleName}($size)"
+    is Map<*, *> -> "${this::class.simpleName}($size)"
+    else -> this::class.simpleName ?: this::class.java.name
+}
+
+/**
+ * @param enabled evaluated per emission, not once at flow construction: callers gate on
+ *   [eu.darken.butler.common.debug.Bugs] flags that the user toggles long after DI built the flow.
+ */
+fun <T> Flow<T>.setupCommonEventHandlers(
+    tag: String,
+    enabled: () -> Boolean = { true },
+    identifier: () -> String,
+) = this
+    .onStart { if (enabled()) log(tag, VERBOSE) { "${identifier()}.onStart()" } }
+    .onEach { if (enabled()) log(tag, VERBOSE) { "${identifier()}.onEach(): ${it.asFlowLogValue()}" } }
+    .onCompletion { if (enabled()) log(tag, VERBOSE) { "${identifier()}.onCompletion()" } }
     .catch {
         if (it.hasCause(CancellationException::class)) {
-            log(tag, VERBOSE) { "${identifier()} cancelled" }
+            if (enabled()) log(tag, VERBOSE) { "${identifier()} cancelled" }
         } else {
             log(tag, ERROR) { "${identifier()} failed: ${it.asLog()}" }
             throw it

--- a/app-common/src/test/java/eu/darken/butler/common/flow/CommonEventHandlersTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/flow/CommonEventHandlersTest.kt
@@ -1,0 +1,137 @@
+package eu.darken.butler.common.flow
+
+import eu.darken.butler.common.debug.logging.Logging
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CommonEventHandlersTest {
+
+    private class CapturingLogger : Logging.Logger {
+        val lines = mutableListOf<String>()
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            lines += message
+        }
+    }
+
+    private data class Listing(val path: String, val items: List<String>)
+
+    private lateinit var logger: CapturingLogger
+
+    @BeforeEach
+    fun setup() {
+        Logging.clearAll()
+        logger = CapturingLogger()
+        Logging.install(logger)
+        // install() logs its own line through the logger it just installed.
+        logger.lines.clear()
+    }
+
+    @AfterEach
+    fun tearDown() = Logging.clearAll()
+
+    private enum class Mode { ACTIVE }
+
+    @Test
+    fun `booleans are logged by value`() = runTest {
+        flowOf(true).setupCommonEventHandlers("test") { "flow" }.launchIn(this)
+        runCurrent()
+        logger.lines.single { it.contains(".onEach()") } shouldContain "onEach(): true"
+    }
+
+    @Test
+    fun `enums log their name`() = runTest {
+        flowOf(Mode.ACTIVE).setupCommonEventHandlers("test") { "flow" }.launchIn(this)
+        runCurrent()
+        logger.lines.single { it.contains(".onEach()") } shouldContain "onEach(): ACTIVE"
+    }
+
+    /** A bare number could be a count or an account id; the generic helper cannot tell them apart. */
+    @Test
+    fun `numbers are reduced to their type`() = runTest {
+        flowOf(4815162342L).setupCommonEventHandlers("test") { "flow" }.launchIn(this)
+        runCurrent()
+
+        val line = logger.lines.single { it.contains(".onEach()") }
+        line shouldContain "onEach(): Long"
+        line shouldNotContain "4815162342"
+    }
+
+    /**
+     * The emission reaches logcat and the bug-report file a user attaches to an issue, so a payload
+     * that carries their paths and filenames must not survive interpolation.
+     */
+    @Test
+    fun `object emissions are reduced to their type`() = runTest {
+        val listing = Listing("/storage/emulated/0/Taxes", listOf("2025-return.pdf"))
+        flowOf(listing).setupCommonEventHandlers("test") { "flow" }.launchIn(this)
+        runCurrent()
+
+        val line = logger.lines.single { it.contains(".onEach()") }
+        line shouldContain "onEach(): Listing"
+        line shouldNotContain "Taxes"
+        line shouldNotContain "2025-return.pdf"
+    }
+
+    @Test
+    fun `collections report size instead of contents`() = runTest {
+        flowOf(listOf("alpha", "beta")).setupCommonEventHandlers("test") { "flow" }.launchIn(this)
+        runCurrent()
+
+        val line = logger.lines.single { it.contains(".onEach()") }
+        line shouldContain "(2)"
+        line shouldNotContain "alpha"
+    }
+
+    /**
+     * Guards the regression this parameter already suffered once: it was declared, three call sites
+     * passed it, and the body never read it.
+     */
+    @Test
+    fun `enabled false suppresses emission logging`() = runTest {
+        flowOf(1, 2).setupCommonEventHandlers("test", enabled = { false }) { "flow" }.launchIn(this)
+        runCurrent()
+        logger.lines.shouldContainExactly(emptyList())
+    }
+
+    /**
+     * Callers gate on debug flags the user toggles long after DI built the flow, so the predicate is
+     * read per emission rather than captured once.
+     */
+    @Test
+    fun `enabled is re-read per emission`() = runTest {
+        var calls = 0
+        flowOf(1, 2, 3)
+            .setupCommonEventHandlers("test", enabled = { calls++; true }) { "flow" }
+            .launchIn(this)
+        runCurrent()
+
+        // onStart + one per emission + onCompletion. A predicate captured at construction would
+        // have been read once.
+        calls shouldBe 5
+    }
+
+    /** A gate that opens mid-stream must change which emissions are logged, not just be re-read. */
+    @Test
+    fun `a gate that opens mid-stream logs only later emissions`() = runTest {
+        var allowed = false
+        flowOf(1, 2, 3)
+            .setupCommonEventHandlers("test", enabled = { allowed }) { "flow" }
+            .onEach { if (it == 1) allowed = true }
+            .launchIn(this)
+        runCurrent()
+
+        // The gate is still closed when the first emission passes the handler, and open for the
+        // other two.
+        logger.lines.count { it.contains(".onEach()") } shouldBe 2
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -86,7 +86,7 @@ class WorkspaceRepo @Inject constructor(
 
     private val _pendingConfirmations = MutableStateFlow<Map<String, PendingWorkspaceConfirmation>>(emptyMap())
     val pendingConfirmations: Flow<Map<String, PendingWorkspaceConfirmation>> = _pendingConfirmations
-        .setupCommonEventHandlers(TAG, enabled = Bugs.isDebug) { "PendingConfirmations" }
+        .setupCommonEventHandlers(TAG, enabled = { Bugs.isDebug }) { "PendingConfirmations" }
         .replayingShare(appScope)
 
     /**
@@ -169,11 +169,11 @@ class WorkspaceRepo @Inject constructor(
         )
     }
         .distinctUntilChanged()
-        .setupCommonEventHandlers(TAG, enabled = Bugs.isTrace) { "WorkspaceState" }
+        .setupCommonEventHandlers(TAG, enabled = { Bugs.isTrace }) { "WorkspaceState" }
         .replayingShare(appScope)
 
     override val events: Flow<WorkspaceEvent> = _events
-        .setupCommonEventHandlers(TAG, enabled = Bugs.isDebug) { "WorkspaceEvents" }
+        .setupCommonEventHandlers(TAG, enabled = { Bugs.isDebug }) { "WorkspaceEvents" }
         .replayingShare(appScope)
 
     override suspend fun emitEvent(event: WorkspaceEvent) {

--- a/app/src/main/java/eu/darken/butler/workspace/ui/session/WorkspaceSessionManager.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/session/WorkspaceSessionManager.kt
@@ -316,6 +316,16 @@ class WorkspaceSessionManager @Inject constructor(
         val session = storage.dao.getSession(DEFAULT_SESSION_ID) ?: newDefaultSession()
         val uiState = buildUiState(workspaceRepo.state.first())
         storage.dao.upsertSession(session.copy(updatedAt = Clock.System.now(), uiState = uiState))
+
+        // This writer persists focus and panes too, and the ON_STOP flush runs it without a
+        // following full save - so without this the last layout before an app kill, the one that
+        // decides which tabs come back, would never reach the log.
+        if (layoutMoved(session.uiState, uiState)) {
+            log(TAG, INFO) {
+                "Session layout: focus=${uiState.focusedWorkspaceId?.shortTag}," +
+                    " panes=${uiState.paneSelections.size}"
+            }
+        }
         log(TAG) {
             "Saved UI state: focused=${uiState.focusedWorkspaceId}," +
                 " scroll=${uiState.scrollPositions.size}, bars=${uiState.barCollapse.size}," +
@@ -382,13 +392,23 @@ class WorkspaceSessionManager @Inject constructor(
     }
 
     private suspend fun doSaveSession() {
-        log(TAG, INFO) { "Saving session" }
+        log(TAG) { "Saving session" }
+
+        // Every mutation below lands here first and is published to [lastSavedWorkspaces] only once
+        // the transaction has committed. Mutating the live cache inside the transaction meant a
+        // failed commit rolled the database back while the cache kept the new keys, so the next save
+        // saw "already saved" and skipped an upsert the database never received.
+        val staged = lastSavedWorkspaces.toMutableMap()
 
         var defaultSession = storage.dao.getSession(DEFAULT_SESSION_ID)
         if (defaultSession == null) {
             defaultSession = newDefaultSession()
             log(TAG) { "Default session will be created: $defaultSession" }
         }
+        // The layout as the database currently holds it. Both writers compare against this rather
+        // than a process-local field, so whichever of them commits a focus change first is the one
+        // that reports it and the other sees no movement.
+        val persistedUiState = defaultSession.uiState
         storage.dao.upsertSession(defaultSession)
 
         // Pull workspace data
@@ -402,6 +422,7 @@ class WorkspaceSessionManager @Inject constructor(
         val now = Clock.System.now()
 
         // Perform incremental save within transaction
+        var counts = SaveCounts()
         storage.database.withTransaction {
             // 1. Upsert session metadata (including UI state)
             storage.dao.upsertSession(
@@ -426,12 +447,16 @@ class WorkspaceSessionManager @Inject constructor(
             val removedIds = (existingIds - currentIds).filter { workspaceRepo.peek(it) == null }
             if (removedIds.isNotEmpty()) {
                 storage.dao.deleteWorkspacesByIds(removedIds)
-                removedIds.forEach { lastSavedWorkspaces.remove(it) }
+                removedIds.forEach { staged.remove(it) }
                 log(TAG) { "Removed ${removedIds.size} deleted workspaces from session" }
             }
 
             // 3. Upsert only changed workspaces
             var changedCount = 0
+            var added = 0
+            var replaced = 0
+            var retitled = 0
+            var reordered = 0
             workspacesToSave.forEachIndexed { index, info ->
                 // peek() instead of retrieve(): a paused workspace must still be saved with the
                 // arguments it holds, and retrieve() reports paused entries as absent.
@@ -455,13 +480,24 @@ class WorkspaceSessionManager @Inject constructor(
                         customTitle = info.customTitle,
                     )
 
-                    if (lastSavedWorkspaces[info.id] != saveKey) {
+                    if (staged[info.id] != saveKey) {
                         // The repo knows when the tab was actually created; the stored value is only
                         // the instant of its FIRST save, which collapses every tab created between
                         // two debounced saves onto one timestamp. Pre-existing rows keep theirs
                         // (still monotonic in save order), so no migration is needed.
                         val existingEntity = storage.dao.getWorkspaceById(info.id)
                         val createdAt = workspaceRepo.peekCreatedAt(info.id) ?: existingEntity?.createdAt ?: now
+
+                        // Counted against the stored row, not against the in-memory cache: a cache
+                        // that was never seeded (or was seeded and lost) would otherwise make an
+                        // existing row look newly added.
+                        if (existingEntity == null) {
+                            added++
+                        } else {
+                            if (existingEntity.type != info.type) replaced++
+                            if (existingEntity.customTitle != info.customTitle) retitled++
+                            if (existingEntity.orderIndex != index) reordered++
+                        }
 
                         storage.dao.upsertWorkspace(
                             WorkspaceInstanceEntity(
@@ -475,21 +511,78 @@ class WorkspaceSessionManager @Inject constructor(
                                 customTitle = info.customTitle,
                             )
                         )
-                        lastSavedWorkspaces[info.id] = saveKey
+                        staged[info.id] = saveKey
                         changedCount++
                     }
+                } catch (e: CancellationException) {
+                    // Must not be absorbed by the catch below: swallowing it here would let a
+                    // cancelled save run on to commit a partial transaction.
+                    throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to save workspace ${info.id}: ${e.asLog()}" }
                 }
             }
 
             log(TAG) { "Updated $changedCount of ${workspacesToSave.size} workspaces" }
+
+            // Rows the database holds once this transaction commits: what it had, minus what this
+            // pass deleted, plus what this pass inserted. Deliberately not derived from
+            // [workspacesToSave] - that snapshot is allowed to be partial (see the delete pass
+            // above), so a row missing from it is not a row missing from the database.
+            counts = SaveCounts(
+                tabs = existingIds.size - removedIds.size + added,
+                added = added,
+                removed = removedIds.size,
+                replaced = replaced,
+                retitled = retitled,
+                reordered = reordered,
+            )
         }
 
-        log(TAG, INFO) {
-            "Saved session with ${workspacesToSave.size} workspaces, focused=${uiState.focusedWorkspaceId}"
+        // Past the commit: safe to publish.
+        lastSavedWorkspaces.clear()
+        lastSavedWorkspaces.putAll(staged)
+
+        log(TAG) { "Saved session with ${workspacesToSave.size} workspaces" }
+
+        if (counts.moved || layoutMoved(persistedUiState, uiState)) {
+            log(TAG, INFO) {
+                "Session layout: tabs=${counts.tabs}, added=${counts.added}, removed=${counts.removed}," +
+                    " replaced=${counts.replaced}, retitled=${counts.retitled}," +
+                    " reordered=${counts.reordered}, focus=${uiState.focusedWorkspaceId?.shortTag}," +
+                    " panes=${uiState.paneSelections.size}"
+            }
         }
     }
+
+    /**
+     * What a committed save changed about the session's durable shape.
+     *
+     * Deliberately not the incremental-save counter: that also ticks for serialized-argument
+     * changes, so it fires on ordinary directory navigation while missing both removals and
+     * focus-only moves - wrong in both directions for the bug class these counts serve, which is
+     * "my tabs came back wrong".
+     */
+    private data class SaveCounts(
+        val tabs: Int = 0,
+        val added: Int = 0,
+        val removed: Int = 0,
+        val replaced: Int = 0,
+        val retitled: Int = 0,
+        val reordered: Int = 0,
+    ) {
+        val moved: Boolean
+            get() = added > 0 || removed > 0 || replaced > 0 || retitled > 0 || reordered > 0
+    }
+
+    /**
+     * Whether focus or pane assignment differs between the stored layout and the one about to
+     * replace it. Scroll offsets, bar fractions and view prefs are excluded: they change constantly
+     * and say nothing about which tabs the user gets back.
+     */
+    private fun layoutMoved(before: WorkspaceUIState, after: WorkspaceUIState): Boolean =
+        before.focusedWorkspaceId != after.focusedWorkspaceId ||
+            before.paneSelections != after.paneSelections
 
     private data class RestoreCandidate(
         val id: Workspace.Id,

--- a/app/src/test/java/eu/darken/butler/workspace/ui/session/WorkspaceSessionManagerTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/session/WorkspaceSessionManagerTest.kt
@@ -27,10 +27,13 @@ import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.scroll.WorkspaceScrollPosition
 import eu.darken.butler.workspace.ui.restore.WorkspaceViewPrefs
 import eu.darken.butler.workspace.ui.scroll.WorkspaceScrollPositions
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import java.io.IOException
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -484,6 +487,39 @@ class WorkspaceSessionManagerTest : BaseTest() {
             upsertedEntities.size shouldBe 2
             upsertedEntities.single { it.workspaceId == wsIdB }.orderIndex shouldBe 0
             upsertedEntities.single { it.workspaceId == wsIdA }.orderIndex shouldBe 1
+        }
+
+        /**
+         * The incremental-save cache is what lets the next save skip a row. If it is updated while
+         * the transaction is still open, a commit that then fails leaves the cache claiming rows the
+         * database rolled back, and the row is never written again.
+         */
+        @Test
+        fun `a failed commit leaves rows to be re-saved`() = runTest {
+            val mockDatabase = storage.database
+            coEvery { mockDatabase.withTransaction(any<suspend () -> Any?>()) } coAnswers {
+                @Suppress("UNCHECKED_CAST")
+                val block = args[1] as suspend () -> Any?
+                block()
+                throw IOException("commit failed")
+            }
+
+            repoStateFlow.value = WorkspaceRemote.State(
+                infos = listOf(makeInfo(wsIdA), makeInfo(wsIdB)),
+            )
+            shouldThrow<IOException> { sessionManager.saveSession() }
+            upsertedEntities.clear()
+
+            // Commit works again; the same unchanged state must still be written, because nothing
+            // from the failed attempt reached the database.
+            coEvery { mockDatabase.withTransaction(any<suspend () -> Any?>()) } coAnswers {
+                @Suppress("UNCHECKED_CAST")
+                val block = args[1] as suspend () -> Any?
+                block()
+            }
+            sessionManager.saveSession()
+
+            upsertedEntities.map { it.workspaceId } shouldContainExactlyInAnyOrder listOf(wsIdA, wsIdB)
         }
 
         @Test


### PR DESCRIPTION
## What changed

Tab changes could be silently lost. When saving the session hit a database error, the write was rolled back but the app still recorded the tabs as saved, so the next save skipped them. The change never reached storage, and the tab came back in its old state after a restart.

Butler's logs are also much quieter and no longer contain your file names. Browsing a folder used to write the entire directory listing into the log on every update, including full paths, and those lines end up in the log file attached to a bug report. Log output while browsing drops by roughly 70%.

## Technical Context

- `setupCommonEventHandlers` interpolated the whole flow emission, so Explorer's state dumped its item list. Emissions now render through a bounded formatter: booleans by value, enums by name, collections as type plus size, everything else as its type. Numbers are excluded deliberately, since the helper wraps every flow in the app and cannot distinguish a list size from an identifier. `FileLogger` overrides no threshold and has no per-entry cap, so level alone was never a privacy boundary here.
- That helper's `enabled` parameter was declared and never read, leaving three `WorkspaceRepo` gates inert, including the trace gate on full `WorkspaceState` dumps. It now takes a lambda rather than a `Boolean`: the flows are built once at DI time while the flags they gate on toggle at runtime, so a captured value would have left the gate just as dead. Both flags became `@Volatile` accordingly.
- The incremental-save cache was mutated inside the Room transaction. Mutations now stage into a copy published only after `withTransaction` returns, and `CancellationException` is rethrown ahead of the per-workspace catch that was absorbing it. Worth close review: `WorkspaceSessionManager.doSaveSession`.
- Session saving logged two INFO lines per save. `RingLogBuffer` is the only logger installed in release builds and keeps INFO in a 512 KB ring, so that trail evicted itself before any crash worth attaching it to. One INFO line remains, edge-triggered on durable layout movement with counts read from the database rather than the cache.
- Both session writers compare the stored `uiState` against the new one instead of a process-local field, so whichever commits a layout change first reports it. This is what covers the `ON_STOP` flush, which persists focus without a following full save and determines which tabs return after a kill.
