### PR TITLE
Workspace: Fix misleading and stale operation performance graphs

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
@@ -5,6 +5,7 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.serialization.InstantSerializer
 import kotlinx.serialization.Serializable
+import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Instant
 
@@ -25,9 +26,10 @@ data class PerformanceSample(
  * Historical performance data with adaptive sampling for memory efficiency.
  *
  * Sampling Strategy:
+ * - Hard cap: 1000 samples. Exceeding it triggers a compaction.
+ * - Compaction target: 800 samples, so the next compaction is ~200 adds away instead of every add.
  * - Percentage-based bucketing: Divides 0-100% progress into 5% buckets (20 total)
- * - Maximum 50 samples per bucket (evenly distributed within bucket)
- * - Total maximum: 1000 samples distributed across entire operation range
+ * - Compaction keeps 800/20 = 40 samples per bucket, endpoint-inclusive so first and last survive
  * - Supports both byte-based (copy/move) and item-based (delete) operations
  * - Uses totalBytes for percentage if available, otherwise uses totalItems
  * - Ensures graph coverage across full 0-100% even with rapid sampling (many small files)
@@ -60,21 +62,25 @@ data class PerformanceHistory(
             DEBUG
         ) { "Adding sample. Current: ${samples.size} → New: ${samples.size + 1}, Speed: ${sample.bytesPerSecond / 1_000_000f} MB/s" }
 
+        // The totals this add carries can grow during scanning, bucketing has to use the new ones
+        val nextTotalBytes = maxOf(this.totalBytes, totalBytes)
+        val nextTotalItems = maxOf(this.totalItems, totalItems)
+
         val updatedSamples = (samples + sample).let { allSamples ->
             if (allSamples.size <= MAX_SAMPLES) {
                 allSamples
             } else {
                 // Apply adaptive sampling: keep recent, downsample old
                 log(TAG, DEBUG) { "Applying adaptive sampling" }
-                adaptiveSample(allSamples)
+                adaptiveSample(allSamples, nextTotalBytes, nextTotalItems)
             }
         }
 
         return copy(
             samples = updatedSamples,
             startTime = startTime ?: sample.timestamp,
-            totalBytes = maxOf(this.totalBytes, totalBytes),
-            totalItems = maxOf(this.totalItems, totalItems)
+            totalBytes = nextTotalBytes,
+            totalItems = nextTotalItems,
         )
     }
 
@@ -121,21 +127,22 @@ data class PerformanceHistory(
             samples.last().timestamp - startTime
         }
 
-    private fun adaptiveSample(allSamples: List<PerformanceSample>): List<PerformanceSample> {
+    private fun adaptiveSample(
+        allSamples: List<PerformanceSample>,
+        totalBytes: Long,
+        totalItems: Int,
+    ): List<PerformanceSample> {
         // Determine which metric to use for percentage calculation
         val useItems = totalBytes == 0L && totalItems > 0
 
         if (totalBytes == 0L && totalItems == 0) {
             // Can't determine percentage without either metric, fallback to keeping last N
-            return allSamples.takeLast(MAX_SAMPLES)
+            return allSamples.takeLast(COMPACT_TARGET)
         }
 
         // Percentage-based downsampling: ensure samples distributed across 0-100% range
-        // Use 5% buckets (20 total: 0-19), with dynamic samples per bucket
-        val bucketSize = 5.0
-        val numBuckets = 20
-        // Calculate samples per bucket to ensure total never exceeds MAX_SAMPLES
-        val samplesPerBucket = (MAX_SAMPLES.toDouble() / numBuckets).toInt().coerceAtLeast(1)
+        val bucketSize = 100.0 / NUM_BUCKETS
+        val samplesPerBucket = (COMPACT_TARGET / NUM_BUCKETS).coerceAtLeast(1)
 
         val buckets = allSamples.groupBy { sample ->
             val percentage = if (useItems) {
@@ -143,20 +150,22 @@ data class PerformanceHistory(
             } else {
                 (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
             }
-            // Clamp percentage to [0.0, 100.0] and ensure bucket index is [0, 19]
+            // Clamp percentage to [0.0, 100.0] and ensure bucket index is [0, NUM_BUCKETS - 1]
             val clampedPercentage = percentage.coerceIn(0.0, 100.0)
-            minOf(numBuckets - 1, (clampedPercentage / bucketSize).toInt())
+            minOf(NUM_BUCKETS - 1, (clampedPercentage / bucketSize).toInt())
         }
 
-        // Downsample each bucket to max samplesPerBucket, keeping evenly distributed samples
+        // Downsample each bucket, endpoint-inclusive so both ends of a bucket survive
         val downsampledSamples = buckets.flatMap { (_, samplesInBucket) ->
-            if (samplesInBucket.size <= samplesPerBucket) {
-                samplesInBucket
-            } else {
-                // Keep evenly distributed samples from this bucket
-                val step = samplesInBucket.size.toDouble() / samplesPerBucket
-                (0 until samplesPerBucket).map { i ->
-                    samplesInBucket[(i * step).toInt()]
+            when {
+                samplesInBucket.size <= samplesPerBucket -> samplesInBucket
+                samplesPerBucket == 1 -> listOf(samplesInBucket.last())
+                else -> {
+                    val lastIndex = samplesInBucket.size - 1
+                    (0 until samplesPerBucket)
+                        .map { i -> ((i.toDouble() * lastIndex) / (samplesPerBucket - 1)).roundToInt() }
+                        .distinct()
+                        .map { samplesInBucket[it] }
                 }
             }
         }.sortedBy { it.timestamp }  // Maintain chronological order
@@ -170,6 +179,8 @@ data class PerformanceHistory(
 
     companion object {
         private const val MAX_SAMPLES = 1000
+        private const val COMPACT_TARGET = 800
+        private const val NUM_BUCKETS = 20
         private val TAG = logTag("PerformanceHistory")
     }
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
@@ -137,7 +137,7 @@ data class PerformanceHistory(
 
         if (totalBytes == 0L && totalItems == 0) {
             // Can't determine percentage without either metric, fallback to keeping last N
-            return allSamples.takeLast(COMPACT_TARGET)
+            return allSamples.takeLast(COMPACT_TARGET).sortedBy { it.timestamp }
         }
 
         // Percentage-based downsampling: ensure samples distributed across 0-100% range

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PathOperationProgressTrackerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PathOperationProgressTrackerTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.TestClock
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Instant
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Tests for PathOperationProgressTracker - progress and performance tracking.
@@ -105,30 +105,33 @@ class PathOperationProgressTrackerTest : BaseTest() {
 
     @Test
     fun `samples recorded with zero time delta have estimated speeds`() {
-        val tracker = PathOperationProgressTracker()
+        val clock = TestClock()
+        val tracker = PathOperationProgressTracker(clock = clock)
         tracker.totalItems = 10
         tracker.totalBytes = 1_000_000L
 
-        val startTime = Instant.fromEpochMilliseconds(1000)
-
-        // First sample
+        // First sample, no elapsed time yet
         tracker.completeItem(bytes = 100_000L)
         tracker.shouldReportProgress(force = true)
         tracker.performanceHistory.samples.size shouldBe 1
 
-        // Second sample with < 1ms elapsed (zero time delta)
-        // Simulate by completing another item instantly
+        // Second sample one second later, speeds come from the delta
+        clock += 1.seconds
         tracker.completeItem(bytes = 100_000L)
         tracker.shouldReportProgress(force = true)
-
-        // Should still record the sample (not skip it)
         tracker.performanceHistory.samples.size shouldBe 2
 
-        val secondSample = tracker.performanceHistory.samples[1]
-        secondSample.totalBytesProcessed shouldBe 200_000L
-        secondSample.totalItemsProcessed shouldBe 2
-        // Speed should be estimated (not zero, not infinite)
-        // Either from total progress or previous sample
+        // Third sample at the very same timestamp: zero delta, speeds fall back to totals/elapsed
+        tracker.completeItem(bytes = 300_000L)
+        tracker.shouldReportProgress(force = true)
+        tracker.performanceHistory.samples.size shouldBe 3
+
+        val thirdSample = tracker.performanceHistory.samples[2]
+        thirdSample.totalBytesProcessed shouldBe 500_000L
+        thirdSample.totalItemsProcessed shouldBe 3
+        // 500_000 bytes / 1s elapsed, 3 items / 1s elapsed
+        thirdSample.bytesPerSecond shouldBe 500_000L
+        thirdSample.itemsPerSecond shouldBe 3f
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
@@ -751,8 +751,7 @@ class PerformanceHistoryTest : BaseTest() {
         var history = PerformanceHistory()
         val totalBytes = 2_000_000_000L
 
-        // Create 2000 samples evenly distributed
-        repeat(2000) { i ->
+        fun addSample(i: Int) {
             history = history.addSample(
                 PerformanceSample(
                     timestamp = startTime + (i * 10).milliseconds,
@@ -766,21 +765,119 @@ class PerformanceHistoryTest : BaseTest() {
             )
         }
 
-        // Group by buckets
+        // The bound only holds right after a compaction, mid-amortization there are up to ~200
+        // uncompacted trailing samples that all land in the same bucket
+        repeat(1001) { addSample(it) }
+
         val buckets = history.samples.groupBy { sample ->
             val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
             (percentage / 5.0).toInt().coerceIn(0, 19)
         }
 
-        // Calculate average samples per bucket
         val avgSamplesPerBucket = history.samples.size.toDouble() / 20
 
-        // No bucket should have more than 2x the average (allowing some variance)
         buckets.values.forEach { samplesInBucket ->
             samplesInBucket.size shouldBeLessThanOrEqual (avgSamplesPerBucket * 2).toInt()
         }
 
         println("Bucket distribution: ${buckets.mapValues { it.value.size }}")
+
+        // The cap still holds while amortizing towards the next compaction
+        (1001 until 2000).forEach { addSample(it) }
+        history.samples.size shouldBeLessThanOrEqual 1000
+    }
+
+    @Test
+    fun `compaction is amortized - one compaction lands on the target`() {
+        val startTime = Instant.fromEpochMilliseconds(1000)
+        var history = PerformanceHistory()
+        val totalBytes = 1_001_000_000L
+
+        repeat(1001) { i ->
+            history = history.addSample(
+                PerformanceSample(
+                    timestamp = startTime + (i * 10).milliseconds,
+                    bytesPerSecond = 1_000_000L,
+                    itemsPerSecond = 10f,
+                    totalBytesProcessed = (i + 1) * (totalBytes / 1001),
+                    totalItemsProcessed = i + 1
+                ),
+                totalBytes = totalBytes,
+                totalItems = 1001
+            )
+        }
+
+        history.samples shouldHaveSize 800
+    }
+
+    @Test
+    fun `final sample survives compaction`() {
+        val startTime = Instant.fromEpochMilliseconds(1000)
+        var history = PerformanceHistory()
+        val totalBytes = 1_001_000_000L
+        lateinit var lastSample: PerformanceSample
+
+        // Even distribution puts 50+ samples into every bucket, so every bucket gets downsampled
+        repeat(1001) { i ->
+            lastSample = PerformanceSample(
+                timestamp = startTime + (i * 10).milliseconds,
+                bytesPerSecond = 1_000_000L,
+                itemsPerSecond = 10f,
+                totalBytesProcessed = (i + 1) * (totalBytes / 1001),
+                totalItemsProcessed = i + 1
+            )
+            history = history.addSample(lastSample, totalBytes = totalBytes, totalItems = 1001)
+        }
+
+        history.samples.last() shouldBe lastSample
+    }
+
+    @Test
+    fun `totals jumping on the cap-crossing add drive bucket assignment`() {
+        val startTime = Instant.fromEpochMilliseconds(1000)
+        var history = PerformanceHistory()
+
+        // 1000 samples that look complete under the old total of 1000 items
+        repeat(1000) { i ->
+            history = history.addSample(
+                PerformanceSample(
+                    timestamp = startTime + (i * 10).milliseconds,
+                    bytesPerSecond = 0L,
+                    itemsPerSecond = 10f,
+                    totalBytesProcessed = 0L,
+                    totalItemsProcessed = i + 1
+                ),
+                totalBytes = 0L,
+                totalItems = 1000
+            )
+        }
+
+        // The add that crosses the cap discovers 9000 more items
+        history = history.addSample(
+            PerformanceSample(
+                timestamp = startTime + 10_010.milliseconds,
+                bytesPerSecond = 0L,
+                itemsPerSecond = 10f,
+                totalBytesProcessed = 0L,
+                totalItemsProcessed = 1001
+            ),
+            totalBytes = 0L,
+            totalItems = 10_000
+        )
+
+        history.totalItems shouldBe 10_000
+
+        // Under the new denominator everything sits below 11%, so only the first three buckets
+        // are populated: 40 + 40 + 2. Stale totals would have spread them over all 20 buckets.
+        history.samples shouldHaveSize 82
+
+        history.samples.forEach { sample ->
+            val percentage = (sample.totalItemsProcessed.toDouble() / history.totalItems) * 100.0
+            (percentage / 5.0).toInt() shouldBeLessThanOrEqual 2
+        }
+
+        history.samples.first().totalItemsProcessed shouldBe 1
+        history.samples.last().totalItemsProcessed shouldBe 1001
     }
 
     // ============ BYTE-BASED VS ITEM-BASED OPERATIONS ============
@@ -877,8 +974,8 @@ class PerformanceHistoryTest : BaseTest() {
             )
         }
 
-        // Should fallback to takeLast(1000)
-        history.samples.size shouldBe 1000
+        // Should fallback to takeLast(800): add 1001 compacts, the remaining 199 adds accumulate
+        history.samples.size shouldBe 999
     }
 
     // ============ EDGE CASES ============

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
@@ -978,6 +978,34 @@ class PerformanceHistoryTest : BaseTest() {
         history.samples.size shouldBe 999
     }
 
+    @Test
+    fun `fallback compaction keeps chronological order`() {
+        val startTime = Instant.fromEpochMilliseconds(1000)
+        var history = PerformanceHistory()
+
+        // Stop at the first compaction, later adds would append past the sorted block again
+        repeat(1001) { i ->
+            // Every tenth sample is recorded out of insertion order
+            val offsetMs = if (i % 10 == 0) (i * 10) - 25 else i * 10
+            history = history.addSample(
+                PerformanceSample(
+                    timestamp = startTime + offsetMs.milliseconds,
+                    bytesPerSecond = 1_000_000L,
+                    itemsPerSecond = 10f,
+                    totalBytesProcessed = 0L,
+                    totalItemsProcessed = 0
+                ),
+                totalBytes = 0L,  // No total to calculate percentage
+                totalItems = 0
+            )
+        }
+
+        history.samples shouldHaveSize 800
+        history.samples.zipWithNext().forEach { (prev, next) ->
+            (prev.timestamp <= next.timestamp) shouldBe true
+        }
+    }
+
     // ============ EDGE CASES ============
 
     @Test

--- a/app-common/src/main/java/eu/darken/butler/common/ByteFormatting.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/ByteFormatting.kt
@@ -63,7 +63,11 @@ fun formatItemSpeed(
 ): String = context.resources.getQuantityString(
     R.plurals.general_progress_items_per_second,
     itemsPerSecond.toInt(),
-    if (itemsPerSecond >= 1.0) itemsPerSecond.toInt() else itemsPerSecond
+    if (itemsPerSecond >= 1.0) {
+        itemsPerSecond.toInt()
+    } else {
+        String.format(Locale.getDefault(), "%.1f", itemsPerSecond)
+    }
 )
 
 @Composable

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -14,8 +14,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -35,13 +37,13 @@ import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.common.Fill
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
-import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
@@ -50,7 +52,7 @@ import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import eu.darken.butler.common.formatByteSpeed
 import eu.darken.butler.common.formatItemSpeed
 import eu.darken.butler.workspace.R
-import kotlin.math.max
+import java.util.Locale
 import kotlin.time.Duration.Companion.milliseconds
 
 private val TAG = logTag("PerformanceGraph")
@@ -63,7 +65,9 @@ fun OperationPerformanceGraph(
 ) {
     val backgroundColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f)
 
-    if (!performanceHistory.canShowGraph) {
+    val graphData = remember(performanceHistory) { PerformanceGraphData.from(performanceHistory) }
+
+    if (graphData == null) {
         // Not enough data - show message
         Box(
             modifier = modifier
@@ -71,7 +75,7 @@ fun OperationPerformanceGraph(
                 .height(180.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(backgroundColor),
-            contentAlignment = androidx.compose.ui.Alignment.Center
+            contentAlignment = Alignment.Center
         ) {
             Text(
                 text = stringResource(R.string.workspace_operation_performance_not_enough_data),
@@ -82,152 +86,17 @@ fun OperationPerformanceGraph(
         return
     }
 
-    val modelProducer = remember { CartesianChartModelProducer() }
+    val byteSpeeds = graphData.byteSpeeds
+    // Keyed by mode so a two series model can't be handed to a single layer chart
+    val modelProducer = remember(byteSpeeds != null) { CartesianChartModelProducer() }
 
-    // State for Y-axis ranges (calculated from smoothed data)
-    var minSpeed = remember { androidx.compose.runtime.mutableDoubleStateOf(0.0) }
-    var maxSpeed = remember { androidx.compose.runtime.mutableDoubleStateOf(100.0) }
-    var minItems = remember { androidx.compose.runtime.mutableDoubleStateOf(0.0) }
-    var maxItems = remember { androidx.compose.runtime.mutableDoubleStateOf(10.0) }
-
-    LaunchedEffect(performanceHistory.samples.size, performanceHistory.totalBytes) {
-        log(
-            TAG,
-            DEBUG
-        ) { "Rendering graph with ${performanceHistory.samples.size} samples, totalBytes: ${performanceHistory.totalBytes}" }
-
-        // Filter samples to avoid Vico precision errors with many small files
-        // Include samples where EITHER bytes% OR items% changed by at least 0.5%
-        val filteredSamples = mutableListOf<PerformanceSample>()
-        var lastBytesPercentage = -1f
-        var lastItemsPercentage = -1f
-
-        performanceHistory.samples.forEach { sample ->
-            val bytesPercentage = if (performanceHistory.totalBytes > 0) {
-                (sample.totalBytesProcessed.toFloat() / performanceHistory.totalBytes.toFloat()) * 100f
-            } else {
-                0f
-            }
-
-            val itemsPercentage = if (performanceHistory.totalItems > 0) {
-                (sample.totalItemsProcessed.toFloat() / performanceHistory.totalItems.toFloat()) * 100f
-            } else {
-                0f
-            }
-
-            // Always include first sample, and samples where EITHER percentage changed by >= 0.5%
-            val bytesChanged = (bytesPercentage - lastBytesPercentage) >= 0.5f
-            val itemsChanged = (itemsPercentage - lastItemsPercentage) >= 0.5f
-
-            if (filteredSamples.isEmpty() || bytesChanged || itemsChanged) {
-                filteredSamples.add(sample)
-                lastBytesPercentage = bytesPercentage
-                lastItemsPercentage = itemsPercentage
-            }
-        }
-
-        // Always include the last sample to show final state
-        val lastSample = performanceHistory.samples.lastOrNull()
-        if (lastSample != null && (filteredSamples.lastOrNull() != lastSample)) {
-            filteredSamples.add(lastSample)
-        }
-
-        log(TAG, DEBUG) { "Filtered to ${filteredSamples.size} samples from ${performanceHistory.samples.size}" }
-
-        // Map filtered samples to independent completion percentages (X-axes) and speeds (Y-axes)
-        // Bytes completion percentage - used for bytes/s line
-        val bytesCompletionPercentages = filteredSamples.map { sample ->
-            val raw = if (performanceHistory.totalBytes > 0) {
-                (sample.totalBytesProcessed.toFloat() / performanceHistory.totalBytes.toFloat()) * 100f
-            } else {
-                0f
-            }
-            // Round to nearest 0.5% to ensure clean GCD calculation (prevents Vico precision errors)
-            (kotlin.math.round(raw * 2) / 2.0).toFloat()
-        }
-
-        // Items completion percentage - used for items/s line
-        val itemsCompletionPercentages = filteredSamples.map { sample ->
-            val raw = if (performanceHistory.totalItems > 0) {
-                (sample.totalItemsProcessed.toFloat() / performanceHistory.totalItems.toFloat()) * 100f
-            } else {
-                0f
-            }
-            // Round to nearest 0.5% to ensure clean GCD calculation (prevents Vico precision errors)
-            (kotlin.math.round(raw * 2) / 2.0).toFloat()
-        }
-
-        val bytesPerSecondMB = filteredSamples.map { sample ->
-            sample.bytesPerSecond / 1_000_000f // Convert to MB/s
-        }
-
-        val itemsPerSecond = filteredSamples.map { sample ->
-            sample.itemsPerSecond
-        }
-
-        // Apply moving average smoothing to reduce graph noise
-        fun List<Number>.movingAverage(windowSize: Int = 10): List<Float> {
-            if (size <= windowSize) return map { it.toFloat() }
-            return indices.map { i ->
-                val start = maxOf(0, i - windowSize / 2)
-                val end = minOf(size, i + windowSize / 2 + 1)
-                subList(start, end).sumOf { it.toDouble() }.toFloat() / (end - start)
-            }
-        }
-
-        val smoothedBytesPerSecondMB = bytesPerSecondMB.movingAverage()
-        val smoothedItemsPerSecond = itemsPerSecond.movingAverage()
-
-        // Calculate Y-axis ranges from smoothed data for accurate axis scaling
-        minSpeed.doubleValue = smoothedBytesPerSecondMB.minOrNull()?.toDouble() ?: 0.0
-        maxSpeed.doubleValue = smoothedBytesPerSecondMB.maxOrNull()?.toDouble() ?: 100.0
-        minItems.doubleValue = smoothedItemsPerSecond.minOrNull()?.toDouble() ?: 0.0
-        maxItems.doubleValue = smoothedItemsPerSecond.maxOrNull()?.toDouble() ?: 10.0
-
+    LaunchedEffect(graphData) {
         log(TAG, DEBUG) {
-            "Smoothed bytes range: min=${"%.2f".format(minSpeed.doubleValue)} MB/s, max=${
-                "%.2f".format(
-                    maxSpeed.doubleValue
-                )
-            } MB/s"
+            "Plotting ${graphData.progress.size} points from ${performanceHistory.samples.size} samples"
         }
-        log(
-            TAG,
-            DEBUG
-        ) { "Smoothed items range: min=${"%.1f".format(minItems.doubleValue)} items/s, max=${"%.1f".format(maxItems.doubleValue)} items/s" }
-
-        // Log filtered samples for debugging
-        filteredSamples.take(3).forEachIndexed { idx, sample ->
-            val pct = when {
-                performanceHistory.totalBytes > 0 -> (sample.totalBytesProcessed.toFloat() / performanceHistory.totalBytes * 100f)
-                performanceHistory.totalItems > 0 -> (sample.totalItemsProcessed.toFloat() / performanceHistory.totalItems * 100f)
-                else -> 0f
-            }
-            log(
-                TAG,
-                DEBUG
-            ) { "FilteredSample[$idx]: ${"%.1f".format(pct)}% complete, ${sample.bytesPerSecond / 1_000_000f} MB/s" }
-        }
-        if (filteredSamples.size > 3) {
-            log(TAG, DEBUG) { "... (${filteredSamples.size - 6} filtered samples omitted) ..." }
-            filteredSamples.takeLast(3).forEachIndexed { idx, sample ->
-                val pct = when {
-                    performanceHistory.totalBytes > 0 -> (sample.totalBytesProcessed.toFloat() / performanceHistory.totalBytes * 100f)
-                    performanceHistory.totalItems > 0 -> (sample.totalItemsProcessed.toFloat() / performanceHistory.totalItems * 100f)
-                    else -> 0f
-                }
-                val actualIdx = filteredSamples.size - 3 + idx
-                log(
-                    TAG,
-                    DEBUG
-                ) { "FilteredSample[$actualIdx]: ${"%.1f".format(pct)}% complete, ${sample.bytesPerSecond / 1_000_000f} MB/s" }
-            }
-        }
-
         modelProducer.runTransaction {
-            // Each lineSeries block maps to a separate layer with independent X-axes
-            lineSeries { series(x = bytesCompletionPercentages, y = smoothedBytesPerSecondMB) }  // Layer 0 (bytes)
-            lineSeries { series(x = itemsCompletionPercentages, y = smoothedItemsPerSecond) }    // Layer 1 (items)
+            if (byteSpeeds != null) lineSeries { series(x = graphData.progress, y = byteSpeeds) }
+            lineSeries { series(x = graphData.progress, y = graphData.itemSpeeds) }
         }
     }
 
@@ -240,10 +109,83 @@ fun OperationPerformanceGraph(
             val bytesLineColor = MaterialTheme.colorScheme.primary
             val itemsLineColor = MaterialTheme.colorScheme.secondary
 
-            val axisLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
-            val axisLabel = rememberAxisLabelComponent(
-                color = axisLabelColor
+            val axisLabel = rememberAxisLabelComponent(color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+            val maxBytes = axisMax(graphData.maxByteSpeed)
+            val maxItems = axisMax(graphData.maxItemSpeed)
+
+            val bytesLayer = if (byteSpeeds != null) {
+                rememberLineCartesianLayer(
+                    lineProvider = LineCartesianLayer.LineProvider.series(
+                        LineCartesianLayer.rememberLine(
+                            fill = remember(bytesLineColor) {
+                                LineCartesianLayer.LineFill.single(Fill(bytesLineColor.toArgb()))
+                            },
+                            areaFill = remember(bytesLineColor) {
+                                LineCartesianLayer.AreaFill.single(
+                                    Fill(bytesLineColor.copy(alpha = 0.3f).toArgb())
+                                )
+                            },
+                            pointConnector = remember {
+                                LineCartesianLayer.PointConnector.cubic(curvature = 0.2f)
+                            },
+                        )
+                    ),
+                    rangeProvider = remember(maxBytes) { speedRangeProvider(maxBytes) },
+                    verticalAxisPosition = Axis.Position.Vertical.Start,
+                )
+            } else {
+                null
+            }
+
+            val itemsLayer = rememberLineCartesianLayer(
+                lineProvider = LineCartesianLayer.LineProvider.series(
+                    LineCartesianLayer.rememberLine(
+                        fill = remember(itemsLineColor) {
+                            LineCartesianLayer.LineFill.single(Fill(itemsLineColor.toArgb()))
+                        },
+                        areaFill = null,  // No area fill for items line to reduce clutter
+                        pointConnector = remember {
+                            LineCartesianLayer.PointConnector.cubic(curvature = 0.2f)
+                        },
+                    )
+                ),
+                rangeProvider = remember(maxItems) { speedRangeProvider(maxItems) },
+                verticalAxisPosition = if (byteSpeeds != null) {
+                    Axis.Position.Vertical.End
+                } else {
+                    Axis.Position.Vertical.Start
+                },
             )
+
+            val itemsUnitLabel = stringResource(R.string.workspace_operation_performance_unit_items)
+            val bytesUnitLabel = graphData.byteUnit?.let { stringResource(it.labelRes) }
+
+            // Without byte data the single start axis belongs to the items layer
+            val startAxis = VerticalAxis.rememberStart(
+                label = axisLabel,
+                guideline = null,  // Hide grid lines
+                itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
+                valueFormatter = remember(maxBytes, maxItems, byteSpeeds != null) {
+                    speedValueFormatter(if (byteSpeeds != null) maxBytes else maxItems)
+                },
+                title = bytesUnitLabel ?: itemsUnitLabel,
+                titleComponent = rememberAxisLabelComponent(
+                    color = if (byteSpeeds != null) bytesLineColor else itemsLineColor,
+                ),
+            )
+            val endAxis = if (byteSpeeds != null) {
+                VerticalAxis.rememberEnd(
+                    label = axisLabel,
+                    guideline = null,  // Hide grid lines
+                    itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
+                    valueFormatter = remember(maxItems) { speedValueFormatter(maxItems) },
+                    title = itemsUnitLabel,
+                    titleComponent = rememberAxisLabelComponent(color = itemsLineColor),
+                )
+            } else {
+                null
+            }
 
             CartesianChartHost(
                 modifier = Modifier
@@ -252,90 +194,10 @@ fun OperationPerformanceGraph(
                     .clip(RoundedCornerShape(8.dp))
                     .background(backgroundColor),
                 chart = rememberCartesianChart(
-                    // Layer 1: Bytes per second (left Y-axis) - series index 0
-                    rememberLineCartesianLayer(
-                        lineProvider = LineCartesianLayer.LineProvider.series(
-                            LineCartesianLayer.rememberLine(
-                                fill = remember(bytesLineColor) {
-                                    LineCartesianLayer.LineFill.single(Fill(bytesLineColor.toArgb()))
-                                },
-                                areaFill = remember(bytesLineColor) {
-                                    LineCartesianLayer.AreaFill.single(
-                                        Fill(bytesLineColor.copy(alpha = 0.3f).toArgb())
-                                    )
-                                },
-                                pointConnector = remember {
-                                    LineCartesianLayer.PointConnector.cubic(curvature = 0.2f)
-                                },
-                            )
-                        ),
-                        rangeProvider = remember(minSpeed.doubleValue, maxSpeed.doubleValue) {
-                            object : CartesianLayerRangeProvider {
-                                override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
-                                    return 0.0
-                                }
-
-                                override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
-                                    return max(maxSpeed.doubleValue * 1.20, 5.0)
-                                }
-
-                                override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore): Double {
-                                    return 0.0 // Fixed 0 to 100% range
-                                }
-
-                                override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore): Double {
-                                    return 100.0 // Fixed 0 to 100% range
-                                }
-                            }
-                        },
-                        verticalAxisPosition = Axis.Position.Vertical.Start,
-                    ),
-                    // Layer 2: Items per second (right Y-axis) - series index 1
-                    rememberLineCartesianLayer(
-                        lineProvider = LineCartesianLayer.LineProvider.series(
-                            LineCartesianLayer.rememberLine(
-                                fill = remember(itemsLineColor) {
-                                    LineCartesianLayer.LineFill.single(Fill(itemsLineColor.toArgb()))
-                                },
-                                areaFill = null,  // No area fill for items line to reduce clutter
-                                pointConnector = remember {
-                                    LineCartesianLayer.PointConnector.cubic(curvature = 0.2f)
-                                },
-                            )
-                        ),
-                        rangeProvider = remember(minItems.doubleValue, maxItems.doubleValue) {
-                            object : CartesianLayerRangeProvider {
-                                override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
-                                    return 0.0
-                                }
-
-                                override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
-                                    return max(maxItems.doubleValue * 1.20, 10.0)
-                                }
-
-                                override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore): Double {
-                                    return 0.0 // Fixed 0 to 100% range
-                                }
-
-                                override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore): Double {
-                                    return 100.0 // Fixed 0 to 100% range
-                                }
-                            }
-                        },
-                        verticalAxisPosition = Axis.Position.Vertical.End,
-                    ),
-                    startAxis = VerticalAxis.rememberStart(
-                        label = axisLabel,
-                        guideline = null,  // Hide grid lines
-                        itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
-                        valueFormatter = { _, value, _ -> value.toInt().toString() }
-                    ),
-                    endAxis = VerticalAxis.rememberEnd(
-                        label = axisLabel,
-                        guideline = null,  // Hide grid lines
-                        itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
-                        valueFormatter = { _, value, _ -> value.toInt().toString() }
-                    ),
+                    // Layer order matches the series order in the transaction above
+                    *listOfNotNull(bytesLayer, itemsLayer).toTypedArray(),
+                    startAxis = startAxis,
+                    endAxis = endAxis,
                     bottomAxis = HorizontalAxis.rememberBottom(
                         label = null,  // Hide X-axis labels like Windows Explorer
                         guideline = null,  // Hide grid lines
@@ -351,43 +213,73 @@ fun OperationPerformanceGraph(
             )
 
             // Recent average byte speed label (top-left, matches left Y-axis)
-            if (performanceHistory.samples.isNotEmpty()) {
-                val averageSpeed = performanceHistory.getRecentBytesPerSecond()
-
-                Text(
-                    text = formatByteSpeed(averageSpeed),
-                    style = MaterialTheme.typography.labelSmall,
+            if (byteSpeeds != null) {
+                SpeedChip(
+                    text = formatByteSpeed(performanceHistory.getRecentBytesPerSecond()),
                     color = bytesLineColor,
                     modifier = Modifier
-                        .align(androidx.compose.ui.Alignment.TopStart)
-                        .offset(x = 48.dp, y = 16.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-                            shape = RoundedCornerShape(4.dp)
-                        )
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                        .align(Alignment.TopStart)
+                        .offset(x = 48.dp, y = 16.dp),
                 )
             }
 
             // Recent average item speed label (top-right, matches right Y-axis)
-            if (performanceHistory.samples.isNotEmpty()) {
-                val averageItems = performanceHistory.getRecentItemsPerSecond().toInt()
-
-                Text(
-                    text = formatItemSpeed(averageItems.toDouble()),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = itemsLineColor,
-                    modifier = Modifier
-                        .align(androidx.compose.ui.Alignment.TopEnd)
-                        .offset(x = (-48).dp, y = 16.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-                            shape = RoundedCornerShape(4.dp)
-                        )
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                )
-            }
+            SpeedChip(
+                text = formatItemSpeed(performanceHistory.getRecentItemsPerSecond().toDouble()),
+                color = itemsLineColor,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = (-48).dp, y = 16.dp),
+            )
         }
+    }
+}
+
+@Composable
+private fun SpeedChip(
+    modifier: Modifier = Modifier,
+    text: String,
+    color: Color,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = color,
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    )
+}
+
+private val ByteSpeedUnit.labelRes: Int
+    get() = when (this) {
+        ByteSpeedUnit.B_S -> R.string.workspace_operation_performance_unit_bytes
+        ByteSpeedUnit.KB_S -> R.string.workspace_operation_performance_unit_kilobytes
+        ByteSpeedUnit.MB_S -> R.string.workspace_operation_performance_unit_megabytes
+        ByteSpeedUnit.GB_S -> R.string.workspace_operation_performance_unit_gigabytes
+    }
+
+private fun axisMax(maxValue: Double): Double = if (maxValue == 0.0) 1.0 else maxValue * 1.20
+
+private fun speedRangeProvider(rangeMaxY: Double) = object : CartesianLayerRangeProvider {
+    override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double = 0.0
+
+    override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double = rangeMaxY
+
+    override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore): Double = 0.0
+
+    override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore): Double = 100.0
+}
+
+/** Slow axes need decimals, fast ones would only repeat the same rounded label. */
+private fun speedValueFormatter(maxY: Double) = CartesianValueFormatter { _, value, _ ->
+    when {
+        maxY >= 10.0 -> String.format(Locale.getDefault(), "%.0f", value)
+        maxY >= 1.0 -> String.format(Locale.getDefault(), "%.1f", value)
+        else -> String.format(Locale.getDefault(), "%.2f", value)
     }
 }
 
@@ -442,6 +334,7 @@ private fun OperationPerformanceGraphHalfDataPreview() {
             samples = samples,
             startTime = baseTime,
             totalBytes = totalBytes,
+            totalItems = 1000,
         )
     }
     OperationPerformanceGraph(performanceHistory = history)
@@ -478,6 +371,67 @@ private fun OperationPerformanceGraphFullDataPreview() {
             samples = samples,
             startTime = baseTime,
             totalBytes = totalBytes,
+            totalItems = 1000,
+        )
+    }
+    OperationPerformanceGraph(performanceHistory = history)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationPerformanceGraphItemsOnlyPreview() {
+    // Deleting 500 empty files: no bytes anywhere, only the items axis has data
+    val history = remember {
+        val baseTime = kotlin.time.Clock.System.now()
+        val totalItems = 500
+
+        val samples = (0..100).map { i ->
+            val items = (40.0 + (kotlin.math.sin(i * 0.35) * 15.0)).coerceAtLeast(10.0).toFloat()
+            PerformanceSample(
+                timestamp = baseTime + (i * 250).milliseconds,
+                bytesPerSecond = 0L,
+                itemsPerSecond = items,
+                totalBytesProcessed = 0L,
+                totalItemsProcessed = (totalItems * (i / 100f)).toInt(),
+            )
+        }
+
+        PerformanceHistory(
+            samples = samples,
+            startTime = baseTime,
+            totalItems = totalItems,
+        )
+    }
+    OperationPerformanceGraph(performanceHistory = history)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationPerformanceGraphSingleFilePreview() {
+    // A single large file: the item count never moves, item speed stays below 1/s
+    val history = remember {
+        val baseTime = kotlin.time.Clock.System.now()
+        val totalBytes = 4_000_000_000L
+
+        val samples = (0..100).map { i ->
+            val progress = i / 100f
+            val speed = (80_000_000 + (kotlin.math.sin(i * 0.25) * 20_000_000)).toLong()
+            PerformanceSample(
+                timestamp = baseTime + (i * 500).milliseconds,
+                bytesPerSecond = speed,
+                itemsPerSecond = 0.02f,
+                totalBytesProcessed = (totalBytes * progress).toLong(),
+                totalItemsProcessed = 0,
+            )
+        }
+
+        PerformanceHistory(
+            samples = samples,
+            startTime = baseTime,
+            totalBytes = totalBytes,
+            totalItems = 1,
         )
     }
     OperationPerformanceGraph(performanceHistory = history)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -166,8 +166,9 @@ fun OperationPerformanceGraph(
                 label = axisLabel,
                 guideline = null,  // Hide grid lines
                 itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
-                valueFormatter = remember(maxBytes, maxItems, byteSpeeds != null) {
-                    speedValueFormatter(if (byteSpeeds != null) maxBytes else maxItems)
+                // Label precision follows the actual series maxima, not the padded axis range
+                valueFormatter = remember(graphData.maxByteSpeed, graphData.maxItemSpeed, byteSpeeds != null) {
+                    speedValueFormatter(if (byteSpeeds != null) graphData.maxByteSpeed else graphData.maxItemSpeed)
                 },
                 title = bytesUnitLabel ?: itemsUnitLabel,
                 titleComponent = rememberAxisLabelComponent(
@@ -179,7 +180,7 @@ fun OperationPerformanceGraph(
                     label = axisLabel,
                     guideline = null,  // Hide grid lines
                     itemPlacer = remember { VerticalAxis.ItemPlacer.count(count = { 5 }) },
-                    valueFormatter = remember(maxItems) { speedValueFormatter(maxItems) },
+                    valueFormatter = remember(graphData.maxItemSpeed) { speedValueFormatter(graphData.maxItemSpeed) },
                     title = itemsUnitLabel,
                     titleComponent = rememberAxisLabelComponent(color = itemsLineColor),
                 )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
@@ -26,12 +26,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 
 @Composable
 internal fun OperationPerformanceGraphSection(
     operation: OperationDisplay,
+    graphContent: @Composable (PerformanceHistory) -> Unit = { OperationPerformanceGraph(performanceHistory = it) },
 ) {
     // Extract performance history from the operation state
     val performanceHistory = when (val state = operation.state) {
@@ -79,9 +81,9 @@ internal fun OperationPerformanceGraphSection(
                         Icons.TwoTone.ExpandMore
                     },
                     contentDescription = if (isExpanded) {
-                        "Collapse performance graph"
+                        stringResource(R.string.workspace_operation_performance_graph_collapse)
                     } else {
-                        "Expand performance graph"
+                        stringResource(R.string.workspace_operation_performance_graph_expand)
                     },
                     modifier = Modifier.size(20.dp),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
@@ -91,10 +93,7 @@ internal fun OperationPerformanceGraphSection(
             // Graph content
             AnimatedVisibility(visible = isExpanded) {
                 Column(modifier = Modifier.padding(vertical = 8.dp)) {
-                    OperationPerformanceGraph(
-                        modifier = Modifier.fillMaxWidth(),
-                        performanceHistory = performanceHistory,
-                    )
+                    graphContent(performanceHistory)
                 }
             }
         }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -1,0 +1,123 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.operations.core.PerformanceSample
+import kotlin.math.max
+import kotlin.math.round
+
+enum class ByteSpeedUnit(val divisor: Double) {
+    B_S(1.0),
+    KB_S(1_000.0),
+    MB_S(1_000_000.0),
+    GB_S(1_000_000_000.0),
+}
+
+/**
+ * Plot-ready series for [OperationPerformanceGraph].
+ *
+ * All series share the [progress] x values, which are completion percentages rounded to 0.5 steps.
+ */
+data class PerformanceGraphData(
+    val progress: List<Float>,
+    val byteSpeeds: List<Float>?,
+    val itemSpeeds: List<Float>,
+    val byteUnit: ByteSpeedUnit?,
+    val maxByteSpeed: Double,
+    val maxItemSpeed: Double,
+) {
+
+    companion object {
+        private const val PROGRESS_STEP = 0.5f
+        private const val SMOOTHING_WINDOW = 10
+
+        fun from(history: PerformanceHistory): PerformanceGraphData? {
+            if (!history.canShowGraph) return null
+            // Without either total there is no x domain, every percentage would divide by zero
+            if (history.totalBytes == 0L && history.totalItems == 0) return null
+
+            val samples = mutableListOf<PerformanceSample>()
+            val progress = mutableListOf<Float>()
+
+            history.samples.forEach { sample ->
+                val x = history.progressOf(sample)
+                if (progress.isEmpty() || x - progress.last() >= PROGRESS_STEP) {
+                    samples.add(sample)
+                    progress.add(x)
+                }
+            }
+
+            // The final state matters even when it didn't advance enough to pass the filter
+            val finalSample = history.samples.last()
+            if (samples.last() !== finalSample) {
+                val finalX = history.progressOf(finalSample)
+                if (finalX == progress.last()) {
+                    samples[samples.lastIndex] = finalSample
+                    progress[progress.lastIndex] = finalX
+                } else {
+                    samples.add(finalSample)
+                    progress.add(finalX)
+                }
+            }
+
+            // A flat x domain (e.g. an all-skipped operation) has nothing to plot against
+            if (progress.distinct().size < 2) return null
+
+            val hasByteData = history.samples.any { it.bytesPerSecond > 0L || it.totalBytesProcessed > 0L }
+            val byteUnit = if (hasByteData) unitFor(samples.maxOf { it.bytesPerSecond }) else null
+
+            val byteSpeeds = byteUnit?.let { unit ->
+                samples.map { it.bytesPerSecond / unit.divisor }.trailingAverage()
+            }
+            val itemSpeeds = samples.map { it.itemsPerSecond.toDouble() }.trailingAverage()
+
+            return PerformanceGraphData(
+                progress = progress,
+                byteSpeeds = byteSpeeds,
+                itemSpeeds = itemSpeeds,
+                byteUnit = byteUnit,
+                maxByteSpeed = byteSpeeds?.max()?.toDouble() ?: 0.0,
+                maxItemSpeed = itemSpeeds.max().toDouble(),
+            )
+        }
+
+        /**
+         * Completion percentage of a sample, rounded to 0.5 steps.
+         *
+         * Bytes and items are unified via max() so that operations where one metric stalls, e.g. a
+         * copy that skips items, still reach 100%.
+         */
+        private fun PerformanceHistory.progressOf(sample: PerformanceSample): Float {
+            val bytesPercentage = if (totalBytes > 0L) {
+                (sample.totalBytesProcessed.toFloat() / totalBytes.toFloat()) * 100f
+            } else {
+                0f
+            }
+            val itemsPercentage = if (totalItems > 0) {
+                (sample.totalItemsProcessed.toFloat() / totalItems.toFloat()) * 100f
+            } else {
+                0f
+            }
+            val raw = max(bytesPercentage.coerceIn(0f, 100f), itemsPercentage.coerceIn(0f, 100f))
+            return round(raw * 2) / 2f
+        }
+
+        private fun unitFor(maxBytesPerSecond: Long): ByteSpeedUnit = when {
+            maxBytesPerSecond < 1_000L -> ByteSpeedUnit.B_S
+            maxBytesPerSecond < 1_000_000L -> ByteSpeedUnit.KB_S
+            maxBytesPerSecond < 1_000_000_000L -> ByteSpeedUnit.MB_S
+            else -> ByteSpeedUnit.GB_S
+        }
+
+        /**
+         * Moving average over the current and the previous [window] - 1 values.
+         *
+         * Trailing, not centered: a point may never be smoothed by values that come after it.
+         */
+        private fun List<Double>.trailingAverage(window: Int = SMOOTHING_WINDOW): List<Float> = indices.map { i ->
+            val start = maxOf(0, i - window + 1)
+            var sum = 0.0
+            for (j in start..i) sum += this[j]
+            (sum / (i - start + 1)).toFloat()
+        }
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -55,7 +55,7 @@ data class PerformanceGraphData(
                         samples[samples.lastIndex] = finalSample
                         progress[progress.lastIndex] = finalX
                     }
-                    // A revised down total moves the final sample back onto steps that were already plotted
+                    // Defensive: non-monotonic sample order (e.g. a wall-clock jump) can move the final sample back onto steps already plotted
                     finalX < progress.last() -> {
                         while (progress.isNotEmpty() && progress.last() >= finalX) {
                             samples.removeAt(samples.lastIndex)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -50,12 +50,24 @@ data class PerformanceGraphData(
             val finalSample = history.samples.last()
             if (samples.last() !== finalSample) {
                 val finalX = history.progressOf(finalSample)
-                if (finalX == progress.last()) {
-                    samples[samples.lastIndex] = finalSample
-                    progress[progress.lastIndex] = finalX
-                } else {
-                    samples.add(finalSample)
-                    progress.add(finalX)
+                when {
+                    finalX == progress.last() -> {
+                        samples[samples.lastIndex] = finalSample
+                        progress[progress.lastIndex] = finalX
+                    }
+                    // A revised down total moves the final sample back onto steps that were already plotted
+                    finalX < progress.last() -> {
+                        while (progress.isNotEmpty() && progress.last() >= finalX) {
+                            samples.removeAt(samples.lastIndex)
+                            progress.removeAt(progress.lastIndex)
+                        }
+                        samples.add(finalSample)
+                        progress.add(finalX)
+                    }
+                    else -> {
+                        samples.add(finalSample)
+                        progress.add(finalX)
+                    }
                 }
             }
 

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -227,6 +227,13 @@
 
     <!-- Performance Graph -->
     <string name="workspace_operation_performance_not_enough_data">Not enough data</string>
+    <string name="workspace_operation_performance_graph_expand">Expand performance graph</string>
+    <string name="workspace_operation_performance_graph_collapse">Collapse performance graph</string>
+    <string name="workspace_operation_performance_unit_bytes">B/s</string>
+    <string name="workspace_operation_performance_unit_kilobytes">kB/s</string>
+    <string name="workspace_operation_performance_unit_megabytes">MB/s</string>
+    <string name="workspace_operation_performance_unit_gigabytes">GB/s</string>
+    <string name="workspace_operation_performance_unit_items">items/s</string>
 
     <!-- Error Display (shared across workspaces) -->
     <string name="workspace_error_show_details_action">Show technical details</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
@@ -1,0 +1,109 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ContentCopy
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.operations.core.PerformanceSample
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+
+class OperationPerformanceGraphSectionTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val expandLabel = context.getString(R.string.workspace_operation_performance_graph_expand)
+    private val collapseLabel = context.getString(R.string.workspace_operation_performance_graph_collapse)
+    private val graphTag = "test-graph"
+
+    private val startTime = Instant.fromEpochMilliseconds(1000)
+
+    private fun history() = PerformanceHistory(
+        samples = (0 until 20).map { i ->
+            PerformanceSample(
+                timestamp = startTime + (i * 250).milliseconds,
+                bytesPerSecond = 50_000_000L,
+                itemsPerSecond = 5f,
+                totalBytesProcessed = i * 50_000_000L,
+                totalItemsProcessed = i,
+            )
+        },
+        startTime = startTime,
+        totalBytes = 1_000_000_000L,
+        totalItems = 20,
+    )
+
+    private fun operation(history: PerformanceHistory) = OperationDisplay(
+        id = Operation.Id(),
+        startedAt = Clock.System.now(),
+        icon = Icons.TwoTone.ContentCopy,
+        title = "Copying files".toCaString(),
+        description = "3 of 10".toCaString(),
+        state = OperationDisplay.State.Running(performanceHistory = history),
+    )
+
+    @Test
+    fun `toggling the section flips the expand affordance`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraphSection(
+                    operation = operation(history()),
+                    graphContent = { Text(text = "graph", modifier = Modifier.testTag(graphTag)) },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithContentDescription(collapseLabel).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription(collapseLabel).performClick()
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `graph is only composed while expanded`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraphSection(
+                    operation = operation(history()),
+                    graphContent = { Text(text = "graph", modifier = Modifier.testTag(graphTag)) },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(graphTag).assertDoesNotExist()
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun `real graph renders for a byte and item history`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraphSection(operation = operation(history()))
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithContentDescription(collapseLabel).assertIsDisplayed()
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
@@ -1,0 +1,315 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.operations.core.PerformanceSample
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+
+/**
+ * Tests for [PerformanceGraphData] - turning a [PerformanceHistory] into plottable series.
+ */
+class PerformanceGraphDataTest : BaseTest() {
+
+    private val startTime = Instant.fromEpochMilliseconds(1000)
+
+    private fun sample(
+        index: Int,
+        bytesPerSecond: Long = 0L,
+        itemsPerSecond: Float = 0f,
+        totalBytesProcessed: Long = 0L,
+        totalItemsProcessed: Int = 0,
+    ) = PerformanceSample(
+        timestamp = startTime + (index * 100).milliseconds,
+        bytesPerSecond = bytesPerSecond,
+        itemsPerSecond = itemsPerSecond,
+        totalBytesProcessed = totalBytesProcessed,
+        totalItemsProcessed = totalItemsProcessed,
+    )
+
+    private fun history(
+        samples: List<PerformanceSample>,
+        totalBytes: Long = 0L,
+        totalItems: Int = 0,
+    ) = PerformanceHistory(
+        samples = samples,
+        startTime = startTime,
+        totalBytes = totalBytes,
+        totalItems = totalItems,
+    )
+
+    // ============ BYTE UNIT SELECTION ============
+
+    @Test
+    fun `slow transfer is scaled into kilobytes per second`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 500_000L,
+                    itemsPerSecond = 4f,
+                    totalBytesProcessed = i * 500_000L,
+                    totalItemsProcessed = i,
+                )
+            },
+            totalBytes = 10_000_000L,
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.byteUnit shouldBe ByteSpeedUnit.KB_S
+        data.byteSpeeds.shouldNotBeNull().forEach { it shouldBe 500f }
+        data.maxByteSpeed shouldBe 500.0
+    }
+
+    @Test
+    fun `byte unit is selected from the fastest sample`() {
+        fun unitFor(bytesPerSecond: Long): ByteSpeedUnit? {
+            val history = history(
+                samples = (0 until 20).map { i ->
+                    sample(
+                        index = i,
+                        bytesPerSecond = bytesPerSecond,
+                        itemsPerSecond = 1f,
+                        totalBytesProcessed = i * 10L,
+                        totalItemsProcessed = i,
+                    )
+                },
+                totalItems = 20,
+            )
+            return PerformanceGraphData.from(history).shouldNotBeNull().byteUnit
+        }
+
+        unitFor(999L) shouldBe ByteSpeedUnit.B_S
+        unitFor(1_000L) shouldBe ByteSpeedUnit.KB_S
+        unitFor(999_999L) shouldBe ByteSpeedUnit.KB_S
+        unitFor(1_000_000L) shouldBe ByteSpeedUnit.MB_S
+        unitFor(999_999_999L) shouldBe ByteSpeedUnit.MB_S
+        unitFor(1_000_000_000L) shouldBe ByteSpeedUnit.GB_S
+    }
+
+    @Test
+    fun `bytes moved without a measured speed still get a byte series`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 0L,
+                    itemsPerSecond = 2f,
+                    totalBytesProcessed = i * 100_000L,
+                    totalItemsProcessed = i,
+                )
+            },
+            totalBytes = 2_000_000L,
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.byteUnit shouldBe ByteSpeedUnit.B_S
+        data.byteSpeeds.shouldNotBeNull().forEach { it shouldBe 0f }
+        data.maxByteSpeed shouldBe 0.0
+    }
+
+    // ============ SERIES PRESENCE ============
+
+    @Test
+    fun `item only operation has no byte series`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i)
+            },
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.byteSpeeds shouldBe null
+        data.byteUnit shouldBe null
+        data.maxByteSpeed shouldBe 0.0
+        data.progress shouldBe (0 until 20).map { it * 5f }
+    }
+
+    @Test
+    fun `unknown size transfer keeps its byte series and plots against items`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 4_000_000L,
+                    itemsPerSecond = 2f,
+                    totalBytesProcessed = i * 4_000_000L,
+                    totalItemsProcessed = i,
+                )
+            },
+            totalBytes = 0L,  // Size unknown up front, e.g. a stream copy
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.byteUnit shouldBe ByteSpeedUnit.MB_S
+        data.byteSpeeds.shouldNotBeNull() shouldHaveSize 20
+        data.progress shouldBe (0 until 20).map { it * 5f }
+    }
+
+    // ============ NO GRAPH ============
+
+    @Test
+    fun `history without totals has no x domain`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(index = i, bytesPerSecond = 1_000_000L, itemsPerSecond = 5f)
+            },
+        )
+
+        PerformanceGraphData.from(history) shouldBe null
+    }
+
+    @Test
+    fun `flat progress is not plottable`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = 0)
+            },
+            totalItems = 100,
+        )
+
+        PerformanceGraphData.from(history) shouldBe null
+    }
+
+    @Test
+    fun `too few samples produce no data`() {
+        val history = history(
+            samples = (0 until 9).map { i ->
+                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i)
+            },
+            totalItems = 9,
+        )
+
+        PerformanceGraphData.from(history) shouldBe null
+    }
+
+    // ============ X DOMAIN ============
+
+    @Test
+    fun `skipped items still let progress reach 100 percent`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 1_000L,
+                    itemsPerSecond = 2f,
+                    // Bytes stall at 10%: the remaining items were skipped
+                    totalBytesProcessed = minOf(i, 2) * 50_000L,
+                    totalItemsProcessed = i + 1,
+                )
+            },
+            totalBytes = 1_000_000L,
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress.last() shouldBe 100f
+    }
+
+    @Test
+    fun `progress beyond the total is clamped to 100 percent`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 1_000_000L,
+                    itemsPerSecond = 2f,
+                    // The last few samples report more than the total
+                    totalBytesProcessed = (i + 1) * 100_000L,
+                    totalItemsProcessed = i,
+                )
+            },
+            totalBytes = 1_000_000L,
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress.max() shouldBe 100f
+        data.progress.last() shouldBe 100f
+    }
+
+    @Test
+    fun `single large file still advances along the byte axis`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 50_000_000L,
+                    itemsPerSecond = 0.05f,
+                    totalBytesProcessed = i * 50_000_000L,
+                    totalItemsProcessed = 0,  // The single file is only counted once it is done
+                )
+            },
+            totalBytes = 1_000_000_000L,
+            totalItems = 1,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress shouldBe data.progress.distinct()
+        data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+    }
+
+    // ============ FILTERING ============
+
+    @Test
+    fun `samples are kept once progress advanced half a percent`() {
+        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
+        val samples = (0 until 10).map { i ->
+            sample(index = i, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i + 1)
+        }
+        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
+
+        data.progress shouldBe listOf(0f, 0.5f, 1f)
+        // The final sample replaced the entry that shared its 1.0% step: (10 + 30 + 100) / 3
+        data.itemSpeeds.last() shouldBe (46.667f plusOrMinus 0.01f)
+    }
+
+    @Test
+    fun `a final sample that lands on a new step is appended`() {
+        val samples = (0 until 10).map { i ->
+            sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
+        } + sample(index = 10, itemsPerSecond = 5f, totalItemsProcessed = 4)  // Progress reported lower
+
+        val data = PerformanceGraphData.from(history(samples, totalItems = 10)).shouldNotBeNull()
+
+        data.progress shouldHaveSize 11
+        data.progress.last() shouldBe 40f
+    }
+
+    // ============ SMOOTHING ============
+
+    @Test
+    fun `smoothing only averages over preceding samples`() {
+        val samples = (0 until 15).map { i ->
+            sample(index = i, itemsPerSecond = (i + 1).toFloat(), totalItemsProcessed = i + 1)
+        }
+
+        val data = PerformanceGraphData.from(history(samples, totalItems = 15)).shouldNotBeNull()
+
+        data.itemSpeeds shouldHaveSize 15
+        // Partial window at the start: (1 + 2 + 3 + 4) / 4
+        data.itemSpeeds[3] shouldBe (2.5f plusOrMinus 0.001f)
+        // Full trailing window of 10: (4 + 5 + … + 13) / 10
+        data.itemSpeeds[12] shouldBe (8.5f plusOrMinus 0.001f)
+        // The last point knows nothing beyond itself: (6 + 7 + … + 15) / 10
+        data.itemSpeeds.last() shouldBe (10.5f plusOrMinus 0.001f)
+        data.maxItemSpeed shouldBe (10.5 plusOrMinus 0.001)
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
@@ -282,15 +282,29 @@ class PerformanceGraphDataTest : BaseTest() {
     }
 
     @Test
-    fun `a final sample that lands on a new step is appended`() {
+    fun `a final sample below earlier progress truncates back to it`() {
         val samples = (0 until 10).map { i ->
             sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
         } + sample(index = 10, itemsPerSecond = 5f, totalItemsProcessed = 4)  // Progress reported lower
 
         val data = PerformanceGraphData.from(history(samples, totalItems = 10)).shouldNotBeNull()
 
-        data.progress shouldHaveSize 11
-        data.progress.last() shouldBe 40f
+        data.progress shouldBe listOf(10f, 20f, 30f, 40f)
+        data.progress shouldBe data.progress.distinct()
+    }
+
+    @Test
+    fun `a final sample above the last kept step is appended`() {
+        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
+        val samples = (0 until 11).map { i ->
+            sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
+        } + sample(index = 11, itemsPerSecond = 5f, totalItemsProcessed = 100)  // A batch of items landed at once
+
+        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
+
+        data.progress shouldBe listOf(0f, 0.5f, 1f, 10f)
+        data.progress shouldBe data.progress.distinct()
+        data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
     }
 
     // ============ SMOOTHING ============


### PR DESCRIPTION
## What changed

The performance graph in operation details is now accurate and readable across all operation types. Slow transfers (kB/s range) no longer render as a flat line squashed at the bottom, both axes now show their unit (kB/s, MB/s, items/s) tinted to match their line, both lines share one progress axis so they can no longer draw vertical zig-zag artifacts, operations without byte data (e.g. deleting empty files) show a single clean items line instead of a meaningless byte area, item speeds below 1/s display as "0.3 items/s" instead of "0 items/s", the end of an operation is no longer missing from the graph, and the live graph no longer freezes during very long operations. The expand/collapse control is announced in the app language for screen readers.

## Technical Context

- The graph math lived inline in the composable behind a `LaunchedEffect` keyed on `(samples.size, totalBytes)`, which goes stale once compaction keeps the size constant; it is now a pure, unit-tested preparation layer recomputed via structural equality on the whole immutable history.
- The sample store's compaction could silently drop the newest (including final) sample due to endpoint-exclusive bucket index math, and bucketed against pre-add totals; selection is now endpoint-inclusive, totals resolve before compaction, and compaction is amortized (hard cap 1000, target 800) to cut per-add churn on many-small-file operations.
- Both series plot over one unified progress domain, `max(bytes%, items%)` clamped to 0..100, so operations with skipped items still reach 100%; byte-series presence derives from observed byte data rather than `totalBytes > 0`, keeping unknown-size transfers' byte line and dropping it for zero-byte deletes.
- The shared item-speed formatter printed the raw `Double` representation for sub-1.0 values ("0.20000000298023224 items/s"); it now formats one locale-aware decimal, changing other call sites only for sub-1.0 values where the old output was the defect.
- Deserves close review: the final-sample replace/truncate/append logic in the new preparation layer, and the compaction index math in the sample store. Manual emulator verification covered the dual-axis, single-large-file, and item-only rendering modes, which CI cannot exercise.
