### PR TITLE
General: Fix back presses that did nothing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,8 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "devtools@claude-code-cafe": true
+    "devtools@claude-code-cafe": true,
+    "google-play@claude-code-cafe": true,
+    "support@claude-code-cafe": true
   }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
@@ -257,7 +257,17 @@ private fun FileOptionsContent(
             FileActionRow(
                 icon = Workspace.Type.VIEWER.icon,
                 title = stringResource(R.string.explorer_file_action_open),
-                subtitle = stringResource(R.string.explorer_file_action_open_subtitle),
+                // Only a Viewer stacks inside this tab and returns here on back. A text file
+                // routes to the Editor, which is a tab of its own, making this row do exactly
+                // what the "open in new tab" row below does. Routing pinned by
+                // OpenInNewTabsUseCaseTest.
+                subtitle = stringResource(
+                    if (isTextFile) {
+                        R.string.explorer_file_action_open_in_tab_subtitle
+                    } else {
+                        R.string.explorer_file_action_open_subtitle
+                    },
+                ),
                 onClick = { onAction(ExplorerActionBarItem.File.Open(item)) },
             )
 

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="explorer_file_info_size_label">Size</string>
     <string name="explorer_file_info_modified_label">Modified</string>
     <string name="explorer_file_action_open">Open</string>
-    <string name="explorer_file_action_open_subtitle">View in Butler</string>
+    <string name="explorer_file_action_open_subtitle">View here, back returns to this folder</string>
     <string name="explorer_file_action_open_in_tab">Open in new tab</string>
     <string name="explorer_file_action_open_in_tab_subtitle">View in Butler as its own tab</string>
     <string name="explorer_file_action_open_in_editor">Open in editor</string>

--- a/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
@@ -414,7 +414,10 @@ class MainActivity : Activity2() {
 
     companion object {
         private val TAG = logTag("Main", "Activity")
-        private const val BACK_PRESS_INTERVAL = 2000L // 2 seconds
+        // Must outlast the Toast.LENGTH_SHORT prompt (~2s) that asks for the second press: a window
+        // closing while that instruction is still on screen leaves every slower press restarting
+        // the prompt instead of exiting.
+        private const val BACK_PRESS_INTERVAL = 3500L
         private const val MIME_DOCUMENT_ROOT = "vnd.android.document/root"
         private const val MIME_DOCUMENT_DIRECTORY = "vnd.android.document/directory"
     }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -27,6 +27,10 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceStacks
@@ -43,6 +47,8 @@ import eu.darken.butler.workspace.ui.workspaces.WorkspacesViewModel
 import eu.darken.butler.workspace.ui.workspaces.asPaneInfo
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+
+private val TAG = logTag("Workspace", "Classic", "Container")
 
 // Stable key for the on-demand-creation placeholder page (last index when enabled).
 // Distinct from any Workspace.Id so the pager preserves identity across list churn.
@@ -210,11 +216,25 @@ internal fun ClassicWorkspaceContainer(
             state.fullScreenModalWorkspace == null &&
             !hasGlobalBlockingDialog,
     ) {
-        // On the placeholder and at rest: return to the focused tab. Otherwise the pager is
-        // mid-move or focus has not caught up with a settle yet — swallow the press rather than
-        // let it reach the app-root exit prompt, and let the user press again once things settle.
-        if (isOnPlaceholder && !pagerState.isScrollInProgress) {
-            backTarget?.let { scope.launch { coordinator.scrollToWorkspace(pagerState, tabIds, it) } }
+        val settling = pagerState.isScrollInProgress
+        val settledTab = tabIds.getOrNull(pagerState.settledPage)
+        // Mid-move and the placeholder are the expected reasons to land here. At rest on a real
+        // page means focus and the pager disagree with nothing in flight to reconcile them, and
+        // that is the state presses cannot get out of on their own.
+        log(TAG, if (settling || isOnPlaceholder) VERBOSE else WARN) {
+            "Pane-level back: focusedRoot=$backTarget targetPage=$backTargetPage " +
+                "settled=${pagerState.settledPage} settling=$settling onPlaceholder=$isOnPlaceholder"
+        }
+        when {
+            settling -> Unit
+            // The placeholder is no destination, so here the pager is the one that has to move.
+            isOnPlaceholder -> backTarget?.let {
+                scope.launch { coordinator.scrollToWorkspace(pagerState, tabIds, it) }
+            }
+            // At rest on a real page: that page is what the user is looking at, so focus adopts it
+            // rather than the pager undoing a swipe the user just made. The press itself is still
+            // consumed; the next one reaches the page now that the two agree.
+            settledTab != null -> onWorkspaceScreenAction(WorkspaceScreenAction.Select(settledTab))
         }
     }
 

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ClassicPlaceholderBackDispatchTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ClassicPlaceholderBackDispatchTest.kt
@@ -92,6 +92,7 @@ class ClassicPlaceholderBackDispatchTest : ComposeTest() {
 
     private class Outcome {
         val closedTabs = mutableListOf<Workspace.Id>()
+        val screenActions = mutableListOf<WorkspaceScreenAction>()
         var overlayDismissed = false
         var reachedAppRoot = false
         var dispatcher: OnBackPressedDispatcher? = null
@@ -144,7 +145,9 @@ class ClassicPlaceholderBackDispatchTest : ComposeTest() {
                         state = state,
                         managerDialogs = managerDialogs,
                         isOverlayVisible = overlayVisible,
-                        onWorkspaceScreenAction = {},
+                        // Recorded but not applied: focus must still never follow the swipe,
+                        // or the desync these tests are built on would repair itself.
+                        onWorkspaceScreenAction = { outcome.screenActions.add(it) },
                         managerDialogStates = emptyMap(),
                         onDismissManagerDialog = {},
                         onConfirmManagerDialog = {},
@@ -260,6 +263,30 @@ class ClassicPlaceholderBackDispatchTest : ComposeTest() {
         outcome.closedTabs shouldBe emptyList()
         outcome.reachedAppRoot shouldBe false
         // Nothing moved either: the container swallows the press rather than acting on it.
+        composeTestRule.onNodeWithTag(pageTag(idA)).assertIsDisplayed()
+    }
+
+    /**
+     * The repair for the state above. Consuming the press is only acceptable because it also ends
+     * the disagreement: focus adopts the page the pager rests on, so the next press reaches that
+     * page instead of being consumed again. Without this the container would swallow every press
+     * for as long as focus stayed behind.
+     *
+     * The pager deliberately does not move. The user swiped to this page; back must not undo that.
+     */
+    @Test
+    fun `back at rest hands focus to the page the pager rests on`() {
+        val outcome = compose()
+
+        composeTestRule.onNodeWithTag(pageTag(idB)).performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(pageTag(idA)).assertIsDisplayed()
+        // The settle itself reports a selection; only what the press adds is under test.
+        outcome.screenActions.clear()
+
+        outcome.pressBack()
+
+        outcome.screenActions shouldBe listOf(WorkspaceScreenAction.Select(idA))
         composeTestRule.onNodeWithTag(pageTag(idA)).assertIsDisplayed()
     }
 


### PR DESCRIPTION
## What changed

Pressing back twice to leave Butler now actually leaves it. The prompt asking for a second press stayed on screen slightly longer than the window that accepted it, so anyone who read the prompt before pressing again was always too late, and at a normal pace the app could not be exited at all. This was reported from the editor, which is where it bites hardest: the editor is the only workspace that routinely holds the soft keyboard, and Android gives the keyboard first refusal on back, so the first press only closes the keyboard and never counts.

Back also no longer does nothing at all in the tab pager. When the page on screen and the page the app considered focused had drifted apart, every back press was silently consumed: no navigation, no exit prompt, no feedback. Back now settles that disagreement and the following press behaves normally.

The Explorer's file actions now say where back will take you. "Open" reads "View here, back returns to this folder" for files that open inside the current tab, which is the one way it differs from "Open in new tab" once you are looking at the file.

## Technical Context

* Root cause of the exit prompt: `BACK_PRESS_INTERVAL` was 2000ms while the `Toast.LENGTH_SHORT` prompt describing it is also roughly 2000ms, so the instruction outlived the window. Measured before the change on an emulator: presses 1.5s apart exit on the second press, presses 2.5s apart never exit however many are made.
* The pager fix repairs focus onto the settled page rather than scrolling the pager to the focused tab. The two look equivalent but the latter would undo a swipe the user had just made, which the existing "back is consumed while focus has not caught up" regression test catches.
* A `WARN` now names the back-gate state when a press is consumed at rest on a real page. Mid-move and the trailing placeholder stay at `VERBOSE` because both are expected, so the warning only appears in the anomalous case and a future report of back doing nothing carries enough to tell the causes apart.
* Worth close review: the new `when` branch in `ClassicWorkspaceContainer`. It is the one remaining place back dispatch can consume a press without a visible effect, and the handler's arming conditions are deliberately unchanged.
* A second report, the system back gesture not leaving a Viewer opened from the Explorer, is **not** fixed here. Its cause has since been identified as gesture arbitration rather than back dispatch: it reproduces only on OneUI, where full screen gestures hand the app the edge touch first, so the pager starts a drag, wins the gesture and cancels back, then snaps back because the drag never reaches the fling threshold. AOSP and LineageOS reserve the edge strip outright, which is why it cannot be reproduced on an emulator. That needs the pager to stop consuming drags that begin inside `WindowInsets.systemGestures`, and is being handled separately. The hardening here closes a different dead end, one visible in the code rather than observed.
* Manual on-device testing covered what CI cannot: edge-swipe back closing a drill-down viewer, Explorer back navigating up, the per-file-type subtitles rendering, and the new warning staying silent during normal navigation.
