### PR TITLE
Workspace: Make the operation details card easier to read

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/InfoBlock.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/InfoBlock.kt
@@ -1,0 +1,140 @@
+package eu.darken.butler.common.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+
+data class InfoEntry(
+    val label: String,
+    val value: String,
+    val pairable: Boolean,
+    val valueMaxLines: Int = 2,
+)
+
+/** Groups consecutive pairable entries two-per-row; non-pairable entries get a row of their own. */
+fun groupInfoEntries(entries: List<InfoEntry>): List<List<InfoEntry>> {
+    val rows = mutableListOf<List<InfoEntry>>()
+    var pending = mutableListOf<InfoEntry>()
+    entries.forEach { entry ->
+        if (entry.pairable) {
+            pending.add(entry)
+            if (pending.size == 2) {
+                rows.add(pending)
+                pending = mutableListOf()
+            }
+        } else {
+            if (pending.isNotEmpty()) {
+                rows.add(pending)
+                pending = mutableListOf()
+            }
+            rows.add(listOf(entry))
+        }
+    }
+    if (pending.isNotEmpty()) rows.add(pending)
+    return rows
+}
+
+/** A small label stacked on top of its value, the building block of the metadata grids. */
+@Composable
+fun InfoBlock(
+    modifier: Modifier = Modifier,
+    entry: InfoEntry,
+    valueLeading: (@Composable () -> Unit)? = null,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = entry.label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        val value: @Composable () -> Unit = {
+            Text(
+                text = entry.value,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                // Plain ellipsis: MiddleEllipsis degrades to clipping on multiline Android text.
+                maxLines = entry.valueMaxLines,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (valueLeading != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                valueLeading()
+                value()
+            }
+        } else {
+            value()
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun InfoBlockPreview() {
+    InfoBlock(
+        modifier = Modifier
+            .width(180.dp)
+            .padding(16.dp),
+        entry = InfoEntry(label = "Size", value = "4.59 MB", pairable = true),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun InfoBlockWithLeadingPreview() {
+    InfoBlock(
+        modifier = Modifier
+            .width(180.dp)
+            .padding(16.dp),
+        entry = InfoEntry(label = "Status", value = "Successful", pairable = true),
+        valueLeading = {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+            )
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun InfoBlockUncappedValuePreview() {
+    InfoBlock(
+        modifier = Modifier
+            .width(320.dp)
+            .padding(16.dp),
+        entry = InfoEntry(
+            label = "Result",
+            value = "Moved 12 files, moved 3 folders, skipped 2 files, overwrote 1 file",
+            pairable = false,
+            valueMaxLines = Int.MAX_VALUE,
+        ),
+    )
+}

--- a/app-common/src/test/java/eu/darken/butler/common/compose/InfoBlockGroupingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/InfoBlockGroupingTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.butler.common.compose
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class InfoBlockGroupingTest : BaseTest() {
+
+    private fun pairable(label: String) = InfoEntry(label = label, value = label, pairable = true)
+
+    private fun solo(label: String) = InfoEntry(label = label, value = label, pairable = false)
+
+    @Test
+    fun `nothing to group`() {
+        groupInfoEntries(emptyList()) shouldBe emptyList()
+    }
+
+    @Test
+    fun `consecutive pairable entries go two per row`() {
+        val size = pairable("Size")
+        val modified = pairable("Modified")
+        val created = pairable("Created")
+        val format = pairable("Format")
+
+        groupInfoEntries(listOf(size, modified, created, format)) shouldBe listOf(
+            listOf(size, modified),
+            listOf(created, format),
+        )
+    }
+
+    @Test
+    fun `an odd trailing pairable entry stays alone`() {
+        val size = pairable("Size")
+        val modified = pairable("Modified")
+        val created = pairable("Created")
+
+        groupInfoEntries(listOf(size, modified, created)) shouldBe listOf(
+            listOf(size, modified),
+            listOf(created),
+        )
+    }
+
+    @Test
+    fun `a non pairable entry always gets its own row`() {
+        val size = pairable("Size")
+        val permissions = solo("Permissions")
+        val owner = solo("Owner")
+        val modified = pairable("Modified")
+
+        groupInfoEntries(listOf(size, permissions, owner, modified)) shouldBe listOf(
+            listOf(size),
+            listOf(permissions),
+            listOf(owner),
+            listOf(modified),
+        )
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ApkFileContent.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ApkFileContent.kt
@@ -47,7 +47,10 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapp
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.InfoBlock
+import eu.darken.butler.common.compose.InfoEntry
 import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.groupInfoEntries
 import eu.darken.butler.common.pkgs.apk.ApkArchiveInfo
 import eu.darken.butler.common.pkgs.apk.ApkSignature
 import eu.darken.butler.common.pkgs.apk.apkVersionText

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/FileInfoCard.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/FileInfoCard.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,13 +27,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.InfoBlock
+import eu.darken.butler.common.compose.InfoEntry
 import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.groupInfoEntries
 import eu.darken.butler.common.files.metadata.Ownership
 import eu.darken.butler.common.files.metadata.Permissions
 import eu.darken.butler.common.DateTimeStyle
@@ -44,31 +44,6 @@ import eu.darken.butler.viewer.R
 import eu.darken.butler.viewer.core.ViewerFileInfo
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
-
-internal data class InfoEntry(val label: String, val value: String, val pairable: Boolean)
-
-/** Groups consecutive pairable entries two-per-row; non-pairable entries get a row of their own. */
-internal fun groupInfoEntries(entries: List<InfoEntry>): List<List<InfoEntry>> {
-    val rows = mutableListOf<List<InfoEntry>>()
-    var pending = mutableListOf<InfoEntry>()
-    entries.forEach { entry ->
-        if (entry.pairable) {
-            pending.add(entry)
-            if (pending.size == 2) {
-                rows.add(pending)
-                pending = mutableListOf()
-            }
-        } else {
-            if (pending.isNotEmpty()) {
-                rows.add(pending)
-                pending = mutableListOf()
-            }
-            rows.add(listOf(entry))
-        }
-    }
-    if (pending.isNotEmpty()) rows.add(pending)
-    return rows
-}
 
 /**
  * Collapsed keeps the first row only. That row is Size and Modified for every file the gateway
@@ -272,31 +247,6 @@ private fun FileInfoCardContent(
 
 /** Footprint of the expand/collapse button, and the end inset the first row reserves for it. */
 private val ToggleReservedWidth = 40.dp
-
-@Composable
-internal fun InfoBlock(
-    modifier: Modifier = Modifier,
-    entry: InfoEntry,
-) {
-    Column(modifier = modifier) {
-        Text(
-            text = entry.label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Text(
-            text = entry.value,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Medium,
-            // Plain ellipsis: MiddleEllipsis degrades to clipping on multiline Android text.
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
 
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/FileInfoCardGroupingTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/FileInfoCardGroupingTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.butler.viewer.ui.viewer
 
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.InfoEntry
+import eu.darken.butler.common.compose.groupInfoEntries
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -10,36 +12,6 @@ class FileInfoCardGroupingTest : BaseTest() {
     private fun pairable(label: String) = InfoEntry(label = label, value = label, pairable = true)
 
     private fun solo(label: String) = InfoEntry(label = label, value = label, pairable = false)
-
-    @Test
-    fun `nothing to group`() {
-        groupInfoEntries(emptyList()) shouldBe emptyList()
-    }
-
-    @Test
-    fun `consecutive pairable entries go two per row`() {
-        val size = pairable("Size")
-        val modified = pairable("Modified")
-        val created = pairable("Created")
-        val format = pairable("Format")
-
-        groupInfoEntries(listOf(size, modified, created, format)) shouldBe listOf(
-            listOf(size, modified),
-            listOf(created, format),
-        )
-    }
-
-    @Test
-    fun `an odd trailing pairable entry stays alone`() {
-        val size = pairable("Size")
-        val modified = pairable("Modified")
-        val created = pairable("Created")
-
-        groupInfoEntries(listOf(size, modified, created)) shouldBe listOf(
-            listOf(size, modified),
-            listOf(created),
-        )
-    }
 
     @Test
     fun `permissions only share a row where the column can hold the whole value`() {
@@ -71,20 +43,5 @@ class FileInfoCardGroupingTest : BaseTest() {
     @Test
     fun `collapsing an empty card yields nothing`() {
         visibleInfoRows(emptyList(), expanded = false) shouldBe emptyList()
-    }
-
-    @Test
-    fun `a non pairable entry always gets its own row`() {
-        val size = pairable("Size")
-        val permissions = solo("Permissions")
-        val owner = solo("Owner")
-        val modified = pairable("Modified")
-
-        groupInfoEntries(listOf(size, permissions, owner, modified)) shouldBe listOf(
-            listOf(size),
-            listOf(permissions),
-            listOf(owner),
-            listOf(modified),
-        )
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,46 @@ import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import kotlin.time.Clock
+
+internal data class OperationStateVisuals(
+    val imageVector: ImageVector,
+    val contentDescription: String,
+    val tint: Color,
+)
+
+@Composable
+internal fun operationStateVisuals(state: OperationDisplay.State): OperationStateVisuals = when (state) {
+    is OperationDisplay.State.Queued -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.PauseCircle,
+        contentDescription = stringResource(R.string.operations_state_queued),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    is OperationDisplay.State.Running -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.PauseCircle,
+        contentDescription = stringResource(R.string.operations_state_running),
+        tint = MaterialTheme.colorScheme.primary,
+    )
+    is OperationDisplay.State.Waiting -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.Handyman,
+        contentDescription = stringResource(R.string.operations_state_waiting),
+        tint = MaterialTheme.colorScheme.tertiary,
+    )
+    is OperationDisplay.State.Completed -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.CheckCircle,
+        contentDescription = stringResource(R.string.operations_state_successful),
+        tint = Color(0xFF4CAF50), // Success green
+    )
+    is OperationDisplay.State.Failed -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.Error,
+        contentDescription = stringResource(R.string.operations_state_failed),
+        tint = MaterialTheme.colorScheme.error,
+    )
+    is OperationDisplay.State.Cancelled -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.Cancel,
+        contentDescription = stringResource(R.string.operations_state_cancelled),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
 
 @Composable
 fun OperationActionIndicator(
@@ -42,51 +83,20 @@ fun OperationActionIndicator(
         enabled = effectiveOnClick != null,
         onClick = effectiveOnClick ?: {},
     ) {
-        val (imageVector, contentDescriptionRes, tint) = when (state) {
-            is OperationDisplay.State.Queued -> Triple(
-                Icons.TwoTone.PauseCircle,
-                R.string.operations_state_queued,
-                MaterialTheme.colorScheme.onSurfaceVariant
+        val visuals = when {
+            isActionable -> OperationStateVisuals(
+                imageVector = Icons.TwoTone.Cancel,
+                contentDescription = stringResource(R.string.operations_cancel_operation),
+                tint = MaterialTheme.colorScheme.error,
             )
-            is OperationDisplay.State.Running -> when {
-                isActionable -> Triple(
-                    Icons.TwoTone.Cancel,
-                    R.string.operations_cancel_operation,
-                    MaterialTheme.colorScheme.error
-                )
-                else -> Triple(
-                    Icons.TwoTone.PauseCircle,
-                    R.string.operations_state_running,
-                    MaterialTheme.colorScheme.primary
-                )
-            }
-            is OperationDisplay.State.Waiting -> Triple(
-                Icons.TwoTone.Handyman,
-                R.string.operations_state_waiting,
-                MaterialTheme.colorScheme.tertiary
-            )
-            is OperationDisplay.State.Completed -> Triple(
-                Icons.TwoTone.CheckCircle,
-                R.string.operations_state_successful,
-                Color(0xFF4CAF50) // Success green
-            )
-            is OperationDisplay.State.Failed -> Triple(
-                Icons.TwoTone.Error,
-                R.string.operations_state_failed,
-                MaterialTheme.colorScheme.error
-            )
-            is OperationDisplay.State.Cancelled -> Triple(
-                Icons.TwoTone.Cancel,
-                R.string.operations_state_cancelled,
-                MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            else -> operationStateVisuals(state)
         }
 
         Icon(
-            imageVector = imageVector,
-            contentDescription = stringResource(contentDescriptionRes),
+            imageVector = visuals.imageVector,
+            contentDescription = visuals.contentDescription,
             modifier = modifier,
-            tint = tint,
+            tint = visuals.tint,
         )
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -46,7 +46,7 @@ import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
-import eu.darken.butler.workspace.ui.operations.bar.OperationActionIndicator
+import eu.darken.butler.workspace.ui.operations.bar.operationStateVisuals
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
@@ -217,9 +217,12 @@ private fun OperationOverviewGrid(
                             entry = entry,
                             valueLeading = if (entry === statusEntry) {
                                 {
-                                    OperationActionIndicator(
+                                    val visuals = operationStateVisuals(operation.state)
+                                    Icon(
                                         modifier = Modifier.size(16.dp),
-                                        state = operation.state,
+                                        imageVector = visuals.imageVector,
+                                        contentDescription = visuals.contentDescription,
+                                        tint = visuals.tint,
                                     )
                                 }
                             } else {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -200,8 +200,8 @@ private fun OperationOverviewGrid(
             maxWidth >= OverviewPairingMinWidth -> baseEntries
             else -> baseEntries.map { it.copy(pairable = false) }
         }
-        // Status is always first, and referential identity is what carries the state icon - the
-        // label string is localized and would not survive a translation.
+        // Status is always first, and referential identity is what carries the state icon -
+        // identity cannot collide, whereas a label comparison breaks once two entries share a label.
         val statusEntry = entries.first()
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -3,6 +3,8 @@ package eu.darken.butler.workspace.ui.operations.details
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,9 +12,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.ExpandLess
 import androidx.compose.material.icons.twotone.ExpandMore
+import androidx.compose.material.icons.twotone.Handyman
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -28,14 +32,55 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.InfoBlock
+import eu.darken.butler.common.compose.InfoEntry
+import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.asComposable
+import eu.darken.butler.common.compose.groupInfoEntries
 import eu.darken.butler.common.formatDuration
 import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import eu.darken.butler.workspace.ui.operations.bar.OperationActionIndicator
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+
+/** Below this the two-column grid leaves ~48dp per column; every entry goes full width instead. */
+internal val OverviewPairingMinWidth = 240.dp
+
+/**
+ * Result is never paired and never capped: a move/copy summary concatenates up to four plural
+ * segments, and a two-line cap would hide the tail with no way to read it.
+ */
+internal fun buildOverviewEntries(
+    statusLabel: String,
+    statusValue: String,
+    timeLabel: String,
+    timeValue: String,
+    durationLabel: String,
+    durationValue: String,
+    resultLabel: String,
+    resultValue: String?,
+): List<InfoEntry> = buildList {
+    add(InfoEntry(label = statusLabel, value = statusValue, pairable = true))
+    add(InfoEntry(label = timeLabel, value = timeValue, pairable = true))
+    add(InfoEntry(label = durationLabel, value = durationValue, pairable = true))
+    if (resultValue != null) {
+        add(
+            InfoEntry(
+                label = resultLabel,
+                value = resultValue,
+                pairable = false,
+                valueMaxLines = Int.MAX_VALUE,
+            ),
+        )
+    }
+}
 
 @Composable
 internal fun OperationOverviewSection(
@@ -96,124 +141,165 @@ internal fun OperationOverviewSection(
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        // Status row
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = stringResource(R.string.operations_details_status),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                OperationActionIndicator(
-                                    state = operation.state,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Text(
-                                    text = when (operation.state) {
-                                        is OperationDisplay.State.Queued -> stringResource(R.string.operations_state_queued)
-                                        is OperationDisplay.State.Running -> stringResource(R.string.operations_state_running)
-                                        is OperationDisplay.State.Waiting -> stringResource(R.string.operations_state_waiting)
-                                        is OperationDisplay.State.Completed -> stringResource(R.string.operations_state_successful)
-                                        is OperationDisplay.State.Failed -> stringResource(R.string.operations_state_failed)
-                                        is OperationDisplay.State.Cancelled -> stringResource(R.string.operations_state_cancelled)
-                                    },
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                            }
-                        }
-
-                        // Timing row - show different info based on operation state
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = when (operation.state) {
-                                    is OperationDisplay.State.Completed,
-                                    is OperationDisplay.State.Failed,
-                                    is OperationDisplay.State.Cancelled -> stringResource(R.string.operations_details_completed_at)
-                                    else -> stringResource(R.string.operations_details_started_at)
-                                },
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = when (operation.state) {
-                                    is OperationDisplay.State.Completed -> formatRelativeTime(operation.state.completedAt)
-                                    is OperationDisplay.State.Failed -> formatRelativeTime(operation.state.completedAt)
-                                    is OperationDisplay.State.Cancelled -> formatRelativeTime(operation.state.completedAt)
-                                    else -> formatRelativeTime(operation.startedAt)
-                                },
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                        }
-
-                        // Duration row
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = stringResource(R.string.operations_details_duration),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = when (operation.state) {
-                                    is OperationDisplay.State.Queued -> stringResource(R.string.operations_details_duration_not_started)
-                                    is OperationDisplay.State.Running,
-                                    is OperationDisplay.State.Waiting -> formatDuration(Clock.System.now() - operation.startedAt)
-                                    is OperationDisplay.State.Completed -> formatDuration(operation.state.completedAt - operation.startedAt)
-                                    is OperationDisplay.State.Failed -> formatDuration(operation.state.completedAt - operation.startedAt)
-                                    is OperationDisplay.State.Cancelled -> formatDuration(operation.state.completedAt - operation.startedAt)
-                                },
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                        }
-
-                        // Result/Summary row (for completed/failed/cancelled operations with reports)
-                        val reportSummary = when (operation.state) {
-                            is OperationDisplay.State.Completed -> operation.state.report.summary
-                            is OperationDisplay.State.Failed -> operation.state.report?.summary
-                            is OperationDisplay.State.Cancelled -> operation.state.report?.summary
-                            else -> null
-                        }
-
-                        if (reportSummary != null) {
-                            // Add spacing before result section
-                            Spacer(modifier = Modifier.height(4.dp))
-
-                            // Result label
-                            Text(
-                                text = stringResource(R.string.operations_details_result),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-
-                            // Result text with full width
-                            Text(
-                                text = reportSummary.asComposable(),
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 2.dp),
-                            )
-                        }
-                    }
+                    OperationOverviewGrid(operation = operation)
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun OperationOverviewGrid(
+    modifier: Modifier = Modifier,
+    operation: OperationDisplay,
+) {
+    val reportSummary = when (operation.state) {
+        is OperationDisplay.State.Completed -> operation.state.report.summary
+        is OperationDisplay.State.Failed -> operation.state.report?.summary
+        is OperationDisplay.State.Cancelled -> operation.state.report?.summary
+        else -> null
+    }
+
+    val baseEntries = buildOverviewEntries(
+        statusLabel = stringResource(R.string.operations_details_status),
+        statusValue = when (operation.state) {
+            is OperationDisplay.State.Queued -> stringResource(R.string.operations_state_queued)
+            is OperationDisplay.State.Running -> stringResource(R.string.operations_state_running)
+            is OperationDisplay.State.Waiting -> stringResource(R.string.operations_state_waiting)
+            is OperationDisplay.State.Completed -> stringResource(R.string.operations_state_successful)
+            is OperationDisplay.State.Failed -> stringResource(R.string.operations_state_failed)
+            is OperationDisplay.State.Cancelled -> stringResource(R.string.operations_state_cancelled)
+        },
+        timeLabel = when (operation.state) {
+            is OperationDisplay.State.Completed,
+            is OperationDisplay.State.Failed,
+            is OperationDisplay.State.Cancelled -> stringResource(R.string.operations_details_completed_at)
+            else -> stringResource(R.string.operations_details_started_at)
+        },
+        timeValue = when (operation.state) {
+            is OperationDisplay.State.Completed -> formatRelativeTime(operation.state.completedAt)
+            is OperationDisplay.State.Failed -> formatRelativeTime(operation.state.completedAt)
+            is OperationDisplay.State.Cancelled -> formatRelativeTime(operation.state.completedAt)
+            else -> formatRelativeTime(operation.startedAt)
+        },
+        durationLabel = stringResource(R.string.operations_details_duration),
+        durationValue = when (operation.state) {
+            is OperationDisplay.State.Queued -> stringResource(R.string.operations_details_duration_not_started)
+            is OperationDisplay.State.Running,
+            is OperationDisplay.State.Waiting -> formatDuration(Clock.System.now() - operation.startedAt)
+            is OperationDisplay.State.Completed -> formatDuration(operation.state.completedAt - operation.startedAt)
+            is OperationDisplay.State.Failed -> formatDuration(operation.state.completedAt - operation.startedAt)
+            is OperationDisplay.State.Cancelled -> formatDuration(operation.state.completedAt - operation.startedAt)
+        },
+        resultLabel = stringResource(R.string.operations_details_result),
+        resultValue = if (reportSummary != null) reportSummary.asComposable() else null,
+    )
+
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val entries = when {
+            maxWidth >= OverviewPairingMinWidth -> baseEntries
+            else -> baseEntries.map { it.copy(pairable = false) }
+        }
+        // Status is always first, and referential identity is what carries the state icon - the
+        // label string is localized and would not survive a translation.
+        val statusEntry = entries.first()
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            groupInfoEntries(entries).forEach { row ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    row.forEach { entry ->
+                        InfoBlock(
+                            modifier = Modifier.weight(1f),
+                            entry = entry,
+                            valueLeading = if (entry === statusEntry) {
+                                {
+                                    OperationActionIndicator(
+                                        modifier = Modifier.size(16.dp),
+                                        state = operation.state,
+                                    )
+                                }
+                            } else {
+                                null
+                            },
+                        )
+                    }
+                    // Keeps an odd trailing pairable entry at half width so the grid stays aligned.
+                    if (row.size == 1 && row.first().pairable) Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+private fun previewReport(text: String) = object : Operation.Report {
+    override val summary = text.toCaString()
+    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationOverviewSectionCompletedPreview() {
+    val summary = "Moved 1.204 files and 87 folders, skipped 3 files, overwrote 12 files"
+    Box(modifier = Modifier.width(360.dp)) {
+        OperationOverviewSection(
+            operation = OperationDisplay(
+                id = Operation.Id(),
+                startedAt = Clock.System.now() - 12.minutes,
+                icon = Icons.TwoTone.Handyman,
+                title = "Move".toCaString(),
+                description = "Moving files".toCaString(),
+                state = OperationDisplay.State.Completed(
+                    summary = summary.toCaString(),
+                    completedAt = Clock.System.now(),
+                    report = previewReport(summary),
+                ),
+            ),
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationOverviewSectionRunningPreview() {
+    Box(modifier = Modifier.width(360.dp)) {
+        OperationOverviewSection(
+            operation = OperationDisplay(
+                id = Operation.Id(),
+                startedAt = Clock.System.now() - 3.minutes,
+                icon = Icons.TwoTone.Handyman,
+                title = "Copy".toCaString(),
+                description = "Copying files".toCaString(),
+                state = OperationDisplay.State.Running(),
+            ),
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationOverviewSectionNarrowPreview() {
+    val summary = "Deleted 42 files"
+    Box(modifier = Modifier.width(200.dp)) {
+        OperationOverviewSection(
+            operation = OperationDisplay(
+                id = Operation.Id(),
+                startedAt = Clock.System.now() - 2.minutes,
+                icon = Icons.TwoTone.Handyman,
+                title = "Delete".toCaString(),
+                description = "Deleting files".toCaString(),
+                state = OperationDisplay.State.Completed(
+                    summary = summary.toCaString(),
+                    completedAt = Clock.System.now(),
+                    report = previewReport(summary),
+                ),
+            ),
+        )
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewEntriesTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewEntriesTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class OperationOverviewEntriesTest : BaseTest() {
+
+    private fun entries(resultValue: String? = "Moved 12 files") = buildOverviewEntries(
+        statusLabel = "Status",
+        statusValue = "Successful",
+        timeLabel = "Completed",
+        timeValue = "2 minutes ago",
+        durationLabel = "Duration",
+        durationValue = "12s",
+        resultLabel = "Result",
+        resultValue = resultValue,
+    )
+
+    @Test
+    fun `the result value is never truncated and never shares a row`() {
+        val result = entries().last()
+
+        result.label shouldBe "Result"
+        result.pairable shouldBe false
+        result.valueMaxLines shouldBe Int.MAX_VALUE
+    }
+
+    @Test
+    fun `the short fields pair up and keep the default cap`() {
+        entries().take(3).forEach {
+            it.pairable shouldBe true
+            it.valueMaxLines shouldBe 2
+        }
+    }
+
+    @Test
+    fun `an operation without a report has no result entry`() {
+        entries(resultValue = null).map { it.label } shouldBe listOf("Status", "Completed", "Duration")
+    }
+
+    @Test
+    fun `entries are ordered status, time, duration, result`() {
+        entries().map { it.label } shouldBe listOf("Status", "Completed", "Duration", "Result")
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
@@ -6,7 +6,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Handyman
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -23,8 +28,9 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
 /**
- * Bounds only: Robolectric measures text at a fixed 20px height and 1px per character, so anything
- * about how a value wraps or ellipsizes would pass regardless of the layout. Positions are sound.
+ * Layout assertions here are bounds only: Robolectric measures text at a fixed 20px height and 1px
+ * per character, so anything about how a value wraps or ellipsizes would pass regardless of the
+ * layout. Positions are sound.
  */
 class OperationOverviewSectionTest : ComposeTest() {
 
@@ -86,5 +92,14 @@ class OperationOverviewSectionTest : ComposeTest() {
                 (first.bottom <= second.top || second.bottom <= first.top) shouldBe true
             }
         }
+    }
+
+    @Test
+    fun `the state icon is decorative and claims no touch target`() {
+        renderAt(OverviewPairingMinWidth + 80.dp)
+
+        composeTestRule
+            .onAllNodes(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+            .assertCountEquals(0)
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
@@ -1,0 +1,90 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Handyman
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Bounds only: Robolectric measures text at a fixed 20px height and 1px per character, so anything
+ * about how a value wraps or ellipsizes would pass regardless of the layout. Positions are sound.
+ */
+class OperationOverviewSectionTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val completedOperation = OperationDisplay(
+        id = Operation.Id(),
+        startedAt = Clock.System.now() - 5.minutes,
+        icon = Icons.TwoTone.Handyman,
+        title = "Move".toCaString(),
+        description = "Moving files".toCaString(),
+        state = OperationDisplay.State.Completed(
+            summary = "Moved 12 files".toCaString(),
+            completedAt = Clock.System.now(),
+            report = object : Operation.Report {
+                override val summary = "Moved 12 files".toCaString()
+                override val affectedPaths = emptyList<Operation.Report.PathChange>()
+            },
+        ),
+    )
+
+    private fun renderAt(width: Dp) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Box(modifier = Modifier.width(width)) {
+                    OperationOverviewSection(operation = completedOperation)
+                }
+            }
+        }
+    }
+
+    private fun labelBounds(resId: Int) =
+        composeTestRule.onNodeWithText(context.getString(resId)).getUnclippedBoundsInRoot()
+
+    @Test
+    fun `status and time share a row when there is room for two columns`() {
+        renderAt(OverviewPairingMinWidth + 80.dp)
+
+        val status = labelBounds(R.string.operations_details_status)
+        val completed = labelBounds(R.string.operations_details_completed_at)
+
+        (status.top < completed.bottom && completed.top < status.bottom) shouldBe true
+        (status.right <= completed.left || completed.right <= status.left) shouldBe true
+    }
+
+    @Test
+    fun `every entry goes full width in a narrow pane`() {
+        renderAt(OverviewPairingMinWidth - 60.dp)
+
+        val labels = listOf(
+            R.string.operations_details_status,
+            R.string.operations_details_completed_at,
+            R.string.operations_details_duration,
+            R.string.operations_details_result,
+        ).map { labelBounds(it) }
+
+        labels.forEachIndexed { index, first ->
+            labels.drop(index + 1).forEach { second ->
+                (first.bottom <= second.top || second.bottom <= first.top) shouldBe true
+            }
+        }
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## What changed

The Overview card in the operation details sheet now stacks each field: a small label with its value directly underneath, instead of a label on the left and a right-aligned value. Short fields share a row two at a time, and in a narrow pane they fall back to one per row so nothing gets squeezed into an unreadable column.

The operation result text is also no longer at risk of being cut off. It previously rendered without a line limit, and the shared layout it now uses would have capped it at two lines, which would have hidden the tail of a longer summary with no way to read it.

## Technical Context

- The stacked label/value block already existed as `InfoEntry` / `groupInfoEntries` / `InfoBlock`, internal to `app-workspace-viewer`. `app-workspace` is layer 3 and cannot depend on layer 4, so those three moved down to `app-common`; the viewer keeps its own collapse logic (`visibleInfoRows`, `permissionsFitHalfWidth`) and its row loop.
- `InfoEntry.valueMaxLines` exists specifically because the Overview card's result field previously rendered with no `maxLines`. It defaults to 2, so every existing viewer call site renders exactly as before.
- `OverviewPairingMinWidth` (240dp) collapses the two-column grid to full-width rows. A user-forced `DUAL_VERTICAL` portrait split halves a 360dp phone into 180dp panes, which would otherwise leave roughly 48dp per column.
- The status icon is now a plain `Icon` rather than `OperationActionIndicator`. That composable is an `IconButton`, so it reserved a 48dp minimum interactive box regardless of the 16dp size passed to it; once stacked directly under its label, that box covered the label and collapsed its accessibility bounds to 4px while exposing a phantom disabled Button node over it. The state-to-visuals mapping moved to `operationStateVisuals()` so the button keeps its existing behavior everywhere it is genuinely interactive.
- Worth a close read: the status entry is selected by referential identity (`entry === statusEntry`) after `groupInfoEntries` regroups the list and after the narrow branch copies entries. `groupInfoEntries` only re-buckets the instances it is given and never copies them, so identity holds on both paths. Verified on an emulator that the Status label's accessibility bounds are correct after the icon change and that a long result summary wraps to two lines instead of truncating.
