### PR TITLE
Workspace: Make clipboard entry details readable and name their tab

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/clipboard/ClipboardClip.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/clipboard/ClipboardClip.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.core.clipboard
 
+import android.content.Context
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
 import eu.darken.butler.common.ca.toCaString
@@ -40,19 +41,44 @@ sealed interface ClipboardClip {
 
         override val description: CaString
             get() = caString {
-                if (paths.size == 1) {
-                    paths.single().userReadablePath.get(it)
-                } else {
-                    it.getQuantityString2(
+                val locations = sourceLocations(it)
+                when {
+                    paths.size == 1 -> paths.single().userReadablePath.get(it)
+                    locations.size > 1 -> {
+                        val locationsPhrase = it.getQuantityString2(
+                            R.plurals.clipboard_paths_locations,
+                            locations.size,
+                            locations.size,
+                        )
+                        it.getQuantityString2(
+                            when (mode) {
+                                Mode.COPY -> R.plurals.clipboard_paths_description_copy_multi
+                                Mode.CUT -> R.plurals.clipboard_paths_description_cut_multi
+                            },
+                            paths.size,
+                            paths.size, locationsPhrase
+                        )
+                    }
+
+                    else -> it.getQuantityString2(
                         when (mode) {
                             Mode.COPY -> R.plurals.clipboard_paths_description_copy
                             Mode.CUT -> R.plurals.clipboard_paths_description_cut
                         },
                         paths.size,
-                        paths.size, paths.first().parent?.userReadablePath?.get(it) ?: "?"
+                        paths.size, locations.first()
                     )
                 }
             }
+
+        /**
+         * The distinct directories the clipped paths were taken from. A path at the filesystem
+         * root has no parent and reads as "/", the same as an item directly below the root, so
+         * both count as one location.
+         */
+        fun sourceLocations(context: Context): List<String> = paths
+            .map { path -> path.parent?.userReadablePath?.get(context) ?: "/" }
+            .distinct()
 
         enum class Mode {
             COPY,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/LocalWorkspaceTitles.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/LocalWorkspaceTitles.kt
@@ -1,0 +1,41 @@
+package eu.darken.butler.workspace.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.res.stringResource
+import eu.darken.butler.common.ca.CaString
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.label
+
+/**
+ * Resolved workspace titles, for UI that names a workspace it does not host.
+ *
+ * The value is nullable and carries three distinct meanings:
+ * - `null`: this composition host keeps no workspace registry, so nothing can be said about any
+ *   workspace. Detached compositions and previews land here, as does the first frame before the
+ *   workspace state has arrived.
+ * - a map that does not contain the id: the workspace is gone.
+ * - a map that contains the id: the title to render.
+ *
+ * An `emptyMap()` default would collapse the first two cases and make a live workspace read as
+ * closed.
+ */
+val LocalWorkspaceTitles = compositionLocalOf<Map<Workspace.Id, String>?> { null }
+
+/**
+ * The label for [origin], or `null` when the caller should omit the field entirely.
+ */
+@Composable
+internal fun originWorkspaceLabel(origin: Workspace.Id): String? {
+    val titles = LocalWorkspaceTitles.current ?: return null
+    return titles[origin] ?: stringResource(R.string.clipboard_info_workspace_closed)
+}
+
+/**
+ * The name a workspace is referred to by outside its own chrome: the user's name for it when set,
+ * otherwise the generic name of its type.
+ */
+val Workspace.Info.tabLabel: CaString
+    get() = customTitle?.takeIf { it.isNotBlank() }?.toCaString() ?: type.label

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -44,6 +45,7 @@ import eu.darken.butler.workspace.ui.clipboard.mockFileLookup
 import eu.darken.butler.common.ui.SwipeToDismissItem
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
 import kotlinx.coroutines.delay
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
@@ -282,9 +284,12 @@ fun ClipboardBarSingleItemPreview() {
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 fun ClipboardBarExpandedPreview() {
+    val picturesOrigin = Workspace.Id(Uuid.random())
+    val documentsOrigin = Workspace.Id(Uuid.random())
+    val closedOrigin = Workspace.Id(Uuid.random())
     val mockEntries = listOf(
         ClipboardClip.Paths(
-            origin = Workspace.Id(Uuid.random()),
+            origin = picturesOrigin,
             mode = ClipboardClip.Paths.Mode.COPY,
             paths = listOf(
                 mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
@@ -294,7 +299,7 @@ fun ClipboardBarExpandedPreview() {
             clippedAt = Clock.System.now() - 5.minutes,
         ),
         ClipboardClip.Paths(
-            origin = Workspace.Id(Uuid.random()),
+            origin = documentsOrigin,
             mode = ClipboardClip.Paths.Mode.CUT,
             paths = listOf(
                 mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
@@ -302,7 +307,7 @@ fun ClipboardBarExpandedPreview() {
             clippedAt = Clock.System.now() - 2.minutes,
         ),
         ClipboardClip.Paths(
-            origin = Workspace.Id(Uuid.random()),
+            origin = closedOrigin,
             mode = ClipboardClip.Paths.Mode.COPY,
             paths = listOf(
                 mockFileLookup("/storage/emulated/0/Downloads/app.apk"),
@@ -310,21 +315,27 @@ fun ClipboardBarExpandedPreview() {
             clippedAt = Clock.System.now() - 1.minutes,
         ),
     )
+    val titles = mapOf(
+        picturesOrigin to "Pictures",
+        documentsOrigin to "Documents",
+    )
 
     PreviewWrapper {
-        Box(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background)
-                .padding(16.dp)
-        ) {
-            ClipboardBar(
-                workspaceType = Workspace.Type.EXPLORER,
-                initialExpanded = true,
-                clipboardEntries = mockEntries,
-                onPasteClick = {},
-                onRemoveClick = {},
-                onClearAll = {},
-            )
+        CompositionLocalProvider(LocalWorkspaceTitles provides titles) {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(16.dp)
+            ) {
+                ClipboardBar(
+                    workspaceType = Workspace.Type.EXPLORER,
+                    initialExpanded = true,
+                    clipboardEntries = mockEntries,
+                    onPasteClick = {},
+                    onRemoveClick = {},
+                    onClearAll = {},
+                )
+            }
         }
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardEntryRow.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardEntryRow.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -37,6 +38,8 @@ import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
+import eu.darken.butler.workspace.ui.originWorkspaceLabel
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.Uuid
@@ -127,27 +130,30 @@ fun ClipboardEntryRow(
                             )
                         }
 
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                imageVector = Icons.TwoTone.Workspaces,
-                                contentDescription = null,
-                                modifier = Modifier.size(12.dp),
-                                tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
-                            )
+                        val originLabel = originWorkspaceLabel(entry.origin)
+                        if (originLabel != null) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.TwoTone.Workspaces,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(12.dp),
+                                    tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+                                )
 
-                            Spacer(modifier = Modifier.width(6.dp))
+                                Spacer(modifier = Modifier.width(6.dp))
 
-                            Text(
-                                text = stringResource(R.string.clipboard_origin, entry.origin.shortTag),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f),
-                            )
+                                Text(
+                                    text = stringResource(R.string.clipboard_origin, originLabel),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
                         }
                     }
                 } else {
@@ -261,27 +267,30 @@ fun ClipboardEntryRow(
                             )
                         }
 
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                imageVector = Icons.TwoTone.Workspaces,
-                                contentDescription = null,
-                                modifier = Modifier.size(12.dp),
-                                tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
-                            )
+                        val originLabel = originWorkspaceLabel(entry.origin)
+                        if (originLabel != null) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.TwoTone.Workspaces,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(12.dp),
+                                    tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+                                )
 
-                            Spacer(modifier = Modifier.width(6.dp))
+                                Spacer(modifier = Modifier.width(6.dp))
 
-                            Text(
-                                text = stringResource(R.string.clipboard_origin, entry.origin.shortTag),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f),
-                            )
+                                Text(
+                                    text = stringResource(R.string.clipboard_origin, originLabel),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
                         }
                     }
                 } else {
@@ -370,20 +379,23 @@ private fun ClipboardEntryRowCollapsedPreview() {
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun ClipboardEntryRowExpandedPreview() {
-    ClipboardEntryRow(
-        entry = ClipboardClip.Paths(
-            origin = Workspace.Id(Uuid.random()),
-            mode = ClipboardClip.Paths.Mode.CUT,
-            paths = listOf(
-                mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
+    val origin = Workspace.Id(Uuid.random())
+    CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Documents")) {
+        ClipboardEntryRow(
+            entry = ClipboardClip.Paths(
+                origin = origin,
+                mode = ClipboardClip.Paths.Mode.CUT,
+                paths = listOf(
+                    mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
+                ),
+                clippedAt = Clock.System.now() - 2.minutes,
             ),
-            clippedAt = Clock.System.now() - 2.minutes,
-        ),
-        workspaceType = Workspace.Type.SEARCHER,
-        onPasteClick = {},
-        onEntryClick = {},
-        showOrigin = true,
-    )
+            workspaceType = Workspace.Type.SEARCHER,
+            onPasteClick = {},
+            onEntryClick = {},
+            showOrigin = true,
+        )
+    }
 }
 
 @Preview2
@@ -407,15 +419,18 @@ private fun ClipboardEntryRowTextCollapsedPreview() {
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun ClipboardEntryRowTextExpandedPreview() {
-    ClipboardEntryRow(
-        entry = ClipboardClip.Text(
-            origin = Workspace.Id(Uuid.random()),
-            content = "function greet(name) {\n  return `Hello, \${name}!`;\n}",
-            clippedAt = Clock.System.now() - 1.minutes,
-        ),
-        workspaceType = Workspace.Type.EXPLORER,
-        onPasteClick = {},
-        onEntryClick = {},
-        showOrigin = true,
-    )
+    val origin = Workspace.Id(Uuid.random())
+    CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Editor")) {
+        ClipboardEntryRow(
+            entry = ClipboardClip.Text(
+                origin = origin,
+                content = "function greet(name) {\n  return `Hello, \${name}!`;\n}",
+                clippedAt = Clock.System.now() - 1.minutes,
+            ),
+            workspaceType = Workspace.Type.EXPLORER,
+            onPasteClick = {},
+            onEntryClick = {},
+            showOrigin = true,
+        )
+    }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/details/ClipboardInfoBottomSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/details/ClipboardInfoBottomSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,7 +62,11 @@ import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
+import eu.darken.butler.workspace.ui.dialogs.InfoField
+import eu.darken.butler.workspace.ui.dialogs.InfoValueStyle
+import eu.darken.butler.workspace.ui.originWorkspaceLabel
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.Uuid
@@ -112,13 +117,16 @@ private fun ClipboardInfoContent(
     ) {
         when (clip) {
             is ClipboardClip.Paths -> {
+                val context = LocalContext.current
+                val sources = clip.sourceLocations(context)
+
                 // Header Section
                 ClipboardInfoHeader(clip = clip)
 
                 Spacer(modifier = Modifier.height(1.dp))
 
                 // Overview Section
-                ClipboardOverviewSection(clip = clip)
+                ClipboardOverviewSection(clip = clip, sources = sources)
 
                 // Files Section
                 if (clip.paths.isNotEmpty()) {
@@ -135,6 +143,7 @@ private fun ClipboardInfoContent(
                         onNavigateToSource = onNavigateToSource,
                         onPaste = onPaste,
                         onRemove = onRemove,
+                        multipleSources = sources.size > 1,
                     )
                 }
             }
@@ -204,7 +213,7 @@ private fun ClipboardInfoHeader(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                overflow = TextOverflow.MiddleEllipsis,
             )
         }
     }
@@ -213,6 +222,7 @@ private fun ClipboardInfoHeader(
 @Composable
 private fun ClipboardOverviewSection(
     clip: ClipboardClip.Paths,
+    sources: List<String>,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -222,10 +232,11 @@ private fun ClipboardOverviewSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
+                .padding(vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
+                modifier = Modifier.padding(horizontal = 12.dp),
                 text = stringResource(R.string.clipboard_info_overview).uppercase(),
                 style = MaterialTheme.typography.labelMedium,
                 fontFamily = FontFamily.Monospace,
@@ -233,6 +244,7 @@ private fun ClipboardOverviewSection(
             )
 
             HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 12.dp),
                 thickness = 0.5.dp,
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
             )
@@ -240,99 +252,57 @@ private fun ClipboardOverviewSection(
             Column(
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                // Operation type
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_info_operation),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = when (clip.mode) {
+                    InfoField(
+                        modifier = Modifier.weight(1f),
+                        label = stringResource(R.string.clipboard_info_operation),
+                        value = when (clip.mode) {
                             ClipboardClip.Paths.Mode.COPY -> stringResource(R.string.clipboard_copy)
                             ClipboardClip.Paths.Mode.CUT -> stringResource(R.string.clipboard_cut)
                         },
-                        style = MaterialTheme.typography.bodyMedium,
+                    )
+
+                    InfoField(
+                        modifier = Modifier.weight(1f),
+                        label = stringResource(R.string.clipboard_info_items),
+                        value = clip.paths.size.toString(),
                     )
                 }
 
-                // Item count
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_info_items),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = clip.paths.size.toString(),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-
-                // Source location
-                if (clip.paths.isNotEmpty()) {
-                    val sourcePath = clip.paths.first().parent
-                        ?.userReadablePath?.get(LocalContext.current)
-                        ?: "/"
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.clipboard_info_source),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    val workspaceLabel = originWorkspaceLabel(clip.origin)
+                    if (workspaceLabel != null) {
+                        InfoField(
+                            modifier = Modifier.weight(1f),
+                            label = stringResource(R.string.clipboard_info_workspace),
+                            value = workspaceLabel,
                         )
-                        Text(
-                            text = sourcePath,
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                    } else {
+                        Spacer(modifier = Modifier.weight(1f))
                     }
-                }
 
-                // Origin workspace
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_info_workspace),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = clip.origin.shortTag,
-                        style = MaterialTheme.typography.bodyMedium,
+                    InfoField(
+                        modifier = Modifier.weight(1f),
+                        label = stringResource(R.string.clipboard_info_time),
+                        value = formatRelativeTime(clip.clippedAt),
                     )
                 }
 
-                // Time timestamp
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_info_time),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = formatRelativeTime(clip.clippedAt),
-                        style = MaterialTheme.typography.bodyMedium,
+                if (clip.paths.isNotEmpty()) {
+                    InfoField(
+                        label = stringResource(
+                            if (sources.size == 1) {
+                                R.string.clipboard_info_source
+                            } else {
+                                R.string.clipboard_info_sources
+                            },
+                        ),
+                        value = sources.joinToString("\n"),
+                        valueStyle = InfoValueStyle.MONOSPACE,
                     )
                 }
             }
@@ -485,7 +455,7 @@ private fun ClipboardTextInfoHeader(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                overflow = TextOverflow.MiddleEllipsis,
             )
         }
     }
@@ -503,10 +473,11 @@ private fun ClipboardTextOverviewSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
+                .padding(vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
+                modifier = Modifier.padding(horizontal = 12.dp),
                 text = stringResource(R.string.clipboard_info_overview).uppercase(),
                 style = MaterialTheme.typography.labelMedium,
                 fontFamily = FontFamily.Monospace,
@@ -514,6 +485,7 @@ private fun ClipboardTextOverviewSection(
             )
 
             HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 12.dp),
                 thickness = 0.5.dp,
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
             )
@@ -521,93 +493,48 @@ private fun ClipboardTextOverviewSection(
             Column(
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                // Character count
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_text_info_characters),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    InfoField(
+                        modifier = Modifier.weight(1f),
+                        label = stringResource(R.string.clipboard_text_info_characters),
+                        value = clip.content.length.toString(),
                     )
-                    Text(
-                        text = clip.content.length.toString(),
-                        style = MaterialTheme.typography.bodyMedium,
+
+                    InfoField(
+                        modifier = Modifier.weight(1f),
+                        label = stringResource(R.string.clipboard_text_info_lines),
+                        value = (clip.content.count { it == '\n' } + 1).toString(),
                     )
                 }
 
-                // Line count
-                val lineCount = clip.content.count { it == '\n' } + 1
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_text_info_lines),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = lineCount.toString(),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-
-                // Source file (if any)
-                clip.sourcePath?.let { sourcePath ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.clipboard_info_source),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    val workspaceLabel = originWorkspaceLabel(clip.origin)
+                    if (workspaceLabel != null) {
+                        InfoField(
+                            modifier = Modifier.weight(1f),
+                            label = stringResource(R.string.clipboard_info_workspace),
+                            value = workspaceLabel,
                         )
-                        Text(
-                            text = sourcePath.userReadablePath.get(LocalContext.current),
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                    } else {
+                        Spacer(modifier = Modifier.weight(1f))
                     }
-                }
 
-                // Origin workspace
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_info_workspace),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = clip.origin.shortTag,
-                        style = MaterialTheme.typography.bodyMedium,
+                    InfoField(
+                        modifier = Modifier.weight(1f),
+                        label = stringResource(R.string.clipboard_info_time),
+                        value = formatRelativeTime(clip.clippedAt),
                     )
                 }
 
-                // Time timestamp
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.clipboard_info_time),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = formatRelativeTime(clip.clippedAt),
-                        style = MaterialTheme.typography.bodyMedium,
+                clip.sourcePath?.let { sourcePath ->
+                    InfoField(
+                        label = stringResource(R.string.clipboard_info_source),
+                        value = sourcePath.userReadablePath.get(LocalContext.current),
+                        valueStyle = InfoValueStyle.MONOSPACE,
                     )
                 }
             }
@@ -697,6 +624,7 @@ private fun ClipboardActionsSection(
     onNavigateToSource: (() -> Unit)? = null,
     onPaste: (() -> Unit)? = null,
     onRemove: (() -> Unit)? = null,
+    multipleSources: Boolean = false,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -736,7 +664,15 @@ private fun ClipboardActionsSection(
                             modifier = Modifier.size(18.dp)
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.clipboard_info_go_to_source))
+                        Text(
+                            stringResource(
+                                if (multipleSources) {
+                                    R.string.clipboard_info_go_to_first_source
+                                } else {
+                                    R.string.clipboard_info_go_to_source
+                                },
+                            )
+                        )
                     }
                 }
 
@@ -783,8 +719,9 @@ private fun getPathIcon(path: APathLookup<*>): ImageVector = when (path.fileType
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun ClipboardInfoBottomSheetPreview() {
+    val origin = Workspace.Id(Uuid.random())
     val mockClip = ClipboardClip.Paths(
-        origin = Workspace.Id(Uuid.random()),
+        origin = origin,
         mode = ClipboardClip.Paths.Mode.COPY,
         paths = listOf(
             mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
@@ -795,14 +732,16 @@ private fun ClipboardInfoBottomSheetPreview() {
     )
 
     PreviewWrapper {
-        ClipboardInfoBottomSheet(
-            clip = mockClip,
-            onDismiss = {},
-            onNavigateToSource = {},
-            onPaste = {},
-            onRemove = {},
-            onCopyPath = {},
-        )
+        CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Pictures")) {
+            ClipboardInfoBottomSheet(
+                clip = mockClip,
+                onDismiss = {},
+                onNavigateToSource = {},
+                onPaste = {},
+                onRemove = {},
+                onCopyPath = {},
+            )
+        }
     }
 }
 
@@ -810,8 +749,9 @@ private fun ClipboardInfoBottomSheetPreview() {
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun ClipboardInfoSingleFilePreview() {
+    val origin = Workspace.Id(Uuid.random())
     val mockClip = ClipboardClip.Paths(
-        origin = Workspace.Id(Uuid.random()),
+        origin = origin,
         mode = ClipboardClip.Paths.Mode.CUT,
         paths = listOf(
             mockFileLookup("/storage/emulated/0/Documents/important_document.pdf"),
@@ -820,13 +760,74 @@ private fun ClipboardInfoSingleFilePreview() {
     )
 
     PreviewWrapper {
-        ClipboardInfoBottomSheet(
-            clip = mockClip,
-            onDismiss = {},
-            onNavigateToSource = {},
-            onPaste = {},
-            onRemove = {},
-        )
+        CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Documents")) {
+            ClipboardInfoBottomSheet(
+                clip = mockClip,
+                onDismiss = {},
+                onNavigateToSource = {},
+                onPaste = {},
+                onRemove = {},
+            )
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ClipboardInfoLongPathPreview() {
+    val origin = Workspace.Id(Uuid.random())
+    val mockClip = ClipboardClip.Paths(
+        origin = origin,
+        mode = ClipboardClip.Paths.Mode.CUT,
+        paths = listOf(
+            mockFileLookup(
+                "/storage/emulated/0/Android/data/eu.darken.butler/files/backups/2026/quarterly-financial-review-final.pdf"
+            ),
+        ),
+        clippedAt = Clock.System.now() - 12.minutes,
+    )
+
+    PreviewWrapper {
+        CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Backups")) {
+            ClipboardInfoBottomSheet(
+                clip = mockClip,
+                onDismiss = {},
+                onNavigateToSource = {},
+                onPaste = {},
+                onRemove = {},
+            )
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ClipboardInfoMultiSourcePreview() {
+    val origin = Workspace.Id(Uuid.random())
+    val mockClip = ClipboardClip.Paths(
+        origin = origin,
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(
+            mockFileLookup("/storage/emulated/0/Pictures/photo1.jpg"),
+            mockFileLookup("/storage/emulated/0/Documents/report.pdf"),
+            mockFileLookup("/storage/emulated/0/Download/installer.apk"),
+        ),
+        clippedAt = Clock.System.now() - 7.minutes,
+    )
+
+    PreviewWrapper {
+        CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Home")) {
+            ClipboardInfoBottomSheet(
+                clip = mockClip,
+                onDismiss = {},
+                onNavigateToSource = {},
+                onPaste = {},
+                onRemove = {},
+                onCopyPath = {},
+            )
+        }
     }
 }
 
@@ -834,19 +835,22 @@ private fun ClipboardInfoSingleFilePreview() {
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun ClipboardInfoTextPreview() {
+    val origin = Workspace.Id(Uuid.random())
     val mockClip = ClipboardClip.Text(
-        origin = Workspace.Id(Uuid.random()),
+        origin = origin,
         content = "Hello, this is a sample text snippet that was copied from the editor.\nIt contains multiple lines.\nAnd more text here.",
         sourcePath = LocalPath.build("/storage/emulated/0/Documents/notes.txt"),
         clippedAt = Clock.System.now() - 3.minutes,
     )
 
     PreviewWrapper {
-        ClipboardInfoBottomSheet(
-            clip = mockClip,
-            onDismiss = {},
-            onPaste = {},
-            onRemove = {},
-        )
+        CompositionLocalProvider(LocalWorkspaceTitles provides mapOf(origin to "Notes")) {
+            ClipboardInfoBottomSheet(
+                clip = mockClip,
+                onDismiss = {},
+                onPaste = {},
+                onRemove = {},
+            )
+        }
     }
 }

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -24,6 +24,18 @@
         <item quantity="one">%d item from %s</item>
         <item quantity="other">%d items from %s</item>
     </plurals>
+    <plurals name="clipboard_paths_locations">
+        <item quantity="one">%d location</item>
+        <item quantity="other">%d locations</item>
+    </plurals>
+    <plurals name="clipboard_paths_description_copy_multi">
+        <item quantity="one">%1$d item from %2$s</item>
+        <item quantity="other">%1$d items from %2$s</item>
+    </plurals>
+    <plurals name="clipboard_paths_description_cut_multi">
+        <item quantity="one">%1$d item from %2$s</item>
+        <item quantity="other">%1$d items from %2$s</item>
+    </plurals>
     <string name="clipboard_text_title">Text snippet</string>
     <plurals name="clipboard_text_description">
         <item quantity="one">%1$d character</item>
@@ -39,11 +51,14 @@
     <string name="clipboard_info_operation">Operation</string>
     <string name="clipboard_info_items">Items</string>
     <string name="clipboard_info_source">Source</string>
+    <string name="clipboard_info_sources">Sources</string>
     <string name="clipboard_info_workspace">Workspace</string>
+    <string name="clipboard_info_workspace_closed">Closed</string>
     <string name="clipboard_info_time">Time</string>
     <string name="clipboard_info_items_with_count">Items (%1$d)</string>
     <string name="clipboard_info_actions">Actions</string>
     <string name="clipboard_info_go_to_source">Go to source</string>
+    <string name="clipboard_info_go_to_first_source">Go to first source</string>
     <string name="clipboard_info_remove">Remove from clipboard</string>
 
     <!-- Clipboard Settings -->

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/clipboard/ClipboardClipDescriptionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/clipboard/ClipboardClipDescriptionTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.butler.workspace.core.clipboard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+// Robolectric: the clip description is a CaString, so asserting what it renders needs a context.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class, sdk = [34])
+class ClipboardClipDescriptionTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun lookup(path: String) = LocalPathLookup(
+        lookedUp = LocalPath.build(path),
+        fileType = FileType.FILE,
+        size = null,
+        modifiedAt = null,
+    )
+
+    private fun clip(vararg paths: String) = ClipboardClip.Paths(
+        origin = Workspace.Id(),
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = paths.map { lookup(it) },
+    )
+
+    @Test
+    fun `one parent names the location`() {
+        val description = clip(
+            "/storage/emulated/0/Download/a.txt",
+            "/storage/emulated/0/Download/b.txt",
+        ).description.get(context)
+
+        description shouldBe "2 items from /storage/emulated/0/Download"
+    }
+
+    @Test
+    fun `several parents count the locations instead of naming one`() {
+        val description = clip(
+            "/storage/emulated/0/Download/a.txt",
+            "/storage/emulated/0/Download/b.txt",
+            "/storage/emulated/0/Documents/c.txt",
+        ).description.get(context)
+
+        description shouldBe "3 items from 2 locations"
+    }
+
+    @Test
+    fun `the root and an item below it are one location`() {
+        val description = clip("/", "/sdcard").description.get(context)
+
+        description shouldBe "2 items from /"
+    }
+
+    @Test
+    fun `a single path still shows the path itself`() {
+        val description = clip("/storage/emulated/0/Download/a.txt").description.get(context)
+
+        description shouldBe "/storage/emulated/0/Download/a.txt"
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspaceTabLabelTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspaceTabLabelTest.kt
@@ -1,0 +1,44 @@
+package eu.darken.butler.workspace.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+// Robolectric: the type fallback is a string resource, so asserting what it renders needs a context.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class, sdk = [34])
+class WorkspaceTabLabelTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun info(customTitle: String?) = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "/storage/emulated/0/Download".toCaString(),
+        customTitle = customTitle,
+    )
+
+    @Test
+    fun `a custom name wins`() {
+        info("Holiday photos").tabLabel.get(context) shouldBe "Holiday photos"
+    }
+
+    @Test
+    fun `without a custom name the type names the tab`() {
+        info(null).tabLabel.get(context) shouldBe "Explorer"
+    }
+
+    @Test
+    fun `a blank custom name falls back to the type`() {
+        info("   ").tabLabel.get(context) shouldBe "Explorer"
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardEntryRowOriginTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardEntryRowOriginTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.butler.workspace.ui.clipboard.bar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.TestApplication
+
+/** The bar renders the origin of both clip variants, so each gets the registry cases of its own. */
+@Config(application = TestApplication::class, sdk = [34], qualifiers = "w411dp-h891dp")
+class ClipboardEntryRowOriginTest : ComposeTest() {
+
+    private val origin = Workspace.Id()
+
+    private val pathsClip = ClipboardClip.Paths(
+        origin = origin,
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(
+            LocalPathLookup(
+                lookedUp = LocalPath.build("/storage/emulated/0/Download/a.txt"),
+                fileType = FileType.FILE,
+                size = null,
+                modifiedAt = null,
+            ),
+        ),
+    )
+
+    private val textClip = ClipboardClip.Text(
+        origin = origin,
+        content = "Hello",
+    )
+
+    @Composable
+    private fun Case(
+        clip: ClipboardClip,
+        titles: Map<Workspace.Id, String>?,
+    ) {
+        PreviewWrapper {
+            CompositionLocalProvider(LocalWorkspaceTitles provides titles) {
+                ClipboardEntryRow(
+                    entry = clip,
+                    workspaceType = Workspace.Type.EXPLORER,
+                    onPasteClick = {},
+                    onEntryClick = {},
+                    showOrigin = true,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a paths entry names its origin`() {
+        composeTestRule.setContent {
+            Case(clip = pathsClip, titles = mapOf(origin to "Holiday photos"))
+        }
+
+        composeTestRule.onNodeWithText("Origin: Holiday photos").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a text entry names its origin`() {
+        composeTestRule.setContent {
+            Case(clip = textClip, titles = mapOf(origin to "Holiday photos"))
+        }
+
+        composeTestRule.onNodeWithText("Origin: Holiday photos").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a paths entry omits the origin line without a registry`() {
+        composeTestRule.setContent {
+            Case(clip = pathsClip, titles = null)
+        }
+
+        composeTestRule.onNodeWithText("Origin: ", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a text entry omits the origin line without a registry`() {
+        composeTestRule.setContent {
+            Case(clip = textClip, titles = null)
+        }
+
+        composeTestRule.onNodeWithText("Origin: ", substring = true).assertDoesNotExist()
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/details/ClipboardInfoOverviewTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/details/ClipboardInfoOverviewTest.kt
@@ -1,0 +1,194 @@
+package eu.darken.butler.workspace.ui.clipboard.details
+
+import android.content.Context
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import eu.darken.butler.workspace.ui.tabLabel
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.TestApplication
+
+/**
+ * The title registry is three-valued (see `LocalWorkspaceTitles`), so each of its three meanings
+ * gets a case of its own here.
+ */
+@Config(application = TestApplication::class, sdk = [34], qualifiers = "w411dp-h891dp")
+class ClipboardInfoOverviewTest : ComposeTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val origin = Workspace.Id()
+
+    private fun lookup(path: String) = LocalPathLookup(
+        lookedUp = LocalPath.build(path),
+        fileType = FileType.FILE,
+        size = null,
+        modifiedAt = null,
+    )
+
+    private fun clip(vararg paths: String) = ClipboardClip.Paths(
+        origin = origin,
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = paths.map { lookup(it) },
+    )
+
+    /** Built the way `WorkspacesScreen` builds the map it provides. */
+    private fun titlesOf(vararg infos: Workspace.Info) = infos.associate {
+        it.id to it.tabLabel.get(context)
+    }
+
+    @Composable
+    private fun Case(
+        clip: ClipboardClip,
+        titles: Map<Workspace.Id, String>?,
+    ) {
+        PreviewWrapper {
+            CompositionLocalProvider(LocalWorkspaceTitles provides titles) {
+                PaneLayerHost(
+                    modifier = Modifier.fillMaxSize(),
+                    paneFocused = true,
+                ) {
+                    ClipboardInfoBottomSheet(
+                        clip = clip,
+                        onDismiss = {},
+                        onNavigateToSource = {},
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the workspace cell names an unnamed tab by its type`() {
+        composeTestRule.setContent {
+            Case(
+                clip = clip("/storage/emulated/0/Download/a.txt"),
+                titles = titlesOf(
+                    Workspace.Info(
+                        id = origin,
+                        type = Workspace.Type.EXPLORER,
+                        title = "/storage/emulated/0/Pictures".toCaString(),
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Explorer").assertIsDisplayed()
+        composeTestRule.onNodeWithText("/storage/emulated/0/Pictures").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the workspace cell shows a custom tab name`() {
+        composeTestRule.setContent {
+            Case(
+                clip = clip("/storage/emulated/0/Download/a.txt"),
+                titles = titlesOf(
+                    Workspace.Info(
+                        id = origin,
+                        type = Workspace.Type.EXPLORER,
+                        title = "Download".toCaString(),
+                        customTitle = "Holiday photos",
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Holiday photos").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Download").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a registry without the origin means the workspace is gone`() {
+        composeTestRule.setContent {
+            Case(clip = clip("/storage/emulated/0/Download/a.txt"), titles = emptyMap())
+        }
+
+        composeTestRule.onNodeWithText("Closed").assertIsDisplayed()
+    }
+
+    @Test
+    fun `without a registry the workspace cell is omitted and time keeps its half of the row`() {
+        val titles = mutableStateOf<Map<Workspace.Id, String>?>(null)
+        composeTestRule.setContent {
+            Case(clip = clip("/storage/emulated/0/Download/a.txt"), titles = titles.value)
+        }
+
+        composeTestRule.onNodeWithText("Workspace").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Closed").assertDoesNotExist()
+        val omitted = composeTestRule.onNodeWithText("Time").getUnclippedBoundsInRoot().left
+
+        composeTestRule.runOnIdle { titles.value = mapOf(origin to "Download") }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Workspace").assertExists()
+        composeTestRule.onNodeWithText("Time").getUnclippedBoundsInRoot().left shouldBe omitted
+    }
+
+    @Test
+    fun `one shared parent is a single source`() {
+        composeTestRule.setContent {
+            Case(
+                clip = clip(
+                    "/storage/emulated/0/Download/a.txt",
+                    "/storage/emulated/0/Download/b.txt",
+                ),
+                titles = mapOf(origin to "Download"),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Source").assertExists()
+        composeTestRule.onNodeWithText("Sources").assertDoesNotExist()
+        composeTestRule.onNodeWithText("/storage/emulated/0/Download").assertExists()
+    }
+
+    @Test
+    fun `two parents are listed as sources and the navigate action says first`() {
+        composeTestRule.setContent {
+            Case(
+                clip = clip(
+                    "/storage/emulated/0/Download/a.txt",
+                    "/storage/emulated/0/Documents/b.txt",
+                ),
+                titles = mapOf(origin to "Download"),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Sources").assertExists()
+        composeTestRule
+            .onNodeWithText("/storage/emulated/0/Download\n/storage/emulated/0/Documents")
+            .assertExists()
+        composeTestRule.onNodeWithText("Go to first source").assertExists()
+    }
+
+    @Test
+    fun `a path at the filesystem root contributes a slash of its own`() {
+        composeTestRule.setContent {
+            Case(
+                clip = clip("/", "/storage/emulated/0/Download/a.txt"),
+                titles = mapOf(origin to "Download"),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Sources").assertExists()
+        composeTestRule.onNodeWithText("/\n/storage/emulated/0/Download").assertExists()
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -346,6 +346,19 @@ class WorkspaceRepo @Inject constructor(
     fun peekAll(): List<Workspace<out Workspace.Arguments>> = _workspaces.value
 
     /**
+     * The current workspaces with their custom names applied, read from the authoritative state
+     * rather than [state], whose replay can still hold the snapshot from before a create, close or
+     * rename that has already been committed. Preview capture and fetch start right after such a
+     * mutation, so naming from the replay is what bakes a stale name into a cached thumbnail.
+     *
+     * [lock] is NOT reentrant, so this must not be called from a path that already holds it.
+     */
+    suspend fun peekInfos(): List<Workspace.Info> = lock.withLock {
+        val titles = _customTitles.value
+        _workspaces.value.map { it.info.value.withCustomTitle(titles) }
+    }
+
+    /**
      * When [id] was created, or null when it is unknown. Survives a pause/resume round-trip - the
      * map is keyed by id and [executeResume] only swaps the instance in its list slot - so session
      * saving can persist the true creation instant instead of the instant of the first save.

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCaptureService.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCaptureService.kt
@@ -23,7 +23,9 @@ import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.label
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
 import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.tabLabel
 import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -87,6 +89,8 @@ class WorkspacePreviewCaptureService @Inject constructor(
             }
 
             val themeState = generalSettings.themeStateBlocking
+            val workspaceTitles = workspaceRepo.peekInfos()
+                .associate { it.id to it.tabLabel.get(captureContext) }
 
             withContext(dispatcherProvider.Main) {
                 composableBitmapRenderer.renderToBitmap(
@@ -96,7 +100,10 @@ class WorkspacePreviewCaptureService @Inject constructor(
                 ) {
                     // Only the page host's Content is rendered (via WorkspaceMapper) — a preview
                     // thumbnail must never compose a workspace's dialogs or sheets.
-                    WorkspacePreviewCompositionLocals(pageHosts = pageHosts) {
+                    WorkspacePreviewCompositionLocals(
+                        pageHosts = pageHosts,
+                        workspaceTitles = workspaceTitles,
+                    ) {
                         ButlerTheme(state = themeState) {
                             WorkspaceMapper(
                                 info = WorkspacePaneInfo(
@@ -136,7 +143,9 @@ class WorkspacePreviewCaptureService @Inject constructor(
  * registered" error content, and reading a local that has no default (the guided-tour controller)
  * throws outright — which the service's catch-all would silently turn into a null thumbnail.
  * Focus is off so no page pops the keyboard, and the view-state registries are deliberately fresh
- * detached ones so a capture cannot read or clobber the live scroll and bar-collapse state.
+ * detached ones so a capture cannot read or clobber the live scroll and bar-collapse state. The
+ * workspace titles are the live ones, so a captured clipboard bar names its origin the same way the
+ * on-screen one does.
  *
  * Extracted from [WorkspacePreviewCaptureService] so this set can be asserted on: the renderer
  * itself needs a VirtualDisplay and real bitmaps, neither of which exist in a unit test.
@@ -144,6 +153,7 @@ class WorkspacePreviewCaptureService @Inject constructor(
 @Composable
 internal fun WorkspacePreviewCompositionLocals(
     pageHosts: Map<Workspace.Type, @JvmSuppressWildcards WorkspacePageHostEntry>,
+    workspaceTitles: Map<Workspace.Id, String>,
     content: @Composable () -> Unit,
 ) {
     val previewScrollPositions = remember { WorkspaceScrollPositions() }
@@ -154,6 +164,7 @@ internal fun WorkspacePreviewCompositionLocals(
         LocalWorkspaceScrollPositions provides previewScrollPositions,
         LocalWorkspaceBarCollapseStates provides previewBarCollapse,
         LocalGuidedTourController provides NoOpGuidedTourAccess,
+        LocalWorkspaceTitles provides workspaceTitles,
         content = content,
     )
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewFetcher.kt
@@ -22,7 +22,6 @@ import eu.darken.butler.common.hasApiLevel
 import eu.darken.butler.main.ui.MainActivity
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.preview.WorkspacePreviewModel
-import kotlinx.coroutines.flow.first
 import okio.Buffer
 import okio.FileSystem
 import java.io.ByteArrayOutputStream
@@ -74,7 +73,7 @@ class WorkspacePreviewFetcher @Inject constructor(
         // Step 2: Disk cache miss - generate preview
         log(TAG) { "Disk cache MISS for ${data.workspaceId.shortTag} - generating preview" }
 
-        val workspaceInfo = workspaceRepo.state.first().infos.find { it.id == data.workspaceId }
+        val workspaceInfo = workspaceRepo.peekInfos().find { it.id == data.workspaceId }
 
         if (workspaceInfo == null) {
             log(TAG, WARN) { "Workspace ${data.workspaceId.shortTag} not found in repo" }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -36,6 +36,8 @@ import eu.darken.butler.main.ui.motd.MotdCard
 import eu.darken.butler.main.ui.review.ReviewCard
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
+import eu.darken.butler.workspace.ui.tabLabel
 import eu.darken.butler.workspace.ui.LocalWorkspacePagerVisibility
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceRemote
@@ -342,12 +344,19 @@ fun WorkspacesScreenHost(
 
     val state by vm.state.collectAsState(initial = null)
 
+    val workspaceTitles = state?.let { current ->
+        remember(current.all, context) {
+            current.all.associate { it.id to it.tabLabel.get(context) }
+        }
+    }
+
     CompositionLocalProvider(
         LocalWorkspaceButtonProvider provides workspaceButtonVm,
         LocalWorkspacePageHosts provides vm.pageHosts,
         LocalWorkspaceScrollPositions provides vm.scrollPositions,
         LocalWorkspaceBarCollapseStates provides vm.barCollapseStates,
         LocalWorkspacePagerVisibility provides vm.pagerVisibility,
+        LocalWorkspaceTitles provides workspaceTitles,
     ) {
         state?.let { state ->
             WorkspaceScreen(

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCaptureServiceTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCaptureServiceTest.kt
@@ -18,6 +18,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,15 +46,24 @@ class WorkspacePreviewCaptureServiceTest : BaseTest() {
     }
     private val pauseGate = WorkspacePauseGate()
 
-    private fun info(id: Workspace.Id, lifecycleState: Workspace.LifecycleState) = Workspace.Info(
+    private fun info(
+        id: Workspace.Id,
+        lifecycleState: Workspace.LifecycleState,
+        customTitle: String? = null,
+    ) = Workspace.Info(
         id = id,
         type = Workspace.Type.EXPLORER,
         title = "Workspace".toCaString(),
         lifecycleState = lifecycleState,
+        customTitle = customTitle,
     )
 
-    private fun workspace(id: Workspace.Id, lifecycleState: Workspace.LifecycleState): Workspace<Workspace.Arguments> {
-        val infoState = MutableStateFlow(info(id, lifecycleState))
+    private fun workspace(
+        id: Workspace.Id,
+        lifecycleState: Workspace.LifecycleState,
+        customTitle: String? = null,
+    ): Workspace<Workspace.Arguments> {
+        val infoState = MutableStateFlow(info(id, lifecycleState, customTitle))
         return mockk<Workspace<Workspace.Arguments>>().apply { every { info } returns infoState }
     }
 
@@ -73,6 +83,8 @@ class WorkspacePreviewCaptureServiceTest : BaseTest() {
     private val workspaceRepo = mockk<WorkspaceRepo>().apply {
         every { state } returns repoState
         every { peek(any()) } answers { liveWorkspaces[firstArg()] }
+        // The authoritative snapshot, i.e. what the repo would report while holding its own lock
+        coEvery { peekInfos() } answers { liveWorkspaces.values.map { it.info.value } }
         // Captures lease the ownership root, so a pause of the whole unit holds them off. These are
         // flat topologies, so every workspace is its own root.
         every { peekOwnershipRoot(any()) } answers { firstArg() }
@@ -87,11 +99,16 @@ class WorkspacePreviewCaptureServiceTest : BaseTest() {
         pageHosts = emptyMap(),
     )
 
+    // The capture composition names a clipboard entry's origin, so it resolves every live title
+    private val captureContext = mockk<Context>().apply {
+        every { getString(any()) } returns "Explorer"
+    }
+
     private suspend fun capture(id: Workspace.Id) = service.captureWorkspace(
         workspaceId = id,
         workspaceType = Workspace.Type.EXPLORER,
         size = DpSize(width = 360.dp, height = 640.dp),
-        captureContext = mockk<Context>(),
+        captureContext = captureContext,
     )
 
     @Test
@@ -177,6 +194,22 @@ class WorkspacePreviewCaptureServiceTest : BaseTest() {
         capture.await() shouldBe null
         coVerify(exactly = 0) { renderer.renderToBitmap(any(), any(), any(), any(), any()) }
     }
+
+    @Test
+    fun `a capture names workspaces from the authoritative snapshot, not the shared state flow`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // A rename that is already committed, while the share still replays the old names
+            liveWorkspaces[idA] = workspace(idA, Workspace.LifecycleState.Ready, customTitle = "Renamed")
+            liveWorkspaces[idB] = workspace(idB, Workspace.LifecycleState.Ready, customTitle = "Also renamed")
+
+            capture(idA) shouldBe bitmap
+
+            coVerify(exactly = 1) { workspaceRepo.peekInfos() }
+            verify(exactly = 0) { workspaceRepo.state }
+            // Names off the stale snapshot carry no custom title and would fall back to the type's
+            // generic label, which is the only thing here that resolves against a Context
+            verify(exactly = 0) { captureContext.getString(any()) }
+        }
 
     @Test
     fun `a capture is not blocked by a pause of another workspace`() = runTest(UnconfinedTestDispatcher()) {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCompositionLocalsTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCompositionLocalsTest.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.compose.tour.NoOpGuidedTourAccess
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
 import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import io.kotest.matchers.shouldBe
@@ -38,6 +39,10 @@ class WorkspacePreviewCompositionLocalsTest : ComposeTest() {
         Workspace.Type.TEMPLATES to BlankPageHost,
     )
 
+    private val workspaceTitles = mapOf(
+        Workspace.Id() to "Downloads",
+    )
+
     @Test
     fun `a captured page can read the tour controller, the page hosts and the focus flag`() {
         var tourAccess: GuidedTourAccess? = null
@@ -45,7 +50,10 @@ class WorkspacePreviewCompositionLocalsTest : ComposeTest() {
         var focused: Boolean? = null
 
         composeTestRule.setContent {
-            WorkspacePreviewCompositionLocals(pageHosts = pageHosts) {
+            WorkspacePreviewCompositionLocals(
+                pageHosts = pageHosts,
+                workspaceTitles = workspaceTitles,
+            ) {
                 tourAccess = LocalGuidedTourController.current
                 seenHosts = LocalWorkspacePageHosts.current
                 focused = LocalWorkspaceFocused.current
@@ -58,5 +66,24 @@ class WorkspacePreviewCompositionLocalsTest : ComposeTest() {
         tourAccess shouldBe NoOpGuidedTourAccess
         seenHosts shouldBe pageHosts
         focused shouldBe false
+    }
+
+    @Test
+    fun `a captured page reads the live workspace titles, not an empty registry`() {
+        var seenTitles: Map<Workspace.Id, String>? = null
+
+        composeTestRule.setContent {
+            WorkspacePreviewCompositionLocals(
+                pageHosts = pageHosts,
+                workspaceTitles = workspaceTitles,
+            ) {
+                seenTitles = LocalWorkspaceTitles.current
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // An unprovided (null) registry would omit a clipboard entry's origin, an empty one would
+        // label every live workspace as closed.
+        seenTitles shouldBe workspaceTitles
     }
 }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreenHostTitlesTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreenHostTitlesTest.kt
@@ -1,0 +1,131 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.flow.SingleEventFlow
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.LocalWorkspaceTitles
+import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.WorkspacePageManager
+import eu.darken.butler.workspace.ui.WorkspaceVisibilityTracker
+import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.manager.WorkspaceButtonViewModel
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
+import eu.darken.butler.workspace.ui.scroll.WorkspaceScrollPositions
+import eu.darken.butler.workspace.ui.tabLabel
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * [WorkspacesScreenHost] is the only production provider of [LocalWorkspaceTitles]. The local is
+ * three-valued and an unprovided registry means "this composition knows nothing about workspaces",
+ * so dropping the provider silently removes every field that names a workspace it does not host -
+ * no crash and no log. Composed through the real host, not a stand-in provider, for that reason.
+ */
+class WorkspacesScreenHostTitlesTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val namedId = Workspace.Id()
+    private val unnamedId = Workspace.Id()
+
+    private fun info(id: Workspace.Id, customTitle: String? = null) = Workspace.Info(
+        id = id,
+        type = Workspace.Type.EXPLORER,
+        title = "Explorer".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+        customTitle = customTitle,
+    )
+
+    // A renamed tab and a default-named one: the two branches tabLabel resolves through
+    private val infos = listOf(info(namedId, customTitle = "Camera dump"), info(unnamedId))
+
+    /** The real Explorer page instantiates Hilt ViewModels, so the occupied pane gets a stand-in. */
+    private class TitleReadingPageHost : WorkspacePageHostEntry {
+        var compositions = 0
+        var seen: Map<Workspace.Id, String>? = null
+
+        @Composable
+        override fun Content(id: Workspace.Id, design: WorkspaceDesign) {
+            compositions++
+            seen = LocalWorkspaceTitles.current
+        }
+
+        @Composable
+        override fun Overlays(id: Workspace.Id, design: WorkspaceDesign) {
+        }
+    }
+
+    private val pageHost = TitleReadingPageHost()
+
+    private val screenState = WorkspacesViewModel.State(
+        state = WorkspaceRemote.State(
+            infos = infos,
+            portraitPanelMode = WorkspacePanelMode.SINGLE,
+            landscapePanelMode = WorkspacePanelMode.SINGLE,
+        ),
+        focusedWorkspace = namedId,
+        selectedWorkspaces = mapOf(0 to namedId),
+        visiblePaneSelections = mapOf(0 to namedId),
+        isUpgraded = true,
+        swipeGesturesEnabled = false,
+        onDemandWorkspaceCreation = false,
+    )
+
+    private val pageManager = mockk<WorkspacePageManager>(relaxed = true).apply {
+        every { state } returns MutableStateFlow(WorkspacePageManager.State())
+    }
+
+    private val vm = mockk<WorkspacesViewModel>(relaxed = true).apply {
+        every { errorEvents } returns SingleEventFlow()
+        every { navEvents } returns SingleEventFlow()
+        every { shareIntentEvent } returns SingleEventFlow()
+        every { bannerStates } returns MutableStateFlow(emptyMap())
+        every { showClearSessionConfirmation } returns MutableStateFlow(false)
+        every { managerDialogs } returns MutableStateFlow(emptyList())
+        every { workspacePageManager } returns pageManager
+        every { pageHosts } returns mapOf(Workspace.Type.EXPLORER to pageHost)
+        every { scrollPositions } returns WorkspaceScrollPositions()
+        every { barCollapseStates } returns WorkspaceBarCollapseStates()
+        every { pagerVisibility } returns WorkspaceVisibilityTracker()
+        every { state } returns MutableStateFlow(screenState)
+    }
+
+    private val buttonVm = mockk<WorkspaceButtonViewModel>(relaxed = true).apply {
+        every { errorEvents } returns SingleEventFlow()
+        every { navEvents } returns SingleEventFlow()
+        every { state } returns emptyFlow()
+    }
+
+    private val managerVm = mockk<WorkspaceManagerViewModel>(relaxed = true).apply {
+        every { errorEvents } returns SingleEventFlow()
+        every { navEvents } returns SingleEventFlow()
+        every { state } returns emptyFlow()
+    }
+
+    @Test
+    fun `the screen host publishes the resolved workspace titles to the pages it hosts`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspacesScreenHost(vm = vm, workspaceButtonVm = buttonVm, managerVm = managerVm)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        (pageHost.compositions > 0) shouldBe true
+        // Every open workspace, named the way the tab strip names it - not just the hosted one, and
+        // not an empty registry, which would read as "all of them are closed".
+        pageHost.seen shouldBe infos.associate { it.id to it.tabLabel.get(context) }
+    }
+}


### PR DESCRIPTION
## What changed

The clipboard entry details sheet now reads as stacked fields: a small label with its value directly below, two per row where the values are short, and the source path on a full-width row of its own so a long path wraps instead of colliding with its label. Long paths in the sheet's subtitle now shorten in the middle, so the filename stays visible.

The "Workspace" field used to show an internal four-character id such as "270b". It now names the tab the way the tab manager does: the name you gave the tab, or otherwise the kind of tab it is. The clipboard bar's "Origin:" line had the same problem and is fixed with it. A tab renamed while the sheet is open updates immediately, and an entry whose tab has since been closed says so.

An entry holding items from more than one folder no longer claims they all came from the first one. It says how many locations are involved, lists each of them, and the navigate action reads "Go to first source" so it is clear which one it opens.

Tab thumbnails could bake in a tab's old name when one was captured right after a rename; they now read the current name.

## Technical Context

- The Workspace value resolves through a new `Workspace.Info.tabLabel` (custom name, else type label), matching `WorkspaceGridItem`. The obvious-looking `displayTitle` is wrong here: for an Explorer tab its automatic title is the current directory path, so the field rendered a duplicate of the Source field directly below it. On-device testing is what caught that.
- `LocalWorkspaceTitles` is a nullable CompositionLocal with a deliberately three-valued contract: null means the host provides no registry and the field is omitted, a map missing the id means the workspace is closed, a map with the id carries the name. An `emptyMap()` default would collapse the first two and make a live workspace read as "Closed" inside detached compositions such as tab-preview capture. Worth reviewing closely: that null default also makes losing the single production provider silent, which is why `WorkspacesScreenHostTitlesTest` pins it.
- The location count and the source list are computed by one resolver, `ClipboardClip.Paths.sourceLocations`, which normalizes a missing parent to `/` before deduplicating. Two independent rules previously disagreed for a clip containing the filesystem root and an item directly below it.
- `WorkspaceRepo.peekInfos()` reads the workspace list and custom-title overlay under the repo lock, because `state` is `replayingShare`d and its replay can lag a just-committed rename. Both preview call sites moved onto it together, so they cannot drift apart. The lock is not reentrant; the KDoc records that constraint.
- Manual on-device testing covered the rename-propagation and closed-tab paths on an emulator, which the Compose tests cannot reach end to end.
