### PR TITLE
Workspace: Fix the system back gesture doing nothing next to the tab pager

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,8 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "devtools@claude-code-cafe": true
+    "devtools@claude-code-cafe": true,
+    "google-play@claude-code-cafe": true,
+    "support@claude-code-cafe": true
   }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
@@ -257,7 +257,17 @@ private fun FileOptionsContent(
             FileActionRow(
                 icon = Workspace.Type.VIEWER.icon,
                 title = stringResource(R.string.explorer_file_action_open),
-                subtitle = stringResource(R.string.explorer_file_action_open_subtitle),
+                // Only a Viewer stacks inside this tab and returns here on back. A text file
+                // routes to the Editor, which is a tab of its own, making this row do exactly
+                // what the "open in new tab" row below does. Routing pinned by
+                // OpenInNewTabsUseCaseTest.
+                subtitle = stringResource(
+                    if (isTextFile) {
+                        R.string.explorer_file_action_open_in_tab_subtitle
+                    } else {
+                        R.string.explorer_file_action_open_subtitle
+                    },
+                ),
                 onClick = { onAction(ExplorerActionBarItem.File.Open(item)) },
             )
 

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="explorer_file_info_size_label">Size</string>
     <string name="explorer_file_info_modified_label">Modified</string>
     <string name="explorer_file_action_open">Open</string>
-    <string name="explorer_file_action_open_subtitle">View in Butler</string>
+    <string name="explorer_file_action_open_subtitle">View here, back returns to this folder</string>
     <string name="explorer_file_action_open_in_tab">Open in new tab</string>
     <string name="explorer_file_action_open_in_tab_subtitle">View in Butler as its own tab</string>
     <string name="explorer_file_action_open_in_editor">Open in editor</string>

--- a/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
@@ -414,7 +414,10 @@ class MainActivity : Activity2() {
 
     companion object {
         private val TAG = logTag("Main", "Activity")
-        private const val BACK_PRESS_INTERVAL = 2000L // 2 seconds
+        // Must outlast the Toast.LENGTH_SHORT prompt (~2s) that asks for the second press: a window
+        // closing while that instruction is still on screen leaves every slower press restarting
+        // the prompt instead of exiting.
+        private const val BACK_PRESS_INTERVAL = 3500L
         private const val MIME_DOCUMENT_ROOT = "vnd.android.document/root"
         private const val MIME_DOCUMENT_DIRECTORY = "vnd.android.document/directory"
     }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -258,7 +258,11 @@ internal fun ClassicWorkspaceContainer(
         if (state.tabWorkspaces.isNotEmpty()) {
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.fillMaxSize(),
+                // Swiping the page out from under an in-flight system back gesture is what makes
+                // Back appear dead on ROMs that hand the app the edge touch first.
+                modifier = Modifier
+                    .fillMaxSize()
+                    .ignoreEdgeHorizontalDrags(),
                 flingBehavior = flingBehavior,
                 userScrollEnabled = state.swipeGesturesEnabled,
                 key = { page ->

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -27,6 +27,10 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceStacks
@@ -43,6 +47,8 @@ import eu.darken.butler.workspace.ui.workspaces.WorkspacesViewModel
 import eu.darken.butler.workspace.ui.workspaces.asPaneInfo
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+
+private val TAG = logTag("Workspace", "Classic", "Container")
 
 // Stable key for the on-demand-creation placeholder page (last index when enabled).
 // Distinct from any Workspace.Id so the pager preserves identity across list churn.
@@ -210,11 +216,25 @@ internal fun ClassicWorkspaceContainer(
             state.fullScreenModalWorkspace == null &&
             !hasGlobalBlockingDialog,
     ) {
-        // On the placeholder and at rest: return to the focused tab. Otherwise the pager is
-        // mid-move or focus has not caught up with a settle yet — swallow the press rather than
-        // let it reach the app-root exit prompt, and let the user press again once things settle.
-        if (isOnPlaceholder && !pagerState.isScrollInProgress) {
-            backTarget?.let { scope.launch { coordinator.scrollToWorkspace(pagerState, tabIds, it) } }
+        val settling = pagerState.isScrollInProgress
+        val settledTab = tabIds.getOrNull(pagerState.settledPage)
+        // Mid-move and the placeholder are the expected reasons to land here. At rest on a real
+        // page means focus and the pager disagree with nothing in flight to reconcile them, and
+        // that is the state presses cannot get out of on their own.
+        log(TAG, if (settling || isOnPlaceholder) VERBOSE else WARN) {
+            "Pane-level back: focusedRoot=$backTarget targetPage=$backTargetPage " +
+                "settled=${pagerState.settledPage} settling=$settling onPlaceholder=$isOnPlaceholder"
+        }
+        when {
+            settling -> Unit
+            // The placeholder is no destination, so here the pager is the one that has to move.
+            isOnPlaceholder -> backTarget?.let {
+                scope.launch { coordinator.scrollToWorkspace(pagerState, tabIds, it) }
+            }
+            // At rest on a real page: that page is what the user is looking at, so focus adopts it
+            // rather than the pager undoing a swipe the user just made. The press itself is still
+            // consumed; the next one reaches the page now that the two agree.
+            settledTab != null -> onWorkspaceScreenAction(WorkspaceScreenAction.Select(settledTab))
         }
     }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/EdgeBackGestureGuard.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/EdgeBackGestureGuard.kt
@@ -1,0 +1,66 @@
+package eu.darken.butler.workspace.ui.workspaces.classic
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.systemGestures
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import kotlin.math.abs
+
+/**
+ * Keeps a horizontal drag that starts in a system back-gesture strip away from the pager.
+ *
+ * A Compose scrollable that starts dragging asks the host window to stop intercepting touches. On
+ * ROMs that hand the app the edge touch before deciding the back gesture is theirs, that cancels
+ * the gesture mid-flight: the page shifts a few pixels, back never fires, and the drag dies below
+ * the fling threshold so the pager snaps back. The press looks like it did nothing. ROMs that
+ * reserve the strip up front never deliver the touch at all and are unaffected either way.
+ *
+ * Only a drag that both starts inside the strip and is predominantly horizontal is swallowed. Taps
+ * and vertical scrolls in the strip still reach the content, and a swipe starting anywhere else
+ * still turns the page.
+ *
+ * The claim is made on [PointerEventPass.Initial] and below the pager's own touch slop, so the
+ * pager's drag never begins and the window is never asked to stop intercepting. Zeroing the scroll
+ * delta afterwards would not do: by then the drag has started and the gesture is already lost.
+ */
+fun Modifier.ignoreEdgeHorizontalDrags(edgeWidthPx: Int): Modifier {
+    if (edgeWidthPx <= 0) return this
+    return pointerInput(edgeWidthPx) {
+        val claimSlop = viewConfiguration.touchSlop / 2f
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            val fromEdge = down.position.x <= edgeWidthPx || down.position.x >= size.width - edgeWidthPx
+            if (!fromEdge) return@awaitEachGesture
+
+            var claimed = false
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                if (!change.pressed) break
+                if (!claimed) {
+                    val dx = abs(change.position.x - down.position.x)
+                    val dy = abs(change.position.y - down.position.y)
+                    // Horizontal intent, decided before the pager's slop would have been crossed.
+                    if (dx > dy && dx > claimSlop) claimed = true
+                }
+                if (claimed) change.consume()
+            }
+        }
+    }
+}
+
+/** [ignoreEdgeHorizontalDrags] sized from the window's own back-gesture strips. */
+@Composable
+fun Modifier.ignoreEdgeHorizontalDrags(): Modifier {
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val gestures = WindowInsets.systemGestures
+    val edge = maxOf(gestures.getLeft(density, layoutDirection), gestures.getRight(density, layoutDirection))
+    return ignoreEdgeHorizontalDrags(edge)
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ClassicPlaceholderBackDispatchTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ClassicPlaceholderBackDispatchTest.kt
@@ -92,6 +92,7 @@ class ClassicPlaceholderBackDispatchTest : ComposeTest() {
 
     private class Outcome {
         val closedTabs = mutableListOf<Workspace.Id>()
+        val screenActions = mutableListOf<WorkspaceScreenAction>()
         var overlayDismissed = false
         var reachedAppRoot = false
         var dispatcher: OnBackPressedDispatcher? = null
@@ -144,7 +145,9 @@ class ClassicPlaceholderBackDispatchTest : ComposeTest() {
                         state = state,
                         managerDialogs = managerDialogs,
                         isOverlayVisible = overlayVisible,
-                        onWorkspaceScreenAction = {},
+                        // Recorded but not applied: focus must still never follow the swipe,
+                        // or the desync these tests are built on would repair itself.
+                        onWorkspaceScreenAction = { outcome.screenActions.add(it) },
                         managerDialogStates = emptyMap(),
                         onDismissManagerDialog = {},
                         onConfirmManagerDialog = {},
@@ -260,6 +263,30 @@ class ClassicPlaceholderBackDispatchTest : ComposeTest() {
         outcome.closedTabs shouldBe emptyList()
         outcome.reachedAppRoot shouldBe false
         // Nothing moved either: the container swallows the press rather than acting on it.
+        composeTestRule.onNodeWithTag(pageTag(idA)).assertIsDisplayed()
+    }
+
+    /**
+     * The repair for the state above. Consuming the press is only acceptable because it also ends
+     * the disagreement: focus adopts the page the pager rests on, so the next press reaches that
+     * page instead of being consumed again. Without this the container would swallow every press
+     * for as long as focus stayed behind.
+     *
+     * The pager deliberately does not move. The user swiped to this page; back must not undo that.
+     */
+    @Test
+    fun `back at rest hands focus to the page the pager rests on`() {
+        val outcome = compose()
+
+        composeTestRule.onNodeWithTag(pageTag(idB)).performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(pageTag(idA)).assertIsDisplayed()
+        // The settle itself reports a selection; only what the press adds is under test.
+        outcome.screenActions.clear()
+
+        outcome.pressBack()
+
+        outcome.screenActions shouldBe listOf(WorkspaceScreenAction.Select(idA))
         composeTestRule.onNodeWithTag(pageTag(idA)).assertIsDisplayed()
     }
 

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/EdgeBackGestureGuardTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/EdgeBackGestureGuardTest.kt
@@ -1,0 +1,110 @@
+package eu.darken.butler.workspace.ui.workspaces.classic
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.unit.dp
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The guard exists so an in-flight system back gesture is not cancelled by the pager starting a
+ * drag. What it must not cost is the ordinary swipe, so both halves are pinned here.
+ *
+ * The pixel-taking overload is used directly: Robolectric reports no system gesture insets, so the
+ * composable overload would size the strip to zero and every case below would pass vacuously.
+ */
+class EdgeBackGestureGuardTest : ComposeTest() {
+
+    private val edgePx = 100
+
+    private lateinit var pagerState: PagerState
+
+    private fun composePager(pages: Int = 3) {
+        composeTestRule.setContent {
+            pagerState = rememberPagerState(pageCount = { pages })
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .size(500.dp)
+                    .testTag(PAGER)
+                    .ignoreEdgeHorizontalDrags(edgePx),
+            ) {
+                Box(modifier = Modifier.fillMaxSize())
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `a horizontal drag starting in the edge strip does not turn the page`() {
+        composePager()
+
+        composeTestRule.onNodeWithTag(PAGER).performTouchInput {
+            swipe(start = Offset(5f, centerY), end = Offset(width - 5f, centerY))
+        }
+        composeTestRule.waitForIdle()
+
+        pagerState.settledPage shouldBe 0
+    }
+
+    @Test
+    fun `a horizontal drag starting away from the edge still turns the page`() {
+        composePager()
+
+        composeTestRule.onNodeWithTag(PAGER).performTouchInput {
+            swipe(start = Offset(centerX, centerY), end = Offset(centerX - width / 2f, centerY))
+        }
+        composeTestRule.waitForIdle()
+
+        pagerState.settledPage shouldBe 1
+    }
+
+    /** The strip is only closed to horizontal drags; everything else must still land. */
+    @Test
+    fun `a tap in the edge strip still reaches the content`() {
+        var taps = 0
+        composeTestRule.setContent {
+            pagerState = rememberPagerState(pageCount = { 2 })
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .size(500.dp)
+                    .testTag(PAGER)
+                    .ignoreEdgeHorizontalDrags(edgePx),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(CONTENT)
+                        .clickable { taps++ },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(CONTENT).performTouchInput {
+            click(Offset(5f, centerY))
+        }
+        composeTestRule.waitForIdle()
+
+        taps shouldBe 1
+    }
+
+    companion object {
+        private const val PAGER = "pager"
+        private const val CONTENT = "content"
+    }
+}


### PR DESCRIPTION
## What changed

Swiping in from the screen edge to go back could leave you on the same screen. The tab pager was competing with the system for that swipe, and when the pager won, the back gesture was cancelled while the page slid a few pixels and snapped back, so nothing appeared to happen at all.

Reported on OneUI. LineageOS and AOSP are not affected, because they reserve the edge strip before the app ever sees the touch.

A drag is now ignored when it both starts inside the system's back-gesture strip and is predominantly horizontal. Tapping and vertical scrolling near the edge still work, and swiping between tabs from anywhere else is unchanged.

## Technical Context

* Cause: a Compose scrollable asks its host window to stop intercepting touches as soon as a drag begins, which cancels an in-flight back gesture. The drag then never reaches the fling threshold, so the pager snaps back to where it started. The reporter pinned it exactly: if the swipe did not drag the tab, back worked, and if the tab moved even one pixel, back was lost.
* The claim has to happen on `PointerEventPass.Initial` and below the pager's touch slop, because the goal is that the drag never starts. Zeroing the scroll delta afterwards, via a nested scroll connection, would be too late: by then the window has already been asked to stop intercepting.
* **Not verified against the real failure.** It does not reproduce with adb-injected gestures even on a OneUI device with gesture navigation enabled: fast, slow and tiny-travel synthetic edge swipes all fired back correctly, while a real finger loses the arbitration on that same device. A mid-screen swipe moving the pager confirmed the control. This wants a confirmation from the reporter on a real build before it merges, which is why it is a draft.
* Worth close review: the claim heuristic in `EdgeBackGestureGuard`. It decides horizontal intent from the first movement that exceeds half the touch slop, and that threshold is the whole trade-off between catching the gesture early enough and not stealing a legitimate diagonal drag.
* The tests drive the pixel-taking overload directly. Robolectric reports no system gesture insets, so the composable overload would size the strip to zero and every case would pass without exercising anything.
