### PR TITLE
Editor: Fix the cursor landing on the wrong line after scrolling

### DIFF
--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
@@ -2,7 +2,6 @@ package eu.darken.butler.editor.ui.editor
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
@@ -45,7 +44,7 @@ import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
-import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarContentPadding
 import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
@@ -320,18 +319,17 @@ fun EditorWorkspacePage(
         )
 
         // Main content area
-        val topContentPadding = topBarStackState.contentPaddingDp()
-        val bottomContentPadding = bottomBarStackState.contentPaddingDp()
+        val contentPadding = rememberFloatingBarContentPadding(
+            topStackState = topBarStackState,
+            bottomStackState = bottomBarStackState,
+        )
 
         Box(modifier = Modifier.fillMaxSize()) {
             if (!state.hasFile && state.isLoading) {
                 EditorLoadingOverlay()
             } else {
                 LazyTextEditor(
-                    contentPadding = PaddingValues(
-                        top = topContentPadding,
-                        bottom = bottomContentPadding,
-                    ),
+                    contentPadding = contentPadding,
                     content = state.currentContent,
                     totalLines = state.totalLines,
                     cursorPosition = state.cursorPosition,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtils.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtils.kt
@@ -276,12 +276,11 @@ internal fun calculatePositionFromOffset(
     charWidthPx: Float,
     tabSize: Int,
     textLayouts: Map<Long, TextLayoutResult> = emptyMap(),
-    contentPaddingTop: Float = 0f,
     lineStartColumns: Map<Long, Long> = emptyMap(),
 ): PositionCalculationResult? {
     val layoutInfo = contentListState.layoutInfo
-    // Adjust Y for content padding - tap offset includes padding, item.offset doesn't
-    val adjustedY = offset.y - contentPaddingTop
+    // The tap covers the whole list, item offsets start below its top content padding.
+    val adjustedY = layoutInfo.containerToItemY(offset.y)
     val clickedItem = layoutInfo.visibleItemsInfo.find { item ->
         adjustedY >= item.offset && adjustedY < (item.offset + item.size)
     }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtils.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtils.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.editor.ui.editor.text
 
+import androidx.compose.foundation.lazy.LazyListLayoutInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.TextLayoutResult
@@ -253,6 +254,19 @@ internal fun expandedColumnFromX(adjustedX: Float, charWidthPx: Float, maxColumn
     val column = if (adjustedX > cell * charWidthPx + charWidthPx / 2f) cell + 1 else cell
     return column.coerceIn(0, maxColumn.coerceAtLeast(0))
 }
+
+/**
+ * Container space (pointer offsets over the whole lazy layout, top content padding included) to item
+ * space ([androidx.compose.foundation.lazy.LazyListItemInfo.offset], measured from the content
+ * region's origin below that padding).
+ *
+ * [LazyListLayoutInfo.viewportStartOffset] is the negated top content padding of the layout being
+ * read, so a live read stays exact while an animated padding shrinks or grows.
+ */
+internal fun LazyListLayoutInfo.containerToItemY(containerY: Float): Float = containerY + viewportStartOffset
+
+/** Inverse of [containerToItemY]. */
+internal fun LazyListLayoutInfo.itemToContainerY(itemY: Float): Float = itemY - viewportStartOffset
 
 internal fun calculatePositionFromOffset(
     offset: Offset,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/LazyTextEditor.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/LazyTextEditor.kt
@@ -462,7 +462,6 @@ private fun DualColumnEditorContent(
     }
     rememberCoroutineScope()
     val density = LocalDensity.current
-    val contentPaddingTopPx = with(density) { contentPadding.calculateTopPadding().toPx() }
 
     // Track measured heights for each line when word wrap is enabled
     val lineHeights = remember { mutableStateMapOf<Long, Int>() }
@@ -1013,7 +1012,6 @@ private fun DualColumnEditorContent(
                 textLayouts = textLayouts,
                 visibleLineContent = currentVisibleLineContent,
                 tabSize = tabSize,
-                contentPaddingTop = contentPaddingTopPx,
                 lineStartColumn = startColumns[start.line] ?: 0L,
             )
 
@@ -1047,7 +1045,6 @@ private fun DualColumnEditorContent(
                 textLayouts = textLayouts,
                 visibleLineContent = currentVisibleLineContent,
                 tabSize = tabSize,
-                contentPaddingTop = contentPaddingTopPx,
                 lineStartColumn = startColumns[end.line] ?: 0L,
             )
         }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/LazyTextEditor.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/LazyTextEditor.kt
@@ -844,7 +844,6 @@ private fun DualColumnEditorContent(
                                     charWidthPx = charWidthPx,
                                     tabSize = tabSize,
                                     textLayouts = textLayouts,
-                                    contentPaddingTop = contentPaddingTopPx,
                                     lineStartColumns = currentStartColumns,
                                 )
 
@@ -911,7 +910,6 @@ private fun DualColumnEditorContent(
                                     charWidthPx = charWidthPx,
                                     tabSize = tabSize,
                                     textLayouts = textLayouts,
-                                    contentPaddingTop = contentPaddingTopPx,
                                     lineStartColumns = currentStartColumns,
                                 )
 
@@ -1004,7 +1002,6 @@ private fun DualColumnEditorContent(
                         charWidthPx = charWidthPx,
                         tabSize = tabSize,
                         textLayouts = textLayouts,
-                        contentPaddingTop = contentPaddingTopPx,
                         lineStartColumns = currentStartColumns,
                     )
 
@@ -1039,7 +1036,6 @@ private fun DualColumnEditorContent(
                         charWidthPx = charWidthPx,
                         tabSize = tabSize,
                         textLayouts = textLayouts,
-                        contentPaddingTop = contentPaddingTopPx,
                         lineStartColumns = currentStartColumns,
                     )
 

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/SelectionHandle.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/SelectionHandle.kt
@@ -55,7 +55,6 @@ internal fun SelectionHandle(
     textLayouts: Map<Long, TextLayoutResult> = emptyMap(),
     visibleLineContent: Map<Long, String> = emptyMap(),
     tabSize: Int = 4,
-    contentPaddingTop: Float = 0f,
     lineStartColumn: Long = 0L,
 ) {
     // [position.column] is an absolute engine column; the rendered line starts at its window anchor.
@@ -169,8 +168,10 @@ internal fun SelectionHandle(
 
                     // Use translation for GPU-accelerated positioning
                     translationX = xPosition
-                    // Add visual line offset for wrapped text positioning and content padding top
-                    translationY = currentYPos + visualLineOffsetY + contentPaddingTop
+                    // The anchor is an item offset, the handle is placed over the whole list; the
+                    // visual line offset then picks the wrapped line the caret sits on.
+                    val anchorY = contentListState.layoutInfo.itemToContainerY(currentYPos)
+                    translationY = anchorY + visualLineOffsetY
                 }
                 .pointerInput(lineNumberWidthPx, wordWrap, charWidth) {
                     detectDragGestures(
@@ -194,8 +195,8 @@ internal fun SelectionHandle(
 
                         // Convert handle-relative position to LazyColumn coordinates
                         val lazyColumnX = (change.position.x + xPosition) - lineNumberWidthPx + horizontalScrollOffset
-                        // Add contentPaddingTop to match tap coordinate space (full LazyColumn area)
-                        val lazyColumnY = change.position.y + currentYPosition + visualLineOffsetY + contentPaddingTop
+                        val anchorY = contentListState.layoutInfo.itemToContainerY(currentYPosition)
+                        val lazyColumnY = change.position.y + anchorY + visualLineOffsetY
 
                         currentOnDrag(Offset(lazyColumnX, lazyColumnY))
                         change.consume()

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/TextLineItem.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/text/TextLineItem.kt
@@ -1,11 +1,5 @@
 package eu.darken.butler.editor.ui.editor.text
 
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.keyframes
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -19,7 +13,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -51,6 +47,11 @@ import eu.darken.butler.editor.core.engine.SearchResult
 import eu.darken.butler.editor.core.engine.TextPosition
 import eu.darken.butler.editor.core.syntax.Token
 import eu.darken.butler.editor.core.syntax.TokenType
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+
+/** Half a blink period: the caret is opaque for this long, then hidden for the same. */
+private val CURSOR_BLINK_INTERVAL = 530.milliseconds
 
 private data class SelectionBounds(
     val left: Float,
@@ -103,30 +104,22 @@ internal fun TextLineItem(
         }
     }
 
-    // Blinking animation when focused
-    val infiniteTransition = rememberInfiniteTransition(label = "cursor_blink")
-    val cursorAlpha by infiniteTransition.animateFloat(
-        initialValue = 1f,
-        targetValue = if (isFocused) 0f else 1f,
-        animationSpec = if (isFocused) {
-            infiniteRepeatable(
-                animation = keyframes {
-                    durationMillis = 1060
-                    1f at 0
-                    1f at 530
-                    0f at 531
-                    0f at 1060
-                },
-                repeatMode = RepeatMode.Restart
-            )
-        } else {
-            infiniteRepeatable(
-                animation = tween(1),
-                repeatMode = RepeatMode.Restart
-            )
-        },
-        label = "cursor_alpha"
-    )
+    // Blink only on the line that actually draws a caret; every other line holds a constant alpha
+    // and never schedules a frame.
+    val shouldBlink = isFocused && isCurrentLine && selection == null
+    var cursorAlpha by remember { mutableFloatStateOf(1f) }
+    LaunchedEffect(shouldBlink) {
+        if (!shouldBlink) {
+            cursorAlpha = 1f
+            return@LaunchedEffect
+        }
+        while (true) {
+            cursorAlpha = 1f
+            delay(CURSOR_BLINK_INTERVAL)
+            cursorAlpha = 0f
+            delay(CURSOR_BLINK_INTERVAL)
+        }
+    }
 
     // When word wrap is OFF, highlight entire line. When ON, we'll draw only the cursor's visual line.
     val backgroundColor = if (isCurrentLine && !wordWrap) {

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtilsPaddingTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtilsPaddingTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.butler.editor.ui.editor.text
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * Hit-testing a tap against a [LazyColumn] that carries top content padding.
+ *
+ * Geometry is pinned: items are 20px tall and the top padding is 64px, so a tap that ignores the
+ * container/item coordinate difference lands three items away from the one under the finger.
+ * Heights are explicit because Robolectric's text measurement is fake (see [ComposeTest]).
+ */
+class EditorPositionUtilsPaddingTest : ComposeTest() {
+
+    private val itemCount = 12
+    private val itemHeightPx = 20f
+    private val visibleLineContent = (0 until itemCount).associate { it.toLong() to "line $it" }
+
+    private var topPaddingPx by mutableFloatStateOf(64f)
+
+    private lateinit var listState: LazyListState
+    private lateinit var density: Density
+
+    /** Physical item tops in the list's own coordinate space, published by the layout itself. */
+    private val itemTops = mutableMapOf<Int, Float>()
+    private var listTop = 0f
+
+    private fun setList() {
+        composeTestRule.setContent {
+            density = LocalDensity.current
+            listState = rememberLazyListState()
+            LazyColumn(
+                state = listState,
+                contentPadding = PaddingValues(top = with(density) { topPaddingPx.toDp() }),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onGloballyPositioned { listTop = it.positionInRoot().y },
+            ) {
+                items(itemCount) { index ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(with(density) { itemHeightPx.toDp() })
+                            .onGloballyPositioned { itemTops[index] = it.positionInRoot().y },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun physicalTopOf(index: Int): Float = itemTops.getValue(index) - listTop
+
+    private fun tapAt(containerY: Float) = calculatePositionFromOffset(
+        offset = Offset(0f, containerY),
+        contentListState = listState,
+        visibleLineContent = visibleLineContent,
+        density = density,
+        charWidthPx = 1f,
+        tabSize = 4,
+    )
+
+    @Test
+    fun `a tap on an item's physical centre resolves to that item`() {
+        setList()
+
+        for (index in listOf(0, 3, 7)) {
+            tapAt(physicalTopOf(index) + itemHeightPx / 2f)!!.position.line shouldBe index.toLong()
+        }
+    }
+
+    @Test
+    fun `an item's physical top is its item offset converted to container space`() {
+        setList()
+
+        val layoutInfo = listState.layoutInfo
+        for (item in layoutInfo.visibleItemsInfo) {
+            physicalTopOf(item.index) shouldBe (item.offset - layoutInfo.viewportStartOffset).toFloat()
+        }
+    }
+
+    @Test
+    fun `taps follow the padding when it changes on an already laid out list`() {
+        setList()
+        tapAt(physicalTopOf(5) + itemHeightPx / 2f)!!.position.line shouldBe 5L
+
+        topPaddingPx = 12f
+        composeTestRule.waitForIdle()
+
+        tapAt(physicalTopOf(5) + itemHeightPx / 2f)!!.position.line shouldBe 5L
+    }
+
+    @Test
+    fun `a tap above the first item hits nothing`() {
+        setList()
+
+        tapAt(physicalTopOf(0) - 10f).shouldBeNull()
+    }
+}

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtilsTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/text/EditorPositionUtilsTest.kt
@@ -1,6 +1,10 @@
 package eu.darken.butler.editor.ui.editor.text
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListLayoutInfo
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.IntSize
 import eu.darken.butler.editor.core.engine.TextPosition
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -504,6 +508,53 @@ class EditorPositionUtilsTest {
         @Test
         fun `empty line clamps to zero`() {
             expandedColumnFromX(adjustedX = 500f, charWidthPx = 10f, maxColumn = 0) shouldBe 0
+        }
+    }
+
+    @Nested
+    inner class LazyListCoordinates {
+
+        private fun layoutInfo(topContentPadding: Int) = object : LazyListLayoutInfo {
+            override val visibleItemsInfo: List<LazyListItemInfo> = emptyList()
+            override val viewportStartOffset: Int = -topContentPadding
+            override val viewportEndOffset: Int = 0
+            override val totalItemsCount: Int = 0
+            override val viewportSize: IntSize = IntSize.Zero
+            override val orientation: Orientation = Orientation.Vertical
+            override val reverseLayout: Boolean = false
+            override val beforeContentPadding: Int = topContentPadding
+            override val afterContentPadding: Int = 0
+            override val mainAxisItemSpacing: Int = 0
+        }
+
+        @Test
+        fun `without top padding both directions are the identity`() {
+            val info = layoutInfo(topContentPadding = 0)
+
+            info.containerToItemY(0f) shouldBe 0f
+            info.containerToItemY(37f) shouldBe 37f
+            info.itemToContainerY(37f) shouldBe 37f
+        }
+
+        @Test
+        fun `top padding shifts the two spaces against each other`() {
+            val info = layoutInfo(topContentPadding = 64)
+
+            // The item-space origin, the first item's top, sits 64px down the container.
+            info.containerToItemY(64f) shouldBe 0f
+            info.itemToContainerY(0f) shouldBe 64f
+            // A tap inside the padding band is above the content region.
+            info.containerToItemY(10f) shouldBe -54f
+        }
+
+        @Test
+        fun `the two directions round-trip at non-zero padding`() {
+            val info = layoutInfo(topContentPadding = 64)
+
+            for (y in listOf(-100f, 0f, 12.5f, 64f, 1000f)) {
+                info.itemToContainerY(info.containerToItemY(y)) shouldBe y
+                info.containerToItemY(info.itemToContainerY(y)) shouldBe y
+            }
         }
     }
 }

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/text/SelectionHandlePaddingTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/text/SelectionHandlePaddingTest.kt
@@ -1,0 +1,146 @@
+package eu.darken.butler.editor.ui.editor.text
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.editor.core.engine.TextPosition
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * A selection handle over a [LazyColumn] that carries top content padding: the handle has to sit on
+ * its line, and the offsets its drag emits have to land back on that same line when they are run
+ * through [calculatePositionFromOffset].
+ *
+ * Both halves are asserted by one drag. The handle is only 24px tall, so a touch aimed at its line
+ * reaches the gesture at all only when the handle is placed there; `graphicsLayer` translations
+ * reach hit testing but not `boundsInRoot`, so injection coordinates are root coordinates.
+ *
+ * Items are 20px tall and the padding is 64px, so a handle or a drag offset that is off by the
+ * padding lands three lines away.
+ */
+class SelectionHandlePaddingTest : ComposeTest() {
+
+    private val handleTag = "test.selection.handle"
+
+    private val itemCount = 12
+    private val itemHeightPx = 20f
+    private val handleLine = 5L
+    private val column = 30
+
+    /** Long enough that [column] is not clamped away. */
+    private val visibleLineContent = (0 until itemCount).associate { it.toLong() to "x".repeat(60) }
+
+    /** No `TextLayoutResult` is reported, so the handle falls back to the measured advance. */
+    private val handleCenterX = 8f + column * 1f - 12f + 12f
+
+    private var topPaddingPx by mutableFloatStateOf(64f)
+
+    private lateinit var listState: LazyListState
+    private lateinit var density: Density
+    private val dragged = mutableListOf<Offset>()
+
+    private fun setHandle() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                density = LocalDensity.current
+                listState = rememberLazyListState()
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(
+                        state = listState,
+                        contentPadding = PaddingValues(top = with(density) { topPaddingPx.toDp() }),
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        items(itemCount) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(with(density) { itemHeightPx.toDp() }),
+                            )
+                        }
+                    }
+                    SelectionHandle(
+                        modifier = Modifier.testTag(handleTag),
+                        position = TextPosition(offset = 0L, line = handleLine, column = column),
+                        contentListState = listState,
+                        lineNumberWidth = 0.dp,
+                        horizontalScrollState = rememberScrollState(),
+                        actualCharWidth = 1f,
+                        onDrag = { dragged += it },
+                        visibleLineContent = visibleLineContent,
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /** Touches the handle at the vertical centre of its line and reports where the drag lands. */
+    private fun dragOnHandleLine(): List<Long> {
+        val lineCentreY = topPaddingPx + handleLine * itemHeightPx + itemHeightPx / 2f
+        dragged.clear()
+        composeTestRule.onNodeWithTag(handleTag).performTouchInput {
+            down(Offset(handleCenterX, lineCentreY))
+            // Far enough to clear touch slop, and horizontal so the line under the finger is fixed.
+            moveTo(Offset(handleCenterX + 40f, lineCentreY))
+            moveTo(Offset(handleCenterX + 60f, lineCentreY))
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        return dragged.map { offset ->
+            calculatePositionFromOffset(
+                offset = offset,
+                contentListState = listState,
+                visibleLineContent = visibleLineContent,
+                density = density,
+                charWidthPx = 1f,
+                tabSize = 4,
+            )!!.position.line
+        }
+    }
+
+    @Test
+    fun `a drag on the handle's line stays on that line`() {
+        setHandle()
+
+        val lines = dragOnHandleLine()
+
+        lines.shouldNotBeEmpty()
+        lines.distinct() shouldBe listOf(handleLine)
+    }
+
+    @Test
+    fun `the handle follows a padding change on an already laid out list`() {
+        setHandle()
+        dragOnHandleLine().distinct() shouldBe listOf(handleLine)
+
+        topPaddingPx = 12f
+        composeTestRule.waitForIdle()
+
+        val lines = dragOnHandleLine()
+
+        lines.shouldNotBeEmpty()
+        lines.distinct() shouldBe listOf(handleLine)
+    }
+}


### PR DESCRIPTION
## What changed

Tapping in the text editor placed the cursor a few lines above where you tapped, but only after you had scrolled. Selection handles drifted the same way when dragged after a scroll. Both now land where you put them.

The editor also no longer redraws its entire contents on every frame while the toolbar and info bar animate, and the cursor blink now runs only on the line that shows a cursor instead of on every line on screen.

Closes #63

## Technical Context

- Root cause: the tap-to-line conversion subtracted a top content padding that was captured during composition, inside a gesture scope whose restart keys did not include it. The workspace's floating bars shrink that padding as they collapse on scroll, so after a collapse the hit test subtracted more than the list was actually laid out with and matched a line above the tap. Compose binds a gesture handler on the first pointer event, and its reset check compares the keys plus the handler's class, which cannot distinguish successive lambdas originating at one call site, so the captured value never refreshed.
- The correction is now derived from the list's live layout instead of being plumbed in, so it cannot go stale. `viewportStartOffset` is the negated top content padding, and item offsets are invariant under a padding change (verified against `LazyListMeasure.kt` and `LazyListMeasuredItem.kt`, not just the KDoc). Two extracted helpers hold the two directions, so the sign lives in one place instead of three.
- The page migration to `rememberFloatingBarContentPadding` and the hit-test change are coupled and have to land together: with the lazily resolving instance in place but the old composition-time read still present, that read would freeze at its first value, turning an intermittent wrong-line bug into a permanent one.
- A reviewer proposed folding the padding into the selection handle's existing async snapshot, so that both components come from a single layout generation. That was investigated and rejected: item offsets are padding-invariant, so the live read is exact during a collapse, whereas the folded version would lag a frame and jump roughly 60-80dp at the toolbar's content swap, which is the failure it was meant to prevent.
- Worth close review: the sign at the two selection-handle sites. An inversion displaces the handle by twice the padding and is completely silent, which is why the conversion helpers and their round-trip test exist. Manual testing on an Android 17 emulator matching the reporter's device covered what CI cannot: after a scroll-driven bar collapse, a tap resolved to exactly the tapped line.
