### PR TITLE
Release: Fix Google Play uploads failing on tagged releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -165,7 +165,7 @@ jobs:
     needs: validate-tag
     if: always() && (needs.validate-tag.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
-    environment: gplay-production
+    environment: gplay-production-upload
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/fastlane/Gemfile
     steps:
@@ -187,6 +187,12 @@ jobs:
           mkdir -p "${TMP_SERVICEKEY_DIR}"
           TMP_SERVICEKEY_FILE_PATH="${TMP_SERVICEKEY_DIR}"/service_account.json
           echo $ENCODED_SERVICE_KEY | base64 -di > "${TMP_SERVICEKEY_FILE_PATH}"
+          # An unset secret decodes to an empty file and exits 0, so the failure would
+          # otherwise only surface in supply after the bundle build.
+          if ! jq -e . "${TMP_SERVICEKEY_FILE_PATH}" >/dev/null 2>&1; then
+            echo "::error::GPLAY_SERVICE_ACCOUNT_KEY_JSON_BASE64 is missing or not valid base64-encoded JSON in this environment." >&2
+            exit 1
+          fi
           echo "SUPPLY_JSON_KEY=$(echo $TMP_SERVICEKEY_FILE_PATH)" >> $GITHUB_ENV
 
       - name: Checkout source code


### PR DESCRIPTION
## What changed

No user-facing behavior change.

Cutting a release tag could not have delivered a build to Google Play. The job that uploads the app bundle to the closed testing track looked for the Play service-account credentials in a deployment environment that does not hold them, so the upload would have failed on every tag. It now reads them from the environment where they actually live, and a missing credential is reported straight away instead of ten minutes into the build.

## Technical Context

- Root cause: `release-gplay` declared `environment: gplay-production`, but `GPLAY_SERVICE_ACCOUNT_KEY_JSON_BASE64` is only defined on `gplay-production-upload`. Both environments carry the same four keystore secret names and identical protection rules (required reviewer, `main` + `v*` tag policy), so nothing in the workflow file hinted at the mismatch.
- The failure would have surfaced late and misleadingly. An undefined secret expands to an empty string, and piping that into `base64 -di` writes a zero-byte file and exits 0, so the decode step went green. `supply` then rejected the empty file with "doesn't seem to be a JSON file", after `bundleGplayBeta` had already spent the full build.
- The decode step now validates the result with `jq` and fails with a named `::error::` annotation, so a future environment or secret mistake fails in seconds rather than after a build.
- Worth a close look: the environment switch also changes where the *signing* secrets come from, since `SIGNING_KEYSTORE_BASE64` / `KEY_ALIAS` / `STORE_PASSWORD` / `KEY_PASSWORD` exist under both names. Their values are not readable from the API, so this assumes both environments hold the same upload keystore. If they diverge, the AAB gets signed with the wrong key and Play rejects it.
- This job has never run to completion, so the change is unproven end to end: on `v0.1.0-beta0` the GitHub release job succeeded and the Play job was rejected at the approval gate before reaching the decode step. `gplay-production` is now referenced by no workflow.
