### PR TITLE
Workspace: Explain the add-tab button's long-press shortcut

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceSettings.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceSettings.kt
@@ -32,8 +32,6 @@ class WorkspaceSettings @Inject constructor(
 
     val showTipBadgeExplanation = dataStore.createValue("workspace.manager.tip.badgeexplanation.show", true)
 
-    val showTipFabLongPress = dataStore.createValue("workspace.manager.tip.addtablongpress.show", true)
-
     val swipeGesturesEnabled = dataStore.createValue("workspace.swipe.gestures.enabled", true)
 
     val onDemandWorkspaceCreation = dataStore.createValue("workspace.swipe.ondemand.enabled", true)
@@ -59,7 +57,6 @@ class WorkspaceSettings @Inject constructor(
     override val mapper = PreferenceStoreMapper(
         debugSettings.isDebugMode,
         showTipBadgeExplanation,
-        showTipFabLongPress,
         swipeGesturesEnabled,
         onDemandWorkspaceCreation,
         livePreview,

--- a/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
@@ -470,7 +470,6 @@ private fun WorkspaceManagerBody() {
                 ),
             ),
             showBadgeExplanation = false,
-            showLongPressHint = false,
             operationsCount = 2,
             attentionCount = 1,
         ),
@@ -483,7 +482,6 @@ private fun WorkspaceManagerBody() {
         onQuickCreate = {},
         onNavigateBack = {},
         onDismissBadgeExplanation = {},
-        onDismissLongPressHint = {},
         onCloseAllWorkspaces = {},
     )
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerFAB.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerFAB.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Close
@@ -15,17 +14,12 @@ import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,9 +34,10 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.asComposable
+import eu.darken.butler.common.compose.tour.guidedTourTarget
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
-import kotlinx.coroutines.launch
 
 @Composable
 fun WorkspaceManagerFAB(
@@ -52,75 +47,37 @@ fun WorkspaceManagerFAB(
     onQuickCreate: (QuickCreateItem) -> Unit,
     onShowCloseAllDialog: () -> Unit,
     modifier: Modifier = Modifier,
-    showLongPressHint: Boolean = true,
-    onDismissLongPressHint: () -> Unit = {},
 ) {
     var showDropdown by remember { mutableStateOf(false) }
-    var showLongPressHintThisSession by remember { mutableStateOf(showLongPressHint) }
     val hapticFeedback = LocalHapticFeedback.current
-    val tooltipState = rememberTooltipState(isPersistent = true)
-    val scope = rememberCoroutineScope()
 
     Box(modifier = modifier) {
-        TooltipBox(
-            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(
-                spacingBetweenTooltipAndAnchor = 16.dp
-            ),
-            tooltip = {
-                PlainTooltip(
-                    modifier = Modifier.widthIn(max = 280.dp)
-                ) {
-                    Text(stringResource(R.string.workspace_fab_longpress_hint))
-                }
-            },
-            state = tooltipState,
-            enableUserInput = false,
+        Surface(
+            modifier = Modifier.guidedTourTarget(WorkspaceManagerTour.ADD_TAB_TARGET),
+            shape = FloatingActionButtonDefaults.extendedFabShape,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            tonalElevation = 6.dp,
+            shadowElevation = 6.dp,
         ) {
-            Surface(
-                shape = FloatingActionButtonDefaults.extendedFabShape,
-                color = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                tonalElevation = 6.dp,
-                shadowElevation = 6.dp,
-            ) {
-                Row(
-                    modifier = Modifier
-                        .combinedClickable(
-                            onClick = {
-                                if (showLongPressHint) {
-                                    if (showLongPressHintThisSession) {
-                                        scope.launch { tooltipState.show() }
-                                        showLongPressHintThisSession = false
-                                    } else {
-                                        onDismissLongPressHint()
-                                        scope.launch { tooltipState.dismiss() }
-                                    }
-                                }
-                                // Always execute action
-                                onCreateWorkspace(Workspace.Type.TEMPLATES)
-                            },
-                            onLongClick = {
-                                // Long press: dismiss tooltip if showing, show dropdown
-                                if (showLongPressHint) {
-                                    onDismissLongPressHint()
-                                    scope.launch { tooltipState.dismiss() }
-                                    showLongPressHintThisSession = false
-                                }
-
-                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                showDropdown = true
-                            }
-                        )
-                        .padding(horizontal = 16.dp, vertical = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.TwoTone.Add,
-                        contentDescription = null
+            Row(
+                modifier = Modifier
+                    .combinedClickable(
+                        onClick = { onCreateWorkspace(Workspace.Type.TEMPLATES) },
+                        onLongClick = {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            showDropdown = true
+                        }
                     )
-                    Text(stringResource(R.string.workspace_fab_add_workspace))
-                }
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.Add,
+                    contentDescription = null
+                )
+                Text(stringResource(R.string.workspace_fab_add_workspace))
             }
         }
 
@@ -178,7 +135,5 @@ private fun WorkspaceManagerFABPreview() {
         onCreateWorkspace = {},
         onQuickCreate = {},
         onShowCloseAllDialog = {},
-        showLongPressHint = true,
-        onDismissLongPressHint = {}
     )
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
@@ -55,7 +55,6 @@ fun WorkspaceManagerScreen(
     onQuickCreate: (QuickCreateItem) -> Unit,
     onNavigateBack: () -> Unit,
     onDismissBadgeExplanation: () -> Unit,
-    onDismissLongPressHint: () -> Unit,
     onCloseAllWorkspaces: () -> Unit,
     onRenameWorkspace: (Workspace.Id, String?) -> Unit = { _, _ -> },
     onTabsClick: () -> Unit = {},
@@ -131,8 +130,6 @@ fun WorkspaceManagerScreen(
                         onCreateWorkspace = onCreateWorkspace,
                         onQuickCreate = onQuickCreate,
                         onShowCloseAllDialog = { showCloseAllDialog = true },
-                        showLongPressHint = state.showLongPressHint,
-                        onDismissLongPressHint = onDismissLongPressHint
                     )
                 }
             }
@@ -241,7 +238,6 @@ private fun WorkspaceManagerScreenPreview() {
         onQuickCreate = {},
         onNavigateBack = {},
         onDismissBadgeExplanation = {},
-        onDismissLongPressHint = {},
         onCloseAllWorkspaces = {}
     )
 }
@@ -265,7 +261,6 @@ private fun WorkspaceManagerScreenEmptyPreview() {
         onQuickCreate = {},
         onNavigateBack = {},
         onDismissBadgeExplanation = {},
-        onDismissLongPressHint = {},
         onCloseAllWorkspaces = {}
     )
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -50,13 +50,12 @@ class WorkspaceManagerViewModel @Inject constructor(
     val state = combine(
         workspaceRepo.state,
         workspaceSettings.showTipBadgeExplanation.flow,
-        workspaceSettings.showTipFabLongPress.flow,
         workspaceSettings.livePreview.flow,
         workspacePageManager.state,
         filterOperationsFlow,
         filterAttentionFlow,
         quickCreateItems,
-    ) { repoState, showBadge, showFabLongPressHint, livePreview, pageManagerState, filterOps, filterAtt, quickCreate ->
+    ) { repoState, showBadge, livePreview, pageManagerState, filterOps, filterAtt, quickCreate ->
         val stacks = WorkspaceStacks(repoState.infos)
         val focusedId = pageManagerState.focusedWorkspaceId
         val topChains = stacks.topChainByRoot(focusedId)
@@ -95,7 +94,6 @@ class WorkspaceManagerViewModel @Inject constructor(
             },
             useLivePreview = livePreview,
             showBadgeExplanation = showBadge,
-            showLongPressHint = showFabLongPressHint,
             operationsCount = repoState.operationCount,
             attentionCount = repoState.attentionCount,
             currentPaneCount = pageManagerState.currentPaneCount,
@@ -236,10 +234,6 @@ class WorkspaceManagerViewModel @Inject constructor(
         workspaceSettings.showTipBadgeExplanation.value(false)
     }
 
-    fun dismissLongPressHint() = launch {
-        workspaceSettings.showTipFabLongPress.value(false)
-    }
-
     fun closeAllWorkspaces() = launch {
         log(tag) { "closeAllWorkspaces()" }
         workspaceRepo.execute(WorkspaceAction.CloseAll)
@@ -269,7 +263,6 @@ class WorkspaceManagerViewModel @Inject constructor(
     data class State(
         val workspaces: List<WorkspaceItem> = emptyList(),
         val showBadgeExplanation: Boolean = true,
-        val showLongPressHint: Boolean = true,
         val useLivePreview: Boolean = true,
         val operationsCount: Int = 0,
         val attentionCount: Int = 0,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTour.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTour.kt
@@ -1,0 +1,34 @@
+package eu.darken.butler.workspace.ui.manager.tour
+
+import eu.darken.butler.R
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.tour.GuidedTour
+import eu.darken.butler.common.compose.tour.TourDefinition
+import eu.darken.butler.common.compose.tour.TourId
+import eu.darken.butler.common.compose.tour.TourStep
+
+/**
+ * Points at the tab manager's add-tab button, whose long-press shortcut is otherwise unadvertised.
+ *
+ * No `prepareTarget`: the button hides itself while the grid scrolls down, but the overlay always
+ * opens unscrolled, so the anchor is registered by the time the tour starts.
+ */
+object WorkspaceManagerTour : GuidedTour {
+
+    override val id: TourId = TourId("tour.workspace.manager")
+
+    const val ADD_TAB_TARGET = "workspaceManager.addTab"
+
+    val definition: TourDefinition = TourDefinition(
+        id = id,
+        clickProtection = true,
+        steps = listOf(
+            TourStep(
+                stepId = "addTab",
+                targetId = ADD_TAB_TARGET,
+                title = R.string.tour_manager_add_tab_title.toCaString(),
+                body = R.string.tour_manager_add_tab_body.toCaString(),
+            ),
+        ),
+    )
+}

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -50,6 +50,7 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceButtonViewModel
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerScreen
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
+import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
 import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.manager.rememberWindowSizeInfo
 import eu.darken.butler.workspace.ui.scroll.LocalWorkspaceScrollPositions
@@ -335,6 +336,19 @@ fun WorkspacesScreenHost(
         }
     }
 
+    val tourController = LocalGuidedTourController.current
+    // Gated on the manager's own state, not just the overlay flag: a restored session makes the
+    // overlay visible before that state arrives, and the manager - with the tour's only anchor -
+    // is composed no earlier than the state is non-null. A tour started in that window finds no
+    // anchor, grace-skips its single step, and suppresses itself for the rest of the process.
+    val managerTourReady = pageManagerState.isManagerOverlayVisible && managerState != null
+    LaunchedEffect(managerTourReady) {
+        if (!managerTourReady) return@LaunchedEffect
+        // No attempted-flag: this key already runs the body once per open, and tryStart itself
+        // refuses a tour that is completed, dismissed, or skipped this process.
+        tourController.tryStart(WorkspaceManagerTour.definition)
+    }
+
     ManagerOverlayBackHandler(
         isOverlayVisible = pageManagerState.isManagerOverlayVisible,
         onDismiss = { vm.workspacePageManager.hideManagerOverlay() },
@@ -384,7 +398,6 @@ fun WorkspacesScreenHost(
                     onQuickCreate = managerVm::createWorkspace,
                     onNavigateBack = managerVm::navigateBack,
                     onDismissBadgeExplanation = managerVm::dismissBadgeExplanation,
-                    onDismissLongPressHint = managerVm::dismissLongPressHint,
                     onCloseAllWorkspaces = managerVm::closeAllWorkspaces,
                     onRenameWorkspace = managerVm::renameWorkspace,
                     onTabsClick = managerVm::clearFilters,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@
     <!-- Workspace > Guided tour -->
     <string name="tour_first_tab_title">Start with a tab</string>
     <string name="tour_first_tab_body">Butler works in tabs, like a browser: each one is a tool of its own — Explorer, Searcher, Editor, and more. Create your first tab.</string>
+    <string name="tour_manager_add_tab_title">Add a tab</string>
+    <string name="tour_manager_add_tab_body">Tap this to pick a tool for a new tab. Long-press it instead for a shortcut list of the tools you use most, and for closing every tab at once.</string>
 
     <string name="workspace_creating_placeholder">Creating tab…</string>
     <string name="workspace_ondemand_swipe_title">Swipe to create new tab</string>
@@ -342,7 +344,6 @@
     <!-- Workspace Manager FAB -->
     <string name="workspace_fab_add_workspace">Add tab</string>
     <string name="workspace_fab_close_all">Close all tabs</string>
-    <string name="workspace_fab_longpress_hint">Tip: Long-press for quick access to all tab types</string>
 
     <!-- Workspace Navigation Rail -->
     <string name="workspace_pane_assign_action">Assign to pane %1$d</string>

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
@@ -51,7 +51,6 @@ class WorkspaceManagerViewModelTest : BaseTest() {
         }
         workspaceSettings = mockk(relaxed = true) {
             every { showTipBadgeExplanation } returns mockk { every { flow } returns flowOf(false) }
-            every { showTipFabLongPress } returns mockk { every { flow } returns flowOf(false) }
             every { livePreview } returns mockk { every { flow } returns flowOf(true) }
         }
         workspacePageManager = mockk(relaxed = true) {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTourTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTourTest.kt
@@ -1,0 +1,40 @@
+package eu.darken.butler.workspace.ui.manager.tour
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The tour id is persisted as "completed", and the target id has to match the one the manager's FAB
+ * registers — a drift in either silently turns the tour into a no-op or replays it.
+ */
+class WorkspaceManagerTourTest : BaseTest() {
+
+    private val definition = WorkspaceManagerTour.definition
+
+    @Test
+    fun `the tour id is stable`() {
+        WorkspaceManagerTour.id.raw shouldBe "tour.workspace.manager"
+        definition.id shouldBe WorkspaceManagerTour.id
+    }
+
+    @Test
+    fun `a single step anchors on the add-tab target`() {
+        definition.steps.size shouldBe 1
+        definition.steps.single().let {
+            it.stepId shouldBe "addTab"
+            it.targetId shouldBe WorkspaceManagerTour.ADD_TAB_TARGET
+        }
+        WorkspaceManagerTour.ADD_TAB_TARGET shouldBe "workspaceManager.addTab"
+    }
+
+    @Test
+    fun `the step needs no prepareTarget because the overlay opens unscrolled`() {
+        definition.steps.single().prepareTarget shouldBe null
+    }
+
+    @Test
+    fun `click protection is on so the highlighted button cannot be tapped through the scrim`() {
+        definition.clickProtection shouldBe true
+    }
+}


### PR DESCRIPTION
## What changed

The add-tab button in the tab manager opens a shortcut menu when you long-press it, listing the tools you use most and an option to close every tab at once. Nothing told you that.

There was a hint, but it only appeared after you tapped the button, so it required tapping the very control whose second gesture it was describing. Long-pressing the button marked the hint as seen without ever showing it, which meant anyone who stumbled onto the gesture lost the explanation permanently.

Opening the tab manager now runs a short guided tour that points at the button and explains both gestures. Like the other tours it can be skipped, dismissed for good, or turned off entirely, and Settings → Reset guided tours brings it back.

## Technical Context

- The tab manager had two ad-hoc onboarding widgets with their own `workspace.manager.tip.*` DataStore keys: a dismissible card and a programmatic persistent tooltip on the FAB. Neither had a reset path or an opt-out, so once the key flipped the lesson was unreachable. This moves the FAB half onto the guided-tour framework, which already provides all of that.
- The badge-explanation card is deliberately left alone rather than migrated. Its subject is the Butler button's badges, and the tab manager renders no Butler button, so a tour step would have nothing to anchor on. It also carries a colour-matched chip legend that a text-only tour bubble cannot express.
- Worth a close read: the tour start in `WorkspacesScreen` is gated on `managerState != null`, not only on overlay visibility. A restored session flips the visibility flag before the manager's state arrives, and the manager holds the tour's only anchor, so starting in that window would grace-skip the single step and suppress the tour for the rest of the process.
- `workspace.manager.tip.addtablongpress.show` is dropped without migrating it into the tour's completed state, so users who previously dismissed the old hint will see the tour once. That key is not a trustworthy record of who learned the gesture, since the long-press path wrote `false` without displaying anything; honouring it would deny the replacement to exactly the users the old code shortchanged.
