### PR TITLE
Workspace: Show where an operation put your files

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/InfoBlock.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/InfoBlock.kt
@@ -25,7 +25,11 @@ data class InfoEntry(
     val value: String,
     val pairable: Boolean,
     val valueMaxLines: Int = 2,
-)
+    val valueStyle: ValueStyle = ValueStyle.DEFAULT,
+) {
+    /** [PATH] pins the value to a single line so the trailing file name survives truncation. */
+    enum class ValueStyle { DEFAULT, PATH }
+}
 
 /** Groups consecutive pairable entries two-per-row; non-pairable entries get a row of their own. */
 fun groupInfoEntries(entries: List<InfoEntry>): List<List<InfoEntry>> {
@@ -65,15 +69,17 @@ fun InfoBlock(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+        val isPath = entry.valueStyle == InfoEntry.ValueStyle.PATH
         val value: @Composable () -> Unit = {
             Text(
                 text = entry.value,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface,
                 fontWeight = FontWeight.Medium,
-                // Plain ellipsis: MiddleEllipsis degrades to clipping on multiline Android text.
-                maxLines = entry.valueMaxLines,
-                overflow = TextOverflow.Ellipsis,
+                // MiddleEllipsis degrades to clipping on multiline Android text, so it only ever
+                // pairs with maxLines = 1 and [valueMaxLines] does not apply to it.
+                maxLines = if (isPath) 1 else entry.valueMaxLines,
+                overflow = if (isPath) TextOverflow.MiddleEllipsis else TextOverflow.Ellipsis,
             )
         }
         if (valueLeading != null) {
@@ -135,6 +141,23 @@ private fun InfoBlockUncappedValuePreview() {
             value = "Moved 12 files, moved 3 folders, skipped 2 files, overwrote 1 file",
             pairable = false,
             valueMaxLines = Int.MAX_VALUE,
+        ),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun InfoBlockPathValuePreview() {
+    InfoBlock(
+        modifier = Modifier
+            .width(320.dp)
+            .padding(16.dp),
+        entry = InfoEntry(
+            label = "Destination path",
+            value = "/storage/emulated/0/Documents/Projects/Archive/2026/Quarter-01/reports/final-report.pdf",
+            pairable = false,
+            valueStyle = InfoEntry.ValueStyle.PATH,
         ),
     )
 }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/EditorWorkspace.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/EditorWorkspace.kt
@@ -618,7 +618,7 @@ class EditorWorkspace @AssistedInject constructor(
 
     suspend fun saveFile() {
         // TODO: Wrap as an Operation submitted via OperationsManager so editor saves appear in
-        // the global Operation History (kind = SAVE, intendedPaths = [filePath]). Same applies to
+        // the global Operation History (kind = SAVE, pathPlan targets = [filePath]). Same applies to
         // auto-save call sites. Out of scope for History v1.
         // Progress is emitted by EditorEngine during save
         saveMutex.withLock { currentEngine().saveFile() }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperation.kt
@@ -28,6 +28,7 @@ import eu.darken.butler.explorer.R
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
@@ -47,6 +48,9 @@ class CompressOperation @AssistedInject constructor(
 
     private val tag = logTag("Explorer", "Workspace", workspaceId.shortTag, "Operation", "Compress")
 
+    /** [ExplorerCommand.Compress.archiveName] already carries the format's extension. */
+    private val outputPath = command.destinationDir.child(command.archiveName)
+
     override val metadata: Operation.Metadata = object : Operation.Metadata {
         override val origin = Operation.Metadata.Origin.Explorer(workspaceId)
         override val icon: ImageVector = Icons.TwoTone.Compress
@@ -60,7 +64,13 @@ class CompressOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.COMPRESS
-        override val intendedPaths = command.sources + command.destinationDir
+        override val pathPlan = OperationPathPlan(
+            targets = command.sources.toList(),
+            destination = OperationPathPlan.Destination.RequestedTarget(outputPath),
+            // The archive itself is already indexed as a reported change; keeping the directory as
+            // the scope candidate is what puts its parent in the attempted-paths rows.
+            scopePaths = command.sources.toList() + command.destinationDir,
+        )
     }
 
     override fun perform(operationContext: Operation.Context): Flow<State> = channelFlow {
@@ -87,8 +97,6 @@ class CompressOperation @AssistedInject constructor(
     ) {
         var stateActive = State.Active(startedAt = operationContext.startedAt)
         send(stateActive)
-
-        val outputPath = command.destinationDir.child(command.archiveName)
 
         // Never let the growing archive become one of its own inputs.
         command.sources.forEach { source ->

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperation.kt
@@ -23,6 +23,7 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.buildTransferProgressMetrics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -64,7 +65,10 @@ class CopyOperation @AssistedInject constructor(
         }
         override val kind = Operation.Metadata.Kind.COPY
         override val intent = command.intent
-        override val intendedPaths = command.sources + command.destination
+        override val pathPlan = OperationPathPlan(
+            targets = command.sources.toList(),
+            destination = OperationPathPlan.Destination.Container(command.destination),
+        )
     }
 
     override fun perform(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperation.kt
@@ -52,14 +52,14 @@ class CopyOperation @AssistedInject constructor(
                     R.string.explorer_operation_copy_description_single,
                     source.name,
                     source.parent?.userReadablePath?.get(cx) ?: source.userReadablePath.get(cx),
-                    command.destination.userReadablePath.get(cx)
+                    command.destination.path.userReadablePath.get(cx)
                 )
             } else {
                 cx.getQuantityString2(
                     R.plurals.explorer_operation_copy_description,
                     command.sources.size,
                     command.sources.size,
-                    command.destination.userReadablePath.get(cx)
+                    command.destination.path.userReadablePath.get(cx)
                 )
             }
         }
@@ -67,7 +67,7 @@ class CopyOperation @AssistedInject constructor(
         override val intent = command.intent
         override val pathPlan = OperationPathPlan(
             targets = command.sources.toList(),
-            destination = OperationPathPlan.Destination.Container(command.destination),
+            destination = command.destination,
         )
     }
 
@@ -85,7 +85,7 @@ class CopyOperation @AssistedInject constructor(
         val result = command.sources
             .copy(
                 gateway = gatewaySwitch,
-                destination = command.destination,
+                destination = command.destination.path,
                 options = CopyAction.Options(
                     preserveAttributes = command.options.preserveAttributes,
                     followSymlinks = command.options.followSymlinks,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperation.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.last
@@ -58,7 +59,9 @@ class CreateOperation @AssistedInject constructor(
             ExplorerCommand.Create.Type.FILE -> Operation.Metadata.Kind.CREATE_FILE
             ExplorerCommand.Create.Type.DIRECTORY -> Operation.Metadata.Kind.CREATE_FOLDER
         }
-        override val intendedPaths = setOf(command.parentPath.child(command.name))
+        override val pathPlan = OperationPathPlan(
+            targets = listOf(command.parentPath.child(command.name)),
+        )
     }
 
     override fun perform(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperation.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.last
@@ -48,7 +49,9 @@ class CreateTextFileOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.CREATE_FILE
-        override val intendedPaths = setOf(command.path)
+        override val pathPlan = OperationPathPlan(
+            targets = listOf(command.path),
+        )
     }
 
     override fun perform(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperation.kt
@@ -17,6 +17,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.CoreDeleteExecutor
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.onEach
@@ -54,7 +55,9 @@ class DeleteOperation @AssistedInject constructor(
             }
         }
         override val kind = Operation.Metadata.Kind.DELETE
-        override val intendedPaths = command.targets
+        override val pathPlan = OperationPathPlan(
+            targets = command.targets.toList(),
+        )
     }
 
     override fun perform(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperation.kt
@@ -23,6 +23,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -59,7 +60,10 @@ class DownloadLocalCopyOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.COPY
-        override val intendedPaths = listOf(command.source, command.destinationDir)
+        override val pathPlan = OperationPathPlan(
+            targets = listOf(command.source),
+            destination = OperationPathPlan.Destination.Container(command.destinationDir),
+        )
     }
 
     override fun perform(operationContext: Operation.Context): Flow<State> = channelFlow {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExplorerCommand.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExplorerCommand.kt
@@ -4,6 +4,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.archive.ArchiveFormat
 import eu.darken.butler.common.files.archive.CompressionPreset
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlin.uuid.Uuid
 
 sealed interface ExplorerCommand {
@@ -31,7 +32,7 @@ sealed interface ExplorerCommand {
 
     data class Copy(
         val sources: Set<APath<*>>,
-        val destination: APath<*>,
+        val destination: OperationPathPlan.Destination,
         val options: Options = Options(),
         /**
          * Optional semantic intent override surfaced in operation history
@@ -47,7 +48,7 @@ sealed interface ExplorerCommand {
 
     data class Move(
         val sources: Set<APath<*>>,
-        val destination: APath<*>,
+        val destination: OperationPathPlan.Destination,
         val options: Options = Options(),
         /**
          * Optional semantic intent override surfaced in operation history

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExplorerCommand.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExplorerCommand.kt
@@ -124,7 +124,7 @@ sealed interface ExplorerCommand {
     data class Restore(
         val rootItemIds: Set<Uuid> = emptySet(),
         val nestedItems: List<NestedTarget> = emptyList(),
-        val intendedPaths: List<APath<*>>,
+        val restoredPaths: List<APath<*>>,
     ) : ExplorerCommand {
         data class NestedTarget(
             val parentId: Uuid,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperation.kt
@@ -34,6 +34,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.ProducerScope
@@ -68,7 +69,10 @@ class ExtractOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.EXTRACT
-        override val intendedPaths = listOf(command.archive, command.destinationDir)
+        override val pathPlan = OperationPathPlan(
+            targets = listOf(command.archive),
+            destination = OperationPathPlan.Destination.Container(command.destinationDir),
+        )
     }
 
     override fun perform(operationContext: Operation.Context): Flow<State> = channelFlow {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperation.kt
@@ -52,14 +52,14 @@ class MoveOperation @AssistedInject constructor(
                     R.string.explorer_operation_move_description_single,
                     source.name,
                     source.parent?.userReadablePath?.get(cx) ?: source.userReadablePath.get(cx),
-                    command.destination.userReadablePath.get(cx)
+                    command.destination.path.userReadablePath.get(cx)
                 )
             } else {
                 cx.getQuantityString2(
                     R.plurals.explorer_operation_move_description,
                     command.sources.size,
                     command.sources.size,
-                    command.destination.userReadablePath.get(cx)
+                    command.destination.path.userReadablePath.get(cx)
                 )
             }
         }
@@ -67,7 +67,7 @@ class MoveOperation @AssistedInject constructor(
         override val intent = command.intent
         override val pathPlan = OperationPathPlan(
             targets = command.sources.toList(),
-            destination = OperationPathPlan.Destination.Container(command.destination),
+            destination = command.destination,
         )
     }
 
@@ -85,7 +85,7 @@ class MoveOperation @AssistedInject constructor(
         val result = command.sources
             .move(
                 gateway = gatewaySwitch,
-                destination = command.destination,
+                destination = command.destination.path,
                 options = MoveAction.Options(
                     preserveAttributes = command.options.preserveAttributes,
                 ),

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperation.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.buildTransferProgressMetrics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -64,7 +65,10 @@ class MoveOperation @AssistedInject constructor(
         }
         override val kind = Operation.Metadata.Kind.MOVE
         override val intent = command.intent
-        override val intendedPaths = command.sources + command.destination
+        override val pathPlan = OperationPathPlan(
+            targets = command.sources.toList(),
+            destination = OperationPathPlan.Destination.Container(command.destination),
+        )
     }
 
     override fun perform(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/RestoreOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/RestoreOperation.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.common.trash.TrashRepo
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 
@@ -41,7 +42,7 @@ class RestoreOperation @AssistedInject constructor(
         override val icon: ImageVector = Icons.TwoTone.Restore
         override val title = eu.darken.butler.workspace.R.string.workspace_operation_restore_title.toCaString()
         override val description = caString { cx ->
-            val count = command.intendedPaths.size
+            val count = command.restoredPaths.size
             cx.getQuantityString2(
                 eu.darken.butler.workspace.R.plurals.workspace_operation_restore_description,
                 count,
@@ -49,7 +50,9 @@ class RestoreOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.RESTORE
-        override val intendedPaths = command.intendedPaths
+        override val pathPlan = OperationPathPlan(
+            targets = command.restoredPaths,
+        )
     }
 
     data class Report(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerTrashController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerTrashController.kt
@@ -35,7 +35,7 @@ class ExplorerTrashController(
         restoreViaOperation(
             command = ExplorerCommand.Restore(
                 rootItemIds = items.map { it.itemId }.toSet(),
-                intendedPaths = items.map { it.originalLookup.lookedUp },
+                restoredPaths = items.map { it.originalLookup.lookedUp },
             ),
         )
     }
@@ -119,7 +119,7 @@ class ExplorerTrashController(
                         relativePath = it.relativePath,
                     )
                 },
-                intendedPaths = items.map { it.originalRestoredPath },
+                restoredPaths = items.map { it.originalRestoredPath },
             ),
         )
     }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -103,6 +103,7 @@ import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.core.clipboard.ClipboardRepo
 import eu.darken.butler.workspace.core.clipboard.ClipboardSettings
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.OperationFocusRequest
 import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
 import eu.darken.butler.workspace.core.returnResult
@@ -1434,7 +1435,9 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         getWorkspace().execute(
             ExplorerCommand.Move(
                 sources = setOf(result.item),
-                destination = currentLocation.path.child(result.newName),
+                destination = OperationPathPlan.Destination.RequestedTarget(
+                    currentLocation.path.child(result.newName),
+                ),
                 intent = Operation.Metadata.Intent.RENAME,
             )
         )
@@ -1581,12 +1584,12 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                     val command = when (clip.mode) {
                         ClipboardClip.Paths.Mode.COPY -> ExplorerCommand.Copy(
                             sources = clip.paths.map { it.lookedUp }.toSet(),
-                            destination = currentLocation.path,
+                            destination = OperationPathPlan.Destination.Container(currentLocation.path),
                             intent = Operation.Metadata.Intent.PASTE_COPY,
                         )
                         ClipboardClip.Paths.Mode.CUT -> ExplorerCommand.Move(
                             sources = clip.paths.map { it.lookedUp }.toSet(),
-                            destination = currentLocation.path,
+                            destination = OperationPathPlan.Destination.Container(currentLocation.path),
                             intent = Operation.Metadata.Intent.PASTE_MOVE,
                         )
                     }
@@ -1678,13 +1681,13 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         val command = if (move) {
             ExplorerCommand.Move(
                 sources = sources,
-                destination = target,
+                destination = OperationPathPlan.Destination.Container(target),
                 intent = Operation.Metadata.Intent.DROP_MOVE,
             )
         } else {
             ExplorerCommand.Copy(
                 sources = sources,
-                destination = target,
+                destination = OperationPathPlan.Destination.Container(target),
                 intent = Operation.Metadata.Intent.DROP_COPY,
             )
         }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CompressOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CompressOperationTest.kt
@@ -17,9 +17,11 @@ import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -227,5 +229,28 @@ class CompressOperationTest : BaseTest() {
         val password = "hunter2".toCharArray()
         operation(command(password)).onDiscarded()
         password.all { it == Char(0) } shouldBe true
+    }
+
+    @Test
+    fun `the path plan points at the archive while the scope keeps the destination folder`() {
+        val plan = operation(command()).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(sourcePath)
+        plan.destination shouldBe OperationPathPlan.Destination.RequestedTarget(outputPath)
+        plan.scopePaths shouldContainExactly listOf(sourcePath, destinationDir)
+        plan.representativePath shouldBe sourcePath
+    }
+
+    @Test
+    fun `an alias extension is not doubled onto the archive path`() {
+        val aliased = ExplorerCommand.Compress(
+            sources = setOf(sourcePath),
+            destinationDir = destinationDir,
+            archiveName = "out.tgz",
+            format = ArchiveFormat.TAR_GZ,
+        )
+
+        operation(aliased).metadata.pathPlan!!.destination shouldBe
+            OperationPathPlan.Destination.RequestedTarget(destinationDir.child("out.tgz"))
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
@@ -13,7 +13,9 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemEvent
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -141,5 +143,14 @@ class CreateTextFileOperationTest : BaseTest() {
             it.change shouldBe Operation.Report.PathChange.Change.ADDED
         }
         events.single().shouldBeInstanceOf<FileSystemEvent.Added>().paths.single().lookedUp shouldBe renamedPath
+    }
+
+    @Test
+    fun `the path plan targets the file being created`() {
+        val plan = operation(mockk(), FileSystemHinter()).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(requestedPath)
+        plan.destination shouldBe null
+        plan.scopePaths shouldContainExactly listOf(requestedPath)
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperationTest.kt
@@ -15,8 +15,10 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -216,5 +218,14 @@ class DownloadLocalCopyOperationTest : BaseTest() {
         moves.shouldBeEmpty()
         // Nothing was destroyed, so the temp is a discardable orphan and gets cleaned up.
         coVerify { gatewaySwitch.delete(match<APath<*>> { it.name.endsWith(".part") }, any<Boolean>()) }
+    }
+
+    @Test
+    fun `the path plan targets the source and lands in the destination folder`() {
+        val plan = operation().metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(sourcePath)
+        plan.destination shouldBe OperationPathPlan.Destination.Container(destDir)
+        plan.scopePaths shouldContainExactly listOf(sourcePath, destDir)
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExplorerOperationPathPlanTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExplorerOperationPathPlanTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.explorer.core.operations
 
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -38,9 +39,13 @@ class ExplorerOperationPathPlanTest : BaseTest() {
     )
 
     @Test
-    fun `a move into a folder keeps the sources as targets and the folder as destination`() {
+    fun `a paste or drop move lands the sources inside the target folder`() {
         val plan = moveOperation(
-            ExplorerCommand.Move(sources = setOf(first, second), destination = folder),
+            ExplorerCommand.Move(
+                sources = setOf(first, second),
+                destination = OperationPathPlan.Destination.Container(folder),
+                intent = Operation.Metadata.Intent.PASTE_MOVE,
+            ),
         ).metadata.pathPlan!!
 
         plan.targets shouldContainExactly listOf(first, second)
@@ -50,14 +55,49 @@ class ExplorerOperationPathPlanTest : BaseTest() {
     }
 
     @Test
-    fun `a copy into a folder keeps the sources as targets and the folder as destination`() {
+    fun `a rename move names the exact path the user asked for`() {
+        val renamed = first.parent!!.child("renamed.txt")
+        val plan = moveOperation(
+            ExplorerCommand.Move(
+                sources = setOf(first),
+                destination = OperationPathPlan.Destination.RequestedTarget(renamed),
+                intent = Operation.Metadata.Intent.RENAME,
+            ),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(first)
+        plan.destination shouldBe OperationPathPlan.Destination.RequestedTarget(renamed)
+        plan.scopePaths shouldContainExactly listOf(first, renamed)
+    }
+
+    @Test
+    fun `a paste or drop copy lands the sources inside the target folder`() {
         val plan = copyOperation(
-            ExplorerCommand.Copy(sources = setOf(first), destination = folder),
+            ExplorerCommand.Copy(
+                sources = setOf(first),
+                destination = OperationPathPlan.Destination.Container(folder),
+                intent = Operation.Metadata.Intent.DROP_COPY,
+            ),
         ).metadata.pathPlan!!
 
         plan.targets shouldContainExactly listOf(first)
         plan.destination shouldBe OperationPathPlan.Destination.Container(folder)
         plan.scopePaths shouldContainExactly listOf(first, folder)
+    }
+
+    @Test
+    fun `the destination path reaches the gateway unchanged whichever kind it is`() {
+        val container = ExplorerCommand.Move(
+            sources = setOf(first),
+            destination = OperationPathPlan.Destination.Container(folder),
+        )
+        val requested = ExplorerCommand.Copy(
+            sources = setOf(first),
+            destination = OperationPathPlan.Destination.RequestedTarget(folder),
+        )
+
+        container.destination.path shouldBe folder
+        requested.destination.path shouldBe folder
     }
 
     @Test

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExplorerOperationPathPlanTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExplorerOperationPathPlanTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.butler.explorer.core.operations
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.Test
+import testhelpers.BaseTest
+
+/**
+ * The path plans of the Explorer producers that have no operation test of their own. Each assertion
+ * is what the history scope index and the details card read.
+ */
+class ExplorerOperationPathPlanTest : BaseTest() {
+
+    private val workspaceId = Workspace.Id()
+    private val first = LocalPath.build("/sdcard/Download/a.txt")
+    private val second = LocalPath.build("/sdcard/Download/b.txt")
+    private val folder = LocalPath.build("/sdcard/Backup")
+
+    private fun moveOperation(command: ExplorerCommand.Move) = MoveOperation(
+        workspaceId = workspaceId,
+        command = command,
+        issueHandler = mockk(),
+        gatewaySwitch = mockk(),
+        dispatcherProvider = mockk(),
+        fileSystemHinter = mockk(),
+    )
+
+    private fun copyOperation(command: ExplorerCommand.Copy) = CopyOperation(
+        workspaceId = workspaceId,
+        command = command,
+        issueHandler = mockk(),
+        gatewaySwitch = mockk(),
+        fileSystemHinter = mockk(),
+    )
+
+    @Test
+    fun `a move into a folder keeps the sources as targets and the folder as destination`() {
+        val plan = moveOperation(
+            ExplorerCommand.Move(sources = setOf(first, second), destination = folder),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(first, second)
+        plan.destination shouldBe OperationPathPlan.Destination.Container(folder)
+        plan.scopePaths shouldContainExactly listOf(first, second, folder)
+        plan.representativePath shouldBe first
+    }
+
+    @Test
+    fun `a copy into a folder keeps the sources as targets and the folder as destination`() {
+        val plan = copyOperation(
+            ExplorerCommand.Copy(sources = setOf(first), destination = folder),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(first)
+        plan.destination shouldBe OperationPathPlan.Destination.Container(folder)
+        plan.scopePaths shouldContainExactly listOf(first, folder)
+    }
+
+    @Test
+    fun `a create targets the path that will exist, not the parent folder`() {
+        val plan = CreateOperation(
+            workspaceId = workspaceId,
+            command = ExplorerCommand.Create(
+                parentPath = folder,
+                name = "notes.txt",
+                type = ExplorerCommand.Create.Type.FILE,
+            ),
+            issueHandler = mockk(),
+            gatewaySwitch = mockk(),
+            dispatcherProvider = mockk(),
+            fileSystemHinter = mockk(),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(folder.child("notes.txt"))
+        plan.destination shouldBe null
+    }
+
+    @Test
+    fun `a delete targets the paths and has no destination`() {
+        val plan = DeleteOperation(
+            workspaceId = workspaceId,
+            command = ExplorerCommand.Delete(targets = setOf(first, second)),
+            issueHandler = mockk(),
+            fileSystemHinter = mockk(),
+            coreDeleteExecutor = mockk(),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(first, second)
+        plan.destination shouldBe null
+        plan.scopePaths shouldContainExactly listOf(first, second)
+    }
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExtractOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExtractOperationTest.kt
@@ -25,8 +25,10 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -394,5 +396,15 @@ class ExtractOperationTest : BaseTest() {
         report.extractedFiles shouldBe 0
         report.skippedEntries shouldContain "sub/evil.txt"
         moves shouldBe emptyList()
+    }
+
+    @Test
+    fun `the path plan targets the archive and lands in the destination folder`() {
+        val plan = operation(command()).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(archivePath)
+        plan.destination shouldBe OperationPathPlan.Destination.Container(destDir)
+        plan.scopePaths shouldContainExactly listOf(archivePath, destDir)
+        plan.representativePath shouldBe archivePath
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/RestoreOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/RestoreOperationTest.kt
@@ -12,7 +12,9 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.filesystem.FileSystemEvent
 import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -79,7 +81,7 @@ class RestoreOperationTest : BaseTest() {
             trashRepo = trashRepo,
             trashManager = trashManager,
             hinter = hinter,
-            command = ExplorerCommand.Restore(rootItemIds = setOf(itemId), intendedPaths = listOf(restoredPath)),
+            command = ExplorerCommand.Restore(rootItemIds = setOf(itemId), restoredPaths = listOf(restoredPath)),
         )
 
         val completed = op.perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
@@ -105,7 +107,7 @@ class RestoreOperationTest : BaseTest() {
         val op = operation(
             trashRepo = trashRepo,
             trashManager = trashManager,
-            command = ExplorerCommand.Restore(rootItemIds = setOf(itemId), intendedPaths = listOf(restoredPath)),
+            command = ExplorerCommand.Restore(rootItemIds = setOf(itemId), restoredPaths = listOf(restoredPath)),
         )
 
         val completed = op.perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
@@ -131,7 +133,7 @@ class RestoreOperationTest : BaseTest() {
                     ExplorerCommand.Restore.NestedTarget(parentId = parentId, relativePath = "a.txt"),
                     ExplorerCommand.Restore.NestedTarget(parentId = parentId, relativePath = "b.txt"),
                 ),
-                intendedPaths = listOf(restoredPath),
+                restoredPaths = listOf(restoredPath),
             ),
         )
 
@@ -141,5 +143,21 @@ class RestoreOperationTest : BaseTest() {
         val report = completed.report.shouldBeInstanceOf<RestoreOperation.Report>()
         report.failedCount shouldBe 2
         report.restoredPaths shouldBe emptySet()
+    }
+
+    @Test
+    fun `the path plan targets the paths being restored`() {
+        val plan = operation(
+            trashRepo = mockk(),
+            trashManager = mockk(),
+            command = ExplorerCommand.Restore(
+                rootItemIds = setOf(Uuid.random()),
+                restoredPaths = listOf(restoredPath),
+            ),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(restoredPath)
+        plan.destination shouldBe null
+        plan.scopePaths shouldContainExactly listOf(restoredPath)
     }
 }

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesOperation.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesOperation.kt
@@ -32,6 +32,7 @@ import eu.darken.butler.saver.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.buildTransferProgressMetrics
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -62,6 +63,8 @@ class SaveFilesOperation @AssistedInject constructor(
         )
     }
 
+    private val plannedFiles = command.sources.map { command.targetDirectory.child(it.filename) }
+
     override val metadata: Operation.Metadata = object : Operation.Metadata {
         override val origin: Operation.Metadata.Origin = Operation.Metadata.Origin.Saver(workspaceId)
         override val icon: ImageVector = Icons.TwoTone.Save
@@ -75,7 +78,13 @@ class SaveFilesOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.SAVE
-        override val intendedPaths = command.sources.map { command.targetDirectory.child(it.filename) }
+        override val pathPlan = OperationPathPlan(
+            targets = plannedFiles,
+            destination = OperationPathPlan.Destination.Container(command.targetDirectory),
+            // The target directory is already the parent of every planned file; promoting it to a
+            // candidate of its own would add ITS parent to the attempted-paths rows.
+            scopePaths = plannedFiles,
+        )
     }
 
     override fun perform(operationContext: Operation.Context): Flow<Operation.State> = channelFlow {

--- a/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/operations/SaveFilesOperationTest.kt
+++ b/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/operations/SaveFilesOperationTest.kt
@@ -16,7 +16,9 @@ import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -146,5 +148,15 @@ class SaveFilesOperationTest : BaseTest() {
         capturedIssues.filterIsInstance<PathActionIssue.InsufficientPermission>()
             .single().exception.shouldBeInstanceOf<WriteException>()
         coVerify(exactly = 0) { gatewaySwitch.createFile(any(), any()) }
+    }
+
+    @Test
+    fun `the path plan targets the files to write and keeps the folder out of the scope`() {
+        val plan = operation().metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(targetPath)
+        plan.destination shouldBe OperationPathPlan.Destination.Container(targetDirectory)
+        plan.scopePaths shouldContainExactly listOf(targetPath)
+        plan.representativePath shouldBe targetPath
     }
 }

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperation.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperation.kt
@@ -17,6 +17,7 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.CoreDeleteExecutor
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.onEach
@@ -54,7 +55,9 @@ class DeleteOperation @AssistedInject constructor(
             }
         }
         override val kind = Operation.Metadata.Kind.DELETE
-        override val intendedPaths = command.targets
+        override val pathPlan = OperationPathPlan(
+            targets = command.targets.toList(),
+        )
     }
 
     override fun perform(

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/core/operations/DeleteOperationPathPlanTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/core/operations/DeleteOperationPathPlanTest.kt
@@ -1,0 +1,31 @@
+package eu.darken.butler.searcher.core.operations
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.Test
+import testhelpers.BaseTest
+
+class DeleteOperationPathPlanTest : BaseTest() {
+
+    private val first = LocalPath.build("/sdcard/Download/a.txt")
+    private val second = LocalPath.build("/sdcard/Download/b.txt")
+
+    @Test
+    fun `a delete targets the paths and has no destination`() {
+        val plan = DeleteOperation(
+            workspaceId = Workspace.Id(),
+            command = SearcherCommand.Delete(targets = setOf(first, second)),
+            issueHandler = mockk(),
+            coreDeleteExecutor = mockk(),
+            fileSystemHinter = mockk(),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(first, second)
+        plan.destination shouldBe null
+        plan.scopePaths shouldContainExactly listOf(first, second)
+        plan.representativePath shouldBe first
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperation.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperation.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
 import eu.darken.butler.workspace.core.operations.CoreDeleteExecutor
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.onEach
@@ -48,7 +49,9 @@ class DeleteOperation @AssistedInject constructor(
             )
         }
         override val kind = Operation.Metadata.Kind.DELETE
-        override val intendedPaths = command.targets
+        override val pathPlan = OperationPathPlan(
+            targets = command.targets.toList(),
+        )
     }
 
     override fun perform(

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/operations/DeleteOperationPathPlanTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/operations/DeleteOperationPathPlanTest.kt
@@ -1,0 +1,30 @@
+package eu.darken.butler.viewer.core.operations
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.Test
+import testhelpers.BaseTest
+
+class DeleteOperationPathPlanTest : BaseTest() {
+
+    private val target = LocalPath.build("/sdcard/Download/a.txt")
+
+    @Test
+    fun `a delete targets the path and has no destination`() {
+        val plan = DeleteOperation(
+            workspaceId = Workspace.Id(),
+            command = ViewerCommand.Delete(targets = setOf(target)),
+            issueHandler = mockk(),
+            coreDeleteExecutor = mockk(),
+            fileSystemHinter = mockk(),
+        ).metadata.pathPlan!!
+
+        plan.targets shouldContainExactly listOf(target)
+        plan.destination shouldBe null
+        plan.scopePaths shouldContainExactly listOf(target)
+        plan.representativePath shouldBe target
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
@@ -51,12 +51,13 @@ interface Operation {
         val intent: Intent? get() = null
 
         /**
-         * Paths the operation INTENDED to act on (sources for Copy/Move/Delete; parent for Create).
-         * Captured at submit time so failed/cancelled ops are still queryable by path scope, even
-         * when [Report.affectedPaths] is null/empty (because nothing was actually completed).
-         * Persistence stores the union of intended + actually-affected paths.
+         * What the operation set out to do, in paths: its targets, an optional destination, and the
+         * per-consumer views ([OperationPathPlan.scopePaths], [OperationPathPlan.representativePath])
+         * derived from them. Captured at submit time so failed/cancelled ops are still queryable by
+         * path scope, even when [Report.affectedPaths] is null/empty (because nothing was actually
+         * completed). Persistence stores the union of planned + actually-affected paths.
          */
-        val intendedPaths: Collection<APath<*>>? get() = null
+        val pathPlan: OperationPathPlan? get() = null
 
         enum class Kind { COPY, MOVE, DELETE, RESTORE, CREATE_FOLDER, CREATE_FILE, SAVE, COMPRESS, EXTRACT }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationPathPlan.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationPathPlan.kt
@@ -1,0 +1,39 @@
+package eu.darken.butler.workspace.core.operations
+
+import eu.darken.butler.common.files.APath
+
+/**
+ * What an operation set out to do, in terms of paths. Each consumer reads its own field instead of
+ * a positional convention over one untyped bag.
+ */
+data class OperationPathPlan(
+    /** What the operation acts ON: sources for copy/move/delete, the created path for create. */
+    val targets: List<APath<*>>,
+    val destination: Destination? = null,
+    /**
+     * History scope index + import-sweeper liveness set. Defaults to targets plus the destination;
+     * producers whose destination must not become a scope candidate of its own override it.
+     */
+    val scopePaths: List<APath<*>> = targets + listOfNotNull(destination?.path),
+    /** History row label fallback, used only when the operation reported no changes. */
+    val representativePath: APath<*>? = targets.firstOrNull() ?: destination?.path,
+) {
+
+    /** Every path the operation relates to, for consumers that want the whole set. */
+    val allPaths: List<APath<*>> get() = scopePaths
+
+    /**
+     * Where the operation puts things. The distinction is what the user asked for, not what the
+     * gateway ends up doing: renaming `foo` to `bar` while `bar` exists as a directory is a
+     * [RequestedTarget] that the filesystem resolves as a move into that directory.
+     */
+    sealed interface Destination {
+        val path: APath<*>
+
+        /** A directory the items land INSIDE. */
+        data class Container(override val path: APath<*>) : Destination
+
+        /** The exact final path the user asked for (rename, move-to-path, archive file). */
+        data class RequestedTarget(override val path: APath<*>) : Destination
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -131,7 +131,7 @@ class OperationHistoryRepo @Inject constructor(
             partialErrorCount = state.report?.partialErrorCount ?: 0,
             pathsTruncated = reportedChanges.size > MAX_PATHS_PER_OP,
             primaryPath = reportedChanges.firstOrNull()?.path
-                ?: metadata.intendedPaths?.firstOrNull()?.userReadablePath?.get(context),
+                ?: metadata.pathPlan?.representativePath?.userReadablePath?.get(context),
         )
 
         dao.insertWithPathsAndTrim(
@@ -223,8 +223,9 @@ class OperationHistoryRepo @Inject constructor(
     }
 
     /**
-     * The search index that backs the path-scope filter: intended paths, reported paths and move
-     * sources, plus every one of their parent directories. Never displayed as a change.
+     * The search index that backs the path-scope filter: the operation's planned scope paths,
+     * reported paths and move sources, plus every one of their parent directories. Never displayed
+     * as a change.
      *
      * Uncapped: a scope only matches a row exactly or as its ancestor prefix, so dropping any path
      * would silently make that path unfilterable - an ancestor row can't stand in for it. The total
@@ -238,7 +239,7 @@ class OperationHistoryRepo @Inject constructor(
         state: Operation.State.Completed,
     ): List<String> {
         val candidates = buildList<APath<*>> {
-            metadata.intendedPaths?.let { addAll(it) }
+            metadata.pathPlan?.let { addAll(it.allPaths) }
             state.report?.affectedPaths?.forEach { change ->
                 add(change.path)
                 change.previousPath?.let { add(it) }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.progress.Progress
 import eu.darken.butler.workspace.core.operations.ManagedOperation
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Instant
 
@@ -18,6 +19,7 @@ data class OperationDisplay(
     val description: CaString,
     val state: State = State.Queued,
     val canCancel: Boolean = false,
+    val pathPlan: OperationPathPlan? = null,
 ) {
     sealed interface State {
         data object Queued : State
@@ -58,6 +60,7 @@ fun ManagedOperation.toDisplayModel(): OperationDisplay {
         title = metadata.title,
         description = metadata.description,
         canCancel = canCancel,
+        pathPlan = metadata.pathPlan,
         state = when (state) {
             is Operation.State.Queued -> OperationDisplay.State.Queued
             is Operation.State.Active -> {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -41,10 +41,12 @@ import eu.darken.butler.common.compose.InfoEntry
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.asComposable
 import eu.darken.butler.common.compose.groupInfoEntries
+import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.formatDuration
 import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import eu.darken.butler.workspace.ui.operations.bar.operationStateVisuals
 import kotlin.time.Clock
@@ -55,7 +57,8 @@ internal val OverviewPairingMinWidth = 240.dp
 
 /**
  * Result is never paired and never capped: a move/copy summary concatenates up to four plural
- * segments, and a two-line cap would hide the tail with no way to read it.
+ * segments, and a two-line cap would hide the tail with no way to read it. The destination is
+ * absent for operations that have none (delete, create, restore).
  */
 internal fun buildOverviewEntries(
     statusLabel: String,
@@ -64,12 +67,24 @@ internal fun buildOverviewEntries(
     timeValue: String,
     durationLabel: String,
     durationValue: String,
+    destinationLabel: String?,
+    destinationValue: String?,
     resultLabel: String,
     resultValue: String?,
 ): List<InfoEntry> = buildList {
     add(InfoEntry(label = statusLabel, value = statusValue, pairable = true))
     add(InfoEntry(label = timeLabel, value = timeValue, pairable = true))
     add(InfoEntry(label = durationLabel, value = durationValue, pairable = true))
+    if (destinationLabel != null && destinationValue != null) {
+        add(
+            InfoEntry(
+                label = destinationLabel,
+                value = destinationValue,
+                pairable = false,
+                valueStyle = InfoEntry.ValueStyle.PATH,
+            ),
+        )
+    }
     if (resultValue != null) {
         add(
             InfoEntry(
@@ -160,6 +175,8 @@ private fun OperationOverviewGrid(
         else -> null
     }
 
+    val destination = operation.pathPlan?.destination
+
     val baseEntries = buildOverviewEntries(
         statusLabel = stringResource(R.string.operations_details_status),
         statusValue = when (operation.state) {
@@ -191,6 +208,14 @@ private fun OperationOverviewGrid(
             is OperationDisplay.State.Failed -> formatDuration(operation.state.completedAt - operation.startedAt)
             is OperationDisplay.State.Cancelled -> formatDuration(operation.state.completedAt - operation.startedAt)
         },
+        destinationLabel = when (destination) {
+            is OperationPathPlan.Destination.Container ->
+                stringResource(R.string.operations_details_destination_folder)
+            is OperationPathPlan.Destination.RequestedTarget ->
+                stringResource(R.string.operations_details_destination_path)
+            null -> null
+        },
+        destinationValue = destination?.path?.userReadablePath?.asComposable(),
         resultLabel = stringResource(R.string.operations_details_result),
         resultValue = if (reportSummary != null) reportSummary.asComposable() else null,
     )
@@ -256,6 +281,43 @@ private fun OperationOverviewSectionCompletedPreview() {
                 icon = Icons.TwoTone.Handyman,
                 title = "Move".toCaString(),
                 description = "Moving files".toCaString(),
+                pathPlan = OperationPathPlan(
+                    targets = listOf(LocalPath.build("/storage/emulated/0/Download/report.pdf")),
+                    destination = OperationPathPlan.Destination.Container(
+                        LocalPath.build("/storage/emulated/0/Documents/Projects/Archive/2026"),
+                    ),
+                ),
+                state = OperationDisplay.State.Completed(
+                    summary = summary.toCaString(),
+                    completedAt = Clock.System.now(),
+                    report = previewReport(summary),
+                ),
+            ),
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationOverviewSectionRenamedPreview() {
+    val summary = "Renamed 1 file"
+    Box(modifier = Modifier.width(360.dp)) {
+        OperationOverviewSection(
+            operation = OperationDisplay(
+                id = Operation.Id(),
+                startedAt = Clock.System.now() - 1.minutes,
+                icon = Icons.TwoTone.Handyman,
+                title = "Rename".toCaString(),
+                description = "Renaming a file".toCaString(),
+                pathPlan = OperationPathPlan(
+                    targets = listOf(LocalPath.build("/storage/emulated/0/Documents/report.pdf")),
+                    destination = OperationPathPlan.Destination.RequestedTarget(
+                        LocalPath.build(
+                            "/storage/emulated/0/Documents/Projects/Archive/2026/quarterly-report-final.pdf",
+                        ),
+                    ),
+                ),
                 state = OperationDisplay.State.Completed(
                     summary = summary.toCaString(),
                     completedAt = Clock.System.now(),

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -139,6 +139,8 @@
     <string name="operations_details_handle_issue">Handle issue</string>
     <string name="operations_details_status">Status</string>
     <string name="operations_details_result">Result</string>
+    <string name="operations_details_destination_folder">Destination folder</string>
+    <string name="operations_details_destination_path">Destination path</string>
     <string name="operations_details_affected_paths_with_count">Affected paths (%d)</string>
     <string name="workspace_operations_performance_graph_label">Performance graph</string>
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationPathPlanTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationPathPlanTest.kt
@@ -1,0 +1,90 @@
+package eu.darken.butler.workspace.core.operations
+
+import eu.darken.butler.common.files.LocalPath
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class OperationPathPlanTest : BaseTest() {
+
+    private val source = LocalPath.build("/sdcard/Download/a.txt")
+    private val second = LocalPath.build("/sdcard/Download/b.txt")
+    private val folder = LocalPath.build("/sdcard/Backup")
+
+    @Test
+    fun `scope paths default to the targets plus the destination`() {
+        val plan = OperationPathPlan(
+            targets = listOf(source, second),
+            destination = OperationPathPlan.Destination.Container(folder),
+        )
+
+        plan.scopePaths shouldContainExactly listOf(source, second, folder)
+        plan.allPaths shouldContainExactly plan.scopePaths
+    }
+
+    @Test
+    fun `scope paths without a destination are just the targets`() {
+        OperationPathPlan(targets = listOf(source)).scopePaths shouldContainExactly listOf(source)
+    }
+
+    @Test
+    fun `the destination appears once in the path set`() {
+        val plan = OperationPathPlan(
+            targets = listOf(source),
+            destination = OperationPathPlan.Destination.RequestedTarget(folder),
+        )
+
+        plan.allPaths.count { it == folder } shouldBe 1
+    }
+
+    @Test
+    fun `an explicit scope override wins over the default`() {
+        val plan = OperationPathPlan(
+            targets = listOf(source, second),
+            destination = OperationPathPlan.Destination.Container(folder),
+            scopePaths = listOf(source),
+        )
+
+        plan.scopePaths shouldContainExactly listOf(source)
+        plan.allPaths shouldContainExactly listOf(source)
+    }
+
+    @Test
+    fun `the representative path is the first target`() {
+        val plan = OperationPathPlan(
+            targets = listOf(source, second),
+            destination = OperationPathPlan.Destination.Container(folder),
+        )
+
+        plan.representativePath shouldBe source
+    }
+
+    @Test
+    fun `the representative path falls back to the destination without targets`() {
+        val plan = OperationPathPlan(
+            targets = emptyList(),
+            destination = OperationPathPlan.Destination.Container(folder),
+        )
+
+        plan.representativePath shouldBe folder
+    }
+
+    @Test
+    fun `an empty plan degrades gracefully instead of throwing`() {
+        val plan = OperationPathPlan(targets = emptyList())
+
+        plan.representativePath shouldBe null
+        plan.allPaths shouldContainExactly emptyList()
+    }
+
+    @Test
+    fun `an explicit representative override wins over the default`() {
+        val plan = OperationPathPlan(
+            targets = listOf(source, second),
+            representativePath = second,
+        )
+
+        plan.representativePath shouldBe second
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.workspace.core.operations.CompletedOperationSnapshot
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryDatabase
 import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryEntity
 import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryScopeEntity
@@ -139,7 +140,7 @@ class OperationHistoryPersistTest : BaseTest() {
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.COPY,
-                    intended = listOf(source, destinationFolder),
+                    plan = planInto(source, destination = destinationFolder),
                 ),
                 state = TestCompletedState(
                     report = TestReport(
@@ -167,7 +168,7 @@ class OperationHistoryPersistTest : BaseTest() {
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.COPY,
-                    intended = listOf(source, destinationFolder),
+                    plan = planInto(source, destination = destinationFolder),
                 ),
                 state = TestCompletedState(
                     report = TestReport(
@@ -194,7 +195,7 @@ class OperationHistoryPersistTest : BaseTest() {
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.COPY,
-                    intended = listOf(source, destinationFolder),
+                    plan = planInto(source, destination = destinationFolder),
                 ),
                 state = TestCompletedState(
                     report = null,
@@ -222,7 +223,7 @@ class OperationHistoryPersistTest : BaseTest() {
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.DELETE,
-                    intended = listOf(target),
+                    plan = planOver(target),
                 ),
                 state = TestCompletedState(
                     report = null,
@@ -238,12 +239,12 @@ class OperationHistoryPersistTest : BaseTest() {
     @Test
     fun `the affected count derives from reported changes only`() = runTest {
         val reported = (1..3).map { LocalPath.build("/sdcard/Backup/file_$it.txt") }
-        val intended = (1..7).map { LocalPath.build("/sdcard/Download/file_$it.txt") }
+        val sources = (1..7).map { LocalPath.build("/sdcard/Download/file_$it.txt") }
         val id = persist(
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.COPY,
-                    intended = intended + destinationFolder,
+                    plan = planInto(*sources.toTypedArray(), destination = destinationFolder),
                 ),
                 state = TestCompletedState(
                     report = TestReport(
@@ -273,7 +274,7 @@ class OperationHistoryPersistTest : BaseTest() {
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.DELETE,
-                    intended = directories,
+                    plan = planOver(*directories.toTypedArray()),
                 ),
                 state = TestCompletedState(
                     report = TestReport(
@@ -288,6 +289,134 @@ class OperationHistoryPersistTest : BaseTest() {
         val lastDirectory = directories.last().path
         allScopePaths(id).map { it.path } shouldContain lastDirectory
         idsForScopes(lastDirectory) shouldContainExactly listOf(id)
+    }
+
+    /*
+     * The two producers that override OperationPathPlan.scopePaths, pinned as exact ordered row
+     * lists - this is the only place their overrides are observable, and the attempted-paths sheet
+     * renders exactly this order.
+     */
+
+    private val savedA = LocalPath.build("/sdcard/Backup/a.txt")
+    private val savedB = LocalPath.build("/sdcard/Backup/b.txt")
+    private val archived = LocalPath.build("/sdcard/Backup/bundle.zip")
+    private val downloadA = LocalPath.build("/sdcard/Download/a.txt")
+    private val downloadB = LocalPath.build("/sdcard/Download/b.txt")
+
+    /** Mirrors SaveFilesOperation: the planned files are the scope, the target directory is not. */
+    private fun saveFilesPlan() = OperationPathPlan(
+        targets = listOf(savedA, savedB),
+        destination = OperationPathPlan.Destination.Container(destinationFolder),
+        scopePaths = listOf(savedA, savedB),
+    )
+
+    /** Mirrors CompressOperation: the destination DIRECTORY is the scope, not the archive path. */
+    private fun compressPlan() = OperationPathPlan(
+        targets = listOf(downloadA, downloadB),
+        destination = OperationPathPlan.Destination.RequestedTarget(archived),
+        scopePaths = listOf(downloadA, downloadB, destinationFolder),
+    )
+
+    @Test
+    fun `a successful save indexes the written files and their folder, nothing above it`() = runTest {
+        val id = persist(
+            testSnapshot(
+                metadata = testMetadata(
+                    operationKind = Operation.Metadata.Kind.SAVE,
+                    plan = saveFilesPlan(),
+                ),
+                state = TestCompletedState(
+                    report = TestReport(
+                        affectedPaths = listOf(
+                            changeOf(savedA, Operation.Report.PathChange.Change.ADDED),
+                            changeOf(savedB, Operation.Report.PathChange.Change.ADDED),
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        allScopePaths(id).map { it.path } shouldContainExactly listOf(
+            "/sdcard/Backup",
+            "/sdcard/Backup/a.txt",
+            "/sdcard/Backup/b.txt",
+        )
+    }
+
+    @Test
+    fun `a failed save indexes the same rows a successful one would`() = runTest {
+        val id = persist(
+            testSnapshot(
+                metadata = testMetadata(
+                    operationKind = Operation.Metadata.Kind.SAVE,
+                    plan = saveFilesPlan(),
+                ),
+                state = TestCompletedState(
+                    report = null,
+                    error = IOException("No space left on device"),
+                ),
+            )
+        )
+
+        allScopePaths(id).map { it.path } shouldContainExactly listOf(
+            "/sdcard/Backup",
+            "/sdcard/Backup/a.txt",
+            "/sdcard/Backup/b.txt",
+        )
+        database.operationHistoryDao().getById(id)!!.entry.primaryPath shouldBe savedA.path
+    }
+
+    @Test
+    fun `a successful compression indexes the sources, the destination folder and the archive`() = runTest {
+        val id = persist(
+            testSnapshot(
+                metadata = testMetadata(
+                    operationKind = Operation.Metadata.Kind.COMPRESS,
+                    plan = compressPlan(),
+                ),
+                state = TestCompletedState(
+                    report = TestReport(
+                        affectedPaths = listOf(
+                            changeOf(archived, Operation.Report.PathChange.Change.ADDED),
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        allScopePaths(id).map { it.path } shouldContainExactly listOf(
+            "/sdcard/Download",
+            "/sdcard",
+            "/sdcard/Backup",
+            "/sdcard/Download/a.txt",
+            "/sdcard/Download/b.txt",
+            "/sdcard/Backup/bundle.zip",
+        )
+    }
+
+    @Test
+    fun `a failed compression still indexes the destination folder`() = runTest {
+        val id = persist(
+            testSnapshot(
+                metadata = testMetadata(
+                    operationKind = Operation.Metadata.Kind.COMPRESS,
+                    plan = compressPlan(),
+                ),
+                state = TestCompletedState(
+                    report = null,
+                    error = IOException("No space left on device"),
+                ),
+            )
+        )
+
+        allScopePaths(id).map { it.path } shouldContainExactly listOf(
+            "/sdcard/Download",
+            "/sdcard",
+            "/sdcard/Download/a.txt",
+            "/sdcard/Download/b.txt",
+            "/sdcard/Backup",
+        )
+        database.operationHistoryDao().getById(id)!!.entry.primaryPath shouldBe downloadA.path
     }
 
     @Test

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryScopeQueryTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryScopeQueryTest.kt
@@ -169,14 +169,14 @@ class OperationHistoryScopeQueryTest : BaseTest() {
     }
 
     @Test
-    fun `intended sources and reported destinations both reach the index`() = runTest {
+    fun `planned sources and reported destinations both reach the index`() = runTest {
         val id = persist(
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.COPY,
-                    intended = listOf(
+                    plan = planInto(
                         LocalPath.build("/sdcard/Old/file.txt"),
-                        LocalPath.build("/sdcard/New"),
+                        destination = LocalPath.build("/sdcard/New"),
                     ),
                 ),
                 state = TestCompletedState(
@@ -197,12 +197,15 @@ class OperationHistoryScopeQueryTest : BaseTest() {
     }
 
     @Test
-    fun `a move source reaches the index even when it was never an intended path`() = runTest {
+    fun `a move source reaches the index even when the path plan never named it`() = runTest {
         val id = persist(
             testSnapshot(
                 metadata = testMetadata(
                     operationKind = Operation.Metadata.Kind.MOVE,
-                    intended = null,
+                    plan = planInto(
+                        LocalPath.build("/sdcard/Current/notes.txt"),
+                        destination = LocalPath.build("/sdcard/New"),
+                    ),
                     operationIntent = Operation.Metadata.Intent.RENAME,
                 ),
                 state = TestCompletedState(

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.CompletedOperationSnapshot
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryDao
 import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryDatabase
@@ -44,7 +45,7 @@ internal class TestCompletedState(
 
 internal fun testMetadata(
     operationKind: Operation.Metadata.Kind,
-    intended: Collection<APath<*>>? = null,
+    plan: OperationPathPlan? = null,
     operationIntent: Operation.Metadata.Intent? = null,
 ): Operation.Metadata = mockk<Operation.Metadata>().apply {
     every { origin } returns Operation.Metadata.Origin.Explorer(Workspace.Id())
@@ -53,8 +54,20 @@ internal fun testMetadata(
     every { description } returns "description".toCaString()
     every { kind } returns operationKind
     every { intent } returns operationIntent
-    every { intendedPaths } returns intended
+    every { pathPlan } returns plan
 }
+
+/** The plan a copy/move producer builds: sources plus the directory they land in. */
+internal fun planInto(
+    vararg sources: APath<*>,
+    destination: APath<*>,
+) = OperationPathPlan(
+    targets = sources.toList(),
+    destination = OperationPathPlan.Destination.Container(destination),
+)
+
+/** The plan a delete/create producer builds: targets only, no destination. */
+internal fun planOver(vararg targets: APath<*>) = OperationPathPlan(targets = targets.toList())
 
 internal fun testSnapshot(
     metadata: Operation.Metadata,

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewEntriesTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewEntriesTest.kt
@@ -1,20 +1,37 @@
 package eu.darken.butler.workspace.ui.operations.details
 
+import eu.darken.butler.common.compose.InfoEntry
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class OperationOverviewEntriesTest : BaseTest() {
 
-    private fun entries(resultValue: String? = "Moved 12 files") = buildOverviewEntries(
+    private fun entries(
+        resultValue: String? = "Moved 12 files",
+        destinationLabel: String? = null,
+        destinationValue: String? = null,
+    ) = buildOverviewEntries(
         statusLabel = "Status",
         statusValue = "Successful",
         timeLabel = "Completed",
         timeValue = "2 minutes ago",
         durationLabel = "Duration",
         durationValue = "12s",
+        destinationLabel = destinationLabel,
+        destinationValue = destinationValue,
         resultLabel = "Result",
         resultValue = resultValue,
+    )
+
+    private fun withFolder() = entries(
+        destinationLabel = "Destination folder",
+        destinationValue = "/sdcard/Backup",
+    )
+
+    private fun withPath() = entries(
+        destinationLabel = "Destination path",
+        destinationValue = "/sdcard/Backup/renamed.txt",
     )
 
     @Test
@@ -42,5 +59,44 @@ class OperationOverviewEntriesTest : BaseTest() {
     @Test
     fun `entries are ordered status, time, duration, result`() {
         entries().map { it.label } shouldBe listOf("Status", "Completed", "Duration", "Result")
+    }
+
+    @Test
+    fun `an operation without a destination has no path-styled entry`() {
+        entries().none { it.valueStyle == InfoEntry.ValueStyle.PATH } shouldBe true
+    }
+
+    @Test
+    fun `the destination sits between duration and result`() {
+        withFolder().map { it.label } shouldBe
+            listOf("Status", "Completed", "Duration", "Destination folder", "Result")
+    }
+
+    @Test
+    fun `a folder destination renders as a full-width path`() {
+        val destination = withFolder()[3]
+
+        destination.value shouldBe "/sdcard/Backup"
+        destination.pairable shouldBe false
+        destination.valueStyle shouldBe InfoEntry.ValueStyle.PATH
+    }
+
+    @Test
+    fun `a requested-target destination renders as a full-width path`() {
+        val destination = withPath()[3]
+
+        destination.label shouldBe "Destination path"
+        destination.value shouldBe "/sdcard/Backup/renamed.txt"
+        destination.pairable shouldBe false
+        destination.valueStyle shouldBe InfoEntry.ValueStyle.PATH
+    }
+
+    @Test
+    fun `a destination survives an operation that has no report`() {
+        entries(
+            resultValue = null,
+            destinationLabel = "Destination folder",
+            destinationValue = "/sdcard/Backup",
+        ).map { it.label } shouldBe listOf("Status", "Completed", "Duration", "Destination folder")
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/page/WorkspacePageChromeTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/page/WorkspacePageChromeTest.kt
@@ -45,6 +45,7 @@ class WorkspacePageChromeTest : BaseTest() {
             every { icon } returns mockk()
             every { title } returns "op".toCaString()
             every { description } returns "desc".toCaString()
+            every { pathPlan } returns null
         }
         return op
     }

--- a/app/src/main/java/eu/darken/butler/main/core/external/ExternalImportSweeper.kt
+++ b/app/src/main/java/eu/darken/butler/main/core/external/ExternalImportSweeper.kt
@@ -281,7 +281,7 @@ class ExternalImportSweeper(
         }
 
         operationsManager.operations.first().forEach { managed ->
-            managed.operation.metadata.intendedPaths?.forEach { references.add(it.path) }
+            managed.operation.metadata.pathPlan?.allPaths?.forEach { references.add(it.path) }
         }
 
         clipboardRepo.state.first().entries.forEach { clip ->

--- a/app/src/test/java/eu/darken/butler/main/core/external/ExternalImportSweeperTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/core/external/ExternalImportSweeperTest.kt
@@ -10,6 +10,7 @@ import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.core.clipboard.ClipboardRepo
 import eu.darken.butler.workspace.core.operations.ManagedOperation
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.ui.session.WorkspaceSessionManager
 import io.kotest.matchers.shouldBe
@@ -179,7 +180,7 @@ class ExternalImportSweeperTest : BaseTest() {
         val path = mockk<APath<*>>()
         every { path.path } returns "$baseDir/${busy.name}/payload.bin"
         val metadata = mockk<Operation.Metadata>()
-        every { metadata.intendedPaths } returns listOf(path)
+        every { metadata.pathPlan } returns OperationPathPlan(targets = listOf(path))
         val managed = mockk<ManagedOperation>()
         every { managed.operation } returns mockk<Operation>().also { every { it.metadata } returns metadata }
         every { operationsManager.operations } returns flowOf(listOf(managed))


### PR DESCRIPTION
## What changed

The Overview card in the operation details sheet now shows where an operation put things.

Pasting or dropping files shows the destination folder. Renaming a file, or compressing files into an archive, shows the exact destination path including the new file's own name. Operations that have no destination at all (delete, create, restore) show no such row, so nothing new appears where it would be meaningless.

Long paths render on a single line with the ellipsis in the middle, so the trailing folder or file name stays readable instead of being cut off at the end.

## Technical Context

- `Operation.Metadata.intendedPaths` was a single untyped `Collection<APath<*>>` that 12 producers filled by positional convention and three consumers read with incompatible expectations: the history row label wants exactly one path, the history scope index wants the full set plus every parent, and the external-import liveness guard wants the full set. Nothing in the type distinguished a source from a destination, which is why the card could not show one. `OperationPathPlan` gives each consumer its own field (`representativePath`, `scopePaths`, `targets` plus a sealed `destination`).

- Behaviour outside the card is preserved: the history row label and the persisted scope rows are byte-identical for all 12 producers. `SaveFilesOperation` and `CompressOperation` carry explicit `scopePaths` overrides for exactly that reason. `collectScopePaths` indexes each candidate *and* its parent, so promoting a path from "parent of a candidate" to "candidate in its own right" silently adds an index row and an extra ancestor entry in the attempted-paths sheet. Both overrides carry a comment saying so, and exact ordered scope rows are pinned by tests for both, on success and on failure.

- The `ExplorerCommand.Move`/`Copy` destination discriminator is metadata only. Both operations still pass `.path` to the gateway, and `GenericPathMove`, `GenericPathCopy`, and `TransferPathCalculator` are untouched. The command records what the user asked for; the gateway still decides what actually happens, and the two can legitimately disagree (renaming `foo` to `bar` while `bar` exists as a directory moves `foo` inside it). That is why the new row reads as a request, while Result and Affected paths continue to report the outcome.

- `CompressOperation.outputPath` moved from a local inside `performGuarded` to a `private val`, so the metadata, the report builder, and the file operations all share one value. `command.archiveName` already carries the format extension (it is normalised at the call site), so nothing appends it a second time.

- `InfoEntry.ValueStyle.PATH` pins the value to `maxLines = 1` with `TextOverflow.MiddleEllipsis`. Middle-ellipsis degrades to clipping on multiline Android text, so it only ever pairs with a single line, which is why it applies to this row and not to the two-line header subtitle. Verified on an emulator that a paste shows the destination folder, a rename and a compress show the exact destination path with a single file extension, a delete shows no destination row, and a 127-character destination renders on one line with the ellipsis mid-string (checked against rendered pixels, since the accessibility tree exposes the untruncated path).
