### PR TITLE
Workspace: Show unsaved changes in the tab manager and stop closing them silently

### DIFF
--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="general_tab_close_confirmation_message">Are you sure you want to close \"%1$s\"?</string>
     <string name="general_tab_close_unsaved_title">Unsaved changes</string>
     <string name="general_tab_close_unsaved_message">\"%1$s\" has unsaved changes. Close and discard them?</string>
+    <string name="general_tab_close_unsaved_message_multiple">\"%1$s\" and %2$d more have unsaved changes. Close and discard them?</string>
     <string name="general_discard_action">Discard</string>
 
     <!-- Exit app -->

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
@@ -62,6 +62,8 @@ sealed interface ManagerDialog {
             override val targetWorkspaceId: Workspace.Id,
             val workspaceTitle: CaString,
             val hasUnsavedChanges: Boolean = false,
+            /** Unsaved members in the closing subtree; [workspaceTitle] names only one of them. */
+            val unsavedCount: Int = 0,
         ) : WorkspaceTargeted {
             override val isBlocking: Boolean = true
         }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialogHost.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialogHost.kt
@@ -25,6 +25,7 @@ fun ManagerDialogHost(
         is ManagerDialog.WorkspaceTargeted.CloseConfirmation -> WorkspaceCloseConfirmationDialog(
             workspaceTitle = dialog.workspaceTitle,
             hasUnsavedChanges = dialog.hasUnsavedChanges,
+            unsavedCount = dialog.unsavedCount,
             onDismiss = { onDismiss(dialog) },
             onConfirm = { onConfirm(dialog) },
         )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceCloseConfirmationDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceCloseConfirmationDialog.kt
@@ -19,6 +19,8 @@ import eu.darken.butler.common.R as CommonR
 fun WorkspaceCloseConfirmationDialog(
     workspaceTitle: CaString,
     hasUnsavedChanges: Boolean = false,
+    /** Unsaved members the close would discard; [workspaceTitle] names only one of them. */
+    unsavedCount: Int = 0,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
@@ -36,15 +38,25 @@ fun WorkspaceCloseConfirmationDialog(
             )
         },
         text = {
+            val name = workspaceTitle.get(LocalContext.current)
             Text(
-                text = stringResource(
-                    if (hasUnsavedChanges) {
-                        CommonR.string.general_tab_close_unsaved_message
-                    } else {
-                        CommonR.string.general_tab_close_confirmation_message
-                    },
-                    workspaceTitle.get(LocalContext.current)
-                )
+                text = when {
+                    // Closing a tab discards its whole modal stack, so naming one dirty member
+                    // while several go down would understate what the user is agreeing to
+                    hasUnsavedChanges && unsavedCount > 1 -> stringResource(
+                        CommonR.string.general_tab_close_unsaved_message_multiple,
+                        name,
+                        unsavedCount - 1,
+                    )
+                    hasUnsavedChanges -> stringResource(
+                        CommonR.string.general_tab_close_unsaved_message,
+                        name,
+                    )
+                    else -> stringResource(
+                        CommonR.string.general_tab_close_confirmation_message,
+                        name,
+                    )
+                }
             )
         },
         confirmButton = {
@@ -87,6 +99,20 @@ private fun WorkspaceCloseConfirmationDialogUnsavedPreview() {
     WorkspaceCloseConfirmationDialog(
         workspaceTitle = "notes.txt".toCaString(),
         hasUnsavedChanges = true,
+        unsavedCount = 1,
+        onDismiss = {},
+        onConfirm = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceCloseConfirmationDialogUnsavedMultiplePreview() {
+    WorkspaceCloseConfirmationDialog(
+        workspaceTitle = "notes.txt".toCaString(),
+        hasUnsavedChanges = true,
+        unsavedCount = 3,
         onDismiss = {},
         onConfirm = {},
     )

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceCloseConfirmationDialogTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceCloseConfirmationDialogTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.butler.workspace.ui.dialogs
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class WorkspaceCloseConfirmationDialogTest : ComposeTest() {
+
+    private fun setDialog(
+        hasUnsavedChanges: Boolean = false,
+        unsavedCount: Int = 0,
+        onConfirm: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceCloseConfirmationDialog(
+                    workspaceTitle = "notes.txt".toCaString(),
+                    hasUnsavedChanges = hasUnsavedChanges,
+                    unsavedCount = unsavedCount,
+                    onDismiss = {},
+                    onConfirm = onConfirm,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a clean tab gets the plain close copy`() {
+        setDialog()
+
+        composeTestRule.onNode(hasText("notes.txt", substring = true)).assertExists()
+        composeTestRule.onAllNodesWithText("unsaved changes", substring = true).assertCountEquals(0)
+        composeTestRule.onNodeWithText("Close").assertExists()
+    }
+
+    @Test
+    fun `one unsaved member names it and offers to discard`() {
+        setDialog(hasUnsavedChanges = true, unsavedCount = 1)
+
+        composeTestRule
+            .onNode(hasText("\"notes.txt\" has unsaved changes. Close and discard them?"))
+            .assertExists()
+        composeTestRule.onNodeWithText("Discard").assertExists()
+    }
+
+    /** Closing a tab discards its whole modal stack, so naming one member would understate it. */
+    @Test
+    fun `several unsaved members say how many more go down`() {
+        setDialog(hasUnsavedChanges = true, unsavedCount = 3)
+
+        composeTestRule
+            .onNode(hasText("\"notes.txt\" and 2 more have unsaved changes. Close and discard them?"))
+            .assertExists()
+    }
+
+    @Test
+    fun `confirming reports once`() {
+        var confirmed = 0
+        setDialog(hasUnsavedChanges = true, unsavedCount = 1) { confirmed++ }
+
+        composeTestRule.onNodeWithText("Discard").performClick()
+
+        confirmed shouldBe 1
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/core/PendingWorkspaceConfirmation.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/PendingWorkspaceConfirmation.kt
@@ -24,6 +24,11 @@ data class PendingWorkspaceConfirmation(
             val workspaceId: Workspace.Id,
             val workspaceTitle: CaString,
             val hasUnsavedChanges: Boolean = false,
+            /**
+             * How many workspaces in the closing subtree hold unsaved changes. [workspaceTitle]
+             * names one of them, so anything above 1 has to be said out loud.
+             */
+            val unsavedCount: Int = 0,
         ) : ConfirmationData
 
         /**

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -379,10 +379,14 @@ class WorkspaceRepo @Inject constructor(
 
     fun resolveConfirmation(confirmationId: String, confirmed: Boolean) {
         log(TAG, INFO) { "resolveConfirmation($confirmationId, confirmed=$confirmed)" }
+        // Claim before publishing the removal, not after. This runs off the action lock, so an
+        // overlapping close superseding this confirmation is concurrent with it: whoever takes the
+        // action out of the map wins. Dropping the entry first would leave a window where the
+        // supersede takes an action the user has already confirmed, and the close would be lost.
+        val action = pendingActions.remove(confirmationId)
         _pendingConfirmations.update { it - confirmationId }
         // Dismissing a limit dialog drops its parked create too, or it would outlive the dialog
         pendingLimitRecoveries.remove(confirmationId)
-        val action = pendingActions.remove(confirmationId)
         if (confirmed && action != null) {
             appScope.launch {
                 lock.withLock { action() }
@@ -619,31 +623,55 @@ class WorkspaceRepo @Inject constructor(
 
                 val workspace = _workspaces.value.firstOrNull { it.id == action.id }
 
-                // Confirm when explicitly requested OR when the workspace has unsaved changes.
-                val needsConfirmation = action.requireConfirmation ||
-                    workspace?.info?.value?.hasUnsavedChanges == true
+                // Closing a tab takes its whole modal stack down with it, so the guard has to
+                // cover everything executeClose would destroy, not just the id the close names: a
+                // clean tab can own a dirty child (a Saver still holding shared content), and that
+                // child is precisely the thing whose loss has to be confirmed.
+                val dirtyMembers = closingSubtreeOf(action.id)
+                    .filter { it.info.value.hasUnsavedChanges }
+                val needsConfirmation = action.requireConfirmation || dirtyMembers.isNotEmpty()
 
                 if (needsConfirmation) {
-                    if (workspace == null) {
+                    // The dialog has to name something. Usually that is the close target, but a
+                    // close of an id nothing holds still has to be confirmable when it would take
+                    // a dirty orphan down with it.
+                    val naming = dirtyMembers.firstOrNull() ?: workspace
+                    if (naming == null) {
                         log(TAG, WARN) { "Cannot request close confirmation - workspace ${action.id} not found" }
                         return@withLock WorkspaceAction.Close.Result
                     }
 
-                    // De-dupe: don't queue a second close confirmation for the same workspace.
-                    val alreadyPending = _pendingConfirmations.value.values.any {
-                        val data = it.data
+                    // Two closes overlap when one's subtree holds the other's target: answering
+                    // either decides workspaces the other also claims. Only one of them may be
+                    // pending, or the screen renders a single dialog for several queued answers and
+                    // one dismissal only retires one of them.
+                    val closingIds = closingIdsOf(action.id)
+                    val overlapping = _pendingConfirmations.value.filterValues { pending ->
+                        val data = pending.data
                         data is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation &&
-                            data.workspaceId == action.id
+                            (data.workspaceId in closingIds || action.id in closingIdsOf(data.workspaceId))
                     }
-                    if (alreadyPending) {
+                    val duplicate = overlapping.values.any {
+                        val data = it.data as PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation
+                        data.workspaceId == action.id
+                    }
+                    if (duplicate) {
                         log(TAG) { "Close confirmation already pending for ${action.id}, ignoring duplicate" }
                         return@withLock WorkspaceAction.Close.Result
                     }
+                    // The newer request replaces the older rather than being dropped by it: a close
+                    // the user just asked for must not be swallowed by one they have not answered.
+                    overlapping.keys.forEach { supersededId ->
+                        log(TAG, INFO) { "Close confirmation $supersededId overlaps ${action.id}, superseding it" }
+                        pendingActions.remove(supersededId)
+                    }
 
-                    val workspaceInfo = workspace.info.value.withCustomTitle(_customTitles.value)
+                    // The unsaved copy reads "<name> has unsaved changes", so it has to name a
+                    // member holding them; without a dirty member the target names itself.
+                    val workspaceInfo = naming.info.value.withCustomTitle(_customTitles.value)
                     val confirmationId = Uuid.random().toString()
 
-                    log(TAG, INFO) { "Requesting confirmation to close workspace: ${workspaceInfo.displayTitle}" }
+                    log(TAG, INFO) { "Requesting confirmation to close workspace: ${action.id}, naming ${workspaceInfo.displayTitle}" }
 
                     pendingActions[confirmationId] = {
                         executeClose(action.id)
@@ -651,7 +679,7 @@ class WorkspaceRepo @Inject constructor(
                     }
 
                     _pendingConfirmations.update {
-                        it + (confirmationId to PendingWorkspaceConfirmation(
+                        it - overlapping.keys + (confirmationId to PendingWorkspaceConfirmation(
                             id = confirmationId,
                             // Anchors the dialog to the workspace the close was invoked from, which
                             // is the overlay on top when a unit is closed from one of its children.
@@ -659,7 +687,10 @@ class WorkspaceRepo @Inject constructor(
                             data = PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation(
                                 workspaceId = action.id,
                                 workspaceTitle = workspaceInfo.displayTitle,
-                                hasUnsavedChanges = workspaceInfo.hasUnsavedChanges,
+                                hasUnsavedChanges = dirtyMembers.isNotEmpty(),
+                                // The close takes the whole subtree, so naming one member while
+                                // discarding several would understate what is lost
+                                unsavedCount = dirtyMembers.size,
                             ),
                         ))
                     }
@@ -1566,6 +1597,38 @@ class WorkspaceRepo @Inject constructor(
             results = results,
             skippedCount = totalSkipped,
         )
+    }
+
+    /**
+     * Everything a close of [workspaceId] destroys: the workspace itself plus every descendant,
+     * walking the same caller relation [executeClose] recurses over.
+     *
+     * The walk starts from the id rather than from a resolved workspace, because [executeClose]
+     * enumerates children before it looks the target up: an id nothing holds still reaps whatever
+     * names it as caller, and those orphans are exactly what a guard must not miss.
+     *
+     * Cycle-guarded for the same reason [executeClose] is: caller ids are not validated at creation.
+     */
+    private fun closingSubtreeOf(workspaceId: Workspace.Id): List<Workspace<*>> {
+        val ids = closingIdsOf(workspaceId)
+        return _workspaces.value.filter { it.id in ids }
+    }
+
+    /**
+     * [closingSubtreeOf] as bare ids, always including [workspaceId] itself even when nothing holds
+     * it. Two closes overlap exactly when either one's id set contains the other's target, which is
+     * what tells a confirmation that a second one would decide the same workspaces over again.
+     */
+    private fun closingIdsOf(workspaceId: Workspace.Id): Set<Workspace.Id> {
+        val childrenOf = _workspaces.value.groupBy { it.info.value.callerWorkspaceId }
+        val ids = mutableSetOf<Workspace.Id>()
+        val pending = ArrayDeque(listOf(workspaceId))
+        while (pending.isNotEmpty()) {
+            val nextId = pending.removeFirst()
+            if (!ids.add(nextId)) continue
+            childrenOf[nextId].orEmpty().forEach { pending += it.id }
+        }
+        return ids
     }
 
     private suspend fun executeClose(

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -86,6 +86,7 @@ class WorkspaceManagerViewModel @Inject constructor(
                     paneNumber = visibleAssignments.entries.find { it.value == owner.id }?.key,
                     operationCount = members.sumOf { it.operationCount },
                     attentionCount = members.sumOf { it.attentionCount },
+                    hasUnsavedChanges = members.any { it.hasUnsavedChanges },
                     isSubWorkspace = owner.isSubWorkspace,
                     isRecovery = stacks.recoveryUnits.containsKey(owner.id),
                     isPaused = owner.isPaused,
@@ -313,6 +314,12 @@ class WorkspaceManagerViewModel @Inject constructor(
         val paneNumber: Int? = null,
         val operationCount: Int = 0,
         val attentionCount: Int = 0,
+        /**
+         * True when any member of the unit holds unsaved in-memory changes. Deliberately separate
+         * from [attentionCount]: editing without having saved yet is a normal working state, not a
+         * fault, so it must not glow like one.
+         */
+        val hasUnsavedChanges: Boolean = false,
         val customTitle: String? = null,
         /**
          * A stacked workspace only ever gets a card of its own when its ownership cannot be resolved

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItem.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItem.kt
@@ -58,6 +58,7 @@ import eu.darken.butler.common.R as CommonR
 import eu.darken.butler.workspace.R as WorkspaceR
 
 const val TEST_TAG_WORKSPACE_CARD_HEADER = "workspace_card_header"
+const val TEST_TAG_WORKSPACE_CARD_UNSAVED = "workspace_card_unsaved"
 
 @Composable
 fun WorkspaceGridItem(
@@ -162,6 +163,19 @@ fun WorkspaceGridItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+
+                    // Deliberately not the error-red attention glow: an edit that has not been
+                    // saved yet is a normal working state, not a fault.
+                    if (workspace.hasUnsavedChanges) {
+                        Icon(
+                            modifier = Modifier
+                                .size(14.dp)
+                                .testTag(TEST_TAG_WORKSPACE_CARD_UNSAVED),
+                            imageVector = Icons.TwoTone.Edit,
+                            contentDescription = stringResource(R.string.workspace_row_unsaved_content_desc),
+                            tint = MaterialTheme.colorScheme.tertiary,
+                        )
+                    }
 
                     // Sub-workspaces are not persisted, so a rename on them would silently be lost -
                     // but a paused one still needs its Resume entry: a tab is now paused together
@@ -690,4 +704,51 @@ private fun WorkspaceGridItemRecoveryPreview() {
         onSelect = {},
         livePreview = false,
     )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceGridItemUnsavedPreview() {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Unsaved edits alone: the tertiary marker, no error glow
+        val dirtyId = Workspace.Id()
+        WorkspaceGridItem(
+            reorderableScope = createMockReorderableScope(),
+            workspace = WorkspaceManagerViewModel.WorkspaceItem(
+                id = dirtyId,
+                topId = dirtyId,
+                type = Workspace.Type.EDITOR,
+                title = "notes.txt".toCaString(),
+                autoTitle = "notes.txt".toCaString(),
+                subtitle = "/storage/emulated/0/Documents".toCaString(),
+                hasUnsavedChanges = true,
+            ),
+            onClose = {},
+            onSelect = {},
+            livePreview = false,
+        )
+
+        // Both at once: the two signals have to stay tellable apart
+        val bothId = Workspace.Id()
+        WorkspaceGridItem(
+            reorderableScope = createMockReorderableScope(),
+            workspace = WorkspaceManagerViewModel.WorkspaceItem(
+                id = bothId,
+                topId = bothId,
+                type = Workspace.Type.EDITOR,
+                title = "config.xml".toCaString(),
+                autoTitle = "config.xml".toCaString(),
+                subtitle = "Save failed".toCaString(),
+                attentionCount = 1,
+                hasUnsavedChanges = true,
+            ),
+            onClose = {},
+            onSelect = {},
+            livePreview = false,
+        )
+    }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -161,6 +161,7 @@ class WorkspacesViewModel @Inject constructor(
                                 targetWorkspaceId = targetId,
                                 workspaceTitle = data.workspaceTitle,
                                 hasUnsavedChanges = data.hasUnsavedChanges,
+                                unsavedCount = data.unsavedCount,
                             )
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,7 +328,7 @@
     <string name="workspace_badge_tip_title">Tip: Tab button indicators</string>
     <string name="workspace_badge_open_workspaces">Number of open tabs</string>
     <string name="workspace_badge_active_operations">Active operations (file copies, searches, etc.)</string>
-    <string name="workspace_badge_attention_items">Items needing attention (errors, unsaved changes)</string>
+    <string name="workspace_badge_attention_items">Items needing attention (failed or waiting operations, unreachable files)</string>
 
     <!-- Workspace Manager Actions -->
     <string name="workspace_manager_dismiss_content_desc">Dismiss</string>
@@ -357,6 +357,7 @@
     <string name="workspace_row_pause_action">Pause</string>
     <string name="workspace_row_resume_action">Resume</string>
     <string name="workspace_row_stacked_content_desc">Stacked on this tab</string>
+    <string name="workspace_row_unsaved_content_desc">Unsaved changes</string>
 
     <!-- Settings Index -->
     <string name="workspace_settings_subtitle">Configure tab behavior.</string>

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -1548,6 +1548,180 @@ class WorkspaceRepoTest : BaseTest() {
         }
 
     @Test
+    fun `a dirty child blocks the close of its clean owner`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(childId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+
+            // Closing the tab would take the child down with it, so nothing may be released yet
+            fake(tabId).released shouldBe false
+            fake(childId).released shouldBe false
+            repo.pendingConfirmations.first().closeConfirmationsFor(tabId) shouldBe 1
+        }
+
+    @Test
+    fun `the close confirmation names the member holding the unsaved changes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(childId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+
+            val data = repo.pendingConfirmations.first().values
+                .map { it.data }
+                .filterIsInstance<PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation>()
+                .single()
+            data.workspaceId shouldBe tabId
+            data.hasUnsavedChanges shouldBe true
+            data.workspaceTitle shouldBe repo.infoFor(childId).displayTitle
+        }
+
+    @Test
+    fun `a dirty orphan is not reaped by a close of its missing caller`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(childId)
+            // executeClose enumerates children before it looks the target up, so a close naming an
+            // id nothing holds still reaps whatever points at it
+            val missingId = Workspace.Id()
+            fake(childId).info.update { it.copy(callerWorkspaceId = missingId) }
+
+            repo.execute(WorkspaceAction.Close(missingId))
+
+            fake(childId).released shouldBe false
+            repo.pendingConfirmations.first().closeConfirmationsFor(missingId) shouldBe 1
+        }
+
+    @Test
+    fun `every unsaved member of the closing subtree is counted`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val firstChild = repo.createSubWorkspace(caller = tabId)
+            val secondChild = repo.createSubWorkspace(caller = tabId)
+            markDirty(tabId)
+            markDirty(firstChild)
+            markDirty(secondChild)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+
+            val data = repo.pendingConfirmations.first().values
+                .map { it.data }
+                .filterIsInstance<PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation>()
+                .single()
+            data.hasUnsavedChanges shouldBe true
+            data.unsavedCount shouldBe 3
+        }
+
+    @Test
+    fun `a broader close supersedes a pending confirmation for one of its members`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(childId)
+
+            repo.execute(WorkspaceAction.Close(childId))
+            repo.execute(WorkspaceAction.Close(tabId))
+
+            // One dialog, one answer: the tab's close already decides the child's fate
+            val pending = repo.pendingConfirmations.first()
+            pending.closeConfirmationsFor(childId) shouldBe 0
+            pending.closeConfirmationsFor(tabId) shouldBe 1
+        }
+
+    @Test
+    fun `a narrower close supersedes a pending confirmation for its owner`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(childId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+            repo.execute(WorkspaceAction.Close(childId))
+
+            // The newest request wins rather than being dropped by the one it overlaps
+            val pending = repo.pendingConfirmations.first()
+            pending.closeConfirmationsFor(tabId) shouldBe 0
+            pending.closeConfirmationsFor(childId) shouldBe 1
+        }
+
+    @Test
+    fun `closes of unrelated units keep their own confirmations`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val firstId = repo.createTab()
+            val secondId = repo.createTab()
+            markDirty(firstId)
+            markDirty(secondId)
+
+            repo.execute(WorkspaceAction.Close(firstId))
+            repo.execute(WorkspaceAction.Close(secondId))
+
+            val pending = repo.pendingConfirmations.first()
+            pending.closeConfirmationsFor(firstId) shouldBe 1
+            pending.closeConfirmationsFor(secondId) shouldBe 1
+        }
+
+    @Test
+    fun `a superseded confirmation cannot still close its target`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(childId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+            val supersededId = repo.pendingConfirmations.first().keys.single()
+            repo.execute(WorkspaceAction.Close(childId))
+
+            // Resolving the id the superseded dialog carried must not reach a dropped action
+            repo.resolveConfirmation(supersededId, confirmed = true)
+
+            fake(tabId).released shouldBe false
+            fake(childId).released shouldBe false
+        }
+
+    @Test
+    fun `a clean subtree closes without confirmation`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+
+            fake(tabId).released shouldBe true
+            fake(childId).released shouldBe true
+            repo.pendingConfirmations.first() shouldBe emptyMap()
+        }
+
+    @Test
+    fun `closing a clean child does not consult its dirty owner`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(tabId)
+
+            // A close names a subtree, not a whole unit: the owner outlives this and keeps its edits
+            repo.execute(WorkspaceAction.Close(childId))
+
+            fake(childId).released shouldBe true
+            fake(tabId).released shouldBe false
+            repo.pendingConfirmations.first() shouldBe emptyMap()
+        }
+
+    @Test
     fun `closing a clean workspace closes immediately without confirmation`() =
         runTest(UnconfinedTestDispatcher()) {
             val repo = createRepo()

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -1692,6 +1692,25 @@ class WorkspaceRepoTest : BaseTest() {
         }
 
     @Test
+    fun `a dirty member inside a caller cycle still blocks the close`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val first = Workspace.Id()
+            val second = Workspace.Id()
+            val repo = createRepo()
+            // The guard walks the same unvalidated caller relation the close recursion does, so it
+            // has to terminate on a cycle rather than spin looking for unsaved members
+            repo.createSubWorkspaceWithId(id = first, caller = second)
+            repo.createSubWorkspaceWithId(id = second, caller = first)
+            markDirty(second)
+
+            repo.execute(WorkspaceAction.Close(first))
+
+            fake(first).released shouldBe false
+            fake(second).released shouldBe false
+            repo.pendingConfirmations.first().closeConfirmationsFor(first) shouldBe 1
+        }
+
+    @Test
     fun `a clean subtree closes without confirmation`() =
         runTest(UnconfinedTestDispatcher()) {
             val repo = createRepo()

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
@@ -309,6 +309,26 @@ class WorkspaceManagerViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `a dirty member marks the whole unit unsaved`() = runTest {
+        val overlay = childInfo(caller = idA, pausableAsChild = true).copy(hasUnsavedChanges = true)
+        repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA), overlay))
+
+        items().single().let {
+            it.hasUnsavedChanges shouldBe true
+            // Editing without saving yet is not a fault, so it must not inflate the attention count
+            it.attentionCount shouldBe 0
+        }
+    }
+
+    @Test
+    fun `a clean unit is not marked unsaved`() = runTest {
+        val overlay = childInfo(caller = idA, pausableAsChild = true).copy(attentionCount = 2)
+        repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA), overlay))
+
+        items().single().hasUnsavedChanges shouldBe false
+    }
+
+    @Test
     fun `an orphan subtree becomes a single recovery card`() = runTest {
         val orphan = readyInfo(Workspace.Id()).copy(callerWorkspaceId = Workspace.Id())
         val descendant = readyInfo(Workspace.Id()).copy(callerWorkspaceId = orphan.id)

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItemTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItemTest.kt
@@ -50,6 +50,7 @@ class WorkspaceGridItemTest : ComposeTest() {
         canPause: Boolean = false,
         isRecovery: Boolean = false,
         stackDepth: Int = 0,
+        hasUnsavedChanges: Boolean = false,
     ): WorkspaceManagerViewModel.WorkspaceItem {
         val id = Workspace.Id()
         return WorkspaceManagerViewModel.WorkspaceItem(
@@ -64,7 +65,48 @@ class WorkspaceGridItemTest : ComposeTest() {
             isPaused = isPaused,
             canPause = canPause,
             stackDepth = stackDepth,
+            hasUnsavedChanges = hasUnsavedChanges,
         )
+    }
+
+    @Test
+    fun `a dirty tab is marked on the card`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceGridItem(
+                    reorderableScope = noopReorderableScope,
+                    workspace = item(hasUnsavedChanges = true),
+                    onClose = {},
+                    onSelect = {},
+                    livePreview = false,
+                )
+            }
+        }
+
+        composeTestRule
+            .onAllNodesWithTag(TEST_TAG_WORKSPACE_CARD_UNSAVED, useUnmergedTree = true)
+            .assertCountEquals(1)
+        // The marker is icon-only, so the description is the whole of what TalkBack can announce
+        composeTestRule.onNodeWithContentDescription("Unsaved changes").assertExists()
+    }
+
+    @Test
+    fun `a clean tab carries no unsaved marker`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceGridItem(
+                    reorderableScope = noopReorderableScope,
+                    workspace = item(),
+                    onClose = {},
+                    onSelect = {},
+                    livePreview = false,
+                )
+            }
+        }
+
+        composeTestRule
+            .onAllNodesWithTag(TEST_TAG_WORKSPACE_CARD_UNSAVED, useUnmergedTree = true)
+            .assertCountEquals(0)
     }
 
     @Test


### PR DESCRIPTION
## What changed

A tab holding unsaved edits now shows a marker on its card in the tab manager. Previously it looked identical to a saved tab, and the only way to find out was to try closing it. A tab whose stacked modal child is dirty gets the marker too, since closing the tab takes the child with it.

Closing such a tab no longer discards that content silently. Sharing a file into Butler opens a save flow stacked on the tab you were in; closing that tab used to destroy the shared content with no prompt, because the confirmation only asked about the tab itself and not the save flow riding on it. It now asks, names the thing actually holding the changes, and says how many more go down with it when several are dirty.

The tab-button legend claimed the attention counter covered "errors, unsaved changes". It never counted unsaved changes, so the wording now describes what it does count.

## Technical Context

- **Root cause of the data loss:** `WorkspaceAction.Close` checked `hasUnsavedChanges` on the targeted id alone, while `executeClose` recursively destroys descendants. A clean owner with a dirty child therefore skipped confirmation entirely. The guard now walks the whole closing subtree. Worth a close read: the walk is seeded by id rather than by a resolved workspace, because `executeClose` enumerates children *before* it looks the target up, so a close naming a vanished id still reaps orphans pointing at it.
- **Why unsaved is not folded into `attentionCount`:** attention is error-red and drives the card glow and filter. Saver marks itself dirty from creation until a fully successful save, so folding would leave every Saver tab glowing red through its normal workflow. The two stay separate fields; the marker reuses the editor toolbar's tertiary modified-buffer styling instead.
- **Confirmation supersede:** overlapping close confirmations previously stacked. The screen renders one dialog per anchor, so a second queued answer was invisible but survived the first dismissal, requiring two dismissals. Overlap is now defined as either close's subtree containing the other's target, and the newer request supersedes the older, since dropping the newer would swallow a close the user just asked for.
- **Concurrency:** `resolveConfirmation` runs off the action lock, so it races supersede. It now claims the pending action before publishing the removal; the previous order left a window where a supersede took an action the user had already confirmed and the close silently did nothing. This interleaving is not covered by a test, as a deterministic reproduction would have to encode dispatcher scheduling.
- The legend was inaccurate from `aed4b6cb6` (2025-06-28), the commit that introduced `attentionCount`. `Workspace.Info.hasUnsavedChanges` did not exist until `b6583b78b` (2026-06-24), so no revision ever matched the claim.
