### PR TITLE
Bugreport: Bigger record button, and delete all now asks first

### DIFF
--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
@@ -26,9 +26,8 @@ private val TAG = logTag("BugReport", "Workspace", "Overlays")
 /**
  * Overlay slot of the bug report page.
  *
- * Shares the ViewModel with [BugReportWorkspacePageHost]; the event collector that raises the
- * short-recording warning stays there and must not be repeated here. The error handler lives here
- * instead, because it renders a dialog that has to be pane-bound.
+ * Shares the ViewModel with [BugReportWorkspacePageHost]. The error handler lives here because it
+ * renders a dialog that has to be pane-bound.
  */
 @Composable
 fun BugReportWorkspaceOverlaysHost(

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.bugreport.R
+import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel.ActiveDialog
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -62,6 +63,8 @@ fun BugReportWorkspaceOverlaysHost(
             vm.dismissShortRecordingWarning()
             vm.forceStopRecording()
         },
+        onConfirmDeleteAll = { vm.deleteAll() },
+        onDismissDeleteAll = { vm.dismissDeleteAllConfirmation() },
     )
 
     // Last on purpose: layers stack in composition order, so an error raised while one of
@@ -76,19 +79,26 @@ fun BugReportWorkspaceOverlays(
     onDismissShareConsent: () -> Unit = {},
     onKeepRecording: () -> Unit = {},
     onStopRecordingAnyway: () -> Unit = {},
+    onConfirmDeleteAll: () -> Unit = {},
+    onDismissDeleteAll: () -> Unit = {},
 ) {
-    overlayState.shareConsentReportId?.let { reportId ->
-        ShareConsentDialog(
-            onConfirm = { onShareConsent(reportId) },
+    when (val dialog = overlayState.activeDialog) {
+        is ActiveDialog.ShareConsent -> ShareConsentDialog(
+            onConfirm = { onShareConsent(dialog.reportId) },
             onDismiss = onDismissShareConsent,
         )
-    }
 
-    if (overlayState.showShortRecordingWarning) {
-        ShortRecordingWarningDialog(
+        ActiveDialog.ShortRecordingWarning -> ShortRecordingWarningDialog(
             onKeepRecording = onKeepRecording,
             onStopAnyway = onStopRecordingAnyway,
         )
+
+        ActiveDialog.DeleteAllConfirmation -> DeleteAllConfirmationDialog(
+            onConfirm = onConfirmDeleteAll,
+            onDismiss = onDismissDeleteAll,
+        )
+
+        null -> Unit
     }
 }
 
@@ -97,7 +107,7 @@ fun BugReportWorkspaceOverlays(
 @Composable
 private fun BugReportWorkspaceOverlaysShareConsentPreview() {
     BugReportWorkspaceOverlays(
-        overlayState = BugReportWorkspaceViewModel.OverlayState(shareConsentReportId = "report-1"),
+        overlayState = BugReportWorkspaceViewModel.OverlayState(ActiveDialog.ShareConsent("report-1")),
     )
 }
 
@@ -106,6 +116,15 @@ private fun BugReportWorkspaceOverlaysShareConsentPreview() {
 @Composable
 private fun BugReportWorkspaceOverlaysShortRecordingPreview() {
     BugReportWorkspaceOverlays(
-        overlayState = BugReportWorkspaceViewModel.OverlayState(showShortRecordingWarning = true),
+        overlayState = BugReportWorkspaceViewModel.OverlayState(ActiveDialog.ShortRecordingWarning),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun BugReportWorkspaceOverlaysDeleteAllPreview() {
+    BugReportWorkspaceOverlays(
+        overlayState = BugReportWorkspaceViewModel.OverlayState(ActiveDialog.DeleteAllConfirmation),
     )
 }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -11,11 +11,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -37,13 +35,16 @@ import androidx.compose.material.icons.twotone.Stop
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -55,6 +56,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -81,7 +84,7 @@ import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
-import eu.darken.butler.workspace.ui.insets.paneInsets
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarContentPadding
 import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
@@ -161,9 +164,6 @@ fun BugReportWorkspacePage(
         return
     }
 
-    val paneInsets = design.paneInsets()
-    val navBarInset = paneInsets.bottom
-
     val topBarStackState = rememberPaneFloatingBarStackState(
         position = BarPosition.TOP,
         defaultSpacing = 8.dp,
@@ -171,6 +171,21 @@ fun BugReportWorkspacePage(
         contentPadding = 8.dp,
         design = design,
         estimatedContentPadding = 112.dp,
+    )
+    val bottomBarStackState = rememberPaneFloatingBarStackState(
+        position = BarPosition.BOTTOM,
+        workspaceId = state.id,
+        design = design,
+        defaultSpacing = 8.dp,
+        edgePadding = 8.dp,
+        contentPadding = 16.dp,
+        estimatedContentPadding = 80.dp,
+    )
+    val listContentPadding = rememberFloatingBarContentPadding(
+        topBarStackState,
+        bottomBarStackState,
+        start = WorkspacePaddings.ContentHorizontal,
+        end = WorkspacePaddings.ContentHorizontal,
     )
 
     // The ongoing recording is represented by the toolbar's recording row, never as a list card —
@@ -182,19 +197,17 @@ fun BugReportWorkspacePage(
             EmptyState(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = topBarStackState.contentPaddingDp()),
+                    .padding(
+                        top = topBarStackState.contentPaddingDp(),
+                        bottom = bottomBarStackState.contentPaddingDp(),
+                    ),
             )
         } else {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
                     .nestedScroll(topBarStackState.nestedScrollConnection),
-                contentPadding = PaddingValues(
-                    start = WorkspacePaddings.ContentHorizontal,
-                    end = WorkspacePaddings.ContentHorizontal,
-                    top = topBarStackState.contentPaddingDp(),
-                    bottom = navBarInset + 16.dp,
-                ),
+                contentPadding = listContentPadding,
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 items(listReports, key = { it.id }) { info ->
@@ -230,10 +243,33 @@ fun BugReportWorkspacePage(
                         recordingStartedAt = state.recordingStartedAt,
                         recordingLogSize = state.recordingLogSize,
                         isCollapsed = collapsedFraction > 0.5f,
-                        onStartRecording = onStartRecording,
                         onStopRecording = onStopRecording,
                         onDeleteAll = onDeleteAll,
                     )
+                }
+            },
+        )
+
+        FloatingBarStack(
+            state = bottomBarStackState,
+            position = BarPosition.BOTTOM,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            bars = {
+                // Static: the toolbar's recording controls disappear on scroll-collapse, so this is
+                // the only in-pane stop control that is guaranteed to be reachable.
+                FloatingBar(
+                    key = "record",
+                    visible = true,
+                    scrollBehavior = BarScrollBehavior.Static,
+                    estimatedHeight = 56.dp,
+                ) {
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                        RecordButton(
+                            isRecording = state.isRecording,
+                            onStartRecording = onStartRecording,
+                            onStopRecording = onStopRecording,
+                        )
+                    }
                 }
             },
         )
@@ -249,7 +285,6 @@ private fun BugReportToolbarCard(
     recordingStartedAt: Long,
     recordingLogSize: Long,
     isCollapsed: Boolean,
-    onStartRecording: () -> Unit,
     onStopRecording: () -> Unit,
     onDeleteAll: () -> Unit,
 ) {
@@ -322,22 +357,6 @@ private fun BugReportToolbarCard(
                         fontFamily = FontFamily.Monospace,
                         modifier = Modifier.weight(1f),
                     )
-                    // Compact Stop as a plain clickable box (not IconButton, which would enforce a
-                    // 48dp minimum interactive size and keep the collapsed bar taller than the 40dp
-                    // workspace button). Matches WorkspaceButton's own compact tap target.
-                    Box(
-                        modifier = Modifier
-                            .size(WorkspaceButtonDefaults.sizeCompact)
-                            .clip(CircleShape)
-                            .clickable(onClick = onStopRecording),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            imageVector = Icons.TwoTone.Stop,
-                            contentDescription = stringResource(R.string.bugreport_stop_action),
-                            tint = MaterialTheme.colorScheme.error,
-                        )
-                    }
                 } else {
                     Icon(
                         imageVector = Workspace.Type.BUG_REPORT.icon,
@@ -351,15 +370,6 @@ private fun BugReportToolbarCard(
                         style = MaterialTheme.typography.titleSmall,
                         modifier = Modifier.weight(1f),
                     )
-                    if (!isCollapsed && !isRecording) {
-                        IconButton(onClick = onStartRecording) {
-                            Icon(
-                                imageVector = Icons.TwoTone.FiberManualRecord,
-                                contentDescription = stringResource(R.string.bugreport_record_action),
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        }
-                    }
                     if (!isCollapsed && hasReports) {
                         IconButton(onClick = onDeleteAll) {
                             Icon(
@@ -385,6 +395,72 @@ private fun BugReportToolbarCard(
                 )
             }
         }
+    }
+}
+
+/**
+ * Starts/stops a recording from the bottom bar. The error tint only appears while recording, so an
+ * otherwise empty screen isn't dominated by a red pill.
+ *
+ * The content description uses the long-form strings ("Record debug log" / "Stop recording"): the
+ * visible label is a bare "Record"/"Stop", and the toolbar's recording row renders a "Stop" of its
+ * own, so visible text alone identifies neither for a screen reader nor for a test.
+ */
+@Composable
+private fun RecordButton(
+    modifier: Modifier = Modifier,
+    isRecording: Boolean,
+    onStartRecording: () -> Unit,
+    onStopRecording: () -> Unit,
+) {
+    val description = stringResource(
+        if (isRecording) R.string.bugreport_stop_action else R.string.bugreport_record_action,
+    )
+    val defaultContainerColor = FloatingActionButtonDefaults.containerColor
+    val containerColor = if (isRecording) MaterialTheme.colorScheme.errorContainer else defaultContainerColor
+    ExtendedFloatingActionButton(
+        onClick = if (isRecording) onStopRecording else onStartRecording,
+        modifier = modifier.semantics { contentDescription = description },
+        containerColor = containerColor,
+        contentColor = if (isRecording) {
+            MaterialTheme.colorScheme.onErrorContainer
+        } else {
+            contentColorFor(defaultContainerColor)
+        },
+        icon = {
+            if (isRecording) {
+                Icon(imageVector = Icons.TwoTone.Stop, contentDescription = null)
+            } else {
+                Icon(
+                    imageVector = Icons.TwoTone.FiberManualRecord,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        text = {
+            Text(
+                stringResource(
+                    if (isRecording) R.string.bugreport_stop_short_action else R.string.bugreport_record_short_action,
+                ),
+            )
+        },
+    )
+}
+
+@Preview2
+@Composable
+private fun RecordButtonIdlePreview() {
+    PreviewWrapper {
+        RecordButton(isRecording = false, onStartRecording = {}, onStopRecording = {})
+    }
+}
+
+@Preview2
+@Composable
+private fun RecordButtonRecordingPreview() {
+    PreviewWrapper {
+        RecordButton(isRecording = true, onStartRecording = {}, onStopRecording = {})
     }
 }
 

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -107,14 +107,6 @@ fun BugReportWorkspacePageHost(
     val state by vm.state.collectAsState(initial = null)
     val overlayState by vm.overlayState.collectAsState()
 
-    LaunchedEffect(Unit) {
-        vm.events.collect { event ->
-            when (event) {
-                BugReportWorkspaceViewModel.Event.ShowShortRecordingWarning -> vm.showShortRecordingWarning()
-            }
-        }
-    }
-
     state?.let { s ->
         // While the detail view is open, back returns to the list — but let an open dialog consume
         // back first so it isn't dismissed together with the detail.

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -62,10 +62,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.compose.runtime.LaunchedEffect
 import eu.darken.butler.bugreport.R
 import eu.darken.butler.bugreport.ui.detail.BugReportDetailContent
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.DateTimeStyle
@@ -116,13 +118,7 @@ fun BugReportWorkspacePageHost(
     state?.let { s ->
         // While the detail view is open, back returns to the list — but let an open dialog consume
         // back first so it isn't dismissed together with the detail.
-        WorkspaceBackHandler(
-            enabled = s.detail != null &&
-                overlayState.shareConsentReportId == null &&
-                !overlayState.showShortRecordingWarning,
-        ) {
-            vm.closeReport()
-        }
+        WorkspaceBackHandler(enabled = s.detail != null && overlayState.activeDialog == null) { vm.closeReport() }
 
         BugReportWorkspacePage(
             design = design,
@@ -131,7 +127,7 @@ fun BugReportWorkspacePageHost(
             onBack = { vm.closeReport() },
             onShareReport = { report -> vm.requestShareConsent(report.id) },
             onDeleteReport = { id -> vm.delete(id) },
-            onDeleteAll = { vm.deleteAll() },
+            onDeleteAll = { vm.requestDeleteAllConfirmation() },
             onStartRecording = { vm.startRecording() },
             onStopRecording = { vm.stopRecording() },
         )
@@ -638,6 +634,43 @@ internal fun ShortRecordingWarningDialog(
             TextButton(onClick = onKeepRecording) { Text(stringResource(R.string.bugreport_recording_short_keep_action)) }
         },
     )
+}
+
+@Composable
+internal fun DeleteAllConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    PaneBoundAlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.TwoTone.DeleteSweep,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+        },
+        title = { Text(stringResource(R.string.bugreport_delete_all_confirm_title)) },
+        text = { Text(stringResource(R.string.bugreport_delete_all_confirm_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(R.string.bugreport_delete_all_action),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.bugreport_cancel_action)) }
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DeleteAllConfirmationDialogPreview() {
+    DeleteAllConfirmationDialog(onConfirm = {}, onDismiss = {})
 }
 
 @Composable

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -333,7 +333,7 @@ private fun BugReportToolbarCard(
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             // Header row — either the normal title + actions, or (while collapsed and recording) a
-            // compact recording summary that keeps Stop reachable without expanding the card.
+            // compact recording readout: dot, elapsed time and log size.
             // The min height keeps the bar tappable/visible even in states with no action buttons or
             // cutout (e.g. idle-collapsed in a multi-pane layout), where vertical padding is 0.
             Row(

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -13,7 +13,6 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
-import eu.darken.butler.common.flow.SingleEventFlow
 import eu.darken.butler.common.ui.ViewModel3
 import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.CancellationException
@@ -33,12 +32,6 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     private val bugReportRepo: BugReportRepo,
     private val bugReportRecorder: BugReportRecorder,
 ) : ViewModel3(dispatchers, logTag("BugReport", "Workspace", id.shortTag, "Page")) {
-
-    sealed interface Event {
-        data object ShowShortRecordingWarning : Event
-    }
-
-    val events = SingleEventFlow<Event>()
 
     /** The report currently shown in the full-screen detail view, or null while on the list. */
     private val selectedReportId = MutableStateFlow<String?>(null)
@@ -61,8 +54,6 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     fun dismissShareConsent() = _overlayState.update {
         if (it.activeDialog is ActiveDialog.ShareConsent) it.copy(activeDialog = null) else it
     }
-
-    fun showShortRecordingWarning() = requestDialog(ActiveDialog.ShortRecordingWarning)
 
     fun dismissShortRecordingWarning() = _overlayState.update {
         if (it.activeDialog is ActiveDialog.ShortRecordingWarning) it.copy(activeDialog = null) else it
@@ -173,7 +164,7 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     fun stopRecording() = launch {
         log(tag, INFO) { "stopRecording()" }
         when (bugReportRecorder.requestStop()) {
-            is BugReportRecorder.StopResult.TooShort -> events.tryEmit(Event.ShowShortRecordingWarning)
+            is BugReportRecorder.StopResult.TooShort -> requestDialog(ActiveDialog.ShortRecordingWarning)
             is BugReportRecorder.StopResult.Stopped -> {}
             is BugReportRecorder.StopResult.NotRecording -> {}
         }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -49,21 +49,29 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     private val _overlayState = MutableStateFlow(OverlayState())
     val overlayState: StateFlow<OverlayState> = _overlayState
 
-    fun requestShareConsent(reportId: String) {
-        log(tag) { "requestShareConsent($reportId)" }
-        _overlayState.update { it.copy(shareConsentReportId = reportId) }
+    // First-wins: a request arriving while another dialog is up is dropped, so a destructive
+    // confirmation can never turn into a different question under the user's finger.
+    private fun requestDialog(dialog: ActiveDialog) {
+        log(tag) { "requestDialog($dialog)" }
+        _overlayState.update { if (it.activeDialog != null) it else it.copy(activeDialog = dialog) }
     }
 
-    fun dismissShareConsent() {
-        _overlayState.update { it.copy(shareConsentReportId = null) }
+    fun requestShareConsent(reportId: String) = requestDialog(ActiveDialog.ShareConsent(reportId))
+
+    fun dismissShareConsent() = _overlayState.update {
+        if (it.activeDialog is ActiveDialog.ShareConsent) it.copy(activeDialog = null) else it
     }
 
-    fun showShortRecordingWarning() {
-        _overlayState.update { it.copy(showShortRecordingWarning = true) }
+    fun showShortRecordingWarning() = requestDialog(ActiveDialog.ShortRecordingWarning)
+
+    fun dismissShortRecordingWarning() = _overlayState.update {
+        if (it.activeDialog is ActiveDialog.ShortRecordingWarning) it.copy(activeDialog = null) else it
     }
 
-    fun dismissShortRecordingWarning() {
-        _overlayState.update { it.copy(showShortRecordingWarning = false) }
+    fun requestDeleteAllConfirmation() = requestDialog(ActiveDialog.DeleteAllConfirmation)
+
+    fun dismissDeleteAllConfirmation() = _overlayState.update {
+        if (it.activeDialog is ActiveDialog.DeleteAllConfirmation) it.copy(activeDialog = null) else it
     }
 
     // Loads the selected report's log tail. flatMapLatest cancels an in-flight load when the selection
@@ -146,10 +154,15 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         if (selectedReportId.value == reportId) selectedReportId.value = null
     }
 
-    fun deleteAll() = launch {
+    fun deleteAll() {
         log(tag, INFO) { "deleteAll()" }
-        bugReportRepo.deleteAll()
-        selectedReportId.value = null
+        // Dismiss before the IO, like the share consent does: otherwise the confirm button stays live
+        // during the delete, and a throw inside deleteAll() would strand the dialog open.
+        dismissDeleteAllConfirmation()
+        launch {
+            bugReportRepo.deleteAll()
+            selectedReportId.value = null
+        }
     }
 
     fun startRecording() = launch {
@@ -184,11 +197,16 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         val detail: Detail? = null,
     )
 
+    /** A single slot, so two dialogs can never stack on top of each other. */
     data class OverlayState(
-        /** Report awaiting the user's share consent, or null while no consent is being asked for. */
-        val shareConsentReportId: String? = null,
-        val showShortRecordingWarning: Boolean = false,
+        val activeDialog: ActiveDialog? = null,
     )
+
+    sealed interface ActiveDialog {
+        data class ShareConsent(val reportId: String) : ActiveDialog
+        data object ShortRecordingWarning : ActiveDialog
+        data object DeleteAllConfirmation : ActiveDialog
+    }
 
     /** The full-screen detail view's state: the report plus its (async) log tail. */
     data class Detail(

--- a/app-workspace-bugreport/src/main/res/values/strings.xml
+++ b/app-workspace-bugreport/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="bugreport_share_action">Share</string>
     <string name="bugreport_delete_action">Delete</string>
     <string name="bugreport_delete_all_action">Delete all</string>
+    <string name="bugreport_delete_all_confirm_title">Delete all debug logs?</string>
+    <string name="bugreport_delete_all_confirm_message">This will permanently delete all recorded debug log sessions. Active recordings will not be affected.</string>
     <string name="bugreport_cancel_action">Cancel</string>
 
     <string name="bugreport_share_chooser_title">Share bug report</string>

--- a/app-workspace-bugreport/src/main/res/values/strings.xml
+++ b/app-workspace-bugreport/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="bugreport_type_recording">Recording</string>
 
     <string name="bugreport_record_action">Record debug log</string>
+    <string name="bugreport_record_short_action">Record</string>
     <string name="bugreport_stop_action">Stop recording</string>
     <string name="bugreport_stop_short_action">Stop</string>
     <string name="bugreport_recording_ongoing_label">Recording…</string>

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
@@ -8,16 +8,36 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.bugreport.R
+import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel.ActiveDialog
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.debug.bugreport.BugReportRecorder
+import eu.darken.butler.common.debug.bugreport.BugReportRepo
+import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 import testhelpers.ComposeTest
+import testhelpers.coroutine.TestDispatcherProvider
 
 /** The bug report page's dialogs render from the overlay slot, not from the page host. */
 class BugReportWorkspaceOverlaysTest : ComposeTest() {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun createVM() = BugReportWorkspaceViewModel(
+        id = Workspace.Id(),
+        dispatchers = TestDispatcherProvider(),
+        bugReportRepo = mockk<BugReportRepo>(relaxed = true).apply {
+            every { reports } returns flowOf(emptyList())
+        },
+        bugReportRecorder = mockk<BugReportRecorder>(relaxed = true).apply {
+            every { state } returns MutableStateFlow(BugReportRecorder.State())
+        },
+    )
 
     @Test
     fun `nothing renders while no dialog is requested`() {
@@ -37,6 +57,9 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
         composeTestRule
             .onNodeWithText(context.getString(R.string.bugreport_recording_short_title))
             .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.bugreport_delete_all_confirm_title))
+            .assertDoesNotExist()
     }
 
     @Test
@@ -48,7 +71,7 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
                 PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
                     BugReportWorkspaceOverlays(
                         overlayState = BugReportWorkspaceViewModel.OverlayState(
-                            shareConsentReportId = "report-1",
+                            activeDialog = ActiveDialog.ShareConsent("report-1"),
                         ),
                         onShareConsent = { consentedFor = it },
                     )
@@ -72,7 +95,7 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
                 PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
                     BugReportWorkspaceOverlays(
                         overlayState = BugReportWorkspaceViewModel.OverlayState(
-                            showShortRecordingWarning = true,
+                            activeDialog = ActiveDialog.ShortRecordingWarning,
                         ),
                     )
                 }
@@ -82,5 +105,56 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
         composeTestRule
             .onNodeWithText(context.getString(R.string.bugreport_recording_short_title))
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the delete all confirmation renders and reports both answers`() {
+        var confirmed = 0
+        var dismissed = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    BugReportWorkspaceOverlays(
+                        overlayState = BugReportWorkspaceViewModel.OverlayState(
+                            activeDialog = ActiveDialog.DeleteAllConfirmation,
+                        ),
+                        onConfirmDeleteAll = { confirmed++ },
+                        onDismissDeleteAll = { dismissed++ },
+                    )
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.bugreport_delete_all_confirm_title))
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(context.getString(R.string.bugreport_cancel_action)).performClick()
+        composeTestRule.runOnIdle { dismissed shouldBe 1 }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.bugreport_delete_all_action)).performClick()
+        composeTestRule.runOnIdle { confirmed shouldBe 1 }
+    }
+
+    @Test
+    fun `the delete all confirmation is requested and dismissed through the slot`() {
+        val vm = createVM()
+
+        vm.requestDeleteAllConfirmation()
+        vm.overlayState.value.activeDialog shouldBe ActiveDialog.DeleteAllConfirmation
+
+        vm.dismissDeleteAllConfirmation()
+        vm.overlayState.value.activeDialog shouldBe null
+    }
+
+    @Test
+    fun `a dialog request while another dialog is showing is dropped`() {
+        val vm = createVM()
+
+        vm.requestDeleteAllConfirmation()
+        vm.requestShareConsent("report-1")
+
+        vm.overlayState.value.activeDialog shouldBe ActiveDialog.DeleteAllConfirmation
     }
 }

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePageTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePageTest.kt
@@ -1,0 +1,132 @@
+package eu.darken.butler.bugreport.ui
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.bugreport.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.debug.bugreport.BugReport
+import eu.darken.butler.common.debug.bugreport.BugReportInfo
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import kotlin.time.Instant
+
+/** Recording is started and stopped from the bottom bar, not from the toolbar card. */
+@Config(qualifiers = "w400dp-h800dp")
+class BugReportWorkspacePageTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val recordLabel = context.getString(R.string.bugreport_record_action)
+    private val stopLabel = context.getString(R.string.bugreport_stop_action)
+    private val deleteAllLabel = context.getString(R.string.bugreport_delete_all_action)
+
+    private fun report(index: Int) = BugReportInfo(
+        report = BugReport(
+            id = "report-$index",
+            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+            type = BugReport.Type.CRASH,
+            errorClass = "java.lang.IllegalStateException",
+            errorMessage = "failure number $index",
+            stackTrace = "",
+            threadName = "main",
+            appVersion = "v0.0.0-beta1",
+            deviceFingerprint = "Pixel/foo",
+            apiLevel = "36",
+            flavor = "FOSS",
+            buildType = "RELEASE",
+            installId = "abc",
+            locale = "en-US",
+        ),
+        isSeen = true,
+    )
+
+    private fun setPage(
+        reports: List<BugReportInfo> = emptyList(),
+        isRecording: Boolean = false,
+        onStartRecording: () -> Unit = {},
+        onStopRecording: () -> Unit = {},
+        onDeleteAll: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                BugReportWorkspacePage(
+                    state = BugReportWorkspaceViewModel.State(
+                        id = Workspace.Id(),
+                        reports = reports,
+                        isRecording = isRecording,
+                    ),
+                    onStartRecording = onStartRecording,
+                    onStopRecording = onStopRecording,
+                    onDeleteAll = onDeleteAll,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the record button is reachable without any reports`() {
+        var started = 0
+        setPage(onStartRecording = { started++ })
+
+        composeTestRule.onNodeWithContentDescription(recordLabel).assertIsDisplayed().performClick()
+
+        composeTestRule.runOnIdle { started shouldBe 1 }
+    }
+
+    @Test
+    fun `the record button stops an ongoing recording`() {
+        var stopped = 0
+        setPage(isRecording = true, onStopRecording = { stopped++ })
+
+        // By content description, not by the visible "Stop": the toolbar's recording row renders a
+        // Stop button of its own.
+        composeTestRule.onNodeWithContentDescription(stopLabel).assertIsDisplayed().performClick()
+
+        composeTestRule.runOnIdle { stopped shouldBe 1 }
+    }
+
+    @Test
+    fun `only the record button offers to start a recording`() {
+        setPage(reports = listOf(report(1)))
+
+        composeTestRule.onAllNodesWithContentDescription(recordLabel).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the record button stays reachable after scrolling the list`() {
+        var started = 0
+        val reports = (1..40).map { report(it) }
+        setPage(reports = reports, onStartRecording = { started++ })
+
+        val firstMessage = reports.first().report.errorMessage!!
+        composeTestRule.onNodeWithText(firstMessage).assertIsDisplayed()
+
+        composeTestRule.onNode(hasScrollToIndexAction()).performScrollToIndex(reports.lastIndex)
+
+        composeTestRule.onNodeWithText(firstMessage).assertIsNotDisplayed()
+        composeTestRule.onNodeWithContentDescription(recordLabel).assertIsDisplayed().performClick()
+
+        composeTestRule.runOnIdle { started shouldBe 1 }
+    }
+
+    @Test
+    fun `deleting all reports is routed through the caller`() {
+        var deleteAlls = 0
+        setPage(reports = listOf(report(1)), onDeleteAll = { deleteAlls++ })
+
+        composeTestRule.onNodeWithContentDescription(deleteAllLabel).performClick()
+
+        composeTestRule.runOnIdle { deleteAlls shouldBe 1 }
+    }
+}

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePageTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePageTest.kt
@@ -1,15 +1,18 @@
 package eu.darken.butler.bugreport.ui
 
 import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasScrollToIndexAction
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.bugreport.R
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -125,7 +128,11 @@ class BugReportWorkspacePageTest : ComposeTest() {
         var deleteAlls = 0
         setPage(reports = listOf(report(1)), onDeleteAll = { deleteAlls++ })
 
-        composeTestRule.onNodeWithContentDescription(deleteAllLabel).performClick()
+        // CutoutCard's Auto mode subcomposes the toolbar twice (measure + card), so the toolbar
+        // controls exist twice in the semantics tree; both close over the same callback.
+        composeTestRule.onAllNodesWithContentDescription(deleteAllLabel)
+            .onFirst()
+            .performSemanticsAction(SemanticsActions.OnClick)
 
         composeTestRule.runOnIdle { deleteAlls shouldBe 1 }
     }


### PR DESCRIPTION
## What changed

- Recording a debug log now starts and stops from a large, labelled button in the bottom right corner of the Bug reports screen. It used to be a small icon in the bar at the top, which also disappeared as soon as you scrolled the list. The new button stays put.
- Deleting all debug logs now asks for confirmation first. It previously wiped every recorded log on a single tap, with nothing to undo it.

## Technical Context

- The button lives in a new bottom `FloatingBarStack` shared by *both* the empty-state branch and the list branch. Putting it in the list branch alone would hide it from a user who has no reports yet, which is exactly the case where starting a recording matters most.
- The bar is deliberately `BarScrollBehavior.Static`. Both bar stacks are driven by the same list scroll deltas, so a scroll-hiding bottom bar would vanish in the same gesture that collapses the top toolbar — and toolbar collapse is what removes the inline recording controls. The result would be no way to stop a recording from inside the pane at all.
- `OverlayState` moved from one boolean per dialog to a single sealed `ActiveDialog` slot, so two dialogs can no longer be composed at once. Requests are first-wins, and `stopRecording()` now requests the short-recording warning directly rather than routing it through a `SingleEventFlow` and back into the same ViewModel via the page's collector. That round trip had exactly one consumer and widened the window in which a competing dialog could claim the slot.
- `deleteAll()` clears the confirmation synchronously *before* starting the file IO. Clearing it afterwards left the confirm button live during deletion and would strand the dialog open if the delete threw.
- Worth a close look: `BugReportWorkspacePageTest` addresses the toolbar's delete-all button through a semantics-action collection rather than a single node. `CutoutCard` in `Auto` mode subcomposes its content twice — a throwaway measure pass plus the real card — so every toolbar control appears twice in the semantics tree. Any future test that addresses a toolbar control has to account for that.
