### PR TITLE
General: Catch schema changes that would break existing databases

### DIFF
--- a/.claude/rules/technical-patterns.md
+++ b/.claude/rules/technical-patterns.md
@@ -43,6 +43,8 @@
 - **When bumping a `@Database` version**: add the `Migration` to the database's `MIGRATIONS` array and commit the newly exported schema JSON. Enforcement:
     - Per-database `*MigrationTest` (Robolectric + `MigrationTestHelper`) fails if any schema version is unreachable from version 1 via `MIGRATIONS`.
     - CI fails if schema JSONs change without being committed (catches entity changes without a version bump).
+    - Per-database `*SchemaIdentityTest` pins the `identityHash` of every exported version, so a version bump also means adding the new version's hash to the test's expected map.
+    - A hash MISMATCH on an already-exported version is fixed by a version bump plus a migration, never by updating the expected hash — the sole exception is a version that has genuinely never shipped. A missing or malformed schema asset is a broken asset, not a schema change.
 
 ## Logging
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/location/db/SAFLocationDatabaseSchemaIdentityTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/location/db/SAFLocationDatabaseSchemaIdentityTest.kt
@@ -1,0 +1,21 @@
+package eu.darken.butler.common.files.saf.location.db
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SAFLocationDatabaseSchemaIdentityTest : BaseTest() {
+
+    @Test
+    fun `the schema versions are unchanged`() {
+        roomSchemaIdentityHashes(SAFLocationDatabase::class.java) shouldBe mapOf(
+            1 to "c841715e2095b5393d29e18d1660f510",
+        )
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/smb/SmbSchemaIdentityTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/smb/SmbSchemaIdentityTest.kt
@@ -1,56 +1,34 @@
 package eu.darken.butler.common.files.smb
 
-import androidx.test.platform.app.InstrumentationRegistry
+import eu.darken.butler.common.files.smb.credentials.db.SmbCredentialDatabase
+import eu.darken.butler.common.files.smb.location.db.SmbLocationDatabase
 import io.kotest.matchers.shouldBe
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
 
 /**
- * Pins the identity hash of every SMB schema version that has been exported.
- *
- * Room stores this hash inside the database and refuses to open one whose hash disagrees with the
- * build's. CI already fails when a schema JSON is left uncommitted, but it cannot tell a NEW version
- * from an EDITED one: regenerating `1.json` in place and committing it passes every existing check
- * while making every installed database unopenable. Freezing the hashes here is what catches that.
- *
- * A failure means an already-exported version changed. The fix is a version bump plus a migration,
- * never a new expected hash - except for a version that has genuinely never shipped, and this branch
- * is where that judgement gets made.
+ * Covers both SMB databases, the network locations and the credentials they are paired with.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class SmbSchemaIdentityTest : BaseTest() {
 
-    private val json = Json { ignoreUnknownKeys = true }
-
-    private fun identityHash(database: String, version: Int): String {
-        val assets = InstrumentationRegistry.getInstrumentation().context.assets
-        val raw = assets.open("$database/$version.json").bufferedReader().use { it.readText() }
-        return json.parseToJsonElement(raw)
-            .jsonObject.getValue("database")
-            .jsonObject.getValue("identityHash")
-            .jsonPrimitive.content
-    }
-
     @Test
     fun `the network location schema versions are unchanged`() {
-        identityHash(LOCATIONS, 1) shouldBe "eb27303b4a3a1e72d78484ceddc62669"
-        identityHash(LOCATIONS, 2) shouldBe "1ad05dcbfce071dad7fd762b538468fa"
+        roomSchemaIdentityHashes(SmbLocationDatabase::class.java) shouldBe mapOf(
+            1 to "eb27303b4a3a1e72d78484ceddc62669",
+            2 to "1ad05dcbfce071dad7fd762b538468fa",
+        )
     }
 
     @Test
     fun `the credential schema versions are unchanged`() {
-        identityHash(CREDENTIALS, 1) shouldBe "ca94bee1fa1b7ad4e437aa8ee2738863"
-    }
-
-    companion object {
-        private const val LOCATIONS = "eu.darken.butler.common.files.smb.location.db.SmbLocationDatabase"
-        private const val CREDENTIALS = "eu.darken.butler.common.files.smb.credentials.db.SmbCredentialDatabase"
+        roomSchemaIdentityHashes(SmbCredentialDatabase::class.java) shouldBe mapOf(
+            1 to "ca94bee1fa1b7ad4e437aa8ee2738863",
+        )
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/trash/db/TrashDatabaseSchemaIdentityTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/trash/db/TrashDatabaseSchemaIdentityTest.kt
@@ -1,0 +1,21 @@
+package eu.darken.butler.common.trash.db
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TrashDatabaseSchemaIdentityTest : BaseTest() {
+
+    @Test
+    fun `the schema versions are unchanged`() {
+        roomSchemaIdentityHashes(TrashDatabase::class.java) shouldBe mapOf(
+            1 to "67a5d61cc559fd6bac2ca5d0b7d072f5",
+        )
+    }
+}

--- a/app-common-test/src/main/java/testhelpers/room/RoomSchemaVersions.kt
+++ b/app-common-test/src/main/java/testhelpers/room/RoomSchemaVersions.kt
@@ -4,18 +4,51 @@ import android.content.Context
 import androidx.room.migration.Migration
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private val schemaJson = Json { ignoreUnknownKeys = true }
+
+private fun exportedSchemaVersions(databaseClass: Class<*>): List<Int> {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val versions = context.assets.list(databaseClass.canonicalName!!)
+        ?.mapNotNull { it.removeSuffix(".json").toIntOrNull() }
+    check(!versions.isNullOrEmpty()) { "No exported Room schemas found for ${databaseClass.canonicalName}" }
+    return versions
+}
 
 /**
  * Highest exported schema version for [databaseClass], read from the module's `schemas/` dir
  * (exposed as test assets). Requires `exportSchema = true` and the schemas dir added via
  * `sourceSets.getByName("test").assets.srcDir("$projectDir/schemas")`.
  */
-fun latestRoomSchemaVersion(databaseClass: Class<*>): Int {
-    val context = ApplicationProvider.getApplicationContext<Context>()
-    val versions = context.assets.list(databaseClass.canonicalName!!)
-        ?.mapNotNull { it.removeSuffix(".json").toIntOrNull() }
-    check(!versions.isNullOrEmpty()) { "No exported Room schemas found for ${databaseClass.canonicalName}" }
-    return versions.max()
+fun latestRoomSchemaVersion(databaseClass: Class<*>): Int = exportedSchemaVersions(databaseClass).max()
+
+/**
+ * Every exported schema version of [databaseClass] mapped to its Room identity hash. Room stores that
+ * hash inside the database and refuses to open one whose hash disagrees with the build's. CI fails on
+ * an uncommitted schema JSON but cannot tell a NEW version from an EDITED one, so pinning this map in
+ * a test is what catches a version that was regenerated in place.
+ *
+ * A HASH MISMATCH on an already-exported version calls for a version bump plus a migration, never a
+ * new expected hash - the sole exception being a version that has genuinely never shipped. A load or
+ * parse failure means the schema asset is missing or broken; restore the asset instead of bumping.
+ */
+fun roomSchemaIdentityHashes(databaseClass: Class<*>): Map<Int, String> {
+    val assets = ApplicationProvider.getApplicationContext<Context>().assets
+    return exportedSchemaVersions(databaseClass).associateWith { version ->
+        val path = "${databaseClass.canonicalName}/$version.json"
+        try {
+            val raw = assets.open(path).bufferedReader().use { it.readText() }
+            schemaJson.parseToJsonElement(raw)
+                .jsonObject.getValue("database")
+                .jsonObject.getValue("identityHash")
+                .jsonPrimitive.content
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to read the Room identity hash from $path", e)
+        }
+    }
 }
 
 /**

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/sorting/rules/db/FolderSortRuleDatabaseSchemaIdentityTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/sorting/rules/db/FolderSortRuleDatabaseSchemaIdentityTest.kt
@@ -1,0 +1,21 @@
+package eu.darken.butler.explorer.core.sorting.rules.db
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class FolderSortRuleDatabaseSchemaIdentityTest : BaseTest() {
+
+    @Test
+    fun `the schema versions are unchanged`() {
+        roomSchemaIdentityHashes(FolderSortRuleDatabase::class.java) shouldBe mapOf(
+            1 to "50849ef2507af8106097eabfd49894d9",
+        )
+    }
+}

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/core/history/db/SearchHistoryDatabaseSchemaIdentityTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/core/history/db/SearchHistoryDatabaseSchemaIdentityTest.kt
@@ -1,0 +1,21 @@
+package eu.darken.butler.searcher.core.history.db
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SearchHistoryDatabaseSchemaIdentityTest : BaseTest() {
+
+    @Test
+    fun `the schema versions are unchanged`() {
+        roomSchemaIdentityHashes(SearchHistoryDatabase::class.java) shouldBe mapOf(
+            1 to "ce6604e50860f36304273a7c05e9bcc0",
+        )
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryDatabaseSchemaIdentityTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryDatabaseSchemaIdentityTest.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.workspace.core.operations.history.db
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OperationHistoryDatabaseSchemaIdentityTest : BaseTest() {
+
+    @Test
+    fun `the schema versions are unchanged`() {
+        roomSchemaIdentityHashes(OperationHistoryDatabase::class.java) shouldBe mapOf(
+            1 to "d954c3851505bf400b9cddb7fa6df8fe",
+            2 to "5904c0e95136be0e50ce4c6ad0c75012",
+        )
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/session/db/WorkspaceSessionDatabaseSchemaIdentityTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/session/db/WorkspaceSessionDatabaseSchemaIdentityTest.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.workspace.core.session.db
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.room.roomSchemaIdentityHashes
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class WorkspaceSessionDatabaseSchemaIdentityTest : BaseTest() {
+
+    @Test
+    fun `the schema versions are unchanged`() {
+        roomSchemaIdentityHashes(WorkspaceSessionDatabase::class.java) shouldBe mapOf(
+            1 to "2ad11220d9ca13aae6114018d1ec6de7",
+            2 to "fa86981254f536bf2b9c7e06eab7cc03",
+        )
+    }
+}


### PR DESCRIPTION
## What changed

No user-facing behavior change. Each of Butler's databases exports a schema file, and Room refuses to open an installed database whose schema fingerprint no longer matches the one the app was built with. This adds a test per database that freezes those fingerprints, so a change that would leave existing installs unable to open their data fails in CI instead of shipping.

## Technical Context

- The existing enforcement cannot catch this. CI only fails when a schema JSON is left uncommitted, which does not distinguish a new version from an edited one: regenerating `1.json` in place and committing it passes every check, and Room then rejects every installed database on the stored `identityHash`.
- The reader enumerates instead of looking up. `roomSchemaIdentityHashes(dbClass)` in `app-common-test` lists a database's exported versions and returns all of them, so each test asserts a whole map. A newly exported version nobody pinned shows up as an extra key and fails. A hard-coded per-version list would have left it silently unguarded, decaying the guard to whatever existed when it was written.
- `latestRoomSchemaVersion` shares the listing. Its asset enumeration moved into a private helper that both functions call; behavior and failure message are unchanged, which matters because eight migration tests depend on it.
- `SmbSchemaIdentityTest` was the prototype for this and now uses the shared reader, dropping its private JSON parsing and database-name constants. Its three hashes are unchanged.
- Worth close review: the expected hashes come from the committed schema JSONs and must never be "corrected" by regenerating them. `.claude/rules/technical-patterns.md` records the convention, that a mismatch on an already-exported version calls for a version bump plus a migration rather than a new expected hash, and that a missing or malformed schema asset is a broken asset instead of a schema change.
