### PR TITLE
Explorer: Suggest apps that share storage when adding a location

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/SAFPath.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/SAFPath.kt
@@ -35,6 +35,15 @@ data class SAFPath(
             val documentId = treeRootPath?.let { TREE_DOCUMENT_ID_REGEX.matchEntire(it)?.groupValues?.get(1) }
 
             if (documentId != null) {
+                // Path shaped document ID, e.g. "/data/data/com.termux/files/home": there is no
+                // volume to name, and it reads as a plain path. Keyed on the leading slash, not on
+                // the absence of a colon: "primary" has no colon either, and a POSIX path may
+                // contain one.
+                if (documentId.startsWith("/")) {
+                    val allSegments = documentId.split("/").filter { it.isNotEmpty() } + segments
+                    return caString { "/${allSegments.joinToString("/")}" }
+                }
+
                 // Parse document ID: "primary" or "primary:Folder1" or "primary:Folder1/SubFolder"
                 val parts = documentId.split(":", limit = 2)
                 val storageId = parts[0]

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/location/SAFLocationManager.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/location/SAFLocationManager.kt
@@ -117,6 +117,18 @@ interface SAFLocationManager {
     suspend fun setLocationLabel(locationId: String, label: String?)
 
     /**
+     * Set a display label only if the location doesn't have one yet.
+     *
+     * Location IDs are derived from the tree URI, so re-granting an already known location
+     * targets the same entry, including one the user renamed. This never overwrites such a name.
+     *
+     * @param locationId The location ID
+     * @param label Label to apply if none is stored yet
+     * @return The label the location now has: the pre-existing one if there was any, otherwise [label]
+     */
+    suspend fun seedLocationLabel(locationId: String, label: String): String?
+
+    /**
      * Hide a location from the Device view in Explorer.
      *
      * Hidden locations are excluded from getGrantedLocations() but

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImpl.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImpl.kt
@@ -214,10 +214,10 @@ class SAFLocationManagerImpl @Inject constructor(
     override suspend fun seedLocationLabel(locationId: String, label: String): String? {
         log(TAG, VERBOSE) { "seedLocationLabel(locationId=$locationId, label=$label)" }
         // Read the entity, not `locations`: that one drops hidden locations, whose label needs the same protection.
-        val existing = dao.getPreference(locationId)?.userLabel
+        val existing = dao.getPreference(locationId)
         if (existing != null) {
-            log(TAG) { "seedLocationLabel(...): Keeping existing label '$existing' for $locationId" }
-            return existing
+            log(TAG) { "seedLocationLabel(...): Keeping existing label '${existing.userLabel}' for $locationId" }
+            return existing.userLabel
         }
         setLocationLabel(locationId, label)
         return label

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImpl.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImpl.kt
@@ -28,13 +28,16 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 /**
@@ -208,6 +211,18 @@ class SAFLocationManagerImpl @Inject constructor(
         updateLocation(locationId) { it.copy(userLabel = label) }
     }
 
+    override suspend fun seedLocationLabel(locationId: String, label: String): String? {
+        log(TAG, VERBOSE) { "seedLocationLabel(locationId=$locationId, label=$label)" }
+        // Read the entity, not `locations`: that one drops hidden locations, whose label needs the same protection.
+        val existing = dao.getPreference(locationId)?.userLabel
+        if (existing != null) {
+            log(TAG) { "seedLocationLabel(...): Keeping existing label '$existing' for $locationId" }
+            return existing
+        }
+        setLocationLabel(locationId, label)
+        return label
+    }
+
     override suspend fun setLocationHidden(locationId: String, hidden: Boolean) {
         log(TAG, VERBOSE) { "setLocationHidden(locationId=$locationId, hidden=$hidden)" }
         updateLocation(locationId) { it.copy(isHidden = hidden) }
@@ -220,8 +235,22 @@ class SAFLocationManagerImpl @Inject constructor(
 
     private suspend fun updateLocation(locationId: String, update: (SAFLocationEntity) -> SAFLocationEntity) {
         val current = dao.getPreference(locationId) ?: SAFLocationEntity(locationId = locationId)
-        val updated = update(current)
-        dao.upsert(updated.copy(locationId = locationId))
+        val updated = update(current).copy(locationId = locationId)
+        dao.upsert(updated)
+
+        // Room delivers the query invalidation asynchronously, so returning here would let callers
+        // refresh from a cache that still holds the old values. Await the private cache, the public
+        // one omits hidden locations and would never satisfy a hide.
+        val observed = withTimeoutOrNull(CACHE_SYNC_TIMEOUT) {
+            cachedLocations.first { locations ->
+                locations.any {
+                    it.id == locationId && it.userLabel == updated.userLabel && it.isHidden == updated.isHidden
+                }
+            }
+        }
+        if (observed == null) {
+            log(TAG, WARN) { "updateLocation($locationId): Cache did not reflect $updated within $CACHE_SYNC_TIMEOUT" }
+        }
     }
 
     suspend fun cleanup(activeLocationIds: List<String>) = withContext(dispatcherProvider.IO) {
@@ -405,6 +434,7 @@ class SAFLocationManagerImpl @Inject constructor(
     }
 
     companion object {
+        private val CACHE_SYNC_TIMEOUT = 2.seconds
         private val TAG = logTag("SAF", "Location", "Manager")
     }
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/KnownStorageProvider.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/KnownStorageProvider.kt
@@ -3,7 +3,7 @@ package eu.darken.butler.common.storage.saf
 /**
  * Providers we know enough about to open the system picker directly at their storage root.
  *
- * A stale [rootDocumentIdFor] degrades gracefully: it only feeds
+ * A stale [rootIdFor] degrades gracefully: it only feeds
  * [android.provider.DocumentsContract.EXTRA_INITIAL_URI], which the picker treats as a hint.
  */
 enum class KnownStorageProvider(val packageNames: Set<String>) {
@@ -12,7 +12,7 @@ enum class KnownStorageProvider(val packageNames: Set<String>) {
 
     fun authorityFor(pkg: String): String = "$pkg.documents"
 
-    fun rootDocumentIdFor(pkg: String): String = when (this) {
+    fun rootIdFor(pkg: String): String = when (this) {
         TERMUX -> "/data/data/$pkg/files/home"
     }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/KnownStorageProvider.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/KnownStorageProvider.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.common.storage.saf
+
+/**
+ * Providers we know enough about to open the system picker directly at their storage root.
+ *
+ * A stale [rootDocumentIdFor] degrades gracefully: it only feeds
+ * [android.provider.DocumentsContract.EXTRA_INITIAL_URI], which the picker treats as a hint.
+ */
+enum class KnownStorageProvider(val packageNames: Set<String>) {
+    TERMUX(setOf("com.termux")),
+    ;
+
+    fun authorityFor(pkg: String): String = "$pkg.documents"
+
+    fun rootDocumentIdFor(pkg: String): String = when (this) {
+        TERMUX -> "/data/data/$pkg/files/home"
+    }
+
+    companion object {
+        fun forPackage(pkg: String): KnownStorageProvider? = entries.firstOrNull { pkg in it.packageNames }
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilder.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilder.kt
@@ -121,6 +121,24 @@ class SAFPickerIntentBuilder @Inject constructor(
         }
     }
 
+    /**
+     * Builds a SAF picker intent pre-navigated to a provider's own storage root.
+     *
+     * @param authority The documents provider authority
+     * @param rootDocumentId The provider's root document ID
+     */
+    fun buildPickerIntent(authority: String, rootDocumentId: String): Intent {
+        val treeUri = DocumentsContract.buildTreeDocumentUri(authority, rootDocumentId)
+        val navTreeUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, rootDocumentId)
+
+        log(TAG) { "Created picker intent for $authority ($rootDocumentId) -> navigation URI: $navTreeUri" }
+
+        return Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            putExtra("android.content.extra.SHOW_ADVANCED", true)
+            putExtra(DocumentsContract.EXTRA_INITIAL_URI, navTreeUri)
+        }
+    }
+
     companion object {
         private val TAG = logTag("SAF", "PickerBuilder")
     }

--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilder.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilder.kt
@@ -125,17 +125,17 @@ class SAFPickerIntentBuilder @Inject constructor(
      * Builds a SAF picker intent pre-navigated to a provider's own storage root.
      *
      * @param authority The documents provider authority
-     * @param rootDocumentId The provider's root document ID
+     * @param rootId The provider's root ID
      */
-    fun buildPickerIntent(authority: String, rootDocumentId: String): Intent {
-        val treeUri = DocumentsContract.buildTreeDocumentUri(authority, rootDocumentId)
-        val navTreeUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, rootDocumentId)
+    fun buildPickerIntent(authority: String, rootId: String): Intent {
+        // A tree URI would presuppose a grant for this authority, which is exactly what we're asking for.
+        val rootUri = DocumentsContract.buildRootUri(authority, rootId)
 
-        log(TAG) { "Created picker intent for $authority ($rootDocumentId) -> navigation URI: $navTreeUri" }
+        log(TAG) { "Created picker intent for $authority ($rootId) -> navigation URI: $rootUri" }
 
         return Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
             putExtra("android.content.extra.SHOW_ADVANCED", true)
-            putExtra(DocumentsContract.EXTRA_INITIAL_URI, navTreeUri)
+            putExtra(DocumentsContract.EXTRA_INITIAL_URI, rootUri)
         }
     }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/StorageProviderSuggester.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/StorageProviderSuggester.kt
@@ -112,6 +112,8 @@ class StorageProviderSuggester @Inject constructor(
             "com.android.providers.downloads.documents",
             "com.android.providers.media.documents",
             "com.android.mtp.documents",
+            // Browses inside archive files for the system picker, publishes no grantable root.
+            "com.android.documentsui.archives",
         )
     }
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/StorageProviderSuggester.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/StorageProviderSuggester.kt
@@ -1,0 +1,117 @@
+package eu.darken.butler.common.storage.saf
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ProviderInfo
+import android.provider.DocumentsContract
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.asLog
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.withContext
+
+data class StorageProviderSuggestion(
+    val packageName: String,
+    val authority: String,
+    val label: String,
+    /** Non-null means the picker can be opened directly at this app's storage root. */
+    val known: KnownStorageProvider?,
+)
+
+/**
+ * Finds installed apps that expose storage through a documents provider, so they can be offered
+ * as add-storage shortcuts instead of leaving the user to find them in the system picker.
+ */
+@Reusable
+class StorageProviderSuggester @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    suspend fun getSuggestions(): List<StorageProviderSuggestion> = withContext(dispatcherProvider.IO) {
+        val resolved = try {
+            context.packageManager.queryIntentContentProviders(Intent(DocumentsContract.PROVIDER_INTERFACE), 0)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to query documents providers: ${e.asLog()}" }
+            return@withContext emptyList()
+        }
+
+        resolved
+            .mapNotNull { info ->
+                val providerInfo = info.providerInfo ?: return@mapNotNull null
+                try {
+                    providerInfo.toSuggestion()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Skipping ${providerInfo.authority}: ${e.asLog()}" }
+                    null
+                }
+            }
+            .groupBy { it.packageName }
+            .map { (_, candidates) -> candidates.preferred() }
+            .sortedWith(compareBy({ it.known == null }, { it.label.lowercase() }))
+            .also { log(TAG) { "getSuggestions(): $it" } }
+    }
+
+    /**
+     * Label of the app owning [authority], or null when that app would not be suggested either.
+     *
+     * Used to pre-fill the location name after a grant, so an ordinary folder picked through the
+     * system picker keeps its path-derived default name instead of being labelled after the
+     * platform provider that served it.
+     */
+    suspend fun labelForAuthority(authority: String): String? = withContext(dispatcherProvider.IO) {
+        try {
+            context.packageManager.resolveContentProvider(authority, 0)?.toSuggestion()?.label
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to resolve $authority: ${e.asLog()}" }
+            null
+        }
+    }
+
+    private fun ProviderInfo.toSuggestion(): StorageProviderSuggestion? {
+        val authority = authority ?: return null
+        if (!exported) return null
+        if (packageName == context.packageName) return null
+        if (PLATFORM_AUTHORITIES.contains(authority)) return null
+        // Platform and system components register providers an authority list cannot keep up with,
+        // and none of them has a launcher entry the user could act on.
+        if (context.packageManager.getLaunchIntentForPackage(packageName) == null) return null
+
+        return StorageProviderSuggestion(
+            packageName = packageName,
+            authority = authority,
+            label = context.packageManager.getApplicationLabel(applicationInfo).toString(),
+            known = KnownStorageProvider.forPackage(packageName),
+        )
+    }
+
+    /** An app may declare several providers, prefer the one we can deep-link into. */
+    private fun List<StorageProviderSuggestion>.preferred(): StorageProviderSuggestion =
+        firstOrNull { it.known != null && it.authority == it.known.authorityFor(it.packageName) } ?: first()
+
+    companion object {
+        private val TAG = logTag("SAF", "ProviderSuggester")
+
+        /**
+         * Keyed on authority, not package: platform package names drift across versions and OEMs
+         * (`com.android.providers.media` became `com.android.providers.media.module`).
+         */
+        private val PLATFORM_AUTHORITIES = setOf(
+            "com.android.externalstorage.documents",
+            "com.android.providers.downloads.documents",
+            "com.android.providers.media.documents",
+            "com.android.mtp.documents",
+        )
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/SAFPathTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/SAFPathTest.kt
@@ -168,6 +168,15 @@ class SAFPathTest : BaseTest() {
             "seg1",
             "seg2",
         ).userReadablePath.get(mockk()) shouldBe "[3135-3132]/seg1/seg2"
+        SAFPath.build(
+            "content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome",
+            "seg1",
+            "seg2",
+        ).userReadablePath.get(mockk()) shouldBe "/data/data/com.termux/files/home/seg1/seg2"
+        SAFPath.build(
+            "content://com.example.documents/tree/%2Fsrv%2Fbackup%3A2026",
+            "seg1",
+        ).userReadablePath.get(mockk()) shouldBe "/srv/backup:2026/seg1"
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImplTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImplTest.kt
@@ -614,6 +614,24 @@ class SAFLocationManagerImplTest : BaseTest() {
     }
 
     /**
+     * A cleared label is a choice, not an absence: the stored row must survive a re-grant.
+     */
+    @Test
+    fun `seedLocationLabel keeps a deliberately cleared label`() {
+        val locationId = grantedLocationId()
+        preferences.value = listOf(SAFLocationEntity(locationId, userLabel = null, isHidden = true))
+
+        var seeded: String? = "unset"
+        val seed = testScope.launch { seeded = manager.seedLocationLabel(locationId, "Termux") }
+        testDispatcher.scheduler.runCurrent()
+
+        seed.isCompleted shouldBe true
+        seeded shouldBe null
+        coVerify(exactly = 0) { dao.upsert(any()) }
+        preferences.value.single() shouldBe SAFLocationEntity(locationId, userLabel = null, isHidden = true)
+    }
+
+    /**
      * Callers refresh right after a label change, so the write must not return before
      * the location cache carries it.
      */

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImplTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/location/SAFLocationManagerImplTest.kt
@@ -15,9 +15,11 @@ import eu.darken.butler.common.storage.StorageVolumeX
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -48,6 +50,7 @@ class SAFLocationManagerImplTest : BaseTest() {
     private lateinit var contentResolver: ContentResolver
     private lateinit var database: SAFLocationDatabase
     private lateinit var dao: SAFLocationsDao
+    private lateinit var preferences: MutableStateFlow<List<SAFLocationEntity>>
     private lateinit var dispatcherProvider: DispatcherProvider
     private lateinit var storageManager2: StorageManager2
     private lateinit var manager: SAFLocationManagerImpl
@@ -59,12 +62,17 @@ class SAFLocationManagerImplTest : BaseTest() {
         context = mockk(relaxed = true)
         contentResolver = mockk(relaxed = true)
 
-        // Mock DAO with empty preferences
+        // Mock DAO backed by an in-memory table, upserts land in the preference flow like Room's would
+        preferences = MutableStateFlow(emptyList())
         dao = mockk(relaxed = true) {
-            // Return empty list - no stored preferences
-            every { getAllPreferences() } returns flowOf(emptyList<SAFLocationEntity>())
+            every { getAllPreferences() } returns preferences
             // Mock cleanup method to do nothing in tests
             coEvery { cleanup(any()) } returns Unit
+            coEvery { getPreference(any()) } answers { preferences.value.find { it.locationId == firstArg() } }
+            coEvery { upsert(any()) } answers {
+                val entity = firstArg<SAFLocationEntity>()
+                preferences.value = preferences.value.filterNot { it.locationId == entity.locationId } + entity
+            }
         }
 
         // Mock database to return the DAO
@@ -568,6 +576,66 @@ class SAFLocationManagerImplTest : BaseTest() {
         localPath!!.path shouldBe "/storage/emulated/0/Pictures/photo.jpg"
     }
 
+    // --- Preference Update Tests ---
+
+    /**
+     * Seeding a label on a location that has none writes it through.
+     */
+    @Test
+    fun `seedLocationLabel writes when no label is stored`() {
+        val locationId = grantedLocationId()
+
+        var seeded: String? = null
+        val seed = testScope.launch { seeded = manager.seedLocationLabel(locationId, "Termux") }
+        testDispatcher.scheduler.runCurrent()
+
+        seed.isCompleted shouldBe true
+        seeded shouldBe "Termux"
+        preferences.value.single().userLabel shouldBe "Termux"
+    }
+
+    /**
+     * A re-grant must not clobber a name the user set, not even on a hidden location
+     * (those are absent from the public `locations` flow).
+     */
+    @Test
+    fun `seedLocationLabel keeps an existing label`() {
+        val locationId = grantedLocationId()
+        preferences.value = listOf(SAFLocationEntity(locationId, userLabel = "My Termux", isHidden = true))
+
+        var seeded: String? = null
+        val seed = testScope.launch { seeded = manager.seedLocationLabel(locationId, "Termux") }
+        testDispatcher.scheduler.runCurrent()
+
+        seed.isCompleted shouldBe true
+        seeded shouldBe "My Termux"
+        coVerify(exactly = 0) { dao.upsert(any()) }
+        preferences.value.single().userLabel shouldBe "My Termux"
+    }
+
+    /**
+     * Callers refresh right after a label change, so the write must not return before
+     * the location cache carries it.
+     */
+    @Test
+    fun `label update waits for the cache to catch up`() {
+        val locationId = grantedLocationId()
+
+        var written: SAFLocationEntity? = null
+        coEvery { dao.upsert(any()) } answers { written = firstArg() }
+
+        val update = testScope.launch { manager.setLocationLabel(locationId, "Termux") }
+        testDispatcher.scheduler.runCurrent()
+
+        written!!.userLabel shouldBe "Termux"
+        update.isCompleted shouldBe false
+
+        preferences.value = listOf(written!!)
+        testDispatcher.scheduler.runCurrent()
+
+        update.isCompleted shouldBe true
+    }
+
     // --- Helper Methods ---
 
     /**
@@ -585,6 +653,16 @@ class SAFLocationManagerImplTest : BaseTest() {
             every { isWritePermission } returns write
             every { this@mockk.persistedTime } returns persistedTime
         }
+    }
+
+    /**
+     * Register a single granted permission and return its location ID (an MD5 of the tree URI).
+     */
+    private fun grantedLocationId(): String {
+        val permissionUri = Uri.parse("content://$baseAuthority/tree/primary%3AFolderA")
+        every { contentResolver.persistedUriPermissions } returns listOf(mockUriPermission(permissionUri))
+        refreshCache()
+        return manager.findPermissionFor(SAFPath.build(permissionUri))!!.location.id
     }
 
     /**

--- a/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilderTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilderTest.kt
@@ -173,4 +173,33 @@ class SAFPickerIntentBuilderTest : BaseTest() {
 
         navUri.toString() shouldBe "content://com.android.externalstorage.documents/tree/primary%3AAndroid%2Fdata%2Fcom.example.app%2Ffiles/document/primary%3AAndroid%2Fdata%2Fcom.example.app%2Ffiles"
     }
+
+    @Test
+    fun `test builds correct URI for a path shaped document id`() {
+        val builder = SAFPickerIntentBuilder(mockk<StorageManager2>())
+
+        val intent = builder.buildPickerIntent(
+            authority = "com.termux.documents",
+            rootDocumentId = "/data/data/com.termux/files/home",
+        )
+
+        val navUri = intent.getParcelableExtra<Uri>(DocumentsContract.EXTRA_INITIAL_URI)
+        navUri.shouldNotBeNull()
+
+        navUri.toString() shouldBe "content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome/document/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome"
+    }
+
+    @Test
+    fun `test provider picker intent carries both extras`() {
+        val builder = SAFPickerIntentBuilder(mockk<StorageManager2>())
+
+        val intent = builder.buildPickerIntent(
+            authority = "com.termux.documents",
+            rootDocumentId = "/data/data/com.termux/files/home",
+        )
+
+        intent.action shouldBe Intent.ACTION_OPEN_DOCUMENT_TREE
+        intent.hasExtra("android.content.extra.SHOW_ADVANCED") shouldBe true
+        intent.hasExtra(DocumentsContract.EXTRA_INITIAL_URI) shouldBe true
+    }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilderTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/SAFPickerIntentBuilderTest.kt
@@ -175,18 +175,18 @@ class SAFPickerIntentBuilderTest : BaseTest() {
     }
 
     @Test
-    fun `test builds correct URI for a path shaped document id`() {
+    fun `test builds root URI for a path shaped root id`() {
         val builder = SAFPickerIntentBuilder(mockk<StorageManager2>())
 
         val intent = builder.buildPickerIntent(
             authority = "com.termux.documents",
-            rootDocumentId = "/data/data/com.termux/files/home",
+            rootId = "/data/data/com.termux/files/home",
         )
 
         val navUri = intent.getParcelableExtra<Uri>(DocumentsContract.EXTRA_INITIAL_URI)
         navUri.shouldNotBeNull()
 
-        navUri.toString() shouldBe "content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome/document/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome"
+        navUri.toString() shouldBe "content://com.termux.documents/root/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome"
     }
 
     @Test
@@ -195,7 +195,7 @@ class SAFPickerIntentBuilderTest : BaseTest() {
 
         val intent = builder.buildPickerIntent(
             authority = "com.termux.documents",
-            rootDocumentId = "/data/data/com.termux/files/home",
+            rootId = "/data/data/com.termux/files/home",
         )
 
         intent.action shouldBe Intent.ACTION_OPEN_DOCUMENT_TREE

--- a/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
@@ -93,6 +93,8 @@ class StorageProviderSuggesterTest : BaseTest() {
             FakeProvider(pkg = "com.android.providers.downloads", authority = "com.android.providers.downloads.documents"),
             FakeProvider(pkg = "com.android.providers.media.module", authority = "com.android.providers.media.documents"),
             FakeProvider(pkg = "com.android.mtp", authority = "com.android.mtp.documents"),
+            FakeProvider(pkg = "com.android.documentsui", authority = "com.android.documentsui.archives"),
+            FakeProvider(pkg = "com.google.android.documentsui", authority = "com.android.documentsui.archives"),
         )
 
         suggester.getSuggestions().shouldBeEmpty()

--- a/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
@@ -1,0 +1,173 @@
+package eu.darken.butler.common.storage.saf
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.content.pm.ProviderInfo
+import android.content.pm.ResolveInfo
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class StorageProviderSuggesterTest : BaseTest() {
+
+    /** [label] null makes the label lookup throw, i.e. this entry fails while the others don't. */
+    private data class FakeProvider(
+        val pkg: String,
+        val authority: String,
+        val label: String? = "Label",
+        val exported: Boolean = true,
+        val hasLauncher: Boolean = true,
+    )
+
+    private fun FakeProvider.toResolveInfo() = ResolveInfo().apply {
+        providerInfo = ProviderInfo().apply {
+            authority = this@toResolveInfo.authority
+            exported = this@toResolveInfo.exported
+            packageName = pkg
+            applicationInfo = ApplicationInfo().apply { packageName = pkg }
+        }
+    }
+
+    private fun create(vararg providers: FakeProvider): StorageProviderSuggester {
+        val fakes = providers.toList()
+        val resolveInfos = fakes.map { it.toResolveInfo() }
+        val pm = mockk<PackageManager>()
+        every { pm.queryIntentContentProviders(any(), any()) } returns resolveInfos
+        every { pm.getLaunchIntentForPackage(any()) } answers {
+            val pkg = firstArg<String>()
+            if (fakes.any { it.pkg == pkg && it.hasLauncher }) Intent() else null
+        }
+        every { pm.getApplicationLabel(any()) } answers {
+            val pkg = firstArg<ApplicationInfo>().packageName
+            fakes.first { it.pkg == pkg }.label ?: throw IllegalStateException("No label for $pkg")
+        }
+        every { pm.resolveContentProvider(any(), any()) } answers {
+            val authority = firstArg<String>()
+            resolveInfos.firstOrNull { it.providerInfo.authority == authority }?.providerInfo
+        }
+        val context = mockk<Context>()
+        every { context.packageManager } returns pm
+        every { context.packageName } returns OUR_PKG
+
+        return StorageProviderSuggester(context, TestDispatcherProvider())
+    }
+
+    @Test
+    fun `third party provider with a launcher is suggested`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"))
+
+        suggester.getSuggestions() shouldBe listOf(
+            StorageProviderSuggestion(
+                packageName = "com.tabby",
+                authority = "com.tabby.documents",
+                label = "Tabby",
+                known = null,
+            )
+        )
+    }
+
+    @Test
+    fun `our own provider is excluded`() = runTest {
+        val suggester = create(FakeProvider(pkg = OUR_PKG, authority = "$OUR_PKG.provider.documents"))
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `platform providers are excluded`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.android.externalstorage", authority = "com.android.externalstorage.documents"),
+            FakeProvider(pkg = "com.android.providers.downloads", authority = "com.android.providers.downloads.documents"),
+            FakeProvider(pkg = "com.android.providers.media.module", authority = "com.android.providers.media.documents"),
+            FakeProvider(pkg = "com.android.mtp", authority = "com.android.mtp.documents"),
+        )
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `provider without a launcher entry is excluded`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.android.shell", authority = "com.android.shell.documents", hasLauncher = false),
+        )
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `non exported provider is excluded`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", exported = false),
+        )
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `curated providers are tagged and sorted first`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"),
+            FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"),
+        )
+
+        val suggestions = suggester.getSuggestions()
+
+        suggestions.map { it.packageName } shouldBe listOf("com.termux", "com.tabby")
+        suggestions[0].known shouldBe KnownStorageProvider.TERMUX
+        suggestions[1].known.shouldBeNull()
+    }
+
+    @Test
+    fun `a failing provider does not remove the others`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.broken", authority = "com.broken.documents", label = null),
+            FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"),
+        )
+
+        suggester.getSuggestions().map { it.packageName } shouldBe listOf("com.tabby")
+    }
+
+    @Test
+    fun `label lookup resolves a third party authority`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"))
+
+        suggester.labelForAuthority("com.termux.documents") shouldBe "Termux"
+    }
+
+    @Test
+    fun `label lookup returns null for an unknown authority`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"))
+
+        suggester.labelForAuthority("com.example.documents").shouldBeNull()
+    }
+
+    @Test
+    fun `label lookup returns null for a platform authority`() = runTest {
+        val suggester = create(
+            FakeProvider(
+                pkg = "com.android.externalstorage",
+                authority = "com.android.externalstorage.documents",
+                label = "External Storage",
+            ),
+        )
+
+        suggester.labelForAuthority("com.android.externalstorage.documents").shouldBeNull()
+    }
+
+    companion object {
+        private const val OUR_PKG = "eu.darken.butler.debug"
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
@@ -45,7 +45,7 @@ class StorageProviderSuggesterTest : BaseTest() {
         val fakes = providers.toList()
         val resolveInfos = fakes.map { it.toResolveInfo() }
         val pm = mockk<PackageManager>()
-        every { pm.queryIntentContentProviders(any(), any()) } returns resolveInfos
+        every { pm.queryIntentContentProviders(any<Intent>(), any<Int>()) } returns resolveInfos
         every { pm.getLaunchIntentForPackage(any()) } answers {
             val pkg = firstArg<String>()
             if (fakes.any { it.pkg == pkg && it.hasLauncher }) Intent() else null
@@ -54,7 +54,7 @@ class StorageProviderSuggesterTest : BaseTest() {
             val pkg = firstArg<ApplicationInfo>().packageName
             fakes.first { it.pkg == pkg }.label ?: throw IllegalStateException("No label for $pkg")
         }
-        every { pm.resolveContentProvider(any(), any()) } answers {
+        every { pm.resolveContentProvider(any<String>(), any<Int>()) } answers {
             val authority = firstArg<String>()
             resolveInfos.firstOrNull { it.providerInfo.authority == authority }?.providerInfo
         }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/sorting/rules/SortPathKey.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/sorting/rules/SortPathKey.kt
@@ -14,9 +14,10 @@ import eu.darken.butler.common.files.SAFPath
  * named `Budget:2026` cannot collide with `Budget/2026`, and so the archive marker - the only
  * unescaped `!` a key can contain - cannot collide with a real filename containing `!`.
  *
- * SAF keys are deliberately grant-independent: the document ID is parsed exactly the way
- * [SAFPath.userReadablePath] parses it, so a broad `primary:` grant and a narrow
- * `primary:Pictures/Trips` grant of the same folder produce the same key AND the same ancestor list.
+ * SAF keys are deliberately grant-independent: the document ID is split on `:` the way
+ * [SAFPath.userReadablePath] splits colon-form and bare-volume IDs, so a broad `primary:` grant and
+ * a narrow `primary:Pictures/Trips` grant of the same folder produce the same key AND the same
+ * ancestor list. A path-shaped ID has no volume part and simply becomes the whole `storageId`.
  */
 fun APath<*>.sortPathKey(): String = keyComponents().components.joinKey()
 
@@ -50,7 +51,7 @@ private fun APath<*>.keyComponents(): KeyComponents = when (this) {
 
     is SAFPath -> {
         val documentId = treeRootUri.path?.let { TREE_DOCUMENT_ID_REGEX.matchEntire(it)?.groupValues?.get(1) }
-        // Same parse as SAFPath.userReadablePath: split once on ':', then split the base path on '/'
+        // Split once on ':', then split the base path on '/'
         val parts = documentId?.split(":", limit = 2)
         val storageId = parts?.getOrNull(0) ?: treeRootUri.rawUri
         val basePath = parts?.getOrNull(1)?.split("/")?.filter { it.isNotEmpty() } ?: emptyList()

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
@@ -122,9 +122,10 @@ class ExplorerSafLocationController(
 
             val providerLabel = treeUri.authority?.let { storageProviderSuggester.labelForAuthority(it) }
             // Seed the label before the refresh below, otherwise the list renders the path-derived
-            // fallback name until the naming dialog is confirmed.
-            if (providerLabel != null) safLocationManager.setLocationLabel(locationId, providerLabel)
-            dialogs.show(ExplorerDialogState.LocationStorageName(locationId, currentName = providerLabel))
+            // fallback name until the naming dialog is confirmed. Re-granting a location the user
+            // renamed keeps that name, which is what gets offered in the dialog then.
+            val currentName = providerLabel?.let { safLocationManager.seedLocationLabel(locationId, it) }
+            dialogs.show(ExplorerDialogState.LocationStorageName(locationId, currentName = currentName))
 
             // Auto-refresh if currently viewing Device location to show new SAF storage immediately
             if (currentLocation() is ExplorerLocation.Device) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
@@ -121,6 +121,9 @@ class ExplorerSafLocationController(
             val locationId = safLocationManager.grantPermission(treeUri)
 
             val providerLabel = treeUri.authority?.let { storageProviderSuggester.labelForAuthority(it) }
+            // Seed the label before the refresh below, otherwise the list renders the path-derived
+            // fallback name until the naming dialog is confirmed.
+            if (providerLabel != null) safLocationManager.setLocationLabel(locationId, providerLabel)
             dialogs.show(ExplorerDialogState.LocationStorageName(locationId, currentName = providerLabel))
 
             // Auto-refresh if currently viewing Device location to show new SAF storage immediately

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
@@ -7,6 +7,9 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
 import eu.darken.butler.common.flow.SingleEventFlow
+import eu.darken.butler.common.storage.saf.SAFPickerIntentBuilder
+import eu.darken.butler.common.storage.saf.StorageProviderSuggester
+import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.R
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.core.ExplorerWorkspace
@@ -18,7 +21,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
 
 /**
  * SAF storage location management: the add-storage sheet, the system directory picker
@@ -27,7 +35,10 @@ import kotlinx.coroutines.flow.StateFlow
 class ExplorerSafLocationController(
     private val context: Context,
     private val safLocationManager: SAFLocationManager,
+    private val safPickerIntentBuilder: SAFPickerIntentBuilder,
+    private val storageProviderSuggester: StorageProviderSuggester,
     private val dialogs: ExplorerDialogController,
+    private val scope: CoroutineScope,
     private val workspace: suspend () -> ExplorerWorkspace,
     private val currentLocation: suspend () -> ExplorerLocation?,
     private val clearSelection: () -> Unit,
@@ -38,6 +49,20 @@ class ExplorerSafLocationController(
 
     private val showAddStorageSheetFlow = MutableStateFlow(false)
     val showAddStorageSheet: StateFlow<Boolean> = showAddStorageSheetFlow
+
+    /**
+     * Derived from the sheet, never written by a side job: [flatMapLatest] cancels a load whose
+     * sheet was closed or reopened, so a stale list can neither overwrite a newer one nor be shown
+     * again after an app was uninstalled.
+     */
+    val storageSuggestions: StateFlow<List<StorageProviderSuggestion>> = showAddStorageSheetFlow
+        .flatMapLatest { visible ->
+            when {
+                visible -> flow { emit(storageProviderSuggester.getSuggestions()) }
+                else -> flowOf(emptyList())
+            }
+        }
+        .stateIn(scope, SharingStarted.Eagerly, emptyList())
 
     private val _pendingSAFPickerGrant = MutableStateFlow<SAFPickerGrant?>(null)
     val pendingSAFPickerGrant: Flow<SAFPickerGrant?> = _pendingSAFPickerGrant
@@ -68,6 +93,22 @@ class ExplorerSafLocationController(
         safPickerEvents.emit(intent)
     }
 
+    fun addSuggestedSAFLocation(suggestion: StorageProviderSuggestion) = doLaunch {
+        log(tag) { "addSuggestedSAFLocation($suggestion)" }
+        _pendingSAFPickerGrant.value = null
+        val known = suggestion.known
+        val intent = when {
+            known != null -> safPickerIntentBuilder.buildPickerIntent(
+                authority = known.authorityFor(suggestion.packageName),
+                rootDocumentId = known.rootDocumentIdFor(suggestion.packageName),
+            )
+            else -> Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                putExtra("android.content.extra.SHOW_ADVANCED", true)
+            }
+        }
+        safPickerEvents.emit(intent)
+    }
+
     suspend fun handleSAFPickerResult(treeUri: Uri) {
         log(tag) { "handleSAFPickerResult(treeUri=$treeUri)" }
         try {
@@ -79,7 +120,8 @@ class ExplorerSafLocationController(
 
             val locationId = safLocationManager.grantPermission(treeUri)
 
-            dialogs.show(ExplorerDialogState.LocationStorageName(locationId, currentName = null))
+            val providerLabel = treeUri.authority?.let { storageProviderSuggester.labelForAuthority(it) }
+            dialogs.show(ExplorerDialogState.LocationStorageName(locationId, currentName = providerLabel))
 
             // Auto-refresh if currently viewing Device location to show new SAF storage immediately
             if (currentLocation() is ExplorerLocation.Device) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
@@ -100,7 +100,7 @@ class ExplorerSafLocationController(
         val intent = when {
             known != null -> safPickerIntentBuilder.buildPickerIntent(
                 authority = known.authorityFor(suggestion.packageName),
-                rootDocumentId = known.rootDocumentIdFor(suggestion.packageName),
+                rootId = known.rootIdFor(suggestion.packageName),
             )
             else -> Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                 putExtra("android.content.extra.SHOW_ADVANCED", true)

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceOverlays.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceOverlays.kt
@@ -11,6 +11,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.issue.Issue
+import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.core.engine.BrowsingAbortedException
 import eu.darken.butler.explorer.ui.explorer.dialogs.AddDeviceStorageSheet
@@ -51,6 +52,7 @@ fun ExplorerWorkspaceOverlaysHost(
     val issueState by vm.issueState.collectAsState()
     val showIssueSheet by vm.showIssueSheet.collectAsState()
     val showAddStorageSheet by vm.showAddStorageSheet.collectAsState()
+    val storageSuggestions by vm.storageSuggestions.collectAsState()
     val operationDialogState by vm.operationDialogState.collectAsState()
     val cancelConfirmation by vm.cancelOperationConfirmation.collectAsState()
 
@@ -64,6 +66,7 @@ fun ExplorerWorkspaceOverlaysHost(
         cancelConfirmationFor = cancelConfirmation,
         issue = issueState.takeIf { showIssueSheet },
         showAddStorageSheet = showAddStorageSheet,
+        storageSuggestions = storageSuggestions,
         navigationError = state?.error,
         vm = vm,
     )
@@ -86,6 +89,7 @@ fun ExplorerWorkspaceOverlays(
     cancelConfirmationFor: Operation.Id? = null,
     issue: Issue? = null,
     showAddStorageSheet: Boolean = false,
+    storageSuggestions: List<StorageProviderSuggestion> = emptyList(),
     navigationError: Throwable? = null,
     vm: ExplorerWorkspaceViewModel? = null,
 ) {
@@ -129,6 +133,8 @@ fun ExplorerWorkspaceOverlays(
         AddDeviceStorageSheet(
             onDismiss = { vm?.dismissAddStorageSheet() },
             onContinue = { vm?.addSAFLocation() },
+            suggestions = storageSuggestions,
+            onSuggestion = { vm?.addSuggestedSAFLocation(it) },
             topInset = statusBarInset,
             bottomInset = navBarInset,
         )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -19,6 +19,9 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.storage.StorageEnvironment
+import eu.darken.butler.common.storage.saf.SAFPickerIntentBuilder
+import eu.darken.butler.common.storage.saf.StorageProviderSuggester
+import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.archive.ArchiveFormat
 import eu.darken.butler.common.files.archive.CompressionPreset
@@ -149,6 +152,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
     private val filenameValidator: FilenameValidator,
     private val gatewaySwitch: GatewaySwitch,
     internal val safLocationManager: SAFLocationManager,
+    private val safPickerIntentBuilder: SAFPickerIntentBuilder,
+    private val storageProviderSuggester: StorageProviderSuggester,
     private val trashManager: TrashManager,
     private val trashRepo: TrashRepo,
     private val itemInfoCalculator: ItemInfoCalculator,
@@ -196,7 +201,10 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
     private val safLocations = ExplorerSafLocationController(
         context = context,
         safLocationManager = safLocationManager,
+        safPickerIntentBuilder = safPickerIntentBuilder,
+        storageProviderSuggester = storageProviderSuggester,
         dialogs = dialogs,
+        scope = vmScope,
         workspace = ::getWorkspace,
         currentLocation = { getState().currentLocation },
         clearSelection = ::clearSelection,
@@ -1762,6 +1770,11 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
     fun dismissAddStorageSheet() = safLocations.dismissAddStorageSheet()
 
     fun addSAFLocation() = safLocations.addSAFLocation()
+
+    val storageSuggestions get() = safLocations.storageSuggestions
+
+    fun addSuggestedSAFLocation(suggestion: StorageProviderSuggestion) =
+        safLocations.addSuggestedSAFLocation(suggestion)
 
     suspend fun handleSAFPickerResult(treeUri: Uri) = safLocations.handleSAFPickerResult(treeUri)
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/AddDeviceStorageSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/AddDeviceStorageSheet.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.explorer.ui.explorer.dialogs
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.FolderShared
+import androidx.compose.material.icons.twotone.Terminal
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.storage.saf.KnownStorageProvider
+import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.R
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 
@@ -34,6 +38,8 @@ import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 fun AddDeviceStorageSheet(
     onDismiss: () -> Unit,
     onContinue: () -> Unit,
+    suggestions: List<StorageProviderSuggestion> = emptyList(),
+    onSuggestion: (StorageProviderSuggestion) -> Unit = {},
     topInset: Dp = 0.dp,
     bottomInset: Dp = 0.dp,
 ) {
@@ -84,6 +90,24 @@ fun AddDeviceStorageSheet(
                 )
             }
 
+            if (suggestions.isNotEmpty()) {
+                Text(
+                    text = stringResource(R.string.explorer_add_device_storage_suggestions_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                )
+
+                suggestions.forEach { suggestion ->
+                    SuggestionRow(
+                        suggestion = suggestion,
+                        onClick = {
+                            onDismiss()
+                            onSuggestion(suggestion)
+                        },
+                    )
+                }
+            }
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -105,6 +129,57 @@ fun AddDeviceStorageSheet(
     }
 }
 
+@Composable
+private fun SuggestionRow(
+    modifier: Modifier = Modifier,
+    suggestion: StorageProviderSuggestion,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = when {
+                    suggestion.known != null -> Icons.TwoTone.Terminal
+                    else -> Icons.TwoTone.FolderShared
+                },
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = suggestion.label,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                // Only a curated provider gets navigated to, the generic path just opens the picker
+                text = when {
+                    suggestion.known != null -> stringResource(R.string.explorer_add_device_storage_suggestion_desc_direct)
+                    else -> stringResource(R.string.explorer_add_device_storage_suggestion_desc_pick)
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
@@ -112,5 +187,29 @@ private fun AddDeviceStorageSheetPreview() {
     AddDeviceStorageSheet(
         onDismiss = {},
         onContinue = {}
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AddDeviceStorageSheetSuggestionsPreview() {
+    AddDeviceStorageSheet(
+        onDismiss = {},
+        onContinue = {},
+        suggestions = listOf(
+            StorageProviderSuggestion(
+                packageName = "com.termux",
+                authority = "com.termux.documents",
+                label = "Termux",
+                known = KnownStorageProvider.TERMUX,
+            ),
+            StorageProviderSuggestion(
+                packageName = "com.mixplorer",
+                authority = "com.mixplorer.documents",
+                label = "MiXplorer",
+                known = null,
+            ),
+        ),
     )
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/grid/StorageGrid.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/grid/StorageGrid.kt
@@ -83,6 +83,8 @@ fun StorageGrid(
     isEnabled: Boolean = true,
     decorations: ItemDecorations = ItemDecorations(),
 ) {
+    val context = LocalContext.current
+
     FileGridBase(
         modifier = modifier,
         item = item,
@@ -101,13 +103,12 @@ fun StorageGrid(
                 modifier = Modifier.size(20.dp)
             )
         },
-        primaryText = item.displayName.get(LocalContext.current),
+        primaryText = item.displayName.get(context),
         secondaryText = run {
             val totalBytes = item.totalBytes
             val availableBytes = item.availableBytes
             when {
                 totalBytes != null && availableBytes != null -> {
-                    val context = LocalContext.current
                     val total = eu.darken.butler.common.formatFileSize(context, totalBytes, shortFormat = true)
                     val free = eu.darken.butler.common.formatFileSize(context, availableBytes, shortFormat = true)
                     val typeLabel = when (item) {
@@ -119,7 +120,7 @@ fun StorageGrid(
                 else -> null
             }
         },
-        tertiaryText = item.target.path.path,
+        tertiaryText = item.target.path.userReadablePath.get(context),
         backgroundColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
         trailingContent = if (item is ExplorerItem.Storage.SAF) {
             { PermissionIndicator(item.location) }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/row/StorageRow.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/row/StorageRow.kt
@@ -69,7 +69,7 @@ fun StorageRow(
             }
         },
         primaryText = item.displayName.get(context),
-        secondaryText = item.target.path.path,
+        secondaryText = item.target.path.userReadablePath.get(context),
         tertiaryText = run {
             val totalBytes = item.totalBytes
             val availableBytes = item.availableBytes

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -222,6 +222,9 @@
     <string name="explorer_add_device_storage_desc">Use the Storage Access Framework (SAF) to grant Butler access to additional storage locations such as usb drives, virtual app folders and more.</string>
     <string name="explorer_add_device_storage_continue">Continue</string>
     <string name="explorer_add_device_storage_cancel">Cancel</string>
+    <string name="explorer_add_device_storage_suggestions_title">Apps with storage</string>
+    <string name="explorer_add_device_storage_suggestion_desc_direct">Opens this app\'s folder</string>
+    <string name="explorer_add_device_storage_suggestion_desc_pick">Select it in the system picker</string>
 
     <!-- Device Storage Actions -->
     <string name="explorer_device_action_remove_location">Remove location</string>

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
@@ -16,7 +16,6 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.Runs
-import io.mockk.coAnswers
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
@@ -46,6 +46,7 @@ class ExplorerSafLocationControllerTest : BaseTest() {
             coEvery { grantPermission(any()) } returns locationId
             coEvery { revokePermission(any()) } just Runs
             coEvery { setLocationLabel(any(), any()) } just Runs
+            coEvery { seedLocationLabel(any(), any()) } answers { secondArg() }
         }
 
     private fun mockWorkspace(): ExplorerWorkspace = mockk<ExplorerWorkspace>().apply {
@@ -141,14 +142,32 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         val dialogs = dialogs()
         var dialogWhenLabeled: ExplorerDialogState? = null
         val locationManager = mockLocationManager(locationId = "loc-42").apply {
-            coEvery { setLocationLabel(any(), any()) } answers { dialogWhenLabeled = dialogs.current() }
+            coEvery { seedLocationLabel(any(), any()) } answers {
+                dialogWhenLabeled = dialogs.current()
+                secondArg()
+            }
         }
         val controller = controller(locationManager = locationManager, dialogs = dialogs)
 
         controller.handleSAFPickerResult(mockUri("com.termux.documents"))
 
-        coVerify { locationManager.setLocationLabel("loc-42", "Termux") }
+        coVerify { locationManager.seedLocationLabel("loc-42", "Termux") }
         dialogWhenLabeled shouldBe ExplorerDialogState.None
+    }
+
+    @Test
+    fun `re-granting a renamed location keeps the custom name`() = runTest {
+        val dialogs = dialogs()
+        val locationManager = mockLocationManager(locationId = "loc-42").apply {
+            coEvery { seedLocationLabel(any(), any()) } returns "My Termux"
+        }
+        val controller = controller(locationManager = locationManager, dialogs = dialogs)
+
+        controller.handleSAFPickerResult(mockUri("com.termux.documents"))
+
+        coVerify(exactly = 0) { locationManager.setLocationLabel(any(), any()) }
+        val dialog = dialogs.current().shouldBeInstanceOf<ExplorerDialogState.LocationStorageName>()
+        dialog.currentName shouldBe "My Termux"
     }
 
     @Test
@@ -158,6 +177,7 @@ class ExplorerSafLocationControllerTest : BaseTest() {
 
         controller.handleSAFPickerResult(mockUri("com.android.externalstorage.documents"))
 
+        coVerify(exactly = 0) { locationManager.seedLocationLabel(any(), any()) }
         coVerify(exactly = 0) { locationManager.setLocationLabel(any(), any()) }
     }
 

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
@@ -137,6 +137,31 @@ class ExplorerSafLocationControllerTest : BaseTest() {
     }
 
     @Test
+    fun `picker result seeds the provider label before the dialog is shown`() = runTest {
+        val dialogs = dialogs()
+        var dialogWhenLabeled: ExplorerDialogState? = null
+        val locationManager = mockLocationManager(locationId = "loc-42").apply {
+            coEvery { setLocationLabel(any(), any()) } answers { dialogWhenLabeled = dialogs.current() }
+        }
+        val controller = controller(locationManager = locationManager, dialogs = dialogs)
+
+        controller.handleSAFPickerResult(mockUri("com.termux.documents"))
+
+        coVerify { locationManager.setLocationLabel("loc-42", "Termux") }
+        dialogWhenLabeled shouldBe ExplorerDialogState.None
+    }
+
+    @Test
+    fun `picker result without a provider label leaves the default name`() = runTest {
+        val locationManager = mockLocationManager()
+        val controller = controller(locationManager = locationManager)
+
+        controller.handleSAFPickerResult(mockUri("com.android.externalstorage.documents"))
+
+        coVerify(exactly = 0) { locationManager.setLocationLabel(any(), any()) }
+    }
+
+    @Test
     fun `picker result on device location triggers a refresh`() = runTest {
         val workspace = mockWorkspace()
         val controller = controller(

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
@@ -242,6 +242,7 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         controller.showAddStorageSheet()
         runCurrent()
         controller.dismissAddStorageSheet()
+        runCurrent()
         controller.showAddStorageSheet()
         runCurrent()
         firstLoad.complete(Unit)

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
@@ -4,20 +4,27 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
+import eu.darken.butler.common.storage.saf.KnownStorageProvider
+import eu.darken.butler.common.storage.saf.SAFPickerIntentBuilder
+import eu.darken.butler.common.storage.saf.StorageProviderSuggester
+import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.core.ExplorerWorkspace
 import eu.darken.butler.explorer.core.engine.ExplorerLocation
 import eu.darken.butler.explorer.ui.explorer.dialogs.ExplorerDialogState
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.Runs
+import io.mockk.coAnswers
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -46,6 +53,23 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         coEvery { navigate(any()) } just Runs
     }
 
+    private fun mockUri(uriAuthority: String? = null): Uri = mockk<Uri>().apply {
+        every { authority } returns uriAuthority
+    }
+
+    /** Only knows about a single third-party provider, everything else resolves to no label. */
+    private fun mockSuggester(
+        suggestions: List<StorageProviderSuggestion> = emptyList(),
+    ): StorageProviderSuggester = mockk<StorageProviderSuggester>().apply {
+        coEvery { getSuggestions() } returns suggestions
+        coEvery { labelForAuthority(any()) } answers {
+            when (firstArg<String>()) {
+                "com.termux.documents" -> "Termux"
+                else -> null
+            }
+        }
+    }
+
     private fun dialogs() = ExplorerDialogController(
         filterState = { mockk() },
         useRegexPatterns = { false },
@@ -53,9 +77,10 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         tag = "test",
     )
 
-    private fun CoroutineScope.controller(
+    private fun TestScope.controller(
         context: Context = mockContext(),
         locationManager: SAFLocationManager = mockLocationManager(),
+        suggester: StorageProviderSuggester = mockSuggester(),
         dialogs: ExplorerDialogController = dialogs(),
         workspace: ExplorerWorkspace = mockWorkspace(),
         currentLocation: ExplorerLocation? = null,
@@ -63,7 +88,11 @@ class ExplorerSafLocationControllerTest : BaseTest() {
     ) = ExplorerSafLocationController(
         context = context,
         safLocationManager = locationManager,
+        safPickerIntentBuilder = mockk<SAFPickerIntentBuilder>(),
+        storageProviderSuggester = suggester,
         dialogs = dialogs,
+        // The sharing coroutine never completes, so it must not be a foreground child of the test
+        scope = backgroundScope,
         workspace = { workspace },
         currentLocation = { currentLocation },
         clearSelection = {},
@@ -89,12 +118,23 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         val dialogs = dialogs()
         val controller = controller(locationManager = locationManager, dialogs = dialogs)
 
-        controller.handleSAFPickerResult(mockk<Uri>())
+        controller.handleSAFPickerResult(mockUri("com.android.externalstorage.documents"))
 
         coVerify { locationManager.grantPermission(any()) }
         val dialog = dialogs.current().shouldBeInstanceOf<ExplorerDialogState.LocationStorageName>()
         dialog.locationId shouldBe "loc-42"
         dialog.currentName shouldBe null
+    }
+
+    @Test
+    fun `picker result pre-fills the name with the granting app`() = runTest {
+        val dialogs = dialogs()
+        val controller = controller(dialogs = dialogs)
+
+        controller.handleSAFPickerResult(mockUri("com.termux.documents"))
+
+        val dialog = dialogs.current().shouldBeInstanceOf<ExplorerDialogState.LocationStorageName>()
+        dialog.currentName shouldBe "Termux"
     }
 
     @Test
@@ -105,7 +145,7 @@ class ExplorerSafLocationControllerTest : BaseTest() {
             currentLocation = mockk<ExplorerLocation.Device>(),
         )
 
-        controller.handleSAFPickerResult(mockk<Uri>())
+        controller.handleSAFPickerResult(mockUri())
 
         coVerify { workspace.navigate(ExplorerNavigation.Refresh) }
     }
@@ -118,7 +158,7 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         }
         val controller = controller(locationManager = locationManager, onError = { error = it })
 
-        controller.handleSAFPickerResult(mockk<Uri>())
+        controller.handleSAFPickerResult(mockUri())
 
         error?.message shouldBe "nope"
     }
@@ -162,4 +202,62 @@ class ExplorerSafLocationControllerTest : BaseTest() {
 
         coVerify(exactly = 0) { locationManager.setLocationLabel(any(), any()) }
     }
+
+    @Test
+    fun `suggestions are only loaded while the sheet is open`() = runTest {
+        val suggestion = suggestion("com.termux", "Termux", KnownStorageProvider.TERMUX)
+        val controller = controller(suggester = mockSuggester(listOf(suggestion)))
+        runCurrent()
+
+        controller.storageSuggestions.value.shouldBeEmpty()
+
+        controller.showAddStorageSheet()
+        runCurrent()
+        controller.storageSuggestions.value shouldBe listOf(suggestion)
+
+        controller.dismissAddStorageSheet()
+        runCurrent()
+        controller.storageSuggestions.value.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a reopened sheet does not surface the previous load`() = runTest {
+        val stale = suggestion("com.stale", "Stale")
+        val fresh = suggestion("com.fresh", "Fresh")
+        val firstLoad = CompletableDeferred<Unit>()
+        var calls = 0
+        val suggester = mockk<StorageProviderSuggester>().apply {
+            coEvery { getSuggestions() } coAnswers {
+                when (calls++) {
+                    0 -> {
+                        firstLoad.await()
+                        listOf(stale)
+                    }
+                    else -> listOf(fresh)
+                }
+            }
+        }
+        val controller = controller(suggester = suggester)
+
+        controller.showAddStorageSheet()
+        runCurrent()
+        controller.dismissAddStorageSheet()
+        controller.showAddStorageSheet()
+        runCurrent()
+        firstLoad.complete(Unit)
+        advanceUntilIdle()
+
+        controller.storageSuggestions.value shouldBe listOf(fresh)
+    }
+
+    private fun suggestion(
+        packageName: String,
+        label: String,
+        known: KnownStorageProvider? = null,
+    ) = StorageProviderSuggestion(
+        packageName = packageName,
+        authority = "$packageName.documents",
+        label = label,
+        known = known,
+    )
 }


### PR DESCRIPTION
## What changed

Butler could already access another app's storage through Android's Storage Access Framework, but nothing in the app hinted at it: "Add storage" dropped you straight into the system picker with no indication of what was available in there. The sheet now lists the installed apps that expose storage, so you can see at a glance that Termux, a terminal app or a cloud provider has something to offer.

Picking an app Butler knows about (currently Termux) opens the system picker already at that app's own folder, so granting access is a single tap. Other apps open the normal picker, and their row says that you still need to select the app there. After granting an app's folder, the location's name is pre-filled with the app's name; granting an ordinary folder still leaves the name empty, as before.

Storage locations also display a readable path now. A location added this way used to show `/tree/data/data/com.termux/files/home`, and now shows `/data/data/com.termux/files/home`.

Closes #64.

## Technical Context

- The request was for Shizuku support, which cannot work here: Shizuku's ADB mode runs as uid 2000, and an app's `/data/data/<pkg>` belongs to that app. SAF is the supported route and Butler already handled it, so the gap was purely discoverability. The reporter confirmed the SAF route works on their own device.
- Provider filtering is layered: not exported, our own package, a denylist of platform authorities, and a requirement that the package has a launcher entry. The denylist is keyed on authority rather than package because platform package names drift across versions and OEMs (`com.android.providers.media` ships as `com.android.providers.media.module` on current images). The launcher check is the generic backstop for components such as `com.android.shell` and `com.android.traceur`, which register providers no user can act on.
- `EXTRA_INITIAL_URI` has to be a root URI. A tree-scoped document URI presupposes a grant that does not exist yet at suggestion time, so DocumentsUI silently falls back to internal storage, where its own privacy rule disables the grant button. Both URI variants were measured on a device before settling on this.
- `SAFLocationManager.updateLocation` now waits until a write is visible in its own cache before returning, bounded by a timeout, because callers refresh the location list immediately afterwards and were reading pre-write state. Related: re-granting an already-granted tree returns the same location id (an MD5 of the tree URI), so the name is seeded only when no preference row exists, which preserves both a custom name and one the user deliberately cleared.
- `SortPathKey`'s key computation is deliberately unchanged, since it feeds persisted sort-rule identity; only its doc comment was corrected. Worth a close look during review.
- Not addressed here: renaming an existing storage location leaves the Device list showing the previous name until navigation forces a reload. The rename itself persists correctly. The rename flow and the name-rendering path are both untouched by this change and it appears pre-existing, though that was not confirmed against a `main` build.
