### PR TITLE
Workspace: Fix tabs bouncing back when swiping quickly

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneFocusRequest.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneFocusRequest.kt
@@ -28,6 +28,10 @@ import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
  * focus clear, no focus request, no swallow report. Clearing keyboard focus there would dismiss the
  * IME on behalf of a page the user never chose, and nothing would put it back.
  *
+ * That withholding is unconditional; the pane focus half is not. A [LocalWorkspaceFocusRequest] is
+ * optional, and without one in scope there is nowhere to hand focus to — a press that passes the
+ * gate is then observed and nothing more, while one the gate closes on is still consumed.
+ *
  * @param consumeWhenUnfocused consume the down event of every press arriving while the pane is not
  *        the focused one. Applied on an ancestor of the pane content, the down reaches the
  *        content's tap detectors already claimed, so a press into an unfocused pane only focuses
@@ -52,12 +56,11 @@ fun Modifier.requestPaneFocusOnPress(
     consumeWhenUnfocused: Boolean = false,
     onPressSwallowed: ((Offset) -> Unit)? = null,
 ): Modifier {
-    val requestFocus = LocalWorkspaceFocusRequest.current ?: return this
     val focusManager = LocalFocusManager.current
     val paneFocused = rememberUpdatedState(LocalPaneFocused.current)
     // Read when a press arrives instead of keying the handler on it: a changed lambda identity
     // would restart the event loop mid-gesture.
-    val currentRequestFocus = rememberUpdatedState(requestFocus)
+    val currentRequestFocus = rememberUpdatedState(LocalWorkspaceFocusRequest.current)
     val currentOnPressSwallowed = rememberUpdatedState(onPressSwallowed)
     val pressesAllowed = rememberUpdatedState(LocalPanePressesAllowed.current)
     return this.pointerInput(consumeWhenUnfocused) {
@@ -77,6 +80,10 @@ fun Modifier.requestPaneFocusOnPress(
                     newDowns.forEach { it.consume() }
                     continue
                 }
+                // Everything past the gate needs somewhere to send the pane focus to. Without a
+                // request in scope the press is left alone entirely: clearing focus or reporting a
+                // swallow would be work in service of a hand-over that cannot happen.
+                val requestFocus = currentRequestFocus.value ?: continue
                 if (!paneFocused.value) {
                     // The pane-focus request only resolves a round trip later, but whatever was
                     // pressed asks for keyboard focus on the *up* event. Release the old pane's
@@ -92,7 +99,7 @@ fun Modifier.requestPaneFocusOnPress(
                         }
                     }
                 }
-                currentRequestFocus.value.invoke()
+                requestFocus.invoke()
             }
         }
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneFocusRequest.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneFocusRequest.kt
@@ -24,6 +24,10 @@ import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
  * [consumeWhenUnfocused] unset it never consumes itself, so buttons and text fields inside keep
  * working.
  *
+ * While [LocalPanePressesAllowed] answers false the down is consumed and nothing else happens — no
+ * focus clear, no focus request, no swallow report. Clearing keyboard focus there would dismiss the
+ * IME on behalf of a page the user never chose, and nothing would put it back.
+ *
  * @param consumeWhenUnfocused consume the down event of every press arriving while the pane is not
  *        the focused one. Applied on an ancestor of the pane content, the down reaches the
  *        content's tap detectors already claimed, so a press into an unfocused pane only focuses
@@ -40,7 +44,8 @@ import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
  * @param onPressSwallowed invoked once per down that is actually consumed, with that pointer's
  *        position in this element's coordinate space. Fires only in the [consumeWhenUnfocused] case
  *        — exactly the presses that produce no feedback of their own, since the content's tap
- *        detectors never start.
+ *        detectors never start. A down withheld by [LocalPanePressesAllowed] reports nothing: it is
+ *        not answering the wrong page, it is declining to answer at all.
  */
 @Composable
 fun Modifier.requestPaneFocusOnPress(
@@ -54,6 +59,7 @@ fun Modifier.requestPaneFocusOnPress(
     // would restart the event loop mid-gesture.
     val currentRequestFocus = rememberUpdatedState(requestFocus)
     val currentOnPressSwallowed = rememberUpdatedState(onPressSwallowed)
+    val pressesAllowed = rememberUpdatedState(LocalPanePressesAllowed.current)
     return this.pointerInput(consumeWhenUnfocused) {
         awaitPointerEventScope {
             // A raw event loop over every new down instead of one first-down per gesture: while a
@@ -64,6 +70,13 @@ fun Modifier.requestPaneFocusOnPress(
                 val event = awaitPointerEvent(PointerEventPass.Initial)
                 val newDowns = event.changes.filter { it.changedToDownIgnoreConsumed() }
                 if (newDowns.isEmpty()) continue
+                if (!pressesAllowed.value()) {
+                    // Consuming is the whole of it. The press must not reach the content either —
+                    // a text field taking keyboard focus here would have PaneLayer ask for this
+                    // pane through the focus-arrival path, which this gate does not cover.
+                    newDowns.forEach { it.consume() }
+                    continue
+                }
                 if (!paneFocused.value) {
                     // The pane-focus request only resolves a round trip later, but whatever was
                     // pressed asks for keyboard focus on the *up* event. Release the old pane's
@@ -80,6 +93,32 @@ fun Modifier.requestPaneFocusOnPress(
                     }
                 }
                 currentRequestFocus.value.invoke()
+            }
+        }
+    }
+}
+
+/**
+ * Consumes the down of every press arriving while [allowPresses] answers false.
+ *
+ * The press-withholding half of [requestPaneFocusOnPress] on its own, for content that sits outside
+ * a pane and therefore inherits no [LocalPanePressesAllowed]. Gating the DOWN is what distinguishes
+ * this from wrapping a click callback: `clickable` fires on the up, so a down taken while the gate
+ * was closed, held, and released after it opened would still act.
+ *
+ * @param allowPresses read when a press arrives instead of being keyed on, for the reason
+ *        [requestPaneFocusOnPress] gives: a changed lambda identity would restart the event loop
+ *        mid-gesture.
+ */
+@Composable
+fun Modifier.suppressPressesUnless(allowPresses: () -> Boolean): Modifier {
+    val currentAllowPresses = rememberUpdatedState(allowPresses)
+    return this.pointerInput(Unit) {
+        awaitPointerEventScope {
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                if (currentAllowPresses.value()) continue
+                event.changes.filter { it.changedToDownIgnoreConsumed() }.forEach { it.consume() }
             }
         }
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerHost.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerHost.kt
@@ -83,6 +83,12 @@ internal const val TAG_PANE_HOVER_BARRIER = "pane:hoverBarrier"
  *        because a pane can be the focused one while not being on screen — the classic pager parks
  *        on its trailing placeholder page without focus leaving the last tab. Defaults to
  *        [paneFocused], so a layout that cannot park off its panes needs no extra wiring.
+ * @param allowPresses whether presses arriving in this pane may act, read at event time. Published
+ *        as [LocalPanePressesAllowed] so the per-surface observers on dialogs and sheets withhold
+ *        the same presses the boundary does. Answering false makes the pane tap-inert and stops it
+ *        asking to be focused; it stays scrollable and draggable. A pager-driven layout answers
+ *        false while it is not resting on this pane's page, where two pages share the viewport and
+ *        a down starting the next swipe lands on the neighbour.
  */
 @Composable
 fun PaneLayerHost(
@@ -90,6 +96,7 @@ fun PaneLayerHost(
     paneFocused: Boolean,
     clickToFocus: Boolean = true,
     backActive: Boolean = paneFocused,
+    allowPresses: () -> Boolean = { true },
     paneEdges: PaneEdges = LocalPaneEdges.current,
     content: @Composable BoxScope.() -> Unit,
 ) {
@@ -106,6 +113,9 @@ fun PaneLayerHost(
         // and overrides LocalLayerActive for its subtree, so a value narrowed there would be
         // discarded by every nested dialog and sheet.
         LocalPaneBackActive provides backActive,
+        // Provided above the host's own press observer below, so the boundary is gated by the same
+        // value the dialogs and sheets inside it read.
+        LocalPanePressesAllowed provides allowPresses,
         LocalPaneLayerRank provides PaneLayerRank.CONTENT,
         LocalPaneEdges provides paneEdges,
         // Shared dialogs from app-common (ErrorDialog above all) become pane-bound inside a pane

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerHost.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerHost.kt
@@ -85,10 +85,11 @@ internal const val TAG_PANE_HOVER_BARRIER = "pane:hoverBarrier"
  *        [paneFocused], so a layout that cannot park off its panes needs no extra wiring.
  * @param allowPresses whether presses arriving in this pane may act, read at event time. Published
  *        as [LocalPanePressesAllowed] so the per-surface observers on dialogs and sheets withhold
- *        the same presses the boundary does. Answering false makes the pane tap-inert and stops it
- *        asking to be focused; it stays scrollable and draggable. A pager-driven layout answers
- *        false while it is not resting on this pane's page, where two pages share the viewport and
- *        a down starting the next swipe lands on the neighbour.
+ *        the same presses the boundary does. Answering false withholds taps and long-presses — and
+ *        with them the cross-pane drag `WorkspaceDragSource` arms from a long click — and stops the
+ *        pane asking to be focused; scroll, pager drag and sheet drag still work. A pager-driven
+ *        layout answers false while it is not resting on this pane's page, where two pages share
+ *        the viewport and a down starting the next swipe lands on the neighbour.
  */
 @Composable
 fun PaneLayerHost(

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerState.kt
@@ -121,6 +121,21 @@ val LocalPaneFocused = compositionLocalOf { true }
  */
 val LocalPaneBackActive = compositionLocalOf { true }
 
+/**
+ * Whether a press arriving in this pane may act on it.
+ *
+ * A lambda rather than a boolean because it is read at event time: a pager-driven layout answers
+ * false for a page it is not resting on, which flips several times per swipe and must take effect
+ * without waiting for the subtree to recompose.
+ *
+ * Withholds taps and press-to-focus-the-pane, NOT interaction as such: a withheld down is consumed,
+ * and scroll, drag, sheet-drag and drag-and-drop detectors all accept a consumed down — the pager's
+ * own swipe depends on that. A pane whose gate is closed can still be scrolled and dragged.
+ *
+ * Defaults to `{ true }`: outside a pager-driven pane there is nothing to withhold.
+ */
+val LocalPanePressesAllowed = compositionLocalOf<() -> Boolean> { { true } }
+
 /** Rank a layer registers at when it doesn't pick one explicitly. */
 val LocalPaneLayerRank = compositionLocalOf { PaneLayerRank.CONTENT }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerState.kt
@@ -128,9 +128,12 @@ val LocalPaneBackActive = compositionLocalOf { true }
  * false for a page it is not resting on, which flips several times per swipe and must take effect
  * without waiting for the subtree to recompose.
  *
- * Withholds taps and press-to-focus-the-pane, NOT interaction as such: a withheld down is consumed,
- * and scroll, drag, sheet-drag and drag-and-drop detectors all accept a consumed down — the pager's
- * own swipe depends on that. A pane whose gate is closed can still be scrolled and dragged.
+ * Withholds taps, long-presses and press-to-focus-the-pane, NOT interaction as such: a withheld
+ * down is consumed, and scroll, pager drag and sheet drag all accept a consumed down — the pager's
+ * own swipe depends on that. Long-presses go with the taps because the click detector behind them
+ * waits for an unconsumed down, which also leaves the cross-pane drag `WorkspaceDragSource` arms
+ * from its long-click callback unarmed for that press. A pane whose gate is closed can still be
+ * scrolled and swiped.
  *
  * Defaults to `{ true }`: outside a pager-driven pane there is nothing to withhold.
  */

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/bottomsheet/PaneScopedBottomSheetTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/bottomsheet/PaneScopedBottomSheetTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.workspace.ui.bottomsheet
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,6 +27,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -592,6 +594,46 @@ class PaneScopedBottomSheetTest : ComposeTest() {
         itemBounds(ITEM_COUNT - 1).bottom shouldBeLessThanOrEqualTo card.bottom - 32.dp
     }
 
+    /**
+     * The sheet's own press observers have to inherit the pane's press gate, not just sit under a
+     * boundary that happens to consume first.
+     *
+     * The pane-focus count is what shows the difference. Those observers read the down with
+     * consumption ignored, so a scrim or card tap still asks for the pane after the boundary has
+     * consumed it — the dismissal being withheld would be the boundary's doing, but a request
+     * arriving would be the surface's own.
+     */
+    @Test
+    fun `a sheet withholds the presses its pane withholds`() {
+        var dismissals = 0
+        var contentClicks = 0
+        var paneFocusRequests = 0
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalWorkspaceFocusRequest provides { paneFocusRequests++ },
+            ) {
+                Case(allowPresses = { false }, onDismiss = { dismissals++ }) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(ITEM_HEIGHT)
+                            .testTag(NESTED_TAG)
+                            .clickable { contentClicks++ },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(SCRIM_TAG).performTouchInput { click(Offset(4f, 4f)) }
+        composeTestRule.onNodeWithTag(NESTED_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        dismissals shouldBe 0
+        contentClicks shouldBe 0
+        paneFocusRequests shouldBe 0
+    }
+
     @Composable
     private fun Case(
         visible: Boolean = true,
@@ -602,6 +644,7 @@ class PaneScopedBottomSheetTest : ComposeTest() {
         topInset: Dp = 0.dp,
         bottomInset: Dp = 0.dp,
         paneFocused: Boolean = true,
+        allowPresses: () -> Boolean = { true },
         content: @Composable () -> Unit,
     ) {
         PreviewWrapper {
@@ -610,6 +653,7 @@ class PaneScopedBottomSheetTest : ComposeTest() {
                     .fillMaxSize()
                     .testTag(PANE_TAG),
                 paneFocused = paneFocused,
+                allowPresses = allowPresses,
             ) {
                 PaneScopedBottomSheet(
                     visible = visible,
@@ -737,6 +781,7 @@ class PaneScopedBottomSheetTest : ComposeTest() {
         private const val NESTED_TAG = "sheet.nested"
         private const val FIELD_TAG = "sheet.field"
         private val CARD_TAG = PaneScopedBottomSheetDefaults.CARD_TEST_TAG
+        private val SCRIM_TAG = PaneScopedBottomSheetDefaults.SCRIM_TEST_TAG
 
         private val ITEM_HEIGHT = 60.dp
         private const val ITEM_COUNT = 20

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dialogs/PaneBoundAlertDialogTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dialogs/PaneBoundAlertDialogTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -29,6 +30,7 @@ import androidx.compose.ui.unit.width
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -287,6 +289,52 @@ class PaneBoundAlertDialogTest : ComposeTest() {
         val scrimBounds = composeTestRule.onNodeWithTag(scrim).getUnclippedBoundsInRoot()
         scrimBounds.width shouldBe paneBounds.width
         scrimBounds.height shouldBe paneBounds.height
+    }
+
+    /**
+     * The dialog's own press observers have to inherit the pane's press gate, not just sit under a
+     * boundary that happens to consume first.
+     *
+     * The pane-focus count is what shows the difference. Those observers read the down with
+     * consumption ignored, so a scrim or button tap still asks for the pane after the boundary has
+     * consumed it — the dismissal being withheld would be the boundary's doing, but a request
+     * arriving would be the dialog's own.
+     */
+    @Test
+    fun `a dialog withholds the presses its pane withholds`() {
+        var dismissed = 0
+        var confirmed = 0
+        var paneFocusRequests = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalWorkspaceFocusRequest provides { paneFocusRequests++ },
+                ) {
+                    PaneLayerHost(
+                        modifier = Modifier.fillMaxSize(),
+                        paneFocused = true,
+                        allowPresses = { false },
+                    ) {
+                        PaneBoundAlertDialog(
+                            onDismissRequest = { dismissed++ },
+                            title = { Text("Title") },
+                            confirmButton = { TextButton(onClick = { confirmed++ }) { Text("OK") } },
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(scrim).performTouchInput { click(Offset(4f, 4f)) }
+        composeTestRule.onNodeWithTag(surface).performClick()
+        composeTestRule.onNodeWithText("OK").performClick()
+
+        composeTestRule.runOnIdle {
+            dismissed shouldBe 0
+            confirmed shouldBe 0
+            paneFocusRequests shouldBe 0
+        }
     }
 
     companion object {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/modal/PaneLayerHostTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/modal/PaneLayerHostTest.kt
@@ -2013,6 +2013,50 @@ class PaneLayerHostTest : ComposeTest() {
         }
     }
 
+    /**
+     * A host with no [LocalWorkspaceFocusRequest] above it still withholds presses. Nothing to hand
+     * pane focus to is a reason to skip the hand-over, not a reason to let a press through that the
+     * pane said it cannot answer for.
+     *
+     * The second half is the control: the same press on the same target lands once the gate opens,
+     * so the suppression above is the gate and not the missing provider making the target inert.
+     */
+    @Test
+    fun `presses are withheld even with no pane focus request in scope`() {
+        var allowPresses by mutableStateOf(false)
+        var clicked = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(
+                    modifier = Modifier.fillMaxSize(),
+                    paneFocused = false,
+                    clickToFocus = false,
+                    allowPresses = { allowPresses },
+                ) {
+                    PaneLayer(rank = PaneLayerRank.CONTENT, modal = false) {
+                        Box(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .testTag(PRESS_TARGET_TAG)
+                                .clickable { clicked++ },
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(PRESS_TARGET_TAG).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { clicked shouldBe 0 }
+
+        composeTestRule.runOnIdle { allowPresses = true }
+
+        composeTestRule.onNodeWithTag(PRESS_TARGET_TAG).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle { clicked shouldBe 1 }
+    }
+
     companion object {
         private const val PULSE_DURATION_MS = 420L
         private const val PULSE_COMPOSE_FRAMES = 4

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/modal/PaneLayerHostTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/modal/PaneLayerHostTest.kt
@@ -1773,6 +1773,246 @@ class PaneLayerHostTest : ComposeTest() {
         composeTestRule.onNodeWithTag(TAG_PANE_HOVER_BARRIER).assertDoesNotExist()
     }
 
+    /**
+     * A pane that withholds presses answers a down by consuming it and by doing nothing else.
+     *
+     * Each of the three "nothing else" parts is its own defect if it slips: a focus request commits
+     * the pane the user has not chosen, a forced focus clear dismisses the IME with nothing left to
+     * restore it, and a pulse tells the user a press was taken when none was.
+     */
+    @Test
+    fun `a press into a pane that withholds presses does nothing at all`() {
+        var clicked = 0
+        var paneFocusRequests = 0
+        var elsewhereHasFocus = false
+        val elsewhereFocus = FocusRequester()
+
+        composeTestRule.mainClock.autoAdvance = false
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Row {
+                    Box(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .focusRequester(elsewhereFocus)
+                            .onFocusChanged { elsewhereHasFocus = it.isFocused }
+                            .focusable(),
+                    )
+                    CompositionLocalProvider(
+                        LocalWorkspaceFocusRequest provides { paneFocusRequests++ },
+                    ) {
+                        PaneLayerHost(paneFocused = false, allowPresses = { false }) {
+                            PaneLayer(rank = PaneLayerRank.CONTENT, modal = false) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(48.dp)
+                                        .testTag(PRESS_TARGET_TAG)
+                                        .clickable { clicked++ },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.runOnIdle { elsewhereFocus.requestFocus() }
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.runOnIdle { elsewhereHasFocus shouldBe true }
+
+        composeTestRule.onNodeWithTag(PRESS_TARGET_TAG).performClick()
+        // Far enough for a pulse to have composed, far short of one having faded out again
+        repeat(PULSE_COMPOSE_FRAMES) { composeTestRule.mainClock.advanceTimeByFrame() }
+
+        composeTestRule.runOnIdle {
+            clicked shouldBe 0
+            paneFocusRequests shouldBe 0
+            elsewhereHasFocus shouldBe true
+        }
+        composeTestRule.onNodeWithTag(TAG_PANE_FOCUS_PULSE).assertDoesNotExist()
+    }
+
+    /**
+     * With click-to-focus off the boundary consumes nothing of its own accord, so a press reaches
+     * the content — and content that takes keyboard focus reaches the pane through the *focus
+     * arrival* path, which the gate deliberately does not cover. A press that got that far would
+     * therefore commit the pane anyway, by the back door.
+     *
+     * The target is a real focusable, not a click counter: a counter stays at zero whether the
+     * press was withheld or merely not counted, and would pass without pinning that door shut.
+     *
+     * The last two steps are the control. A programmatic focus request under the very same closed
+     * gate still reaches the pane, so "no request arrived" above is about the press being withheld
+     * and not about the arrival path being broken for everyone.
+     */
+    @Test
+    fun `a withheld press cannot reach content that would take keyboard focus`() {
+        var fieldClicks = 0
+        var fieldHasFocus = false
+        var paneFocusRequests = 0
+        var elsewhereHasFocus = false
+        val elsewhereFocus = FocusRequester()
+        val fieldFocus = FocusRequester()
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Row {
+                    Box(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .focusRequester(elsewhereFocus)
+                            .onFocusChanged { elsewhereHasFocus = it.isFocused }
+                            .focusable(),
+                    )
+                    CompositionLocalProvider(
+                        LocalWorkspaceFocusRequest provides { paneFocusRequests++ },
+                    ) {
+                        PaneLayerHost(
+                            paneFocused = false,
+                            clickToFocus = false,
+                            allowPresses = { false },
+                        ) {
+                            PaneLayer(rank = PaneLayerRank.CONTENT, modal = false) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(48.dp)
+                                        .testTag(PRESS_TARGET_TAG)
+                                        .focusRequester(fieldFocus)
+                                        .onFocusChanged { fieldHasFocus = it.isFocused }
+                                        .focusable()
+                                        .clickable {
+                                            fieldClicks++
+                                            fieldFocus.requestFocus()
+                                        },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle { elsewhereFocus.requestFocus() }
+        composeTestRule.runOnIdle { elsewhereHasFocus shouldBe true }
+
+        composeTestRule.onNodeWithTag(PRESS_TARGET_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            fieldClicks shouldBe 0
+            fieldHasFocus shouldBe false
+            elsewhereHasFocus shouldBe true
+            paneFocusRequests shouldBe 0
+        }
+
+        composeTestRule.runOnIdle { fieldFocus.requestFocus() }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            fieldHasFocus shouldBe true
+            (paneFocusRequests > 0) shouldBe true
+        }
+    }
+
+    /**
+     * Keyboard traversal into a pane the pager is not resting on legitimately wants the pager to
+     * follow, and a dropped arrival request is not retried — it waits out its timeout and then
+     * gives the focus up. So the arrival path stays ungated while presses are withheld.
+     */
+    @Test
+    fun `focus arriving while presses are withheld still asks for the pane`() {
+        var paneFocusRequests = 0
+        var fieldHasFocus = false
+        val fieldFocus = FocusRequester()
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalWorkspaceFocusRequest provides { paneFocusRequests++ },
+                ) {
+                    PaneLayerHost(
+                        modifier = Modifier.fillMaxSize(),
+                        paneFocused = false,
+                        allowPresses = { false },
+                    ) {
+                        PaneLayer(rank = PaneLayerRank.CONTENT, modal = false) {
+                            Box(
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .focusRequester(fieldFocus)
+                                    .onFocusChanged { fieldHasFocus = it.isFocused }
+                                    .focusable(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle { fieldFocus.requestFocus() }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            fieldHasFocus shouldBe true
+            (paneFocusRequests > 0) shouldBe true
+        }
+    }
+
+    /**
+     * The control for the two tests above: the very same press on the very same target lands once
+     * the gate opens, so "nothing happened" there is about the gate and not about the press having
+     * been aimed at something that never answers.
+     */
+    @Test
+    fun `the same press lands once the pane allows presses again`() {
+        var allowPresses by mutableStateOf(false)
+        var clicked = 0
+        var paneFocusRequests = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalWorkspaceFocusRequest provides { paneFocusRequests++ },
+                ) {
+                    PaneLayerHost(
+                        modifier = Modifier.fillMaxSize(),
+                        paneFocused = false,
+                        clickToFocus = false,
+                        allowPresses = { allowPresses },
+                    ) {
+                        PaneLayer(rank = PaneLayerRank.CONTENT, modal = false) {
+                            Box(
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .testTag(PRESS_TARGET_TAG)
+                                    .clickable { clicked++ },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(PRESS_TARGET_TAG).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            clicked shouldBe 0
+            paneFocusRequests shouldBe 0
+        }
+
+        composeTestRule.runOnIdle { allowPresses = true }
+
+        composeTestRule.onNodeWithTag(PRESS_TARGET_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            clicked shouldBe 1
+            paneFocusRequests shouldBe 1
+        }
+    }
+
     companion object {
         private const val PULSE_DURATION_MS = 420L
         private const val PULSE_COMPOSE_FRAMES = 4

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacePane.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacePane.kt
@@ -42,6 +42,9 @@ import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
  * @param backActive whether system Back may be dispatched into this pane. Defaults to
  *        [paneFocused]; a pager-driven layout narrows it, because its focused pane can be scrolled
  *        off screen while focus stays put.
+ * @param allowPresses whether presses arriving in this pane may act, read at event time. The
+ *        press-side counterpart of [backActive]: a pager-driven layout answers false while it is
+ *        not resting on this pane's page. Forwarded to [PaneLayerHost].
  * @param activeWorkspaceId the workspace the user is actually talking to: the deepest occupant of
  *        a focused pane, or null while the pane is unfocused. Deliberately *not* compared against
  *        the globally focused id — a picker opened via `launchPicker` never becomes the focused
@@ -60,6 +63,7 @@ fun WorkspacePane(
     paneFocused: Boolean,
     clickToFocus: Boolean = true,
     backActive: Boolean = paneFocused,
+    allowPresses: () -> Boolean = { true },
     onRequestPaneFocus: () -> Unit,
     managerDialogStates: Map<Workspace.Id, ManagerDialog.WorkspaceTargeted>,
     onDismissManagerDialog: (Workspace.Id) -> Unit,
@@ -86,6 +90,7 @@ fun WorkspacePane(
             paneFocused = paneFocused,
             clickToFocus = clickToFocus,
             backActive = backActive,
+            allowPresses = allowPresses,
             paneEdges = paneEdges,
         ) {
             CompositionLocalProvider(

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -40,6 +40,7 @@ import eu.darken.butler.workspace.ui.insets.paneHorizontalInsetPadding
 import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
+import eu.darken.butler.workspace.ui.modal.suppressPressesUnless
 import eu.darken.butler.workspace.ui.workspaces.WorkspacePane
 import eu.darken.butler.workspace.ui.workspaces.WorkspaceScreenAction
 import eu.darken.butler.workspace.ui.workspaces.WorkspaceSwitchIndicator
@@ -177,6 +178,8 @@ internal fun ClassicWorkspaceContainer(
         },
     )
 
+    val restState = rememberPagerRestState(pagerState)
+
     val hasBlockingDialog = managerDialogs.any { it.isBlocking }
 
     val scope = rememberCoroutineScope()
@@ -274,6 +277,12 @@ internal fun ClassicWorkspaceContainer(
 
                 if (tabInfo == null) {
                     CreatingWorkspacePlaceholder(
+                        // Gated at the down, not on the click: `clickable` fires on the up, so a
+                        // finger put down on the placeholder's sliver mid-swipe and held through
+                        // the settle would create a workspace the gesture never asked for. `page`
+                        // is the composed page identity, so the gate cannot drift onto another
+                        // index while the list changes under the finger.
+                        modifier = Modifier.suppressPressesUnless { restState.isRestingOn(page) },
                         isCreating = isPlaceholderPage && creationController.isCreating,
                         onClick = { creationController.onPlaceholderClick() },
                     )
@@ -312,6 +321,13 @@ internal fun ClassicWorkspaceContainer(
                         // widened press variant: no page may arm a back handler while focus names
                         // no tab.
                         backActive = paneHoldsFocus && pagerState.isSettledOnPage(page),
+                        // The press-side mirror of backActive above: while the pager is moving,
+                        // two pages share the viewport, so a finger-down starting the next swipe
+                        // lands on the partially visible neighbour. Answering it would select a
+                        // tab the gesture never chose, and the swipe would end somewhere else.
+                        // Stricter than isSettledOnPage, which is briefly true in the gap between
+                        // a drag and its fling.
+                        allowPresses = { restState.isRestingOn(page) },
                         activeWorkspaceId = activeId,
                         childModals = chain.map { it.asPaneInfo() },
                         // Always the page's own tab: a Focus() for a stacked child is dropped.

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerFocusCoordinator.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerFocusCoordinator.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.first
 private val TAG = logTag("Workspace", "Container", "Classic", "PagerCoord")
 
 /** How long the pager must have been quiet before a page counts as resting under the finger. */
-private const val REST_QUIESCENCE_MS = 50L
+internal const val REST_QUIESCENCE_MS = 50L
 
 class PagerFocusCoordinatorState internal constructor() {
     // A depth counter, not a flag: animateScrollToPage goes through Compose's MutatorMutex, so a

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerFocusCoordinator.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerFocusCoordinator.kt
@@ -1,21 +1,31 @@
 package eu.darken.butler.workspace.ui.workspaces.classic
 
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import eu.darken.butler.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 
 private val TAG = logTag("Workspace", "Container", "Classic", "PagerCoord")
+
+/** How long the pager must have been quiet before a page counts as resting under the finger. */
+private const val REST_QUIESCENCE_MS = 50L
 
 class PagerFocusCoordinatorState internal constructor() {
     // A depth counter, not a flag: animateScrollToPage goes through Compose's MutatorMutex, so a
@@ -70,6 +80,93 @@ class PagerFocusCoordinatorState internal constructor() {
  */
 internal fun PagerState.isSettledOnPage(page: Int): Boolean =
     !isScrollInProgress && settledPage == page
+
+/**
+ * Whether the pager is genuinely at rest, as opposed to merely reporting no scroll session.
+ *
+ * Stricter than [PagerState.isSettledOnPage], for a case that back dispatch does not have to care
+ * about: a drag's scroll session ends a moment before its fling session begins, and in that gap the
+ * pager reports no scroll while `settledPage` falls back to `currentPage` — which past the drag's
+ * halfway point already names the neighbour. A press landing there belongs to the swipe in
+ * progress, not to the page under the finger.
+ *
+ * The page offset is deliberately not part of the answer. `PagerState`'s saver persists the current
+ * offset fraction, so a configuration change during a swipe restores a non-zero offset with no
+ * scroll session open and no drag to end it — an offset term would leave every page permanently
+ * press-inert, unrecoverable once swipe gestures are off. `settledPage == page` carries the
+ * alignment requirement instead.
+ */
+class PagerRestState internal constructor(
+    private val pagerState: PagerState,
+    restingAtCreation: Boolean,
+) {
+
+    // True between DragInteraction.Start and its terminal Stop/Cancel: the pager's own
+    // isScrollInProgress is false in the gap described above, while the finger is still down.
+    internal var dragInProgress by mutableStateOf(false)
+
+    // The latch: false the moment the pager stops being idle, true again once the idle has held for
+    // REST_QUIESCENCE_MS. Snapshot-backed, so anything reading it through composition follows it.
+    internal var quiescent by mutableStateOf(restingAtCreation)
+
+    internal val isIdle: Boolean
+        get() = !pagerState.isScrollInProgress && !dragInProgress
+
+    /**
+     * Whether the pager is resting on [page] at this instant.
+     *
+     * [isIdle] is re-read here rather than trusted to [quiescent] alone: the latch is driven by a
+     * snapshotFlow collector, which is asynchronous, so a scroll that has just started can still
+     * find it true.
+     */
+    fun isRestingOn(page: Int): Boolean = quiescent && isIdle && pagerState.settledPage == page
+}
+
+/**
+ * Remembers a [PagerRestState] for [pagerState].
+ *
+ * @param interactions test seam; defaults to the pager's own interaction stream, which cannot be
+ *     driven from test code
+ */
+@Composable
+fun rememberPagerRestState(
+    pagerState: PagerState,
+    interactions: Flow<Interaction> = pagerState.interactionSource.interactions,
+): PagerRestState {
+    // Seeded from the instantaneous predicate, not from false: a holder cannot come into existence
+    // mid-gesture, and starting closed would make every page press-inert for the quiescence window
+    // after each composition.
+    val restState = remember(pagerState) {
+        PagerRestState(pagerState, restingAtCreation = !pagerState.isScrollInProgress)
+    }
+
+    LaunchedEffect(restState, interactions) {
+        interactions.collect { interaction ->
+            when (interaction) {
+                is DragInteraction.Start -> restState.dragInProgress = true
+                is DragInteraction.Stop, is DragInteraction.Cancel -> restState.dragInProgress = false
+                else -> Unit
+            }
+        }
+    }
+
+    LaunchedEffect(restState) {
+        snapshotFlow { restState.isIdle }
+            .distinctUntilChanged()
+            // collectLatest, so the fling session starting cancels the pending open and the latch
+            // never opens inside a single swipe.
+            .collectLatest { idle ->
+                if (!idle) {
+                    restState.quiescent = false
+                    return@collectLatest
+                }
+                delay(REST_QUIESCENCE_MS)
+                restState.quiescent = true
+            }
+    }
+
+    return restState
+}
 
 /**
  * Coordinates a [PagerState] with externally-driven workspace focus.

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerRestStateTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerRestStateTest.kt
@@ -1,0 +1,200 @@
+package eu.darken.butler.workspace.ui.workspaces.classic
+
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The signal that decides whether a press may act on the page under the finger.
+ *
+ * Driven through [PagerState.scroll] sessions and the pager's interaction stream rather than by
+ * synthesized swipes: the gap this exists for is a sub-frame window between a drag's scroll session
+ * and its fling's, which a gesture-level test could only reach by accident of harness timing.
+ */
+class PagerRestStateTest : ComposeTest() {
+
+    /**
+     * The latch has to start open. A holder cannot come into existence mid-gesture, and a closed
+     * start would make every page press-inert for the quiescence window after each composition —
+     * with no clock advance in between, which is exactly what a press injected right after
+     * `setContent` gets ([ClassicPaneFocusFallbackTest]).
+     */
+    @Test
+    fun `the pager rests on its page immediately after composition`() {
+        var restState: PagerRestState? = null
+
+        composeTestRule.mainClock.autoAdvance = false
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TestHarness(onRestState = { restState = it })
+            }
+        }
+
+        restState!!.isRestingOn(0) shouldBe true
+    }
+
+    @Test
+    fun `the pager does not rest on a page while a scroll session is open`() {
+        var pagerState: PagerState? = null
+        var restState: PagerRestState? = null
+        var session by mutableStateOf<ScrollSession?>(null)
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TestHarness(
+                    session = session,
+                    onPagerState = { pagerState = it },
+                    onRestState = { restState = it },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        restState!!.isRestingOn(0) shouldBe true
+
+        session = ScrollSession()
+        composeTestRule.waitForIdle()
+
+        // Non-vacuity: a session that never opened would fail here instead of asserting nothing.
+        pagerState!!.isScrollInProgress shouldBe true
+        restState!!.isRestingOn(0) shouldBe false
+    }
+
+    /**
+     * The gap between a drag's scroll session and the fling's, with the page visibly off-centre.
+     * Both sessions belong to the user's one swipe, so the pager is not at rest in between.
+     */
+    @Test
+    fun `the pager does not rest in the gap between drag and fling`() = inTheGap(dragBy = 60f) {
+        // The offset is what makes this the easy half: the page is plainly not where it belongs.
+        (it.currentPageOffsetFraction != 0f) shouldBe true
+    }
+
+    /**
+     * The same gap, reached with the page exactly on its boundary — a drag that ends where it began,
+     * or one whose fling has already snapped. Nothing about the pager's position says "mid-gesture"
+     * here; only the fact that the idle has not held for the quiescence window does. This is the
+     * case a predicate built on the page offset gets wrong.
+     */
+    @Test
+    fun `the pager does not rest in a zero-offset gap between drag and fling`() = inTheGap(dragBy = 0f) {
+        it.currentPageOffsetFraction shouldBe 0f
+    }
+
+    /**
+     * One swipe as the pager reports it: a drag session, a beat in which nothing scrolls and the
+     * finger lifts, then the fling's session. [assertGapSignature] pins what that beat looks like
+     * from the outside.
+     *
+     * Every step in the gap is followed by an elapsed-time check against [REST_QUIESCENCE_MS]: the
+     * harness spends a frame per step, so without it a slower step would let the latch reopen and
+     * the case would silently stop being the one it is named after.
+     */
+    private fun inTheGap(dragBy: Float, assertGapSignature: (PagerState) -> Unit) {
+        val interactions = MutableSharedFlow<Interaction>(extraBufferCapacity = 8)
+        var pagerState: PagerState? = null
+        var restState: PagerRestState? = null
+        var session by mutableStateOf<ScrollSession?>(null)
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TestHarness(
+                    interactions = interactions,
+                    session = session,
+                    onPagerState = { pagerState = it },
+                    onRestState = { restState = it },
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        restState!!.isRestingOn(0) shouldBe true
+
+        val drag = DragInteraction.Start()
+        interactions.tryEmit(drag) shouldBe true
+        val dragSession = ScrollSession(by = dragBy)
+        session = dragSession
+        composeTestRule.waitForIdle()
+        pagerState!!.isScrollInProgress shouldBe true
+        restState!!.isRestingOn(0) shouldBe false
+
+        // The drag ends: its scroll session closes and the finger lifts, both before the fling's
+        // session opens. The pager reports no scroll at all in here.
+        val gapStart = composeTestRule.mainClock.currentTime
+        dragSession.gate.complete(Unit)
+        interactions.tryEmit(DragInteraction.Stop(drag)) shouldBe true
+        composeTestRule.waitForIdle()
+
+        pagerState!!.isScrollInProgress shouldBe false
+        pagerState!!.settledPage shouldBe 0
+        assertGapSignature(pagerState!!)
+        stillInsideQuiescence(gapStart)
+        restState!!.isRestingOn(0) shouldBe false
+
+        // The fling picks the gesture up again, still inside the quiescence window.
+        val flingSession = ScrollSession()
+        session = flingSession
+        composeTestRule.waitForIdle()
+        stillInsideQuiescence(gapStart)
+        pagerState!!.isScrollInProgress shouldBe true
+        restState!!.isRestingOn(0) shouldBe false
+
+        flingSession.gate.complete(Unit)
+        composeTestRule.waitForIdle()
+        composeTestRule.mainClock.advanceTimeBy(REST_QUIESCENCE_MS * 4)
+        restState!!.isRestingOn(0) shouldBe true
+    }
+
+    private fun stillInsideQuiescence(since: Long) {
+        (composeTestRule.mainClock.currentTime - since < REST_QUIESCENCE_MS) shouldBe true
+    }
+}
+
+/** One held-open scroll session: the very API a drag and a fling both scroll through. */
+private class ScrollSession(val by: Float = 0f) {
+    val gate = CompletableDeferred<Unit>()
+}
+
+@Composable
+private fun TestHarness(
+    interactions: Flow<Interaction> = MutableSharedFlow(),
+    session: ScrollSession? = null,
+    onPagerState: (PagerState) -> Unit = {},
+    onRestState: (PagerRestState) -> Unit,
+) {
+    val pagerState = rememberPagerState(pageCount = { 3 })
+    // Handed out during composition, not from an effect: the seeding case has to be observable
+    // before the first frame runs.
+    onPagerState(pagerState)
+    onRestState(rememberPagerRestState(pagerState, interactions = interactions))
+
+    // Keyed on the session's identity, so a new one restarts this — by which time the previous
+    // scroll block has already returned, and cancelling it holds nothing open.
+    LaunchedEffect(session) {
+        if (session == null) return@LaunchedEffect
+        pagerState.scroll {
+            if (session.by != 0f) scrollBy(session.by)
+            session.gate.await()
+        }
+    }
+
+    HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize())
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerRestStateTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/PagerRestStateTest.kt
@@ -67,14 +67,16 @@ class PagerRestStateTest : ComposeTest() {
             }
         }
         composeTestRule.waitForIdle()
-        restState!!.isRestingOn(0) shouldBe true
+        val pager = pagerState!!
+        val rest = restState!!
+        rest.isRestingOn(0) shouldBe true
 
         session = ScrollSession()
         composeTestRule.waitForIdle()
 
         // Non-vacuity: a session that never opened would fail here instead of asserting nothing.
-        pagerState!!.isScrollInProgress shouldBe true
-        restState!!.isRestingOn(0) shouldBe false
+        pager.isScrollInProgress shouldBe true
+        rest.isRestingOn(0) shouldBe false
     }
 
     /**
@@ -124,15 +126,17 @@ class PagerRestStateTest : ComposeTest() {
             }
         }
         composeTestRule.waitForIdle()
-        restState!!.isRestingOn(0) shouldBe true
+        val pager = pagerState!!
+        val rest = restState!!
+        rest.isRestingOn(0) shouldBe true
 
         val drag = DragInteraction.Start()
         interactions.tryEmit(drag) shouldBe true
         val dragSession = ScrollSession(by = dragBy)
         session = dragSession
         composeTestRule.waitForIdle()
-        pagerState!!.isScrollInProgress shouldBe true
-        restState!!.isRestingOn(0) shouldBe false
+        pager.isScrollInProgress shouldBe true
+        rest.isRestingOn(0) shouldBe false
 
         // The drag ends: its scroll session closes and the finger lifts, both before the fling's
         // session opens. The pager reports no scroll at all in here.
@@ -141,24 +145,24 @@ class PagerRestStateTest : ComposeTest() {
         interactions.tryEmit(DragInteraction.Stop(drag)) shouldBe true
         composeTestRule.waitForIdle()
 
-        pagerState!!.isScrollInProgress shouldBe false
-        pagerState!!.settledPage shouldBe 0
-        assertGapSignature(pagerState!!)
+        pager.isScrollInProgress shouldBe false
+        pager.settledPage shouldBe 0
+        assertGapSignature(pager)
         stillInsideQuiescence(gapStart)
-        restState!!.isRestingOn(0) shouldBe false
+        rest.isRestingOn(0) shouldBe false
 
         // The fling picks the gesture up again, still inside the quiescence window.
         val flingSession = ScrollSession()
         session = flingSession
         composeTestRule.waitForIdle()
         stillInsideQuiescence(gapStart)
-        pagerState!!.isScrollInProgress shouldBe true
-        restState!!.isRestingOn(0) shouldBe false
+        pager.isScrollInProgress shouldBe true
+        rest.isRestingOn(0) shouldBe false
 
         flingSession.gate.complete(Unit)
         composeTestRule.waitForIdle()
         composeTestRule.mainClock.advanceTimeBy(REST_QUIESCENCE_MS * 4)
-        restState!!.isRestingOn(0) shouldBe true
+        rest.isRestingOn(0) shouldBe true
     }
 
     private fun stillInsideQuiescence(since: Long) {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/PlaceholderPressGateTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/PlaceholderPressGateTest.kt
@@ -1,0 +1,116 @@
+package eu.darken.butler.workspace.ui.workspaces.classic
+
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.down
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.up
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.modal.suppressPressesUnless
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The trailing creation placeholder carries the press gate itself.
+ *
+ * It is composed outside `WorkspacePane`, so it inherits nothing from the pane contract, and a tap
+ * on the sliver of it that shows mid-swipe creates a blank workspace — a worse outcome than the
+ * focus bounce the pane gate prevents, and one that invalidates whatever the user was doing.
+ */
+class PlaceholderPressGateTest : ComposeTest() {
+
+    private val tabId = Workspace.Id()
+
+    @Test
+    fun `a tap creates nothing while the pager is not resting on the placeholder`() {
+        var created = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper { Placeholder(resting = false, onCreate = { created++ }) }
+        }
+
+        composeTestRule.onNodeWithTag(PLACEHOLDER_TAG).performTouchInput {
+            down(Offset(4f, 4f))
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        created shouldBe 0
+    }
+
+    /**
+     * Why the gate sits on the down rather than around the click callback: `clickable` decides on
+     * the up. A finger that lands on the placeholder mid-swipe, stays put through the settle and is
+     * lifted afterwards would find the gate open by then.
+     */
+    @Test
+    fun `a tap held from before the settle until after it still creates nothing`() {
+        var resting by mutableStateOf(false)
+        var created = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper { Placeholder(resting = resting, onCreate = { created++ }) }
+        }
+
+        composeTestRule.onNodeWithTag(PLACEHOLDER_TAG).performTouchInput { down(Offset(4f, 4f)) }
+        composeTestRule.runOnIdle { resting = true }
+        composeTestRule.onNodeWithTag(PLACEHOLDER_TAG).performTouchInput { up() }
+        composeTestRule.waitForIdle()
+
+        created shouldBe 0
+    }
+
+    /**
+     * The control: the same tap on the same target creates once the pager rests there, so the two
+     * cases above are about the gate and not about the tap never having reached anything.
+     */
+    @Test
+    fun `the same tap creates once the pager rests on the placeholder`() {
+        var created = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper { Placeholder(resting = true, onCreate = { created++ }) }
+        }
+
+        composeTestRule.onNodeWithTag(PLACEHOLDER_TAG).performTouchInput {
+            down(Offset(4f, 4f))
+            up()
+        }
+        composeTestRule.waitForIdle()
+
+        created shouldBe 1
+    }
+
+    /** The placeholder page as the classic container composes it: real controller, real gate. */
+    @Composable
+    private fun Placeholder(resting: Boolean, onCreate: () -> Unit) {
+        val controller = rememberPlaceholderCreationController(
+            // One page, and the placeholder is not it: auto-creation must stay out of this.
+            pagerState = rememberPagerState(pageCount = { 1 }),
+            tabIds = listOf(tabId),
+            onDemandEnabled = true,
+            isInteractionBlocked = false,
+            hasBlockingDialog = false,
+            onCreateRequested = onCreate,
+        )
+        CreatingWorkspacePlaceholder(
+            modifier = Modifier
+                .suppressPressesUnless { resting }
+                .testTag(PLACEHOLDER_TAG),
+            onClick = { controller.onPlaceholderClick() },
+        )
+    }
+
+    companion object {
+        private const val PLACEHOLDER_TAG = "classic.placeholder"
+    }
+}


### PR DESCRIPTION
## What changed

Swiping quickly between workspace tabs could leave you on the tab you swiped away from instead of the one you swiped to. The tab would appear to switch and then snap back a moment later.

The cause was a press landing on the neighbouring page while it was still sliding past. When you swipe fast enough that your finger comes down again before the previous swipe has finished moving, two pages share the screen, and that touch would select whichever page happened to be under it, whether or not the gesture ever went there.

A press now does nothing on a page the pager is not resting on, so starting the next swipe can no longer pick the page sliding underneath. Tapping the trailing "new tab" placeholder mid-swipe likewise no longer creates a workspace nobody asked for.

## Technical Context

- Root cause: the pane press observer requests pane focus on every pointer-down on the Initial pass, which in the classic pager becomes a tab selection. Mid-scroll the down lands on the partially visible neighbour, and the pager coordinator cannot tell that apart from a legitimate external selection, so it defers it and then moves the pager to it.
- The fix sits in the input layer rather than the coordinator because the coordinator receives a phantom press-selection and a real programmatic focus change as the same event. Making the settle authoritative instead races the already-deferred sync and turns one bounce into a visible double jump.
- The rest predicate needs a quiescence window rather than an instantaneous check: the pager reports no scroll for a sub-50ms window between a drag's scroll session and its fling's, and `settledPage` falls back to `currentPage` there, naming the neighbour once the drag is past halfway.
- There is deliberately no page-offset term. `PagerState`'s saver persists the offset fraction, so a configuration change during a swipe restores a non-zero offset with no scroll session left to clear it, which would leave every pane permanently press-inert.
- Worth close review: `PaneFocusRequest.kt`, where a closed gate consumes the down and does nothing else (the focus clear must not run, or the IME is dismissed on behalf of a page the user never chose), and `ClassicWorkspaceContainer.kt`, where the placeholder is gated at the down because `clickable` fires on the up. On-device testing confirmed that ordinary swiping and pressing right after a settle still work, but could not reproduce the original rapid-swipe timing, since injected swipes land seconds apart against a window of roughly half a second; the regression coverage is therefore at the predicate and handler level rather than end to end.
