### PR TITLE
History: Fix rows naming the wrong file

### DIFF
--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/TestDataOperationReport.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/TestDataOperationReport.kt
@@ -15,6 +15,12 @@ data class TestDataOperationReport(
     val totalSize: Long,
 ) : DeveloperOperation.Report {
 
+    /**
+     * The generators add inner files before the directory the user named, and test data never
+     * enters history (its metadata kind is null), so there is no honest subject to name.
+     */
+    override val subjectPath: APath<*>? = null
+
     override val summary: CaString = caString { context ->
         buildString {
             if (filesCreated > 0) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperation.kt
@@ -70,6 +70,9 @@ class CompressOperation @AssistedInject constructor(
             // The archive itself is already indexed as a reported change; keeping the directory as
             // the scope candidate is what puts its parent in the attempted-paths rows.
             scopePaths = command.sources.toList() + command.destinationDir,
+            // Covers the failure before any report exists: the row names the archive the user asked
+            // for, not whichever source happens to lead the list.
+            representativePath = outputPath,
         )
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperationReport.kt
@@ -17,6 +17,8 @@ data class CompressOperationReport(
     override val performanceHistory: PerformanceHistory?,
 ) : ExplorerOperation.Report {
 
+    override val subjectPath: APath<*> get() = outputArchive
+
     override val summary: CaString = caString {
         buildString {
             append(it.getQuantityString2(R.plurals.explorer_operation_report_files_compressed, compressedFiles))

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperation.kt
@@ -155,6 +155,12 @@ class CopyOperation @AssistedInject constructor(
         val copiedDestinations = result.copied.map { it.second }.toSet()
         fileSystemHinter.trackPathsAdded(operationContext.id, copiedDestinations.toSet())
 
+        // Identified by the source it pairs with, so a directory copy names the top-level
+        // destination instead of whichever descendant the engine happened to write first.
+        val firstSource = command.sources.firstOrNull()
+        reportBuilder.setSubjectPath(
+            result.copied.firstOrNull { (source, _) -> source.lookedUp == firstSource }?.second?.lookedUp
+        )
         reportBuilder.addCopiedItems(copiedDestinations)
         reportBuilder.setSkipped(result.skipped)
         reportBuilder.setCopiedBytes(result.copiedBytes)

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperationReport.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.explorer.core.operations
 import android.text.format.Formatter.*
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
@@ -12,6 +13,7 @@ import eu.darken.butler.workspace.core.operations.Operation.Report.*
 
 data class CopyOperationReport(
     override val affectedPaths: Collection<PathChange>,
+    override val subjectPath: APath<*>?,
     val skipped: Collection<APathLookup<*>>,
     val copiedFiles: Int,
     val copiedDirectories: Int,
@@ -65,6 +67,7 @@ data class CopyOperationReport(
         private var copiedDirectories: Int = 0
         private var copiedBytes: Long = 0
         private var performanceHistory: PerformanceHistory? = null
+        private var subjectPath: APath<*>? = null
 
         fun addCopiedItems(lookups: Collection<APathLookup<*>>) {
             val affected = lookups.map { lookup ->
@@ -86,8 +89,14 @@ data class CopyOperationReport(
             this.performanceHistory = history
         }
 
+        /** The top-level destination, not whichever descendant the engine copied first. */
+        fun setSubjectPath(path: APath<*>?) {
+            this.subjectPath = path
+        }
+
         fun build(): CopyOperationReport = CopyOperationReport(
             affectedPaths = affectedPaths.distinct(),
+            subjectPath = subjectPath,
             skipped = skipped,
             copiedFiles = copiedFiles,
             copiedDirectories = copiedDirectories,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperation.kt
@@ -118,6 +118,9 @@ class CreateOperation @AssistedInject constructor(
 
             // Build report
             @Suppress("UNCHECKED_CAST")
+            reportBuilder.setSubjectPath((result.created as APathLookup<*>).lookedUp)
+
+            @Suppress("UNCHECKED_CAST")
             reportBuilder.addPathEvent(
                 FileSystemEvent.Added(
                     operationId = operationContext.id,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperationReport.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.explorer.core.operations
 
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.explorer.R
@@ -10,6 +11,7 @@ import eu.darken.butler.workspace.core.operations.Operation.Report.*
 
 data class CreateOperationReport(
     override val affectedPaths: Collection<PathChange>,
+    override val subjectPath: APath<*>?,
     val createdFiles: Int,
     val createdDirectories: Int,
 ) : ExplorerOperation.Report {
@@ -34,6 +36,7 @@ data class CreateOperationReport(
         private val affectedPaths = mutableListOf<PathChange>()
         private var createdFiles: Int = 0
         private var createdDirectories: Int = 0
+        private var subjectPath: APath<*>? = null
 
         fun addPathEvent(event: FileSystemEvent) {
             affectedPaths.addAll(
@@ -52,8 +55,14 @@ data class CreateOperationReport(
             )
         }
 
+        /** The conflict-resolved path, which is not always the name the user typed. */
+        fun setSubjectPath(path: APath<*>?) {
+            this.subjectPath = path
+        }
+
         fun build(): CreateOperationReport = CreateOperationReport(
             affectedPaths = affectedPaths.distinct(),
+            subjectPath = subjectPath,
             createdFiles = createdFiles,
             createdDirectories = createdDirectories,
         )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperation.kt
@@ -115,6 +115,8 @@ class CreateTextFileOperation @AssistedInject constructor(
             )
 
             // Build report
+            reportBuilder.setSubjectPath(createdPath)
+
             @Suppress("UNCHECKED_CAST")
             reportBuilder.addPathEvent(
                 FileSystemEvent.Added(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperation.kt
@@ -69,6 +69,7 @@ class DeleteOperation @AssistedInject constructor(
         send(stateActive)
 
         val reportBuilder = DeleteOperationReport.Builder()
+        reportBuilder.setSubjectPath(command.targets.firstOrNull())
 
         coreDeleteExecutor.execute(
             targets = command.targets,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperationReport.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.explorer.core.operations
 
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.core.operations.BaseDeleteOperationReport
@@ -14,6 +15,7 @@ data class DeleteOperationReport(
     override val deletedDirectories: Int,
     override val bytesFreed: Long,
     override val performanceHistory: PerformanceHistory?,
+    override val subjectPath: APath<*>?,
 ) : BaseDeleteOperationReport(
     affectedPaths = affectedPaths,
     skipped = skipped,
@@ -23,6 +25,7 @@ data class DeleteOperationReport(
     deletedDirectories = deletedDirectories,
     bytesFreed = bytesFreed,
     performanceHistory = performanceHistory,
+    subjectPath = subjectPath,
 ), ExplorerOperation.Report {
 
     override fun toString(): String {
@@ -39,6 +42,7 @@ data class DeleteOperationReport(
             deletedDirectories = deletedDirectories,
             bytesFreed = _bytesFreed,
             performanceHistory = _performanceHistory,
+            subjectPath = _subjectPath,
         )
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperation.kt
@@ -100,7 +100,9 @@ class DownloadLocalCopyOperation @AssistedInject constructor(
                     send(
                         State.Completed(
                             startedAt = operationContext.startedAt,
-                            report = CopyOperationReport.Builder().build(),
+                            report = CopyOperationReport.Builder()
+                                .apply { setSubjectPath(destPath) }
+                                .build(),
                         ),
                     )
                     return@channelFlow
@@ -172,6 +174,7 @@ class DownloadLocalCopyOperation @AssistedInject constructor(
         fileSystemHinter.trackPathsAdded(operationContext.id, listOf(destLookup))
 
         val report = CopyOperationReport.Builder().apply {
+            setSubjectPath(destPath)
             addCopiedItems(listOf(destLookup))
             setCopiedBytes(written)
         }.build()

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperation.kt
@@ -107,7 +107,12 @@ class ExtractOperation @AssistedInject constructor(
             )
             if (resolution !is PathActionIssue.ArchivePasswordRequired.Resolution.Submit) {
                 log(tag, INFO) { "Password prompt dismissed, aborting extract" }
-                send(State.Completed(startedAt = ctx.startedAt, report = ExtractOperationReport.Builder().build()))
+                send(
+                    State.Completed(
+                        startedAt = ctx.startedAt,
+                        report = ExtractOperationReport.Builder(command.archive).build(),
+                    ),
+                )
                 return
             }
             attemptFailed = true // any subsequent loop means the previous attempt didn't verify
@@ -186,7 +191,12 @@ class ExtractOperation @AssistedInject constructor(
                 is PathActionIssue.PathAlreadyExists.Resolution.Skip -> ConflictDecision.SKIP
                 else -> {
                     log(tag, INFO) { "Merge prompt dismissed, aborting sequential extract" }
-                    send(State.Completed(startedAt = ctx.startedAt, report = ExtractOperationReport.Builder().build()))
+                    send(
+                    State.Completed(
+                        startedAt = ctx.startedAt,
+                        report = ExtractOperationReport.Builder(command.archive).build(),
+                    ),
+                )
                     return
                 }
             }
@@ -199,7 +209,12 @@ class ExtractOperation @AssistedInject constructor(
                     }
                 } else {
                     log(tag, INFO) { "Base path is a file and merge was declined, aborting" }
-                    send(State.Completed(startedAt = ctx.startedAt, report = ExtractOperationReport.Builder().build()))
+                    send(
+                    State.Completed(
+                        startedAt = ctx.startedAt,
+                        report = ExtractOperationReport.Builder(command.archive).build(),
+                    ),
+                )
                     return
                 }
             }
@@ -347,7 +362,11 @@ class ExtractOperation @AssistedInject constructor(
         // destination - lexical segment sanitization alone can't catch a pre-existing symlink at the
         // destination. For SAF/root this is effectively identity (no symlinks), so it just passes through.
         val canonicalBase = runCatching { gatewaySwitch.canonicalize(baseDir) }.getOrDefault(baseDir)
-        return ExtractSession(baseDir = baseDir, canonicalBase = canonicalBase)
+        return ExtractSession(
+            baseDir = baseDir,
+            canonicalBase = canonicalBase,
+            reportBuilder = ExtractOperationReport.Builder(command.archive),
+        )
     }
 
     private suspend fun ProducerScope<State>.finish(
@@ -368,7 +387,7 @@ class ExtractOperation @AssistedInject constructor(
     private class ExtractSession(
         val baseDir: APath<*>,
         val canonicalBase: APath<*>,
-        val reportBuilder: ExtractOperationReport.Builder = ExtractOperationReport.Builder(),
+        val reportBuilder: ExtractOperationReport.Builder,
         val addedLookups: MutableList<APathLookup<*>> = mutableListOf(),
     )
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperationReport.kt
@@ -11,6 +11,7 @@ import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
 
 data class ExtractOperationReport(
     override val affectedPaths: Collection<PathChange>,
+    override val subjectPath: APath<*>,
     val extractedFiles: Int,
     val skippedEntries: Collection<String>,
     val extractedBytes: Long,
@@ -46,7 +47,8 @@ data class ExtractOperationReport(
         }
     }
 
-    class Builder {
+    /** [archive] is required: an extraction is about the archive, never about an entry inside it. */
+    class Builder(private val archive: APath<*>) {
         private val affectedPaths = mutableListOf<PathChange>()
         private val skipped = mutableListOf<String>()
         private var extractedFiles = 0
@@ -69,6 +71,7 @@ data class ExtractOperationReport(
 
         fun build(): ExtractOperationReport = ExtractOperationReport(
             affectedPaths = affectedPaths.distinct(),
+            subjectPath = archive,
             extractedFiles = extractedFiles,
             skippedEntries = skipped,
             extractedBytes = extractedBytes,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperation.kt
@@ -159,6 +159,13 @@ class MoveOperation @AssistedInject constructor(
         val movedDestinations = result.movedFiles.map { it.second }.toSet()
         fileSystemHinter.trackPathsAdded(operationContext.id, movedDestinations.toSet())
 
+        // Identified by the source it pairs with, so a directory move names the top-level
+        // destination instead of whichever descendant the engine happened to move first.
+        val firstSource = command.sources.firstOrNull()
+        reportBuilder.setSubjectPath(
+            result.movedFiles.firstOrNull { (source, _) -> source.lookedUp == firstSource }?.second?.lookedUp
+        )
+
         // Build report
         reportBuilder.addMovedItems(result.movedFiles)
         reportBuilder.setSkipped(result.skippedFiles)

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperationReport.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.explorer.core.operations
 import android.text.format.Formatter.*
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
@@ -12,6 +13,7 @@ import eu.darken.butler.workspace.core.operations.Operation.Report.*
 
 data class MoveOperationReport(
     override val affectedPaths: Collection<PathChange>,
+    override val subjectPath: APath<*>?,
     val skipped: Collection<APathLookup<*>>,
     val movedFiles: Int,
     val movedDirectories: Int,
@@ -65,6 +67,7 @@ data class MoveOperationReport(
         private var movedDirectories: Int = 0
         private var bytesMoved: Long = 0
         private var performanceHistory: PerformanceHistory? = null
+        private var subjectPath: APath<*>? = null
 
         fun addMovedItems(sources: Collection<Pair<APathLookup<*>, APathLookup<*>>>) {
             val affected = sources.map { (source, destLookup) ->
@@ -90,8 +93,14 @@ data class MoveOperationReport(
             this.performanceHistory = history
         }
 
+        /** The top-level destination, not whichever descendant the engine moved first. */
+        fun setSubjectPath(path: APath<*>?) {
+            this.subjectPath = path
+        }
+
         fun build(): MoveOperationReport = MoveOperationReport(
             affectedPaths = affectedPaths.distinct(),
+            subjectPath = subjectPath,
             skipped = skipped,
             movedFiles = movedFiles,
             movedDirectories = movedDirectories,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/RestoreOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/RestoreOperation.kt
@@ -59,7 +59,12 @@ class RestoreOperation @AssistedInject constructor(
         val restoredPaths: Set<APath<*>>,
         val conflictCount: Int,
         val failedCount: Int,
+        /** The subset of [restoredPaths] that came from a trash item the user selected directly. */
+        val rootRestoredPaths: Set<APath<*>> = emptySet(),
     ) : ExplorerOperation.Report {
+        override val subjectPath: APath<*>? =
+            rootRestoredPaths.firstOrNull() ?: restoredPaths.firstOrNull()
+
         override val summary: CaString = caString { cx ->
             cx.getQuantityString2(
                 eu.darken.butler.workspace.R.plurals.workspace_operation_restore_summary,
@@ -79,6 +84,7 @@ class RestoreOperation @AssistedInject constructor(
         send(State.Active(startedAt = operationContext.startedAt))
 
         val restoredPaths = mutableSetOf<APath<*>>()
+        val rootRestoredPaths = mutableSetOf<APath<*>>()
         var conflicts = 0
         var failed = 0
 
@@ -89,6 +95,7 @@ class RestoreOperation @AssistedInject constructor(
                 if (repoItems.isNotEmpty()) {
                     val result = trashManager.restore(repoItems)
                     restoredPaths += result.restored
+                    rootRestoredPaths += result.restored
                     conflicts += result.conflicts.size
                     failed += result.failed.size
                 }
@@ -146,6 +153,7 @@ class RestoreOperation @AssistedInject constructor(
                     restoredPaths = restoredPaths,
                     conflictCount = conflicts,
                     failedCount = failed,
+                    rootRestoredPaths = rootRestoredPaths,
                 ),
                 error = when {
                     restoredPaths.isEmpty() && conflicts + failed > 0 ->

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
@@ -373,6 +373,7 @@ object MockDataProvider {
                 report = object : Operation.Report {
                     override val summary = description.toCaString()
                     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val subjectPath = null
                 }
             ),
             canCancel = false,

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CompressOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CompressOperationTest.kt
@@ -238,7 +238,8 @@ class CompressOperationTest : BaseTest() {
         plan.targets shouldContainExactly listOf(sourcePath)
         plan.destination shouldBe OperationPathPlan.Destination.RequestedTarget(outputPath)
         plan.scopePaths shouldContainExactly listOf(sourcePath, destinationDir)
-        plan.representativePath shouldBe sourcePath
+        // A compression that fails before it reports anything still names the archive it was for.
+        plan.representativePath shouldBe outputPath
     }
 
     @Test

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CopyOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CopyOperationTest.kt
@@ -1,0 +1,99 @@
+package eu.darken.butler.explorer.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.actions.CopyAction
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import org.junit.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+
+/**
+ * A directory copy reports one change per copied descendant. The history subject has to come from
+ * the source-to-destination pair the command asked for, never from the position of a change.
+ */
+class CopyOperationTest : BaseTest() {
+
+    private val gatewaySwitch = mockk<GatewaySwitch>()
+    private val fileSystemHinter = mockk<FileSystemHinter>(relaxed = true)
+
+    private val sourceDir = LocalPath.build("/sdcard/Download/nested")
+    private val destinationDir = LocalPath.build("/sdcard/Backup")
+    private val copiedDir = destinationDir.child("nested")
+    private val copiedChild = copiedDir.child("aaa.txt")
+
+    private fun lookupOf(path: LocalPath, isDir: Boolean = false): APathLookup<APath<*>> {
+        @Suppress("UNCHECKED_CAST")
+        return LocalPathLookup(
+            lookedUp = path,
+            fileType = if (isDir) FileType.DIRECTORY else FileType.FILE,
+            size = 4L,
+            modifiedAt = null,
+        ) as APathLookup<APath<*>>
+    }
+
+    private fun operation() = CopyOperation(
+        workspaceId = Workspace.Id(),
+        command = ExplorerCommand.Copy(
+            sources = setOf(sourceDir),
+            destination = OperationPathPlan.Destination.Container(destinationDir),
+        ),
+        issueHandler = mockk<IssueHandler>(),
+        gatewaySwitch = gatewaySwitch,
+        fileSystemHinter = fileSystemHinter,
+    )
+
+    private fun context() = Operation.Context(id = Operation.Id(), startedAt = Clock.System.now())
+
+    @Test
+    fun `a directory copy is about the top-level destination, not a descendant`() = runTest2 {
+        // The descendant leads the set: a subject read positionally would pick it up.
+        coEvery { gatewaySwitch.copy(any(), any(), any(), any()) } returns flowOf(
+            CopyAction.State.Completed(
+                copied = setOf(
+                    lookupOf(sourceDir.child("aaa.txt")) to lookupOf(copiedChild),
+                    lookupOf(sourceDir, isDir = true) to lookupOf(copiedDir, isDir = true),
+                ),
+                copiedBytes = 8L,
+            )
+        )
+
+        val completed = operation().perform(context()).toList()
+            .filterIsInstance<ExplorerOperation.State.Completed>().single()
+
+        val report = completed.report as CopyOperationReport
+        report.subjectPath shouldBe copiedDir
+        report.affectedPaths.map { it.path } shouldContainExactlyInAnyOrder listOf(copiedChild, copiedDir)
+    }
+
+    @Test
+    fun `a copy that completed nothing names no subject`() = runTest2 {
+        coEvery { gatewaySwitch.copy(any(), any(), any(), any()) } returns flowOf(
+            CopyAction.State.Completed(
+                copied = emptySet(),
+                skipped = setOf(lookupOf(sourceDir, isDir = true)),
+                copiedBytes = 0L,
+            )
+        )
+
+        val completed = operation().perform(context()).toList()
+            .filterIsInstance<ExplorerOperation.State.Completed>().single()
+
+        (completed.report as CopyOperationReport).subjectPath shouldBe null
+    }
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateOperationTest.kt
@@ -1,0 +1,79 @@
+package eu.darken.butler.explorer.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.actions.CreateAction
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
+import org.junit.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class CreateOperationTest : BaseTest() {
+
+    private val parentPath = LocalPath.build("/sdcard/Download")
+    private val requestedPath = parentPath.child("notes")
+    private val renamedPath = parentPath.child("notes-2")
+
+    @Suppress("UNCHECKED_CAST")
+    private fun gateway(createdAs: APath<*>) = mockk<GatewaySwitch>().apply {
+        coEvery { useRes(any<suspend (Any) -> Any?>()) } coAnswers {
+            firstArg<suspend (Any) -> Any?>().invoke(this@apply)
+        }
+        coEvery { create(any(), any(), any()) } returns flowOf(
+            CreateAction.State.Completed(
+                LocalPathLookup(
+                    lookedUp = createdAs as LocalPath,
+                    fileType = FileType.DIRECTORY,
+                    size = null,
+                    modifiedAt = Instant.DISTANT_PAST,
+                ) as APathLookup<APath<*>>
+            )
+        )
+    }
+
+    private fun operation(gatewaySwitch: GatewaySwitch) = CreateOperation(
+        workspaceId = Workspace.Id(),
+        command = ExplorerCommand.Create(
+            parentPath = parentPath,
+            name = "notes",
+            type = ExplorerCommand.Create.Type.DIRECTORY,
+        ),
+        issueHandler = mockk<IssueHandler>(),
+        gatewaySwitch = gatewaySwitch,
+        dispatcherProvider = mockk(),
+        fileSystemHinter = mockk<FileSystemHinter>(relaxed = true),
+    )
+
+    private fun context() = Operation.Context(id = Operation.Id(), startedAt = Clock.System.now())
+
+    @Test
+    fun `the subject is the created folder`() = runTest2 {
+        val completed = operation(gateway(requestedPath)).perform(context())
+            .last() as ExplorerOperation.State.Completed
+
+        (completed.report as CreateOperationReport).subjectPath shouldBe requestedPath
+    }
+
+    @Test
+    fun `a name conflict resolved by renaming names the path that was created`() = runTest2 {
+        val completed = operation(gateway(renamedPath)).perform(context())
+            .last() as ExplorerOperation.State.Completed
+
+        // Naming the requested path would label the row with a folder that was never created.
+        (completed.report as CreateOperationReport).subjectPath shouldBe renamedPath
+    }
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
@@ -142,6 +142,7 @@ class CreateTextFileOperationTest : BaseTest() {
             it.path shouldBe renamedPath
             it.change shouldBe Operation.Report.PathChange.Change.ADDED
         }
+        completed.report.subjectPath shouldBe renamedPath
         events.single().shouldBeInstanceOf<FileSystemEvent.Added>().paths.single().lookedUp shouldBe renamedPath
     }
 

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/DeleteOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/DeleteOperationTest.kt
@@ -1,0 +1,107 @@
+package eu.darken.butler.explorer.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.FileSystemOps
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.actions.DeleteAction
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.operations.deleteGeneric
+import eu.darken.butler.common.trash.TrashManager
+import eu.darken.butler.common.trash.TrashSettings
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.CoreDeleteExecutor
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import org.junit.Before
+import org.junit.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import testhelpers.mockDataStoreValue
+import kotlin.time.Clock
+
+/**
+ * A permanent recursive delete walks the tree post-order, so the folder the user selected is the
+ * LAST reported removal. The history subject has to survive that.
+ *
+ * The delete runs through the real engine over an in-memory [FileSystemOps]; that ops object is not
+ * a routed local one, so the batch subtree route is unavailable and the recursive walk is what
+ * produces the ordering.
+ */
+class DeleteOperationTest : BaseTest() {
+
+    private val folder = LocalPath.build("/sdcard/Download/nested")
+    private val innerFile = folder.child("aaa.txt")
+
+    private val fileSystemOps = mockk<FileSystemOps<LocalPath, LocalPathLookup>>()
+    private val gatewaySwitch = mockk<GatewaySwitch>()
+    private val trashManager = mockk<TrashManager>()
+    private val trashSettings = mockk<TrashSettings>()
+
+    private fun lookupOf(path: LocalPath, isDir: Boolean) = LocalPathLookup(
+        lookedUp = path,
+        fileType = if (isDir) FileType.DIRECTORY else FileType.FILE,
+        size = 4L,
+        modifiedAt = null,
+    )
+
+    @Before
+    fun setup() {
+        every { trashSettings.enabled } returns mockDataStoreValue(false)
+        coEvery { fileSystemOps.lookup(folder, any<LookupOptions>()) } returns lookupOf(folder, isDir = true)
+        coEvery { fileSystemOps.lookup(innerFile, any<LookupOptions>()) } returns lookupOf(innerFile, isDir = false)
+        coEvery { fileSystemOps.listFiles(folder) } returns listOf(innerFile)
+        coEvery { fileSystemOps.delete(any(), any()) } returns true
+        coEvery { gatewaySwitch.delete(any<Set<APath<*>>>(), any<DeleteAction.Options<APath<*>>>()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            firstArg<Set<LocalPath>>()
+                .deleteGeneric(fileSystemOps = fileSystemOps, recursive = true, ignoreMissing = false)
+                    as Flow<DeleteAction.State<APath<*>, APathLookup<APath<*>>>>
+        }
+    }
+
+    private fun operation(targets: Set<APath<*>>) = DeleteOperation(
+        workspaceId = Workspace.Id(),
+        command = ExplorerCommand.Delete(targets = targets),
+        issueHandler = mockk<IssueHandler>(),
+        fileSystemHinter = mockk<FileSystemHinter>(relaxed = true),
+        coreDeleteExecutor = CoreDeleteExecutor(
+            gatewaySwitch = gatewaySwitch,
+            trashManager = trashManager,
+            trashSettings = trashSettings,
+        ),
+    )
+
+    private fun context() = Operation.Context(id = Operation.Id(), startedAt = Clock.System.now())
+
+    @Test
+    fun `a permanent recursive folder delete is about the folder, not a descendant`() = runTest2 {
+        val completed = operation(setOf(folder)).perform(context()).toList()
+            .filterIsInstance<ExplorerOperation.State.Completed>().single()
+
+        val report = completed.report as DeleteOperationReport
+        report.affectedPaths.map { it.path } shouldBe listOf(innerFile, folder)
+        // Documents why the subject cannot be read off the reported changes.
+        report.affectedPaths.first().path shouldNotBe folder
+        report.subjectPath shouldBe folder
+    }
+
+    @Test
+    fun `an empty selection names no subject instead of throwing`() = runTest2 {
+        val completed = operation(emptySet()).perform(context()).toList()
+            .filterIsInstance<ExplorerOperation.State.Completed>().single()
+
+        (completed.report as DeleteOperationReport).subjectPath shouldBe null
+    }
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperationTest.kt
@@ -108,6 +108,7 @@ class DownloadLocalCopyOperationTest : BaseTest() {
         report.copiedFiles shouldBe 1
         report.copiedBytes shouldBe content.size.toLong()
         report.affectedPaths.single().path shouldBe destPath
+        report.subjectPath shouldBe destPath
 
         val (temp, dest) = moves.single()
         dest shouldBe destPath
@@ -153,6 +154,8 @@ class DownloadLocalCopyOperationTest : BaseTest() {
         val report = completed.report as CopyOperationReport
         report.copiedFiles shouldBe 0
         report.affectedPaths.shouldBeEmpty()
+        // The row still has to name the copy that was asked for, not fall back to the source.
+        report.subjectPath shouldBe destPath
         coVerify(exactly = 0) { gatewaySwitch.openInputStream(any()) }
     }
 

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExtractOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/ExtractOperationTest.kt
@@ -27,9 +27,11 @@ import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -396,6 +398,88 @@ class ExtractOperationTest : BaseTest() {
         report.extractedFiles shouldBe 0
         report.skippedEntries shouldContain "sub/evil.txt"
         moves shouldBe emptyList()
+    }
+
+    /*
+     * The subject is what the history row is labelled with. An extraction reports one change per
+     * written entry, in archive-enumeration order, so it must never be derived from those.
+     */
+
+    @Test
+    fun `a successful extraction is about the archive, not an entry inside it`() = runTest2 {
+        mockSeekable(meta("aaa.txt"), meta("sub", "bbb.txt"))
+
+        val report = operation(command()).perform(context()).toList().completed().report
+            as ExtractOperationReport
+
+        report.subjectPath shouldBe archivePath
+        report.affectedPaths.map { it.path } shouldNotContain archivePath
+    }
+
+    @Test
+    fun `a dismissed password prompt still names the archive`() = runTest2 {
+        mockSeekable(meta("a.txt"))
+        coEvery { archiveService.requiresPassword(archivePath) } returns true
+        coEvery { issueHandler.handleIssue(any(), any()) } returns
+            PathActionIssue.ArchivePasswordRequired.Resolution.Cancel()
+
+        val report = operation(command()).perform(context()).toList().completed().report
+            as ExtractOperationReport
+
+        report.subjectPath shouldBe archivePath
+        report.affectedPaths.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a dismissed merge prompt still names the archive`() = runTest2 {
+        mockNotSeekable()
+        coEvery { gatewaySwitch.exists(baseDir) } returns true
+        coEvery { issueHandler.handleIssue(any(), any()) } returns
+            PathActionIssue.PathAlreadyExists.Resolution.Cancel()
+
+        val report = operation(command()).perform(context()).toList().completed().report
+            as ExtractOperationReport
+
+        report.subjectPath shouldBe archivePath
+    }
+
+    @Test
+    fun `a declined merge into a file at the base path still names the archive`() = runTest2 {
+        mockNotSeekable()
+        coEvery { gatewaySwitch.exists(baseDir) } returns true
+        // A regular file at the base path cannot be merged under, so Skip aborts the extraction.
+        coEvery { gatewaySwitch.lookup(baseDir, any<LookupOptions>()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            lookupOf(baseDir, isDir = false) as APathLookup<APath<*>>
+        }
+        coEvery { issueHandler.handleIssue(any(), any()) } returns
+            PathActionIssue.PathAlreadyExists.Resolution.Skip()
+
+        val report = operation(command()).perform(context()).toList().completed().report
+            as ExtractOperationReport
+
+        report.subjectPath shouldBe archivePath
+        coVerify(exactly = 0) { archiveService.extractZipSequential(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a partial failure names the archive, not the entry that made it through`() = runTest2 {
+        mockNotSeekable()
+        coEvery { archiveService.extractZipSequential(any(), any(), any(), any(), any()) } coAnswers {
+            val action = arg<suspend (SequentialEntry, InputStream) -> SequentialOutcome>(4)
+            action(
+                SequentialEntry(ordinal = 0, segments = listOf("a.txt"), rawName = "a.txt", isEncrypted = false),
+                ByteArrayInputStream("alpha".toByteArray()),
+            )
+            throw SequentialAbortException("corrupted stream", archivePath, 1, 0)
+        }
+
+        val completed = operation(command()).perform(context()).toList().completed()
+
+        completed.error.shouldBeInstanceOf<SequentialAbortException>()
+        val report = completed.report as ExtractOperationReport
+        report.affectedPaths.map { it.path } shouldBe listOf(baseDir.child("a.txt"))
+        report.subjectPath shouldBe archivePath
     }
 
     @Test

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/MoveOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/MoveOperationTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.butler.explorer.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.actions.MoveAction
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.OperationPathPlan
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import org.junit.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+
+/**
+ * A directory move reports one change per moved descendant. The history subject has to come from
+ * the source-to-destination pair the command asked for, never from the position of a change.
+ */
+class MoveOperationTest : BaseTest() {
+
+    private val gatewaySwitch = mockk<GatewaySwitch>()
+    private val fileSystemHinter = mockk<FileSystemHinter>(relaxed = true)
+
+    private val sourceDir = LocalPath.build("/sdcard/Download/nested")
+    private val destinationDir = LocalPath.build("/sdcard/Backup")
+    private val movedDir = destinationDir.child("nested")
+    private val movedChild = movedDir.child("aaa.txt")
+
+    private fun lookupOf(path: LocalPath, isDir: Boolean = false): APathLookup<APath<*>> {
+        @Suppress("UNCHECKED_CAST")
+        return LocalPathLookup(
+            lookedUp = path,
+            fileType = if (isDir) FileType.DIRECTORY else FileType.FILE,
+            size = 4L,
+            modifiedAt = null,
+        ) as APathLookup<APath<*>>
+    }
+
+    private fun operation() = MoveOperation(
+        workspaceId = Workspace.Id(),
+        command = ExplorerCommand.Move(
+            sources = setOf(sourceDir),
+            destination = OperationPathPlan.Destination.Container(destinationDir),
+        ),
+        issueHandler = mockk<IssueHandler>(),
+        gatewaySwitch = gatewaySwitch,
+        dispatcherProvider = mockk(),
+        fileSystemHinter = fileSystemHinter,
+    )
+
+    private fun context() = Operation.Context(id = Operation.Id(), startedAt = Clock.System.now())
+
+    @Test
+    fun `a directory move is about the top-level destination, not a descendant`() = runTest2 {
+        // The descendant leads the set: a subject read positionally would pick it up.
+        coEvery { gatewaySwitch.move(any(), any(), any(), any()) } returns flowOf(
+            MoveAction.State.Completed(
+                movedFiles = setOf(
+                    lookupOf(sourceDir.child("aaa.txt")) to lookupOf(movedChild),
+                    lookupOf(sourceDir, isDir = true) to lookupOf(movedDir, isDir = true),
+                ),
+                bytesMoved = 8L,
+            )
+        )
+
+        val completed = operation().perform(context()).toList()
+            .filterIsInstance<ExplorerOperation.State.Completed>().single()
+
+        val report = completed.report as MoveOperationReport
+        report.subjectPath shouldBe movedDir
+        report.affectedPaths.map { it.path } shouldContainExactlyInAnyOrder listOf(movedChild, movedDir)
+    }
+
+    @Test
+    fun `a move that completed nothing names no subject`() = runTest2 {
+        coEvery { gatewaySwitch.move(any(), any(), any(), any()) } returns flowOf(
+            MoveAction.State.Completed(
+                movedFiles = emptySet(),
+                skippedFiles = setOf(lookupOf(sourceDir, isDir = true)),
+                bytesMoved = 0L,
+            )
+        )
+
+        val completed = operation().perform(context()).toList()
+            .filterIsInstance<ExplorerOperation.State.Completed>().single()
+
+        (completed.report as MoveOperationReport).subjectPath shouldBe null
+    }
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/RestoreOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/RestoreOperationTest.kt
@@ -146,6 +146,82 @@ class RestoreOperationTest : BaseTest() {
     }
 
     @Test
+    fun `a mixed restore is about a root item, not a nested one`(): Unit = runTest {
+        val rootPath = LocalPath.build(File("/tmp/restore-test/root-folder"))
+        val nestedPath = LocalPath.build(File("/tmp/restore-test/parent/nested.txt"))
+        val rootId = Uuid.random()
+        val parentId = Uuid.random()
+        val parentItem = mockk<TrashRepo.TrashItem>()
+        val trashRepo = mockk<TrashRepo> {
+            coEvery { getById(rootId) } returns mockk()
+            coEvery { getById(parentId) } returns parentItem
+        }
+        val trashManager = mockk<TrashManager> {
+            coEvery { restore(any()) } returns TrashManager.TrashRestoreReport(
+                restored = setOf(rootPath),
+                failed = emptySet(),
+                conflicts = emptySet(),
+            )
+            coEvery { restoreNested(parentItem, "nested.txt") } returns TrashManager.TrashRestoreReport(
+                restored = setOf(nestedPath),
+                failed = emptySet(),
+                conflicts = emptySet(),
+            )
+        }
+        val op = operation(
+            trashRepo = trashRepo,
+            trashManager = trashManager,
+            command = ExplorerCommand.Restore(
+                rootItemIds = setOf(rootId),
+                nestedItems = listOf(
+                    ExplorerCommand.Restore.NestedTarget(parentId = parentId, relativePath = "nested.txt"),
+                ),
+                restoredPaths = listOf(rootPath, nestedPath),
+            ),
+        )
+
+        val completed = op.perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
+            .last() as ExplorerOperation.State.Completed
+
+        val report = completed.report.shouldBeInstanceOf<RestoreOperation.Report>()
+        report.restoredPaths shouldBe setOf(rootPath, nestedPath)
+        // A nested restore names a file the user reached through a parent, so a root item wins.
+        report.subjectPath shouldBe rootPath
+    }
+
+    @Test
+    fun `a nested-only restore names the nested path`(): Unit = runTest {
+        val nestedPath = LocalPath.build(File("/tmp/restore-test/parent/nested.txt"))
+        val parentId = Uuid.random()
+        val parentItem = mockk<TrashRepo.TrashItem>()
+        val trashRepo = mockk<TrashRepo> {
+            coEvery { getById(parentId) } returns parentItem
+        }
+        val trashManager = mockk<TrashManager> {
+            coEvery { restoreNested(parentItem, "nested.txt") } returns TrashManager.TrashRestoreReport(
+                restored = setOf(nestedPath),
+                failed = emptySet(),
+                conflicts = emptySet(),
+            )
+        }
+        val op = operation(
+            trashRepo = trashRepo,
+            trashManager = trashManager,
+            command = ExplorerCommand.Restore(
+                nestedItems = listOf(
+                    ExplorerCommand.Restore.NestedTarget(parentId = parentId, relativePath = "nested.txt"),
+                ),
+                restoredPaths = listOf(nestedPath),
+            ),
+        )
+
+        val completed = op.perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
+            .last() as ExplorerOperation.State.Completed
+
+        completed.report.shouldBeInstanceOf<RestoreOperation.Report>().subjectPath shouldBe nestedPath
+    }
+
+    @Test
     fun `the path plan targets the paths being restored`() {
         val plan = operation(
             trashRepo = mockk(),

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
@@ -167,8 +167,8 @@ private fun HistoryEntry.subline(timeAgo: String): String {
     return if (pathHint.isNotEmpty()) "$originLabel  ·  $timeAgo  ·  $pathHint" else "$originLabel  ·  $timeAgo"
 }
 
-/** Falls back to the stored representative path so failed and cancelled ops still name a file. */
-private fun HistoryEntry.displayPath(): String? = paths.firstOrNull()?.path ?: primaryPath
+/** The reported changes are an audit trail, so they only stand in when no subject was stored. */
+private fun HistoryEntry.displayPath(): String? = primaryPath ?: paths.firstOrNull()?.path
 
 private fun Operation.Metadata.Kind.entryHeadlineLabel(): String = when (this) {
     Operation.Metadata.Kind.COPY -> "Copied"

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
@@ -1,0 +1,77 @@
+package eu.darken.butler.history.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * An extraction reports one change per written entry, so the row must label itself from the stored
+ * subject instead of the first reported change.
+ */
+class HistoryEntryRowLabelTest : ComposeTest() {
+
+    private val completedAt = Clock.System.now()
+
+    private fun entry(primaryPath: String?, paths: List<String>) = HistoryEntry(
+        id = "entry",
+        kind = Operation.Metadata.Kind.EXTRACT,
+        intent = null,
+        originType = HistoryEntry.OriginType.EXPLORER,
+        originWorkspaceId = "ws",
+        title = "Extract",
+        description = "Extracting",
+        summary = null,
+        startedAt = completedAt - 1.seconds,
+        completedAt = completedAt,
+        duration = 1.seconds,
+        outcome = HistoryOutcome.COMPLETED,
+        errorMessage = null,
+        errorClass = null,
+        affectedPathsCount = paths.size,
+        partialErrorCount = 0,
+        pathsTruncated = false,
+        paths = paths.map {
+            HistoryEntry.PathChange(
+                path = it,
+                previousPath = null,
+                change = Operation.Report.PathChange.Change.ADDED,
+            )
+        },
+        primaryPath = primaryPath,
+    )
+
+    private fun render(entry: HistoryEntry) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                HistoryEntryRow(entry = entry, onClick = {})
+            }
+        }
+    }
+
+    @Test
+    fun `the row is labelled with the subject, not the first reported change`() {
+        render(
+            entry(
+                primaryPath = "/sdcard/ButlerQA/backup.zip",
+                paths = listOf("/sdcard/ButlerQA/backup/aaa.txt", "/sdcard/ButlerQA/backup/zzz.txt"),
+            )
+        )
+
+        composeTestRule.onNodeWithText("backup.zip", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("aaa.txt", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a row without a subject still names its first reported change`() {
+        render(entry(primaryPath = null, paths = listOf("/sdcard/ButlerQA/backup/aaa.txt")))
+
+        composeTestRule.onNodeWithText("aaa.txt", substring = true).assertIsDisplayed()
+    }
+}

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesReport.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesReport.kt
@@ -78,6 +78,14 @@ data class SaveFilesReport(
         }
 
     /**
+     * A save takes many files, so the label is pinned to the first PLANNED file rather than to
+     * whichever one happened to succeed: `[a.txt, b.txt]` with `a.txt` skipped names `b.txt`.
+     */
+    override val subjectPath: APath<*>?
+        get() = (results.firstOrNull() as? FileResult.Success)?.savedPath
+            ?: successes.firstOrNull()?.savedPath
+
+    /**
      * Per-file failures (errors). Skipped files are user-acknowledged choices and not counted.
      * When `errors` is non-empty alongside successes, [HistoryOutcome.PARTIAL] is recorded.
      */

--- a/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/operations/SaveFilesOperationTest.kt
+++ b/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/operations/SaveFilesOperationTest.kt
@@ -18,6 +18,7 @@ import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -46,6 +47,7 @@ class SaveFilesOperationTest : BaseTest() {
     private val sourceUri = mockk<Uri>()
     private val targetDirectory = LocalPath.build("/save")
     private val targetPath = targetDirectory.child("file.txt")
+    private val secondPath = targetDirectory.child("second.txt")
 
     private val capturedIssues = mutableListOf<PathActionIssue>()
     private var conflictResolution: PathActionIssue.Resolution =
@@ -84,10 +86,10 @@ class SaveFilesOperationTest : BaseTest() {
         }
     }
 
-    private fun operation() = SaveFilesOperation(
+    private fun operation(filenames: List<String> = listOf("file.txt")) = SaveFilesOperation(
         workspaceId = workspaceId,
         command = SaveFilesOperation.Command(
-            sources = listOf(SaveFilesOperation.Command.SourceFile(sourceUri, "file.txt", 4L)),
+            sources = filenames.map { SaveFilesOperation.Command.SourceFile(sourceUri, it, 4L) },
             targetDirectory = targetDirectory,
         ),
         context = context,
@@ -95,8 +97,8 @@ class SaveFilesOperationTest : BaseTest() {
         issueHandler = issueHandler,
     )
 
-    private suspend fun performToReport(): SaveFilesReport {
-        val states = operation()
+    private suspend fun performToReport(filenames: List<String> = listOf("file.txt")): SaveFilesReport {
+        val states = operation(filenames)
             .perform(Operation.Context(id = Operation.Id(), startedAt = Clock.System.now()))
             .toList()
         return states.last()
@@ -148,6 +150,39 @@ class SaveFilesOperationTest : BaseTest() {
         capturedIssues.filterIsInstance<PathActionIssue.InsufficientPermission>()
             .single().exception.shouldBeInstanceOf<WriteException>()
         coVerify(exactly = 0) { gatewaySwitch.createFile(any(), any()) }
+    }
+
+    /*
+     * A save takes many files, so its history label is defined by the PLAN order, not by whichever
+     * file happened to succeed first.
+     */
+
+    @Test
+    fun `the subject is the first planned file when everything succeeds`() = runTest2 {
+        val report = performToReport(listOf("file.txt", "second.txt"))
+
+        report.successes.map { it.savedPath } shouldContainExactly listOf(targetPath, secondPath)
+        report.subjectPath shouldBe targetPath
+    }
+
+    @Test
+    fun `the subject moves on when the first planned file is skipped`() = runTest2 {
+        conflictResolution = PathActionIssue.PathAlreadyExists.Resolution.Skip()
+
+        val report = performToReport(listOf("file.txt", "second.txt"))
+
+        report.results.first().shouldBeInstanceOf<SaveFilesReport.FileResult.Skipped>()
+        report.subjectPath shouldBe secondPath
+    }
+
+    @Test
+    fun `a save that wrote nothing names no subject`() = runTest2 {
+        conflictResolution = PathActionIssue.PathAlreadyExists.Resolution.Skip()
+
+        val report = performToReport(listOf("file.txt"))
+
+        report.successes.shouldBeEmpty()
+        report.subjectPath shouldBe null
     }
 
     @Test

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperation.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperation.kt
@@ -69,6 +69,7 @@ class DeleteOperation @AssistedInject constructor(
         send(stateActive)
 
         val reportBuilder = DeleteOperationReport.Builder()
+        reportBuilder.setSubjectPath(command.targets.firstOrNull())
 
         coreDeleteExecutor.execute(
             targets = command.targets,

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperationReport.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperationReport.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.searcher.core.operations
 
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.core.operations.BaseDeleteOperationReport
@@ -14,6 +15,7 @@ data class DeleteOperationReport(
     override val deletedDirectories: Int,
     override val bytesFreed: Long,
     override val performanceHistory: PerformanceHistory?,
+    override val subjectPath: APath<*>?,
 ) : BaseDeleteOperationReport(
     affectedPaths = affectedPaths,
     skipped = skipped,
@@ -23,6 +25,7 @@ data class DeleteOperationReport(
     deletedDirectories = deletedDirectories,
     bytesFreed = bytesFreed,
     performanceHistory = performanceHistory,
+    subjectPath = subjectPath,
 ), SearcherOperation.Report {
 
     override fun toString(): String {
@@ -39,6 +42,7 @@ data class DeleteOperationReport(
             deletedDirectories = deletedDirectories,
             bytesFreed = _bytesFreed,
             performanceHistory = _performanceHistory,
+            subjectPath = _subjectPath,
         )
     }
 }

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/core/operations/DeleteOperationSubjectTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/core/operations/DeleteOperationSubjectTest.kt
@@ -1,0 +1,81 @@
+package eu.darken.butler.searcher.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.CoreDeleteExecutor
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Instant
+
+/** The history row for a delete names the selected target, whatever the engine removed first. */
+class DeleteOperationSubjectTest : BaseTest() {
+
+    private val folder = LocalPath.build("/sdcard/Download/nested")
+    private val innerFile = folder.child("aaa.txt")
+
+    private fun lookupOf(path: LocalPath, isDir: Boolean): APathLookup<*> = LocalPathLookup(
+        lookedUp = path,
+        fileType = if (isDir) FileType.DIRECTORY else FileType.FILE,
+        size = 4L,
+        modifiedAt = Instant.DISTANT_PAST,
+    )
+
+    private fun operation(targets: Set<APath<*>>, deleted: Set<APathLookup<*>>): DeleteOperation {
+        val executor = mockk<CoreDeleteExecutor> {
+            coEvery { execute(any(), any()) } returns flowOf(
+                CoreDeleteExecutor.State.Completed(
+                    result = CoreDeleteExecutor.Result(
+                        deleted = deleted,
+                        trashed = emptySet(),
+                        skipped = emptySet(),
+                        bytesFreed = 0L,
+                        performanceHistory = null,
+                    )
+                )
+            )
+        }
+        return DeleteOperation(
+            workspaceId = Workspace.Id(),
+            command = SearcherCommand.Delete(targets = targets),
+            issueHandler = mockk<IssueHandler>(),
+            coreDeleteExecutor = executor,
+            fileSystemHinter = mockk<FileSystemHinter>(relaxed = true),
+        )
+    }
+
+    private suspend fun DeleteOperation.report(): DeleteOperationReport =
+        perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
+            .toList()
+            .filterIsInstance<SearcherOperation.State.Completed>()
+            .single()
+            .report as DeleteOperationReport
+
+    @Test
+    fun `the subject is the selected target, not the descendant removed first`(): Unit = runTest {
+        val report = operation(
+            targets = setOf(folder),
+            deleted = setOf(lookupOf(innerFile, isDir = false), lookupOf(folder, isDir = true)),
+        ).report()
+
+        report.affectedPaths.first().path shouldBe innerFile
+        report.subjectPath shouldBe folder
+    }
+
+    @Test
+    fun `an empty selection names no subject instead of throwing`(): Unit = runTest {
+        operation(targets = emptySet(), deleted = emptySet()).report().subjectPath shouldBe null
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperation.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperation.kt
@@ -63,6 +63,7 @@ class DeleteOperation @AssistedInject constructor(
         send(stateActive)
 
         val reportBuilder = DeleteOperationReport.Builder()
+        reportBuilder.setSubjectPath(command.targets.firstOrNull())
 
         coreDeleteExecutor.execute(
             targets = command.targets,

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperationReport.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperationReport.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.viewer.core.operations
 
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.core.operations.BaseDeleteOperationReport
@@ -14,6 +15,7 @@ data class DeleteOperationReport(
     override val deletedDirectories: Int,
     override val bytesFreed: Long,
     override val performanceHistory: PerformanceHistory?,
+    override val subjectPath: APath<*>?,
 ) : BaseDeleteOperationReport(
     affectedPaths = affectedPaths,
     skipped = skipped,
@@ -23,6 +25,7 @@ data class DeleteOperationReport(
     deletedDirectories = deletedDirectories,
     bytesFreed = bytesFreed,
     performanceHistory = performanceHistory,
+    subjectPath = subjectPath,
 ), ViewerOperation.Report {
 
     override fun toString(): String {
@@ -40,6 +43,7 @@ data class DeleteOperationReport(
             deletedDirectories = deletedDirectories,
             bytesFreed = _bytesFreed,
             performanceHistory = _performanceHistory,
+            subjectPath = _subjectPath,
         )
     }
 }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/operations/DeleteOperationSubjectTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/operations/DeleteOperationSubjectTest.kt
@@ -1,0 +1,81 @@
+package eu.darken.butler.viewer.core.operations
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.filesystem.FileSystemHinter
+import eu.darken.butler.workspace.core.operations.CoreDeleteExecutor
+import eu.darken.butler.workspace.core.operations.IssueHandler
+import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Instant
+
+/** The history row for a delete names the selected target, whatever the engine removed first. */
+class DeleteOperationSubjectTest : BaseTest() {
+
+    private val folder = LocalPath.build("/sdcard/Download/nested")
+    private val innerFile = folder.child("aaa.txt")
+
+    private fun lookupOf(path: LocalPath, isDir: Boolean): APathLookup<*> = LocalPathLookup(
+        lookedUp = path,
+        fileType = if (isDir) FileType.DIRECTORY else FileType.FILE,
+        size = 4L,
+        modifiedAt = Instant.DISTANT_PAST,
+    )
+
+    private fun operation(targets: Set<APath<*>>, deleted: Set<APathLookup<*>>): DeleteOperation {
+        val executor = mockk<CoreDeleteExecutor> {
+            coEvery { execute(any(), any()) } returns flowOf(
+                CoreDeleteExecutor.State.Completed(
+                    result = CoreDeleteExecutor.Result(
+                        deleted = deleted,
+                        trashed = emptySet(),
+                        skipped = emptySet(),
+                        bytesFreed = 0L,
+                        performanceHistory = null,
+                    )
+                )
+            )
+        }
+        return DeleteOperation(
+            workspaceId = Workspace.Id(),
+            command = ViewerCommand.Delete(targets = targets),
+            issueHandler = mockk<IssueHandler>(),
+            coreDeleteExecutor = executor,
+            fileSystemHinter = mockk<FileSystemHinter>(relaxed = true),
+        )
+    }
+
+    private suspend fun DeleteOperation.report(): DeleteOperationReport =
+        perform(Operation.Context(id = Operation.Id(), startedAt = Instant.DISTANT_PAST))
+            .toList()
+            .filterIsInstance<ViewerOperation.State.Completed>()
+            .single()
+            .report as DeleteOperationReport
+
+    @Test
+    fun `the subject is the selected target, not the descendant removed first`(): Unit = runTest {
+        val report = operation(
+            targets = setOf(folder),
+            deleted = setOf(lookupOf(innerFile, isDir = false), lookupOf(folder, isDir = true)),
+        ).report()
+
+        report.affectedPaths.first().path shouldBe innerFile
+        report.subjectPath shouldBe folder
+    }
+
+    @Test
+    fun `an empty selection names no subject instead of throwing`(): Unit = runTest {
+        operation(targets = emptySet(), deleted = emptySet()).report().subjectPath shouldBe null
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/BaseDeleteOperationReport.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/BaseDeleteOperationReport.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.workspace.core.operations
 import android.text.format.Formatter
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
@@ -19,6 +20,7 @@ abstract class BaseDeleteOperationReport(
     open val deletedDirectories: Int,
     open val bytesFreed: Long,
     override val performanceHistory: PerformanceHistory?,
+    override val subjectPath: APath<*>?,
 ) : Operation.Report, Operation.HasPerformanceHistory {
 
     override val summary: CaString = caString {
@@ -89,6 +91,7 @@ abstract class BaseDeleteOperationReport(
         protected var deletedDirectories: Int = 0
         protected var _bytesFreed: Long = 0
         protected var _performanceHistory: PerformanceHistory? = null
+        protected var _subjectPath: APath<*>? = null
 
         fun setTrashed(items: Set<APathLookup<*>>) {
             items.forEach {
@@ -114,6 +117,11 @@ abstract class BaseDeleteOperationReport(
 
         fun setPerformanceHistory(history: PerformanceHistory?) {
             this._performanceHistory = history
+        }
+
+        /** The target the user selected, not whichever descendant the engine reached first. */
+        fun setSubjectPath(path: APath<*>?) {
+            this._subjectPath = path
         }
 
         abstract fun build(): T

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
@@ -107,6 +107,19 @@ interface Operation {
         val affectedPaths: Collection<PathChange>
 
         /**
+         * The path this operation was ABOUT, shown as its history row label.
+         *
+         * The conflict-resolved path of what the user selected, or - for operations that fan out -
+         * the container or archive the user acted on. Never a path whose name the user did not
+         * choose: an extraction's entries and a recursive delete's descendants are audit records,
+         * not subjects.
+         *
+         * Null when THIS REPORT cannot name one (nothing completed, or the operation is not
+         * history-eligible). The history then falls back to the path plan's representative path.
+         */
+        val subjectPath: APath<*>?
+
+        /**
          * Number of sub-items that DIDN'T complete as intended even though the operation as a whole
          * didn't fail (e.g., save with mixed permissions: some files succeed, some fail per-file
          * with the top-level [Operation.State.Completed.error] still null). Drives the

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/HistoryEntry.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/HistoryEntry.kt
@@ -29,8 +29,9 @@ data class HistoryEntry(
     val pathsTruncated: Boolean,
     val paths: List<PathChange>,
     /**
-     * Representative path for entries without reported changes (failed/cancelled ops), so the list
-     * can still show a filename and folder. Null when the operation named no paths at all.
+     * The path the operation was about, used as the row label. Not necessarily [paths]`[0]`: an
+     * extraction names its archive, a recursive delete names the folder that was selected. Null
+     * when neither the report nor the path plan named one.
      */
     val primaryPath: String? = null,
 ) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -130,7 +130,7 @@ class OperationHistoryRepo @Inject constructor(
             affectedPathsCount = reportedChanges.size,
             partialErrorCount = state.report?.partialErrorCount ?: 0,
             pathsTruncated = reportedChanges.size > MAX_PATHS_PER_OP,
-            primaryPath = reportedChanges.firstOrNull()?.path
+            primaryPath = state.report?.subjectPath?.userReadablePath?.get(context)
                 ?: metadata.pathPlan?.representativePath?.userReadablePath?.get(context),
         )
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryEntity.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryEntity.kt
@@ -44,8 +44,10 @@ data class OperationHistoryEntity(
     /** True when [operation_history_paths] only stores a capped subset (default cap: 200). */
     val pathsTruncated: Boolean = false,
     /**
-     * One representative path (first reported change, else first intended path). Lets the list show
-     * a filename and folder for operations that reported no changes, without loading child rows.
+     * The path the operation was about: the report's subject, else the path plan's representative
+     * path. Lets the list name a file and folder without loading child rows, and stays correct for
+     * operations whose reported changes are an audit trail rather than a subject (an extraction's
+     * entries, a recursive delete's descendants).
      */
     val primaryPath: String? = null,
 )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
@@ -129,6 +129,7 @@ private fun OperationActionIndicatorPreview() {
                 report = object : Operation.Report {
                     override val summary = "Done".toCaString()
                     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val subjectPath = null
                 }
             ),
             modifier = Modifier.size(24.dp)
@@ -140,6 +141,7 @@ private fun OperationActionIndicatorPreview() {
                 report = object : Operation.Report {
                     override val summary = "Error".toCaString()
                     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val subjectPath = null
                 }
             ),
             modifier = Modifier.size(24.dp)
@@ -150,6 +152,7 @@ private fun OperationActionIndicatorPreview() {
                 report = object : Operation.Report {
                     override val summary = "Cancelled".toCaString()
                     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val subjectPath = null
                 }
             ),
             modifier = Modifier.size(24.dp)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
@@ -478,6 +478,7 @@ private fun OperationEntryRowCompletedPreview() {
                     report = object : Operation.Report {
                         override val summary = "Deleted 5 items".toCaString()
                         override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                        override val subjectPath = null
                     }
                 ),
                 startedAt = Clock.System.now(),
@@ -499,6 +500,7 @@ private fun OperationEntryRowCompletedPreview() {
                     report = object : Operation.Report {
                         override val summary = "Deleted 5 items".toCaString()
                         override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                        override val subjectPath = null
                     }
                 ),
                 startedAt = Clock.System.now(),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBar.kt
@@ -272,6 +272,7 @@ private fun OperationsBarPreview() {
                 report = object : Operation.Report {
                     override val summary = "Success".toCaString()
                     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val subjectPath = null
                 }
             ),
             canCancel = false,
@@ -356,6 +357,7 @@ private fun OperationsBarExpandedPreview() {
                 report = object : Operation.Report {
                     override val summary = "Success".toCaString()
                     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val subjectPath = null
                 }
             ),
             canCancel = false,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
@@ -189,6 +189,7 @@ private fun createMockReport(
 ): Operation.Report = object : Operation.Report {
     override val summary = "Completed successfully".toCaString()
     override val affectedPaths = affectedPaths
+    override val subjectPath = null
 }
 
 @Preview2

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -266,6 +266,7 @@ private fun OperationOverviewGrid(
 private fun previewReport(text: String) = object : Operation.Report {
     override val summary = text.toCaString()
     override val affectedPaths = emptyList<Operation.Report.PathChange>()
+    override val subjectPath = null
 }
 
 @Preview2

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
@@ -424,6 +424,100 @@ class OperationHistoryPersistTest : BaseTest() {
         database.operationHistoryDao().getById(id)!!.entry.primaryPath shouldBe archived.path
     }
 
+    /*
+     * The row label. Every fixture below carries THREE distinct paths - a subject, a leading
+     * reported change and a representative path - so each assertion can only pass for one reason.
+     */
+
+    private val subject = LocalPath.build("/sdcard/Backup/nested")
+    private val firstReported = LocalPath.build("/sdcard/Backup/nested/aaa.txt")
+    private val planned = LocalPath.build("/sdcard/Download/nested")
+
+    private fun labelSnapshot(
+        report: Operation.Report?,
+        error: Throwable? = null,
+    ) = testSnapshot(
+        metadata = testMetadata(
+            operationKind = Operation.Metadata.Kind.COPY,
+            plan = planOver(planned),
+        ),
+        state = TestCompletedState(report = report, error = error),
+    )
+
+    private suspend fun primaryPathOf(snapshot: CompletedOperationSnapshot): String? =
+        database.operationHistoryDao().getById(persist(snapshot))!!.entry.primaryPath
+
+    @Test
+    fun `the subject wins over both the reported changes and the plan`() = runTest {
+        primaryPathOf(
+            labelSnapshot(
+                TestReport(
+                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.PathChange.Change.ADDED)),
+                    subjectPath = subject,
+                ),
+            )
+        ) shouldBe subject.path
+    }
+
+    @Test
+    fun `a report that names no subject falls back to the plan, not to a reported change`() = runTest {
+        primaryPathOf(
+            labelSnapshot(
+                TestReport(
+                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.PathChange.Change.ADDED)),
+                    subjectPath = null,
+                ),
+            )
+        ) shouldBe planned.path
+    }
+
+    @Test
+    fun `an operation without a report falls back to the plan`() = runTest {
+        primaryPathOf(labelSnapshot(report = null, error = IOException("boom"))) shouldBe planned.path
+    }
+
+    @Test
+    fun `a partial failure is still labelled with its subject`() = runTest {
+        primaryPathOf(
+            labelSnapshot(
+                report = TestReport(
+                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.PathChange.Change.ADDED)),
+                    subjectPath = subject,
+                    partialErrorCount = 1,
+                ),
+                error = IOException("one item failed"),
+            )
+        ) shouldBe subject.path
+    }
+
+    @Test
+    fun `a recursive delete is labelled with the selected folder, not a descendant`() = runTest {
+        val folder = LocalPath.build("/sdcard/Download/nested")
+        val descendant = folder.child("aaa.txt")
+        val id = persist(
+            testSnapshot(
+                metadata = testMetadata(
+                    operationKind = Operation.Metadata.Kind.DELETE,
+                    plan = planOver(folder),
+                ),
+                state = TestCompletedState(
+                    report = TestReport(
+                        // Post-order removal: the folder is the last change, not the first.
+                        affectedPaths = listOf(
+                            changeOf(descendant, Operation.Report.PathChange.Change.REMOVED),
+                            changeOf(folder, Operation.Report.PathChange.Change.REMOVED),
+                        ),
+                        subjectPath = folder,
+                    ),
+                ),
+            )
+        )
+
+        val stored = database.operationHistoryDao().getById(id)!!
+        stored.paths.first().path shouldBe descendant.path
+        stored.entry.primaryPath shouldBe folder.path
+    }
+
     @Test
     fun `the database is trimmed back under the size limit`() = runTest {
         val now = Clock.System.now()

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
@@ -251,6 +251,7 @@ class OperationHistoryPersistTest : BaseTest() {
                         affectedPaths = reported.map {
                             changeOf(it, Operation.Report.PathChange.Change.ADDED)
                         },
+                        subjectPath = reported.first(),
                     ),
                 ),
             )
@@ -310,11 +311,15 @@ class OperationHistoryPersistTest : BaseTest() {
         scopePaths = listOf(savedA, savedB),
     )
 
-    /** Mirrors CompressOperation: the destination DIRECTORY is the scope, not the archive path. */
+    /**
+     * Mirrors CompressOperation: the destination DIRECTORY is the scope, not the archive path, and
+     * the archive - not a source - is what a failed compression names.
+     */
     private fun compressPlan() = OperationPathPlan(
         targets = listOf(downloadA, downloadB),
         destination = OperationPathPlan.Destination.RequestedTarget(archived),
         scopePaths = listOf(downloadA, downloadB, destinationFolder),
+        representativePath = archived,
     )
 
     @Test
@@ -416,7 +421,7 @@ class OperationHistoryPersistTest : BaseTest() {
             "/sdcard/Download/b.txt",
             "/sdcard/Backup",
         )
-        database.operationHistoryDao().getById(id)!!.entry.primaryPath shouldBe downloadA.path
+        database.operationHistoryDao().getById(id)!!.entry.primaryPath shouldBe archived.path
     }
 
     @Test

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
@@ -31,6 +31,7 @@ import kotlin.time.Instant
 
 internal class TestReport(
     override val affectedPaths: Collection<Operation.Report.PathChange>,
+    override val subjectPath: APath<*>? = null,
     override val partialErrorCount: Int = 0,
     override val summary: CaString = "report".toCaString(),
 ) : Operation.Report

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayStateTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayStateTest.kt
@@ -35,6 +35,7 @@ class OperationsDisplayStateTest : BaseTest() {
     private val dummyReport = object : Operation.Report {
         override val summary = "done".toCaString()
         override val affectedPaths = emptyList<Operation.Report.PathChange>()
+        override val subjectPath = null
     }
 
     @Test

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRowTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRowTest.kt
@@ -99,6 +99,7 @@ class OperationEntryRowTest : ComposeTest() {
                             report = object : Operation.Report {
                                 override val summary = "Deleted 5 items".toCaString()
                                 override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                                override val subjectPath = null
                             },
                         )
                     ),

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
@@ -47,6 +47,7 @@ class OperationOverviewSectionTest : ComposeTest() {
             report = object : Operation.Report {
                 override val summary = "Moved 12 files".toCaString()
                 override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                override val subjectPath = null
             },
         ),
     )


### PR DESCRIPTION
## What changed

The operation history now names what each operation was actually about.

Extracting an archive names the archive, instead of whichever file happened to come out of it first. Deleting a folder names the folder, instead of a file from inside it. Compressing names the archive even when the operation fails. Moving or copying a folder names the folder rather than something nested inside it.

The delete case is visible today to anyone who turns the trash off: permanent deletion removes a folder's children before the folder itself, so the row ended up naming a child.

Nothing else about what an operation reports has changed. The affected-paths list and its count are exactly as before, and existing history rows render exactly as they did.

## Technical Context

- The row derived its subject positionally: `OperationHistoryRepo` took `reportedChanges.firstOrNull()`, and `HistoryEntryRow` preferred the first reported path over `primaryPath`. That was correct for some operations by design, correct for others only by accident of work-queue ordering, and wrong for three. `Operation.Report.subjectPath` replaces the convention with a value each operation states outright.

- The member is **abstract** deliberately. A default would have been wrong or accidental for several current producers, which is precisely how the extract case arose, so making it abstract means the compiler asks each operation the question and the KDoc answers it at the point of decision. That is why ~10 Compose preview objects and 4 test doubles appear in the diff: they are the cost of the compiler enforcing it, not incidental churn.

- No subject depends on collection iteration order. `Set` has no ordering contract, so Copy and Move resolve theirs from the source-to-destination pair in the completed action result, matched against the command's first source. Delete uses `command.targets.firstOrNull()`, since all three delete commands take an unconstrained `Set` and `first()` would throw on an empty one.

- Compress needed both layers: the report's subject covers a partial failure, and `representativePath = outputPath` on its path plan covers failing before any report exists. Extract needs no plan change because its plan targets are already the archive.

- Worth a close read: the row precedence flip (`primaryPath` before the first reported path) cannot change any already-persisted row, because every row a v2 database can hold has `primaryPath == paths[0]` whenever `paths` is non-empty. `MIGRATION_1_2` wipes v1 rows, and every writer since has used that same derivation. Verified on an emulator that extraction names the archive, that a permanent recursive folder delete with the trash disabled names the folder, that trash deletion and compression are unchanged, and that the affected-paths list and count are untouched.
