### PR TITLE
Explorer: Guard against storage locations showing a stale name again

### DIFF
--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerItemListChangeTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerItemListChangeTest.kt
@@ -83,6 +83,15 @@ class ExplorerItemListChangeTest : BaseTest() {
         old.hasSameItemsAs(new) shouldBe false
     }
 
+    /** Storage rows take the full-equality branch, not the id-and-type one that would match here. */
+    @Test
+    fun `a renamed SAF location gets through`() {
+        val old = listOf(MockDataProvider.createMockStorageSAF(name = "SD Card", id = "saf-sdcard"))
+        val new = listOf(MockDataProvider.createMockStorageSAF(name = "Photos", id = "saf-sdcard"))
+
+        old.hasSameItemsAs(new) shouldBe false
+    }
+
     @Test
     fun `a changed network status gets through`() {
         val old = listOf(networkItem())


### PR DESCRIPTION
## What changed

No user-facing behavior change. This adds one regression test and no production code.

Renaming a storage location used to leave the Device list showing the previous name until you
navigated away and came back. The rename itself always saved correctly, only the list on screen was
stale. That is already fixed on main, and a run on a device against this commit confirms it no
longer happens. What was missing was a test holding it that way.

Refs #64.

## Technical Context

- The defect came from the listing deduplication in `ExplorerWorkspaceViewModel`. `hasSameItemsAs`
  used to compare items by id and runtime class alone, and a renamed SAF location keeps both (its id
  is derived from the tree URI), so the refreshed listing was discarded before it reached the screen.
  4fd64c375 fixed it while fixing the same symptom for network locations, by comparing any storage
  row in full; SAF rows benefit generically.
- It went unnoticed because the branch carrying the SAF work was merged rather than rebased, so no
  tree that was ever tested contained the fix.
- The gap this closes is coverage, not behavior. The predicate's storage branch was pinned only by
  network rows, so narrowing it back to `ExplorerItem.Storage.Network` would keep the suite green
  while reintroducing the defect for SAF locations.
- Worth reading the new assertion carefully, because it is easy to misread: it does not prove the
  predicate is sensitive to the label. `CaString` declares no `equals` and `SAFLocation.displayName`
  builds a fresh instance per access, so any two separately constructed storage rows compare unequal
  whatever their labels. What the test discriminates is the id-and-type comparison from the
  full-equality one, which is the regression worth guarding.
- Not addressed here: `SAFLocationManagerImpl.updateLocation` waits up to two seconds for its cache
  to reflect a write and then returns anyway, while `DeviceLocationLoader` samples the location list
  once. A cache still stale at that point could produce the same visible symptom from a different
  cause. It has never been observed firing, and a device run watching the log for it saw nothing.
- The rename scenario was executed on an emulator against this exact commit, covering the grant, the
  rename observed without navigating, persistence across navigation, and the absence of that
  cache-timeout warning. CI cannot cover that path.
