### PR TITLE
Apps: Stop offering storage folders an app does not have

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathNotFoundException.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathNotFoundException.kt
@@ -1,0 +1,14 @@
+package eu.darken.butler.common.files.errors
+
+import eu.darken.butler.common.files.APath
+
+/**
+ * The path is positively known not to exist, as opposed to being unreadable.
+ *
+ * Constructed locally after an existence check answered false, never thrown across the IPC
+ * boundary, and deliberately without a cause: the failure it replaces would otherwise be found
+ * again when the cause chain is classified (see `PermissionErrorClassifierTest`).
+ */
+class PathNotFoundException(
+    path: APath<*>,
+) : ReadException(message = "Path does not exist", path = path)

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.common.files.permissions
 import eu.darken.butler.common.ElevatedAccessUnavailableException
 import eu.darken.butler.common.error.causeChain
 import eu.darken.butler.common.files.errors.PathException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
 import java.io.IOException
@@ -37,6 +38,8 @@ object PermissionErrorClassifier {
         // Pass 3: Generic permission-style exception types without a more specific message.
         for (t in error.causeChain) {
             when (t) {
+                // A path that isn't there is not a path we were kept out of.
+                is PathNotFoundException -> return null
                 is PathException -> return Reason.ACCESS_DENIED
                 is SecurityException -> return Reason.ACCESS_DENIED
                 is java.nio.file.AccessDeniedException -> return Reason.ACCESS_DENIED

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.files.permissions
 
 import eu.darken.butler.common.ElevatedAccessUnavailableException
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
 import eu.darken.butler.common.files.errors.WriteException
@@ -83,5 +84,13 @@ class PermissionErrorClassifierTest : BaseTest() {
     @Test
     fun `IOException without permission keywords returns null`() {
         PermissionErrorClassifier.classify(IOException("Disk full")) shouldBe null
+    }
+
+    @Test
+    fun `a missing path is not a permission failure`() {
+        val e = PathNotFoundException(LocalPath.build("/data/data/eu.darken.butler"))
+
+        PermissionErrorClassifier.classify(e) shouldBe null
+        PermissionErrorClassifier.isPermissionError(e) shouldBe false
     }
 }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppPath.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppPath.kt
@@ -9,4 +9,6 @@ import eu.darken.butler.common.files.APath
 data class AppPath(
     val path: APath<*>,
     val label: CaString,
+    /** What the user still has to set up to browse here, null while nothing is missing. */
+    val requirement: CaString? = null,
 )

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
@@ -17,12 +17,15 @@ import eu.darken.butler.apps.core.details.components.ComponentEntry
 import eu.darken.butler.apps.core.details.components.ComponentToggleAvailability
 import eu.darken.butler.apps.core.details.components.ComponentToggleState
 import eu.darken.butler.common.adb.AdbManager
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.flow.combine
 import eu.darken.butler.common.pkgs.PkgRepo
@@ -33,6 +36,9 @@ import eu.darken.butler.common.pkgs.pkgops.PkgOpsException
 import eu.darken.butler.common.pkgs.pkgs
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.common.root.RootManager
+import eu.darken.butler.permissions.core.PathPermissionCheck
+import eu.darken.butler.permissions.core.PathRequirements
+import eu.darken.butler.setup.core.SetupModule
 import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
 import eu.darken.butler.workspace.contracts.apps.DetailTab
 import eu.darken.butler.workspace.core.Workspace
@@ -49,13 +55,19 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -74,6 +86,8 @@ class AppDetailsWorkspace @AssistedInject constructor(
     private val pkgOps: PkgOps,
     private val apkArchiveParser: ApkArchiveParser,
     private val appSizeCache: AppSizeCache,
+    private val gatewaySwitch: GatewaySwitch,
+    private val pathPermissionCheck: PathPermissionCheck,
     private val rootManager: RootManager,
     private val adbManager: AdbManager,
     private val workspaceRemote: WorkspaceRemote,
@@ -176,6 +190,105 @@ class AppDetailsWorkspace @AssistedInject constructor(
 
     private val _sizeLoading = MutableStateFlow(false)
 
+    private data class StorageCandidate(
+        val path: APath<*>,
+        val label: CaString,
+        /**
+         * Only paths visible from every mount namespace may be withheld. The root host launches
+         * without mount-master, so its view of emulated storage does not carry other apps'
+         * `Android/data` and a stat there answers false for an app that does have external data.
+         */
+        val mayBeWithheld: Boolean = false,
+    )
+
+    /** What the row for a path needs, but only I/O can answer. */
+    private data class PathInsight(
+        val availability: Availability = Availability.UNKNOWN,
+        val requirements: PathRequirements? = null,
+    )
+
+    private enum class Availability {
+        EXISTS,
+        ABSENT,
+
+        /** Nothing was learned; the row is offered and the Explorer reports whatever it finds. */
+        UNKNOWN,
+    }
+
+    // Fixed for the workspace's whole life: its install identity is immutable.
+    // TODO These are user 0's directories while the install carries a user handle, so a
+    //  work-profile install points at the wrong ones.
+    private val storageCandidates: List<StorageCandidate> = listOf(
+        StorageCandidate(
+            path = LocalPath.build("/data/data/${args.packageName}"),
+            label = R.string.apps_path_internal_data_label.toCaString(),
+            mayBeWithheld = true,
+        ),
+        StorageCandidate(
+            path = LocalPath.build("/storage/emulated/0/Android/data/${args.packageName}"),
+            label = R.string.apps_path_external_data_label.toCaString(),
+        ),
+    )
+
+    private val isPrimaryUser = args.installId.userHandle.handleId == 0
+
+    /**
+     * Resolved once per root state instead of inside the state combine, which re-runs on every
+     * emission of its inputs. A pause releases the workspace, so a resume rebuilds this from
+     * scratch and a directory created in the meantime (external app storage is created lazily)
+     * shows up again.
+     */
+    private val pathInsights: StateFlow<Map<APath<*>, PathInsight>> = rootManager.useRoot
+        .distinctUntilChanged()
+        .flatMapLatest { hasRoot ->
+            flow {
+                // The first render must not wait for I/O, and no knowledge means "offer the row".
+                emit(emptyMap<APath<*>, PathInsight>())
+                val known = storageCandidates.associate { candidate ->
+                    candidate.path to PathInsight(availability = resolveAvailability(candidate, hasRoot))
+                }
+                emit(known)
+                // Setup tracking can stall on a module that never resolves, so it is published on
+                // its own and cannot hold back what is already known.
+                emit(known.mapValues { (path, insight) -> insight.copy(requirements = resolveRequirements(path)) })
+            }
+        }
+        .stateIn(scope, SharingStarted.Eagerly, emptyMap())
+
+    /**
+     * [eu.darken.butler.common.files.FileSystemOps.exists] answers false both for "not there" and
+     * for "could not look" - a denied stat returns false without throwing - so a false answer is
+     * only worth trusting with root, and only for the user these paths belong to.
+     *
+     * TODO A strict IO-layer probe reporting present/absent/could-not-tell per backend would say
+     *  which of the two a false answer is, which is what withholding the external row again needs.
+     */
+    private suspend fun resolveAvailability(candidate: StorageCandidate, hasRoot: Boolean): Availability {
+        val path = candidate.path
+        if (!candidate.mayBeWithheld) return Availability.UNKNOWN
+        if (!hasRoot || !isPrimaryUser) return Availability.UNKNOWN
+        return try {
+            val exists = gatewaySwitch.exists(path)
+            currentCoroutineContext().ensureActive()
+            if (exists) Availability.EXISTS else Availability.ABSENT
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // A failed probe says nothing; absent has to be a positive answer.
+            log(tag, WARN) { "Existence check failed for $path: ${e.asLog()}" }
+            Availability.UNKNOWN
+        }
+    }
+
+    private suspend fun resolveRequirements(path: APath<*>): PathRequirements? = try {
+        pathPermissionCheck.monitor(path).first().also { currentCoroutineContext().ensureActive() }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(tag, WARN) { "Requirement check failed for $path: ${e.asLog()}" }
+        null
+    }
+
     data class State(
         val app: AppInfo? = null,
         val selectedTab: DetailTab = DetailTab.OVERVIEW,
@@ -204,8 +317,9 @@ class AppDetailsWorkspace @AssistedInject constructor(
         appSizeCache.isAvailable,
         _sizeLoading,
         packageInfoLoader.state,
+        pathInsights,
     ) { app, selectedTab, hasRoot, hasAdb, componentToggleState, sizeSnapshot, sizesAvailable, isLoadingSize,
-        packageInfo ->
+        packageInfo, insights ->
         val withSize = app?.let { info ->
             val size = sizeSnapshot.sizes[info.installId] ?: return@let info
             info.copy(
@@ -214,7 +328,7 @@ class AppDetailsWorkspace @AssistedInject constructor(
                 cacheSize = size.cacheBytes,
             )
         }
-        val paths = withSize?.let { buildAppPaths(it) } ?: emptyList()
+        val paths = if (withSize != null) buildAppPaths(insights) else emptyList()
         State(
             selectedTab = selectedTab,
             app = withSize,
@@ -280,24 +394,30 @@ class AppDetailsWorkspace @AssistedInject constructor(
         ),
     )
 
-    private fun buildAppPaths(app: AppInfo): List<AppPath> = buildList {
-        // Internal data directory (/data/data/package.name)
-        val internalDataPath = LocalPath.build("/data/data/${app.packageName}")
-        add(
+    private fun buildAppPaths(insights: Map<APath<*>, PathInsight>): List<AppPath> = storageCandidates
+        .mapNotNull { candidate ->
+            val insight = insights[candidate.path] ?: PathInsight()
+            // A row for a directory that is not there only leads to a failed navigation.
+            if (insight.availability == Availability.ABSENT) return@mapNotNull null
             AppPath(
-                path = internalDataPath,
-                label = R.string.apps_path_internal_data_label.toCaString(),
+                path = candidate.path,
+                label = candidate.label,
+                requirement = insight.requirements?.let { requirementLabel(it) },
             )
-        )
+        }
 
-        // External storage directory (/storage/emulated/0/Android/data/package.name)
-        val externalDataPath = LocalPath.build("/storage/emulated/0/Android/data/${app.packageName}")
-        add(
-            AppPath(
-                path = externalDataPath,
-                label = R.string.apps_path_external_data_label.toCaString(),
-            )
-        )
+    /** Null while access is available, including through an existing SAF grant or the SAF picker. */
+    private fun requirementLabel(requirements: PathRequirements): CaString? {
+        if (!requirements.needsSetup) return null
+        // Combos are alternatives, so single-module ones read as "either of these".
+        val alternatives = requirements.combos.takeIf { combos -> combos.all { it.size == 1 } }?.flatten()?.toSet()
+        return when (alternatives) {
+            setOf(SetupModule.Type.ROOT) -> R.string.apps_path_requires_root_label
+            setOf(SetupModule.Type.SHIZUKU) -> R.string.apps_path_requires_shizuku_label
+            setOf(SetupModule.Type.ROOT, SetupModule.Type.SHIZUKU) ->
+                R.string.apps_path_requires_root_or_shizuku_label
+            else -> R.string.apps_path_requires_access_label
+        }.toCaString()
     }
 
     fun updateSelectedTab(tab: DetailTab) {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/StorageListItems.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/StorageListItems.kt
@@ -40,7 +40,9 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.R as CommonR
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.formatFileSize
 
 @Composable
@@ -212,6 +214,14 @@ fun StorageListItems(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    // The row stays clickable: browsing there is what leads to the setup options.
+                    appPath.requirement?.let {
+                        Text(
+                            text = it.get(context),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.tertiary,
+                        )
+                    }
                 }
             }
 
@@ -267,6 +277,28 @@ private fun StorageListItemsPreview() {
         onBrowsePath = {},
         onOpenSetup = {},
         app = null
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun StorageListItemsWithPathsPreview() {
+    StorageListItems(
+        availablePaths = listOf(
+            AppPath(
+                path = LocalPath.build("/data/data/com.android.chrome"),
+                label = R.string.apps_path_internal_data_label.toCaString(),
+                requirement = R.string.apps_path_requires_root_label.toCaString(),
+            ),
+            AppPath(
+                path = LocalPath.build("/storage/emulated/0/Android/data/com.android.chrome"),
+                label = R.string.apps_path_external_data_label.toCaString(),
+            ),
+        ),
+        onBrowsePath = {},
+        onOpenSetup = {},
+        app = AppsMockDataProvider.Presets.chrome,
     )
 }
 

--- a/app-workspace-apps/src/main/res/values/strings.xml
+++ b/app-workspace-apps/src/main/res/values/strings.xml
@@ -68,6 +68,10 @@
     <string name="apps_details_storage_locations_label">Storage locations</string>
     <string name="apps_path_internal_data_label">Internal data</string>
     <string name="apps_path_external_data_label">External storage</string>
+    <string name="apps_path_requires_root_label">Requires root</string>
+    <string name="apps_path_requires_shizuku_label">Requires Shizuku</string>
+    <string name="apps_path_requires_root_or_shizuku_label">Requires root or Shizuku</string>
+    <string name="apps_path_requires_access_label">Requires additional access</string>
     <string name="apps_storage_breakdown_label">Storage Breakdown</string>
     <string name="apps_storage_app_label">Application</string>
 

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/AppSizeResolutionE2ETest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/AppSizeResolutionE2ETest.kt
@@ -5,12 +5,14 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.details.AppDetailsWorkspace
 import eu.darken.butler.apps.core.engine.AppsEngine
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.PkgRepo
 import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.common.pkgs.pkgops.PkgOps
 import eu.darken.butler.common.user.UserHandle2
 import eu.darken.butler.common.user.UserManager2
+import eu.darken.butler.permissions.core.PathRequirements
 import eu.darken.butler.setup.core.SetupStateProvider
 import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
 import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
@@ -194,6 +196,9 @@ class AppSizeResolutionE2ETest : BaseTest() {
         pkgOps = pkgOps,
         apkArchiveParser = mockk(relaxed = true),
         appSizeCache = cache,
+        // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
+        gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+        pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
         rootManager = mockk<eu.darken.butler.common.root.RootManager> {
             every { useRoot } returns flowOf(false)
         },

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceArgumentsTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceArgumentsTest.kt
@@ -2,14 +2,17 @@ package eu.darken.butler.apps.core.details
 
 import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.common.adb.AdbManager
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathRequirements
 import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
 import eu.darken.butler.workspace.contracts.apps.DetailTab
 import eu.darken.butler.workspace.core.Workspace
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,6 +47,9 @@ class AppDetailsWorkspaceArgumentsTest : BaseTest() {
             every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
             every { isAvailable } returns MutableStateFlow(false)
         },
+        // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
+        gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+        pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
         rootManager = mockk<RootManager> { every { useRoot } returns flowOf(false) },
         adbManager = mockk<AdbManager> { every { useAdb } returns flowOf(false) },
         workspaceRemote = mockk(relaxed = true),

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceLabelCaptureTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceLabelCaptureTest.kt
@@ -4,18 +4,22 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.PkgRepo
 import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.common.pkgs.features.Installed
 import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathRequirements
 import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
 import eu.darken.butler.workspace.contracts.apps.DetailTab
 import eu.darken.butler.workspace.core.Workspace
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -67,6 +71,9 @@ class AppDetailsWorkspaceLabelCaptureTest {
                 every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
                 every { isAvailable } returns MutableStateFlow(false)
             },
+            // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
+            gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+            pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
             rootManager = mockk(relaxed = true),
             adbManager = mockk(relaxed = true),
             workspaceRemote = mockk(relaxed = true),

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceSeedTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceSeedTest.kt
@@ -3,15 +3,19 @@ package eu.darken.butler.apps.core.details
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.AppSizeCache
+import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathRequirements
 import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
 import eu.darken.butler.workspace.core.Workspace
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,6 +54,9 @@ class AppDetailsWorkspaceSeedTest {
                 every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
                 every { isAvailable } returns MutableStateFlow(false)
             },
+            // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
+            gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+            pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
             rootManager = mockk(relaxed = true),
             adbManager = mockk(relaxed = true),
             workspaceRemote = mockk(relaxed = true),

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceStoragePathsTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceStoragePathsTest.kt
@@ -1,0 +1,248 @@
+package eu.darken.butler.apps.core.details
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.apps.core.AppPath
+import eu.darken.butler.apps.core.AppSizeCache
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.adb.AdbManager
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.PkgRepo
+import eu.darken.butler.common.pkgs.features.InstallId
+import eu.darken.butler.common.pkgs.features.Installed
+import eu.darken.butler.common.root.RootManager
+import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathPermissionCheck
+import eu.darken.butler.permissions.core.PathRequirements
+import eu.darken.butler.setup.core.SetupModule
+import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * Only the internal data row can ever be withheld, and only when the directory is positively known
+ * to be absent, which the gateway can only answer with root: `exists()` returns false for a denied
+ * stat too. The external row is always offered, see `the external row is never withheld`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AppDetailsWorkspaceStoragePathsTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val primaryInstallId = InstallId(Pkg.Id(PKG), UserHandle2(0))
+    private val workProfileInstallId = InstallId(Pkg.Id(PKG), UserHandle2(10))
+
+    private val gatewaySwitch = mockk<GatewaySwitch>().apply {
+        coEvery { exists(any()) } returns true
+    }
+    private val pathPermissionCheck = mockk<PathPermissionCheck>().apply {
+        every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements())
+    }
+    private val useRootFlow = MutableStateFlow(true)
+
+    private fun installedFor(target: InstallId): Installed {
+        val base = AppsMockDataProvider.createMockInstalled(packageName = PKG, label = "Test App")
+        return object : Installed by base {
+            override val userHandle: UserHandle2 = target.userHandle
+            override val installId: InstallId = target
+        }
+    }
+
+    private fun TestScope.createWorkspace(installId: InstallId = primaryInstallId) = AppDetailsWorkspace(
+        id = Workspace.Id(),
+        creationArguments = AppDetailsArguments(installId = installId),
+        context = context,
+        dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+        pkgRepo = mockk<PkgRepo>().also {
+            every { it.data } returns MutableStateFlow(PkgRepo.PkgData.from(listOf(installedFor(installId))))
+        },
+        pkgOps = mockk(relaxed = true),
+        apkArchiveParser = mockk(relaxed = true),
+        appSizeCache = mockk(relaxed = true) {
+            every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
+            every { isAvailable } returns MutableStateFlow(false)
+        },
+        gatewaySwitch = gatewaySwitch,
+        pathPermissionCheck = pathPermissionCheck,
+        rootManager = mockk<RootManager> { every { useRoot } returns useRootFlow },
+        adbManager = mockk<AdbManager> { every { useAdb } returns flowOf(false) },
+        workspaceRemote = mockk(relaxed = true),
+    )
+
+    private fun TestScope.pathsOf(workspace: AppDetailsWorkspace): List<AppPath> {
+        val seen = mutableListOf<AppDetailsWorkspace.State>()
+        val job = launch { workspace.state.collect { seen += it } }
+        advanceUntilIdle()
+        job.cancel()
+        return seen.last().availablePaths
+    }
+
+    @Test
+    fun `a directory that is not there is not offered`() = runTest {
+        coEvery { gatewaySwitch.exists(match { it.path == INTERNAL }) } returns false
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
+    }
+
+    @Test
+    fun `a directory that is there is offered`() = runTest {
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+    }
+
+    /** Without root the gateway cannot tell "not there" from "not allowed to look". */
+    @Test
+    fun `without root a negative answer is not trusted`() = runTest {
+        useRootFlow.value = false
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+    }
+
+    /**
+     * The probe for the external path escalates to the root client, which stats it in the root
+     * host's own mount namespace - launched without mount-master, so it does not present other
+     * apps' `Android/data` at all. A false answer there is never an absence.
+     */
+    @Test
+    fun `the external row is never withheld`() = runTest {
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
+        coVerify(exactly = 0) { gatewaySwitch.exists(match { it.path == EXTERNAL }) }
+
+        useRootFlow.value = false
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun `the external row is never withheld on older Android versions either`() = runTest {
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
+    }
+
+    /** The paths are user 0's, so for another user their absence says nothing. */
+    @Test
+    fun `a work profile install keeps its rows`() = runTest {
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        pathsOf(createWorkspace(workProfileInstallId)).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+    }
+
+    @Test
+    fun `a failed probe keeps the rows`() = runTest {
+        coEvery { gatewaySwitch.exists(any()) } throws IOException("nope")
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+    }
+
+    /** Cancellation is not an answer, so it must not be caught and turned into one. */
+    @Test
+    fun `a cancelled probe resolves nothing`() = runTest {
+        coEvery { gatewaySwitch.exists(any()) } throws CancellationException("cancelled")
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+
+        coVerify(exactly = 0) { pathPermissionCheck.monitor(any<APath<*>>()) }
+    }
+
+    @Test
+    fun `enabling root re-probes a row that was shown for lack of knowledge`() = runTest {
+        useRootFlow.value = false
+        coEvery { gatewaySwitch.exists(match { it.path == INTERNAL }) } returns false
+        val workspace = createWorkspace()
+
+        val seen = mutableListOf<AppDetailsWorkspace.State>()
+        val job = launch { workspace.state.collect { seen += it } }
+        advanceUntilIdle()
+
+        seen.last().availablePaths.map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+
+        useRootFlow.value = true
+        advanceUntilIdle()
+
+        seen.last().availablePaths.map { it.path.path } shouldBe listOf(EXTERNAL)
+
+        job.cancel()
+    }
+
+    /**
+     * A pause releases the instance and a resume builds a new one, so nothing may be remembered
+     * across that boundary - the directory may have been created in the meantime.
+     */
+    @Test
+    fun `a resumed workspace probes again`() = runTest {
+        coEvery { gatewaySwitch.exists(match { it.path == INTERNAL }) } returns false
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
+
+        coEvery { gatewaySwitch.exists(any()) } returns true
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
+    }
+
+    @Test
+    fun `a row that needs root says so`() = runTest {
+        every { pathPermissionCheck.monitor(match<APath<*>> { it.path == INTERNAL }) } returns flowOf(
+            PathRequirements(combos = setOf(setOf(SetupModule.Type.ROOT)))
+        )
+
+        val paths = pathsOf(createWorkspace())
+
+        paths.first().requirement?.get(context) shouldBe "Requires root"
+        paths.last().requirement shouldBe null
+    }
+
+    @Test
+    fun `a row that needs root or Shizuku says so`() = runTest {
+        every { pathPermissionCheck.monitor(match<APath<*>> { it.path == INTERNAL }) } returns flowOf(
+            PathRequirements(
+                combos = setOf(setOf(SetupModule.Type.ROOT), setOf(SetupModule.Type.SHIZUKU)),
+            )
+        )
+
+        pathsOf(createWorkspace()).first().requirement?.get(context) shouldBe "Requires root or Shizuku"
+    }
+
+    /** An existing SAF grant makes the path accessible as it is, so there is nothing to announce. */
+    @Test
+    fun `a row with a working alternative says nothing`() = runTest {
+        every { pathPermissionCheck.monitor(match<APath<*>> { it.path == EXTERNAL }) } returns flowOf(
+            PathRequirements(
+                combos = setOf(setOf(SetupModule.Type.ROOT)),
+                alternativePath = LocalPath.build("/storage/emulated/0/Android/data/$PKG"),
+            )
+        )
+
+        pathsOf(createWorkspace()).last().requirement shouldBe null
+    }
+
+    companion object {
+        private const val PKG = "eu.darken.butler"
+        private const val INTERNAL = "/data/data/$PKG"
+        private const val EXTERNAL = "/storage/emulated/0/Android/data/$PKG"
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/StorageListItemsTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/StorageListItemsTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.butler.apps.ui.details
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.butler.apps.core.AppPath
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class StorageListItemsTest : ComposeTest() {
+
+    private fun setContent(requirement: String?) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                StorageListItems(
+                    availablePaths = listOf(
+                        AppPath(
+                            path = LocalPath.build(PATH),
+                            label = "Internal data".toCaString(),
+                            requirement = requirement?.toCaString(),
+                        ),
+                    ),
+                    onBrowsePath = {},
+                    onOpenSetup = {},
+                )
+            }
+        }
+    }
+
+    /** Browsing there is the route to the permission card, so the row must not become inert. */
+    @Test
+    fun `a row that needs access says so and stays clickable`() {
+        setContent("Requires root")
+
+        composeTestRule.onNodeWithText("Requires root").assertIsDisplayed()
+        composeTestRule.onNode(hasText("Requires root") and hasClickAction()).assertExists()
+    }
+
+    @Test
+    fun `a row with access says nothing extra`() {
+        setContent(null)
+
+        composeTestRule.onNodeWithText(PATH).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Requires root").assertDoesNotExist()
+    }
+
+    companion object {
+        private const val PATH = "/data/data/eu.darken.butler"
+    }
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoader.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoader.kt
@@ -8,14 +8,17 @@ import eu.darken.butler.common.adb.canUseAdbNow
 import eu.darken.butler.common.ca.caString
 import eu.darken.butler.common.debug.Bugs
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.SmbPath
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.extensions.getFileSystemInfo
 import eu.darken.butler.common.files.extensions.isAncestorOfOrSelf
 import eu.darken.butler.common.files.metadata.FileType
@@ -29,6 +32,7 @@ import eu.darken.butler.explorer.R
 import eu.darken.butler.workspace.core.preview.FolderPreviewResolver
 import eu.darken.butler.permissions.core.PathPermissionCheck
 import eu.darken.butler.workspace.core.Workspace
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
@@ -104,24 +108,66 @@ class DirectoryLocationLoader @AssistedInject constructor(
                     currentCoroutineContext().ensureActive()
                     context.loadFileSystemInfo()
 
-                    currentCoroutineContext().ensureActive()
-                    context.loadPeek()
+                    // Covers every pass, not just the first: the directory can be deleted after the
+                    // peek listing succeeded and before either lookup call.
+                    context.asNotFoundIfGone {
+                        currentCoroutineContext().ensureActive()
+                        context.loadPeek()
 
-                    currentCoroutineContext().ensureActive()
-                    context.loadContent()
+                        currentCoroutineContext().ensureActive()
+                        context.loadContent()
 
-                    currentCoroutineContext().ensureActive()
-                    // A second pass over the network would mean one more round trip per item for
-                    // ownership and permissions an SMB share does not report anyway.
-                    when (context.targetPath) {
-                        is SmbPath -> context.loadNetworkWritability()
-                        else -> context.loadContentExtended()
+                        currentCoroutineContext().ensureActive()
+                        // A second pass over the network would mean one more round trip per item for
+                        // ownership and permissions an SMB share does not report anyway.
+                        when (context.targetPath) {
+                            is SmbPath -> context.loadNetworkWritability()
+                            else -> context.loadContentExtended()
+                        }
                     }
                 }
 
                 currentCoroutineContext().ensureActive()
                 context.updateState { copy(progress = null) }
             }
+        }
+    }
+
+    /**
+     * Turns "the target is gone" into a state the page can render instead of a failure card.
+     *
+     * Restricted to [LocalPath], the only type whose `exists()` reports an actual stat. For SAF a
+     * false answer also covers a provider that is unreachable, crashing or mid-update, and for SMB
+     * and archives it covers an unreachable host or an unreadable container - in each of those the
+     * original error carries the signal the user needs, see `DirectoryLocationLoaderTest`.
+     */
+    private suspend fun <T> LocationLoaderContext<ExplorerLocation.Directory>.asNotFoundIfGone(
+        block: suspend () -> T,
+    ): T {
+        val target = targetPath
+        try {
+            return block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (target !is LocalPath) throw e
+
+            currentCoroutineContext().ensureActive()
+            val stillThere = try {
+                gatewaySwitch.exists(target)
+            } catch (probeError: CancellationException) {
+                throw probeError
+            } catch (probeError: Exception) {
+                log(tag, WARN) { "asNotFoundIfGone(): Probe failed for $target: ${probeError.asLog()}" }
+                true
+            }
+            // The probe can outlive its coroutine, and a cancelled load must not turn into a
+            // "folder gone" state for a target the user has already navigated away from.
+            currentCoroutineContext().ensureActive()
+            if (stillThere) throw e
+
+            log(tag, INFO) { "asNotFoundIfGone(): $target is gone, original error was ${e.asLog()}" }
+            throw PathNotFoundException(target)
         }
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
@@ -25,6 +25,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.dragselect.gridDragSelect
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.actions.ExplorerActionBarItem
@@ -88,8 +89,21 @@ internal fun ExplorerGridContent(
         contentPadding = contentPadding,
     ) {
         if (state.items == null) {
-            if (state.error == null) {
-                items(12, key = { "skeleton-grid-$it" }) {
+            when {
+                // Fills the content area instead of floating over it: there is no content left to
+                // look at, and the state carries the way out of the location.
+                state.error is PathNotFoundException -> item(
+                    span = { GridItemSpan(maxLineSpan) },
+                    key = "notfound",
+                ) {
+                    PathNotFoundState(
+                        modifier = Modifier.fillMaxSize(),
+                        onRetry = { vm?.retryNavigation() },
+                        onLeave = { vm?.dismissNavigationError() },
+                    )
+                }
+
+                state.error == null -> items(12, key = { "skeleton-grid-$it" }) {
                     SkeletonGridItem()
                 }
             }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
@@ -19,6 +19,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.dragselect.listDragSelect
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.actions.ExplorerActionBarItem
 import eu.darken.butler.explorer.core.engine.ExplorerLocation
@@ -62,8 +63,18 @@ internal fun ExplorerListContent(
         contentPadding = contentPadding,
     ) {
         if (state.items == null) {
-            if (state.error == null) {
-                items(10, key = { "skeleton-$it" }) {
+            when {
+                // Fills the content area instead of floating over it: there is no content left to
+                // look at, and the state carries the way out of the location.
+                state.error is PathNotFoundException -> item(key = "notfound") {
+                    PathNotFoundState(
+                        modifier = Modifier.fillParentMaxSize(),
+                        onRetry = { vm?.retryNavigation() },
+                        onLeave = { vm?.dismissNavigationError() },
+                    )
+                }
+
+                state.error == null -> items(10, key = { "skeleton-$it" }) {
                     SkeletonListItem()
                 }
             }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
@@ -30,6 +30,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.archive.ArchiveNotSeekableException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.explorer.R
 import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.BrowsingAbortedException
@@ -182,8 +183,9 @@ internal fun ExplorerReadyContent(
         }
 
         // Error card (floating below top bar stack). A cancelled load is answered by the aborted
-        // dialog in the overlay slot instead, so it must not raise a card of its own.
-        state.error?.takeIf { it !is BrowsingAbortedException }?.let { error ->
+        // dialog in the overlay slot instead, and a vanished target by the content-level
+        // PathNotFoundState, so neither must raise a card of its own.
+        state.error?.takeIf { it !is BrowsingAbortedException && it !is PathNotFoundException }?.let { error ->
             if (error is ArchiveNotSeekableException) {
                 val archiveBusy by (vm?.archiveActionBusy ?: remember { MutableStateFlow(false) }).collectAsState()
                 ArchiveAccessErrorCard(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/PathNotFoundState.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/PathNotFoundState.kt
@@ -1,0 +1,164 @@
+package eu.darken.butler.explorer.ui.explorer.elements
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.FolderOff
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.explorer.R
+import eu.darken.butler.common.R as CommonR
+import kotlinx.coroutines.delay
+
+/**
+ * The target directory no longer exists.
+ *
+ * Leaving is offered next to retrying: a tab opened straight onto a path that will never come back
+ * has no history to go back through, so retry alone would be a dead end.
+ */
+@Composable
+fun PathNotFoundState(
+    modifier: Modifier = Modifier,
+    onRetry: () -> Unit,
+    onLeave: () -> Unit,
+    initiallyVisible: Boolean = false,
+) {
+    var visible by remember { mutableStateOf(initiallyVisible) }
+
+    LaunchedEffect(Unit) {
+        delay(100)
+        visible = true
+    }
+
+    val infiniteTransition = rememberInfiniteTransition(label = "floating")
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 1f,
+        targetValue = 1.1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scale"
+    )
+
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.6f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "alpha"
+    )
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(tween(600)),
+            exit = fadeOut()
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(32.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(96.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                            shape = RoundedCornerShape(24.dp)
+                        )
+                        .scale(scale)
+                        .alpha(alpha),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.TwoTone.FolderOff,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.outline,
+                        modifier = Modifier.size(56.dp)
+                    )
+                }
+
+                Text(
+                    text = stringResource(R.string.explorer_path_not_found_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(top = 24.dp)
+                )
+
+                Text(
+                    text = stringResource(R.string.explorer_path_not_found_caption),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+
+                Row(
+                    modifier = Modifier.padding(top = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(onClick = onLeave) {
+                        Text(text = stringResource(R.string.explorer_path_not_found_back_action))
+                    }
+                    FilledTonalButton(onClick = onRetry) {
+                        Text(text = stringResource(CommonR.string.general_retry_action))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PathNotFoundStatePreview() {
+    PathNotFoundState(
+        onRetry = {},
+        onLeave = {},
+        initiallyVisible = true,
+    )
+}

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -325,6 +325,9 @@
     <string name="explorer_empty_folder_label">Empty folder</string>
     <string name="explorer_empty_filtered_title">No matching items</string>
     <string name="explorer_empty_filtered_caption">Try adjusting your filters</string>
+    <string name="explorer_path_not_found_title">This folder is gone</string>
+    <string name="explorer_path_not_found_caption">It was deleted, renamed or moved somewhere else.</string>
+    <string name="explorer_path_not_found_back_action">Go back</string>
 
     <!-- Status Messages -->
     <string name="explorer_loading">Loading…</string>

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoaderTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoaderTest.kt
@@ -1,24 +1,34 @@
 package eu.darken.butler.explorer.core.engine
 
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.SmbPath
+import eu.darken.butler.common.files.archive.ArchiveNotSeekableException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.metadata.FileSystem
 import eu.darken.butler.permissions.core.PathPermissionCheck
 import eu.darken.butler.permissions.core.PathRequirements
 import eu.darken.butler.workspace.core.Workspace
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.io.IOException
 import kotlin.uuid.Uuid
 
 class DirectoryLocationLoaderTest : BaseTest() {
@@ -65,7 +75,127 @@ class DirectoryLocationLoaderTest : BaseTest() {
         coVerify(exactly = 0) { gatewaySwitch.lookup(any(), any<LookupOptions>()) }
     }
 
+    @Test
+    fun `a local target that is gone fails as not found`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        shouldThrow<PathNotFoundException> { loader().loadDirectory(LOCAL_PATH).toList() }
+    }
+
+    @Test
+    fun `a target that is still there keeps its original error`() = runTest {
+        val original = IOException("something else")
+        coEvery { gatewaySwitch.listFiles(any()) } throws original
+        coEvery { gatewaySwitch.exists(any()) } returns true
+
+        shouldThrow<IOException> { loader().loadDirectory(LOCAL_PATH).toList() } shouldBe original
+    }
+
+    @Test
+    fun `a failing existence probe keeps the original error`() = runTest {
+        val original = IOException("something else")
+        coEvery { gatewaySwitch.listFiles(any()) } throws original
+        coEvery { gatewaySwitch.exists(any()) } throws IOException("probe broke")
+
+        shouldThrow<IOException> { loader().loadDirectory(LOCAL_PATH).toList() } shouldBe original
+    }
+
+    @Test
+    fun `a target that vanishes after the peek also fails as not found`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } returns emptyList()
+        coEvery { gatewaySwitch.lookupFiles(any(), any<LookupOptions>()) } throws IOException("no such file")
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        shouldThrow<PathNotFoundException> { loader().loadDirectory(LOCAL_PATH).toList() }
+    }
+
+    /**
+     * flatMapLatest runs the load in a child coroutine, so a cancellation coming out of it ends the
+     * flow quietly instead of surfacing here. What must not happen is a probe or a not-found error.
+     */
+    @Test
+    fun `a cancelled load is never probed`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } throws CancellationException("cancelled")
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        loader().loadDirectory(LOCAL_PATH).toList()
+
+        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+    }
+
+    /** A cancelled probe must not fall back to the original error either, see above. */
+    @Test
+    fun `a cancelled probe ends the load`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
+        coEvery { gatewaySwitch.exists(any()) } throws CancellationException("cancelled")
+
+        loader().loadDirectory(LOCAL_PATH).toList()
+    }
+
+    /**
+     * The probe can outlive the coroutine that started it: a load cancelled while it ran must not
+     * end as "folder gone" for a target the user has already navigated away from.
+     */
+    @Test
+    fun `a probe that returns after cancellation is not an answer`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
+        coEvery { gatewaySwitch.exists(any()) } coAnswers {
+            currentCoroutineContext().cancel()
+            false
+        }
+
+        val thrown = runCatching { loader().loadDirectory(LOCAL_PATH).toList() }.exceptionOrNull()
+
+        val reported = listOfNotNull(thrown) + thrown?.suppressedExceptions.orEmpty()
+        reported.any { it is PathNotFoundException } shouldBe false
+        coVerify(exactly = 1) { gatewaySwitch.exists(any()) }
+    }
+
+    @Test
+    fun `an unreachable share is never reported as a missing directory`() = runTest {
+        val original = IOException("host unreachable")
+        coEvery { gatewaySwitch.listFiles(any()) } throws original
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        val path = SmbPath(LOCATION_ID, listOf("media"))
+
+        shouldThrow<IOException> { loader().loadDirectory(path).toList() } shouldBe original
+        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+    }
+
+    /**
+     * SAF's exists() is a document-id query whose failures are swallowed, so a false answer covers
+     * a provider that is unreachable, crashing or mid-update just as much as a deleted folder.
+     */
+    @Test
+    fun `a failing document provider is never reported as a missing directory`() = runTest {
+        val original = IOException("provider died")
+        coEvery { gatewaySwitch.listFiles(any()) } throws original
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        val path = SAFPath(SAF_TREE_ROOT, listOf("Music"))
+
+        shouldThrow<IOException> { loader().loadDirectory(path).toList() } shouldBe original
+        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+    }
+
+    @Test
+    fun `a stream-only archive keeps its own error`() = runTest {
+        val container = LocalPath.build("/storage/emulated/0/Download/archive.zip")
+        val original = ArchiveNotSeekableException(container)
+        coEvery { gatewaySwitch.listFiles(any()) } throws original
+        coEvery { gatewaySwitch.exists(any()) } returns false
+
+        val path = ArchivePath(container, emptyList())
+
+        shouldThrow<ArchiveNotSeekableException> { loader().loadDirectory(path).toList() } shouldBe original
+        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+    }
+
     companion object {
         private val LOCATION_ID = Uuid.parse("11111111-2222-3333-4444-555555555555")
+        private val LOCAL_PATH = LocalPath.build("/data/data/eu.darken.butler")
+        private const val SAF_TREE_ROOT = "content://com.android.externalstorage.documents/tree/primary%3AMusic"
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContentErrorTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContentErrorTest.kt
@@ -6,8 +6,12 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.archive.ArchiveNotSeekableException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.core.engine.BrowsingAbortedException
+import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
@@ -17,15 +21,15 @@ import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
 import org.junit.Test
 import testhelpers.ComposeTest
 
-/** A cancelled load is answered by the aborted dialog in the overlay slot, not by an error card. */
+/** Which errors reach the floating error card, and which ones have their own presentation. */
 class ExplorerReadyContentErrorTest : ComposeTest() {
 
-    private fun setContent(error: Throwable) {
+    private fun setContent(state: ExplorerWorkspaceViewModel.State) {
         composeTestRule.setContent {
             PreviewWrapper {
                 ExplorerReadyContent(
                     workspaceId = Workspace.Id(),
-                    state = MockDataProvider.createReadyState().copy(error = error),
+                    state = state,
                     vm = null,
                     listState = rememberLazyListState(),
                     gridState = rememberLazyGridState(),
@@ -44,6 +48,8 @@ class ExplorerReadyContentErrorTest : ComposeTest() {
         }
     }
 
+    private fun setContent(error: Throwable) = setContent(MockDataProvider.createReadyState().copy(error = error))
+
     @Test
     fun `an ordinary navigation error raises the error card`() {
         setContent(RuntimeException("nope"))
@@ -56,5 +62,38 @@ class ExplorerReadyContentErrorTest : ComposeTest() {
         setContent(BrowsingAbortedException(ExplorerNavigation.Target.Home))
 
         composeTestRule.onNodeWithText("Navigation failed").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a vanished target fills the content area instead of raising an error card`() {
+        setContent(MockDataProvider.createErrorState(PathNotFoundException(MISSING_PATH)))
+        // The state fades in after a short delay.
+        composeTestRule.mainClock.advanceTimeBy(500)
+
+        composeTestRule.onNodeWithText("This folder is gone").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Navigation failed").assertDoesNotExist()
+    }
+
+    @Test
+    fun `an ordinary error without content still raises the error card`() {
+        setContent(MockDataProvider.createErrorState(RuntimeException("nope")))
+        composeTestRule.mainClock.advanceTimeBy(500)
+
+        composeTestRule.onNodeWithText("Navigation failed").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This folder is gone").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a stream-only archive still raises the archive card`() {
+        setContent(MockDataProvider.createErrorState(ArchiveNotSeekableException(ARCHIVE_PATH)))
+        composeTestRule.mainClock.advanceTimeBy(500)
+
+        composeTestRule.onNodeWithText("Archive can't be browsed here").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This folder is gone").assertDoesNotExist()
+    }
+
+    companion object {
+        private val MISSING_PATH = LocalPath.build("/data/data/eu.darken.butler")
+        private val ARCHIVE_PATH = LocalPath.build("/storage/emulated/0/Download/archive.zip")
     }
 }


### PR DESCRIPTION
## What changed

The app details screen listed an "Internal data" and an "External storage" row for every app, built from the package name without ever checking the folder was there. Tapping a row whose folder did not exist opened a tab that immediately failed with a navigation error. This affected any package with no internal data directory, and any ordinary app that had never written to external storage, since that folder is only created on first use.

Three changes:

- The internal data row is no longer offered when its folder is confirmed missing.
- A row that needs access you have not granted now says so ("Requires root") and stays tappable, so it still leads to the screen that can grant it.
- Browsing into a folder that has been deleted or moved now shows "This folder is gone" with Go back and Retry, instead of a red error card.

The external storage row is always offered, even when the folder may not exist. See below for why.

## Technical Context

- Root cause: `buildAppPaths` emitted both rows unconditionally by concatenating the package name onto two fixed prefixes, and the Explorer turned the resulting failed load into a generic error card.
- Withholding a row is deliberately narrow. Gateway `exists()` answers `false` both for "not there" and for "could not look" — a denied stat returns false without throwing, so `LocalGateway` AUTO never escalates. A false answer is therefore only trusted when it came back from root, for the primary user, and on a path visible from every mount namespace. The external app-data path fails that last condition: the root host runs without mount-master and its view of emulated storage does not carry other apps' `Android/data`, so a row could be hidden for an app that does have external data. A strict IO-layer probe reporting present/absent/could-not-tell per backend is the follow-up that would let that row be withheld too; there is a TODO at the decision point.
- The not-found signal is constructed client-side after a boolean existence re-check, rather than by type-matching the exception the gateway returned. Typed exceptions do not survive the root IPC boundary in minified builds (R8 strips the single-`String` constructor the reflective unwrap needs), so a type match would pass in debug and silently fail in release.
- The not-found treatment covers local paths only. SAF, SMB and archive backends all answer `exists()` with false for a failure as well as for absence, so an unreachable provider, host or unreadable container would otherwise be reported to the user as a deleted folder while its real error was suppressed.
- `PathNotFoundException` subclasses `ReadException` and is explicitly excluded from `PermissionErrorClassifier`, whose pass 3 would otherwise brand it `ACCESS_DENIED`. It deliberately carries no cause, so the classifier's chain walk cannot re-find the original error through it.
- Worth close review: the tri-state gate in `AppDetailsWorkspace.resolveAvailability`, and the cancellation handling in `DirectoryLocationLoader.asNotFoundIfGone`.
