### PR TITLE
General: Document the unit test compile gate for constructor changes

### DIFF
--- a/.claude/rules/development-commands.md
+++ b/.claude/rules/development-commands.md
@@ -22,6 +22,18 @@
 ./gradlew :app:bundleFossRelease
 ```
 
+## Validating a Constructor Change
+
+A production compile does not compile unit test sources. Adding a parameter to an injected
+constructor therefore breaks every test that builds that class with named arguments while
+`compileFossDebugKotlin` still succeeds, and the failure only surfaces once tests are run.
+Compile the test sources too:
+
+```bash
+# Compile unit test sources without running them
+./gradlew :app:compileFossDebugUnitTestKotlin
+```
+
 ## Code Quality
 
 ```bash


### PR DESCRIPTION
## What changed

No user-facing behavior change. Adds a section to the repo's build documentation recording the Gradle task that compiles unit test sources without running them, and why it is worth running after a constructor change.

## Technical Context

- `compileFossDebugKotlin` builds production sources only. Adding a parameter to an injected constructor leaves it green while breaking every test that constructs that class with named arguments, so the failure first appears when the test task runs, which is much later and more expensive.
- `:app:compileFossDebugUnitTestKotlin` is the cheap early signal for that class of break. CI already catches it via `testFossDebugUnitTest` and `testGplayDebugUnitTest`; this is about shortening the local feedback loop, not adding coverage.
- Task name verified against `./gradlew :app:tasks --all`.
