### PR TITLE
Explorer: Tell a deleted folder apart from one that cannot be reached

### DIFF
--- a/app-common-io/src/main/aidl/eu/darken/butler/common/files/local/ipc/FileOpsConnection.aidl
+++ b/app-common-io/src/main/aidl/eu/darken/butler/common/files/local/ipc/FileOpsConnection.aidl
@@ -111,11 +111,18 @@ interface FileOpsConnection {
     /**
      * Streaming walk with error transport: the returned stream carries WalkEvent chunks
      * (Item/DirError terminated by Done or FatalError, see WalkEvent).
+     */
+    RemoteInputStream walkStreamV2(in LocalPath path, in LookupOptions options, in WalkSpec spec);
+
+    /**
+     * Existence that keeps "not there" apart from "could not look": the returned int is an
+     * Existence.ipcCode, never an exception. A typed exception would not survive the binder in a
+     * minified build, a code does.
      *
      * MUST stay the LAST method: AIDL transaction IDs are positional, and appending keeps every
      * pre-existing method's ID stable if host and client processes ever run different builds.
      * (That window is otherwise closed by host lifecycle: the root host dies with the app process
      * and the Shizuku user service is version-pinned via UserServiceArgs.version.)
      */
-    RemoteInputStream walkStreamV2(in LocalPath path, in LookupOptions options, in WalkSpec spec);
+    int existsStrict(in LocalPath path);
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/Existence.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/Existence.kt
@@ -1,0 +1,19 @@
+package eu.darken.butler.common.files
+
+/**
+ * Answer of a strict existence check: present, absent, or "could not tell".
+ *
+ * The codes are explicit because they cross the AIDL boundary
+ * ([eu.darken.butler.common.files.local.ipc.FileOpsConnection.existsStrict]) and must not shift
+ * when entries are reordered.
+ */
+enum class Existence(val ipcCode: Int) {
+    PRESENT(1),
+    ABSENT(2),
+    UNKNOWN(3),
+    ;
+
+    companion object {
+        fun fromIpcCode(code: Int): Existence = entries.firstOrNull { it.ipcCode == code } ?: UNKNOWN
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/FileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/FileSystemOps.kt
@@ -110,10 +110,28 @@ interface FileSystemOps<P : APath<P>, PL : APathLookup<P>> {
      * Does not follow symlinks - checks if the symlink itself exists, not its target.
      * Does not throw exceptions - returns false if path doesn't exist or cannot be accessed.
      *
+     * Use [existsStrict] when those two answers have to be told apart.
+     *
      * @param path The path to check
      * @return true if path exists, false otherwise
      */
     suspend fun exists(path: P): Boolean
+
+    /**
+     * Check if a path exists, keeping "not there" apart from "could not look".
+     *
+     * Does not follow symlinks - checks the symlink itself, not its target.
+     *
+     * Contract every implementation obeys:
+     * - [Existence.ABSENT] only from a definitive backend signal that there is no such path.
+     * - Every failure to answer - denied access, dead provider, unreachable host, unreadable
+     *   container, service bind failure - is [Existence.UNKNOWN].
+     * - Does not throw for access or backend failures.
+     * - [kotlinx.coroutines.CancellationException] is always rethrown.
+     *
+     * @param path The path to check
+     */
+    suspend fun existsStrict(path: P): Existence
 
     /**
      * Delete a file, symlink, or directory.

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
@@ -194,6 +194,28 @@ class GatewaySwitch @Inject constructor(
     suspend fun exists(path: APath<*>, type: Type): Boolean =
         withFallback(path, type, "exists") { target -> useGateway(target) { exists(it) } }
 
+    override suspend fun existsStrict(path: APath<*>): Existence = existsStrict(path, Type.CURRENT)
+
+    /**
+     * [withFallback] cannot serve this one: it retries on a thrown [ReadException] and an UNKNOWN
+     * answer is a return value. The alternative is only tried for the local/SAF split, the only
+     * pair [toAlternative] can map, and a failure there leaves the primary answer standing.
+     */
+    suspend fun existsStrict(path: APath<*>, type: Type): Existence {
+        val primary = useGateway(path.toTargetType(type)) { existsStrict(it) }
+        if (type != Type.AUTO || primary != Existence.UNKNOWN) return primary
+        if (path !is LocalPath && path !is SAFPath) return primary
+
+        return try {
+            useGateway(path.toAlternative()) { existsStrict(it) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "existsStrict(...): Alternative access failed either: ${e.asLog()}" }
+            primary
+        }
+    }
+
     override suspend fun canWrite(path: APath<*>): Boolean {
         return useGateway(path) { canWrite(path) }
     }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
@@ -202,7 +202,14 @@ class GatewaySwitch @Inject constructor(
      * pair [toAlternative] can map, and a failure there leaves the primary answer standing.
      */
     suspend fun existsStrict(path: APath<*>, type: Type): Existence {
-        val primary = useGateway(path.toTargetType(type)) { existsStrict(it) }
+        val primary = try {
+            useGateway(path.toTargetType(type)) { existsStrict(it) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "existsStrict(...): Primary access failed: ${e.asLog()}" }
+            Existence.UNKNOWN
+        }
         if (type != Type.AUTO || primary != Existence.UNKNOWN) return primary
         if (path !is LocalPath && path !is SAFPath) return primary
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/archive/ArchiveGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/archive/ArchiveGateway.kt
@@ -4,8 +4,12 @@ import eu.darken.butler.common.files.ArchivePath
 
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
+import eu.darken.butler.common.debug.logging.asLog
+import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APathGateway
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.actions.CopyAction
@@ -21,6 +25,7 @@ import eu.darken.butler.common.files.metadata.Ownership
 import eu.darken.butler.common.files.metadata.Permissions
 import eu.darken.butler.common.ipc.fileHandle
 import eu.darken.butler.common.sharedresource.SharedResource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -90,6 +95,34 @@ class ArchiveGateway @Inject constructor(
             path.segments.isEmpty() || index.entriesBySegments.containsKey(path.segments)
         } catch (e: ReadException) {
             false
+        }
+    }
+
+    /**
+     * Indexing reads the container, so its failure alone cannot say whether the entry is there.
+     * A deleted archive fails exactly like a corrupt one (indexing stats the container first), so
+     * the container is probed before answering: only a container that is provably gone makes the
+     * entry ABSENT.
+     */
+    override suspend fun existsStrict(path: ArchivePath): Existence = runIO {
+        val index = try {
+            service.index(path.container)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Not just ReadException: tar scanning propagates raw IOExceptions from commons-compress.
+            return@runIO when (service.containerExistsStrict(path.container)) {
+                Existence.ABSENT -> Existence.ABSENT
+                else -> {
+                    log(TAG, WARN) { "existsStrict($path) could not be answered: ${e.asLog()}" }
+                    Existence.UNKNOWN
+                }
+            }
+        }
+        when {
+            path.segments.isEmpty() -> Existence.PRESENT
+            index.entriesBySegments.containsKey(path.segments) -> Existence.PRESENT
+            else -> Existence.ABSENT
         }
     }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/archive/ArchiveGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/archive/ArchiveGateway.kt
@@ -111,7 +111,14 @@ class ArchiveGateway @Inject constructor(
             throw e
         } catch (e: Exception) {
             // Not just ReadException: tar scanning propagates raw IOExceptions from commons-compress.
-            return@runIO when (service.containerExistsStrict(path.container)) {
+            val container = try {
+                service.containerExistsStrict(path.container)
+            } catch (probeError: CancellationException) {
+                throw probeError
+            } catch (probeError: Exception) {
+                Existence.UNKNOWN
+            }
+            return@runIO when (container) {
                 Existence.ABSENT -> Existence.ABSENT
                 else -> {
                     log(TAG, WARN) { "existsStrict($path) could not be answered: ${e.asLog()}" }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/archive/ArchiveService.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/archive/ArchiveService.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.errors.ReadException
@@ -137,6 +138,13 @@ class ArchiveService @Inject constructor(
         val stripe = commitLockStripes[(output.path.hashCode() and Int.MAX_VALUE) % COMMIT_LOCK_STRIPES]
         stripe.withLock { block() }
     }
+
+    /**
+     * Strict existence of the container itself, for callers that have to tell a deleted archive
+     * apart from an unreadable one. Routed through here because [ArchiveGateway] only holds this
+     * service - the gateway switch is behind a Lazy to break the cycle between the two.
+     */
+    suspend fun containerExistsStrict(container: APath<*>): Existence = gatewaySwitch.existsStrict(container)
 
     /** Container stat used both as cache fingerprint and for archive-root lookups. */
     suspend fun statContainer(container: APath<*>): ContainerStat {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalFileSystemOps.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
@@ -22,6 +23,7 @@ import eu.darken.butler.common.files.metadata.Ownership
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import eu.darken.butler.common.files.metadata.Permissions
 import eu.darken.butler.common.ipc.fileHandle
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import okio.FileHandle
@@ -246,6 +248,27 @@ class LocalFileSystemOps @Inject constructor(
         Files.exists(path.toNioPath(), LinkOption.NOFOLLOW_LINKS)
     } catch (e: Exception) {
         throw ReadException(path = path, cause = e)
+    }
+
+    /**
+     * `Files.exists` has no error channel - a stat it was not allowed to run reads as "not there".
+     * Reading the attributes instead makes the failure available for classification.
+     */
+    override suspend fun existsStrict(path: LocalPath): Existence = try {
+        Files.readAttributes(path.toNioPath(), BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        Existence.PRESENT
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        classifyExistence(path, e)
+    }
+
+    internal fun classifyExistence(path: LocalPath, error: Exception): Existence = when (error) {
+        is NoSuchFileException -> Existence.ABSENT
+        else -> {
+            log(TAG, WARN) { "existsStrict($path) could not be answered: ${error.asLog()}" }
+            Existence.UNKNOWN
+        }
     }
 
     override suspend fun delete(path: LocalPath, recursive: Boolean): Boolean = try {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalGateway.kt
@@ -7,10 +7,12 @@ import eu.darken.butler.common.adb.service.runModuleAction
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.error.causeChain
 import eu.darken.butler.common.files.APathGateway
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
@@ -59,6 +61,7 @@ import eu.darken.butler.common.root.service.runModuleAction
 import eu.darken.butler.common.sharedresource.SharedResource
 import eu.darken.butler.common.sharedresource.keepResourcesAlive
 import eu.darken.butler.common.storage.StorageManager2
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -624,6 +627,71 @@ class LocalGateway @Inject constructor(
         directOp = { fileSystemOps.exists(path) },
         clientOp = { it.exists(path) },
     )
+
+    override suspend fun existsStrict(path: LocalPath): Existence = existsStrict(path, Mode.AUTO)
+
+    /**
+     * Existence keeping "not there" apart from "could not look", so it cannot ride on
+     * [executeWithModeSelection]: that escalates on a thrown [IOException], and an UNKNOWN answer
+     * is a return value, not a throw. Escalation happens on UNKNOWN here instead, and a mode that
+     * cannot be reached at all is UNKNOWN rather than an error.
+     */
+    suspend fun existsStrict(
+        path: LocalPath,
+        mode: Mode = Mode.AUTO
+    ): Existence = runIO {
+        suspend fun direct(): Existence = probeExistence("existsStrict(DIRECT) -> $path") {
+            fileSystemOps.existsStrict(path)
+        }
+
+        suspend fun viaClient(clientMode: Mode): Existence =
+            probeExistence("existsStrict($clientMode) -> $path") {
+                clientOps(clientMode) { it.existsStrict(path) }
+            }
+
+        when (mode) {
+            Mode.DIRECT -> direct()
+            Mode.ISOLATED, Mode.ROOT, Mode.ADB -> viaClient(mode)
+            Mode.AUTO -> {
+                // For removable storage, prefer ISOLATED mode to protect against sudden disconnect
+                if (isOnRemovableStorage(path)) {
+                    return@runIO try {
+                        clientOps(Mode.ISOLATED) { it.existsStrict(path) }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: ServiceBindException) {
+                        log(TAG, WARN) {
+                            "existsStrict: IsolatedService unavailable for removable storage, falling back to DIRECT"
+                        }
+                        direct()
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "existsStrict(AUTO:ISOLATED) -> $path failed: ${e.asLog()}" }
+                        Existence.UNKNOWN
+                    }
+                }
+
+                val directAnswer = when {
+                    accessChecker.shouldTryNormalAccess(path, false) -> direct()
+                    else -> Existence.UNKNOWN
+                }
+                if (directAnswer != Existence.UNKNOWN) return@runIO directAnswer
+
+                when (val escMode = selectEscalationModeOrNull()) {
+                    null -> Existence.UNKNOWN
+                    else -> viaClient(escMode)
+                }
+            }
+        }
+    }
+
+    private suspend fun probeExistence(label: String, block: suspend () -> Existence): Existence = try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "$label failed: ${e.asLog()}" }
+        Existence.UNKNOWN
+    }
 
     override suspend fun canWrite(path: LocalPath): Boolean = canWrite(path, Mode.AUTO)
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsClient.kt
@@ -204,7 +204,7 @@ class FileOpsClient @AssistedInject constructor(
         Existence.fromIpcCode(fileOpsConnection.existsStrict(path))
     } catch (e: CancellationException) {
         throw e
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
         // A dead service or a failed transport is not an answer about the path.
         log(TAG, WARN) { "existsStrict($path) failed: $e" }
         Existence.UNKNOWN

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsClient.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APathGateway
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MoveOutcome
@@ -197,6 +198,16 @@ class FileOpsClient @AssistedInject constructor(
         fileOpsConnection.exists(path)
     } catch (e: Exception) {
         throw e.refineException()
+    }
+
+    override suspend fun existsStrict(path: LocalPath): Existence = try {
+        Existence.fromIpcCode(fileOpsConnection.existsStrict(path))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        // A dead service or a failed transport is not an answer about the path.
+        log(TAG, WARN) { "existsStrict($path) failed: $e" }
+        Existence.UNKNOWN
     }
 
     override suspend fun delete(path: LocalPath, recursive: Boolean): Boolean = try {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsHost.kt
@@ -11,6 +11,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.LookupOptions
@@ -190,6 +191,19 @@ class FileOpsHost @Inject constructor(
     } catch (e: Exception) {
         log(TAG, ERROR) { "exists(path=$path) failed\n${e.asLog()}" }
         throw e.wrapToPropagate()
+    }
+
+    /**
+     * Never throws across the binder: typed exceptions do not survive it in a minified build (R8
+     * strips the single-String constructor [eu.darken.butler.common.ipc.IpcClientModule] needs
+     * reflectively), a code does. A failure here is [Existence.UNKNOWN], the honest answer anyway.
+     */
+    override fun existsStrict(path: LocalPath): Int = try {
+        if (Bugs.isTrace) log(TAG, VERBOSE) { "existsStrict($path)..." }
+        runBlocking { fileSystemOps.existsStrict(path) }.ipcCode
+    } catch (e: Exception) {
+        log(TAG, ERROR) { "existsStrict(path=$path) failed\n${e.asLog()}" }
+        Existence.UNKNOWN.ipcCode
     }
 
     override fun delete(path: LocalPath, recursive: Boolean): Boolean = try {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/routing/RoutedLocalFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/routing/RoutedLocalFileSystemOps.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.local.routing
 
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
@@ -81,6 +82,19 @@ internal class RoutedLocalFileSystemOps(
 
     override suspend fun exists(path: LocalPath): Boolean =
         lookup(path, defaultLookupIntent, LookupOptions.BASE.copy(fallbackToUnknown = true)).fileType != FileType.UNKNOWN
+
+    /**
+     * Asks the route's ops directly instead of going through a fallback lookup like [exists] does:
+     * that lookup reports [FileType.UNKNOWN] for an entry it could not read, which is neither of
+     * the two answers a strict probe may give.
+     */
+    override suspend fun existsStrict(path: LocalPath): Existence = try {
+        router.routeFor(path, AccessIntent.Read).ops.existsStrict(path)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: RouteUnavailableException) {
+        Existence.UNKNOWN
+    }
 
     override suspend fun delete(path: LocalPath, recursive: Boolean): Boolean {
         val route = router.routeFor(path, AccessIntent.Delete)

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/routing/RoutedLocalFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/routing/RoutedLocalFileSystemOps.kt
@@ -92,7 +92,7 @@ internal class RoutedLocalFileSystemOps(
         router.routeFor(path, AccessIntent.Read).ops.existsStrict(path)
     } catch (e: CancellationException) {
         throw e
-    } catch (e: RouteUnavailableException) {
+    } catch (e: Exception) {
         Existence.UNKNOWN
     }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
@@ -311,6 +312,20 @@ class SAFFileSystemOps @Inject constructor(
         docFile.exists
     } catch (e: Exception) {
         throw ReadException(path = path, cause = e)
+    }
+
+    /**
+     * Uses [SAFDocFile.existsStrict], which addresses the provider through a client: no client means
+     * nobody was asked, while [SAFDocFile.exists] cannot tell that from a document that is gone.
+     */
+    override suspend fun existsStrict(path: SAFPath): Existence = try {
+        val docFile = path.resolveDocFile()
+        if (docFile.existsStrict()) Existence.PRESENT else Existence.ABSENT
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "existsStrict($path) could not be answered: ${e.asLog()}" }
+        Existence.UNKNOWN
     }
 
     override suspend fun delete(path: SAFPath, recursive: Boolean): Boolean {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/smb/SmbFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/smb/SmbFileSystemOps.kt
@@ -135,8 +135,9 @@ class SmbFileSystemOps @Inject constructor(
      */
     override suspend fun existsStrict(path: SmbPath): Existence = try {
         read(path, "existsStrict") { lease ->
-            // The lease itself is the proof: it only exists once the share was reached.
-            if (path.segments.isEmpty()) return@read Existence.PRESENT
+            // The lease itself is the proof: it only exists once the share was reached. That proof
+            // covers the share root only, a base path addresses a directory inside it and is probed.
+            if (path.segments.isEmpty() && lease.location.basePath.isEmpty()) return@read Existence.PRESENT
             try {
                 lease.share.getFileInformation(lease.smbPath(path))
                 Existence.PRESENT

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/smb/SmbFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/smb/SmbFileSystemOps.kt
@@ -15,6 +15,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
@@ -122,6 +123,32 @@ class SmbFileSystemOps @Inject constructor(
     } catch (e: Exception) {
         log(TAG, VERBOSE) { "exists($path) -> false ($e)" }
         false
+    }
+
+    /**
+     * One round trip, the same [com.hierynomus.smbj.share.DiskShare.getFileInformation] call
+     * [lookup] uses: probing file and folder separately would answer "neither" for a node that
+     * changes kind between the two calls, which is the false absence this exists to avoid.
+     *
+     * The status is classified inside the lease block, where the raw SMB exception is still
+     * available - [runOp] wraps it on the way out.
+     */
+    override suspend fun existsStrict(path: SmbPath): Existence = try {
+        read(path, "existsStrict") { lease ->
+            // The lease itself is the proof: it only exists once the share was reached.
+            if (path.segments.isEmpty()) return@read Existence.PRESENT
+            try {
+                lease.share.getFileInformation(lease.smbPath(path))
+                Existence.PRESENT
+            } catch (e: Exception) {
+                if (SmbStatusMapper.isMissing(e)) Existence.ABSENT else throw e
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "existsStrict($path) could not be answered: ${e.asLog()}" }
+        Existence.UNKNOWN
     }
 
     override suspend fun delete(path: SmbPath, recursive: Boolean): Boolean = mutate(path, "delete") { lease ->

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/GatewaySwitchExistsStrictTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/GatewaySwitchExistsStrictTest.kt
@@ -1,0 +1,127 @@
+package eu.darken.butler.common.files
+
+import eu.darken.butler.common.files.archive.ArchiveGateway
+import eu.darken.butler.common.files.io.ProxyPfdFactory
+import eu.darken.butler.common.files.local.LocalGateway
+import eu.darken.butler.common.files.saf.SAFGateway
+import eu.darken.butler.common.files.saf.location.SAFLocationManager
+import eu.darken.butler.common.files.smb.SmbGateway
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.uuid.Uuid
+
+/**
+ * AUTO retries an unanswered probe on the alternative path, which only exists for the local/SAF
+ * split. Every other type has to come back as "could not tell" rather than as a failure.
+ */
+class GatewaySwitchExistsStrictTest : BaseTest() {
+
+    private val safGateway: SAFGateway = mockk(relaxed = true)
+    private val localGateway: LocalGateway = mockk(relaxed = true)
+    private val archiveGateway: ArchiveGateway = mockk(relaxed = true)
+    private val smbGateway: SmbGateway = mockk(relaxed = true)
+    private val safLocationManager: SAFLocationManager = mockk(relaxed = true)
+
+    private val gatewaySwitch = GatewaySwitch(
+        appScope = TestScope(),
+        dispatcherProvider = TestDispatcherProvider(),
+        safGateway = safGateway,
+        localGateway = localGateway,
+        archiveGateway = archiveGateway,
+        smbGateway = smbGateway,
+        safLocationManager = safLocationManager,
+        proxyPfdFactory = mockk<ProxyPfdFactory>(relaxed = true),
+    )
+
+    @Test
+    fun `a definitive answer is passed through`() = runTest {
+        val path = LocalPath.build("/sdcard/gone.txt")
+        coEvery { localGateway.existsStrict(path) } returns Existence.ABSENT
+
+        gatewaySwitch.existsStrict(path) shouldBe Existence.ABSENT
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.AUTO) shouldBe Existence.ABSENT
+
+        coVerify(exactly = 0) { safGateway.existsStrict(any()) }
+    }
+
+    @Test
+    fun `AUTO retries an unanswered local probe on the SAF side`() = runTest {
+        val path = LocalPath.build("/storage/emulated/0/Music")
+        val alternative = SAFPath.build(SAF_TREE_ROOT, "Music")
+        coEvery { localGateway.existsStrict(path) } returns Existence.UNKNOWN
+        coEvery { safLocationManager.toSAFPath(path) } returns alternative
+        coEvery { safGateway.existsStrict(alternative) } returns Existence.PRESENT
+
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.AUTO) shouldBe Existence.PRESENT
+    }
+
+    @Test
+    fun `CURRENT keeps an unanswered probe unanswered`() = runTest {
+        val path = LocalPath.build("/storage/emulated/0/Music")
+        coEvery { localGateway.existsStrict(path) } returns Existence.UNKNOWN
+
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.CURRENT) shouldBe Existence.UNKNOWN
+
+        coVerify(exactly = 0) { safGateway.existsStrict(any()) }
+    }
+
+    /** No mapped SAF location means there is no alternative to ask, not a failure to report. */
+    @Test
+    fun `an unmappable path stays unanswered`() = runTest {
+        val path = LocalPath.build("/data/data/eu.darken.butler")
+        coEvery { localGateway.existsStrict(path) } returns Existence.UNKNOWN
+        coEvery { safLocationManager.toSAFPath(path) } returns null
+
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.AUTO) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `a failing alternative leaves the original answer standing`() = runTest {
+        val path = SAFPath.build(SAF_TREE_ROOT, "Music")
+        val alternative = LocalPath.build("/storage/emulated/0/Music")
+        coEvery { safGateway.existsStrict(path) } returns Existence.UNKNOWN
+        coEvery { safLocationManager.toLocalPath(path) } returns alternative
+        coEvery { localGateway.existsStrict(alternative) } throws IllegalStateException("boom")
+
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.AUTO) shouldBe Existence.UNKNOWN
+    }
+
+    /** toAlternative() has none for these two, so AUTO must not turn UNKNOWN into a thrown error. */
+    @Test
+    fun `an unanswered network probe is not a failure`() = runTest {
+        val path = SmbPath(LOCATION_ID, listOf("media"))
+        coEvery { smbGateway.existsStrict(path) } returns Existence.UNKNOWN
+
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.AUTO) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `an unanswered archive probe is not a failure`() = runTest {
+        val path = ArchivePath(LocalPath.build("/sdcard/archive.zip"), listOf("docs"))
+        coEvery { archiveGateway.existsStrict(path) } returns Existence.UNKNOWN
+
+        gatewaySwitch.existsStrict(path, GatewaySwitch.Type.AUTO) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `cancellation propagates`() = runTest {
+        val path = LocalPath.build("/sdcard/file.txt")
+        coEvery { localGateway.existsStrict(path) } throws CancellationException("cancelled")
+
+        shouldThrow<CancellationException> { gatewaySwitch.existsStrict(path) }
+    }
+
+    companion object {
+        private val LOCATION_ID = Uuid.parse("11111111-2222-3333-4444-555555555555")
+        private const val SAF_TREE_ROOT = "content://com.android.externalstorage.documents/tree/primary%3A"
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/archive/ArchiveGatewayExistsStrictTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/archive/ArchiveGatewayExistsStrictTest.kt
@@ -1,0 +1,168 @@
+package eu.darken.butler.common.files.archive
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.errors.PathNotFoundException
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import net.lingala.zip4j.ZipFile
+import okio.Path.Companion.toOkioPath
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.io.File
+import kotlin.time.Instant
+
+/**
+ * A container that cannot be read says nothing about the entry inside it, and indexing stats the
+ * container first, so a deleted archive fails exactly like a corrupt one.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class ArchiveGatewayExistsStrictTest : BaseTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    private val dispatcherProvider = TestDispatcherProvider()
+    private val cacheDir = File(context.cacheDir, "archives")
+
+    private lateinit var workDir: File
+    private lateinit var gatewaySwitch: GatewaySwitch
+
+    @Before
+    fun setup() {
+        workDir = File(context.cacheDir, "archive_exists_test").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        cacheDir.deleteRecursively()
+        gatewaySwitch = mockk<GatewaySwitch>().apply {
+            coEvery { openInputStream(any()) } answers { firstArg<LocalPath>().file.inputStream() }
+            coEvery { file(any(), any()) } answers {
+                okio.FileSystem.SYSTEM.openReadOnly(firstArg<LocalPath>().file.toOkioPath())
+            }
+            coEvery { lookup(any(), any<LookupOptions>()) } answers {
+                val file = firstArg<LocalPath>().file
+                if (!file.exists()) throw PathNotFoundException(firstArg<LocalPath>())
+                @Suppress("UNCHECKED_CAST")
+                file.toLookup() as APathLookup<APath<*>>
+            }
+            coEvery { existsStrict(any()) } answers {
+                if (firstArg<LocalPath>().file.exists()) Existence.PRESENT else Existence.ABSENT
+            }
+        }
+    }
+
+    @After
+    fun teardown() {
+        appScope.cancel()
+        workDir.deleteRecursively()
+        cacheDir.deleteRecursively()
+    }
+
+    private fun File.toLookup() = LocalPathLookup(
+        lookedUp = LocalPath.build(this),
+        fileType = if (isDirectory) FileType.DIRECTORY else FileType.FILE,
+        size = if (isFile) length() else null,
+        modifiedAt = Instant.fromEpochMilliseconds(lastModified()),
+    )
+
+    private fun gateway() = ArchiveGateway(
+        appScope = appScope,
+        dispatcherProvider = dispatcherProvider,
+        service = ArchiveService(
+            dispatcherProvider = dispatcherProvider,
+            gatewaySwitchLazy = { gatewaySwitch },
+            diskCache = ArchiveDiskCache(
+                context = context,
+                appScope = appScope,
+                dispatcherProvider = dispatcherProvider,
+            ),
+            passwordStore = ArchivePasswordStore(),
+        ),
+    )
+
+    private fun buildZip(name: String): LocalPath {
+        val zipFile = File(workDir, name)
+        ZipFile(zipFile).use { zip ->
+            val src = File(workDir, "entry.txt").apply { writeText("content") }
+            zip.addFile(src)
+        }
+        return LocalPath.build(zipFile)
+    }
+
+    private fun buildTar(name: String): LocalPath {
+        val tarFile = File(workDir, name)
+        TarArchiveOutputStream(tarFile.outputStream()).use { tar ->
+            val content = "tar content".toByteArray()
+            tar.putArchiveEntry(TarArchiveEntry("data.txt").apply { size = content.size.toLong() })
+            tar.write(content)
+            tar.closeArchiveEntry()
+        }
+        return LocalPath.build(tarFile)
+    }
+
+    @Test
+    fun `an entry in a readable container is answered from the index`() = runTest2 {
+        val container = buildZip("readable.zip")
+
+        gateway().existsStrict(ArchivePath(container, listOf("entry.txt"))) shouldBe Existence.PRESENT
+        gateway().existsStrict(ArchivePath(container, listOf("nope.txt"))) shouldBe Existence.ABSENT
+        gateway().existsStrict(ArchivePath(container, emptyList())) shouldBe Existence.PRESENT
+    }
+
+    @Test
+    fun `a deleted container makes its root absent`() = runTest2 {
+        val container = buildZip("deleted.zip")
+        container.file.delete()
+
+        gateway().existsStrict(ArchivePath(container, emptyList())) shouldBe Existence.ABSENT
+    }
+
+    @Test
+    fun `a deleted container makes an entry inside it absent`() = runTest2 {
+        val container = buildZip("deleted_entry.zip")
+        container.file.delete()
+
+        gateway().existsStrict(ArchivePath(container, listOf("entry.txt"))) shouldBe Existence.ABSENT
+    }
+
+    @Test
+    fun `a corrupt container cannot answer for its entries`() = runTest2 {
+        val container = buildZip("corrupt.zip")
+        container.file.writeBytes("this is not a zip".toByteArray())
+
+        gateway().existsStrict(ArchivePath(container, listOf("entry.txt"))) shouldBe Existence.UNKNOWN
+    }
+
+    /** Tar scanning propagates raw IOExceptions, which a ReadException-only catch would miss. */
+    @Test
+    fun `a corrupt tar cannot answer for its entries`() = runTest2 {
+        val container = buildTar("corrupt.tar")
+        container.file.writeBytes(ByteArray(2048) { 0x41 })
+
+        gateway().existsStrict(ArchivePath(container, listOf("data.txt"))) shouldBe Existence.UNKNOWN
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalFileSystemOpsTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.local
 
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
@@ -24,10 +25,16 @@ import io.mockk.mockkConstructor
 import io.mockk.spyk
 import io.mockk.unmockkConstructor
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import testhelpers.BaseTest
 import java.io.File
+import java.io.IOException
+import java.nio.file.AccessDeniedException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import kotlin.time.Instant
 
 class LocalFileSystemOpsTest : BaseTest() {
@@ -262,6 +269,56 @@ class LocalFileSystemOpsTest : BaseTest() {
         val path = LocalPath.build(tempDir, "non-existent.txt")
 
         fileSystemOps.exists(path) shouldBe false
+    }
+
+    @Test
+    fun `existsStrict reports an existing file as present`(@TempDir tempDir: File) = runTest {
+        val testFile = File(tempDir, "test.txt").apply { createNewFile() }
+
+        fileSystemOps.existsStrict(LocalPath.build(testFile)) shouldBe Existence.PRESENT
+    }
+
+    @Test
+    fun `existsStrict reports a missing file as absent`(@TempDir tempDir: File) = runTest {
+        fileSystemOps.existsStrict(LocalPath.build(tempDir, "non-existent.txt")) shouldBe Existence.ABSENT
+    }
+
+    /** The link itself is what is checked, so a target that is gone does not make the link absent. */
+    @Test
+    fun `existsStrict reports a dangling symlink as present`(@TempDir tempDir: File) = runTest {
+        val link = File(tempDir, "dangling")
+        Files.createSymbolicLink(link.toPath(), File(tempDir, "nowhere").toPath())
+
+        fileSystemOps.existsStrict(LocalPath.build(link)) shouldBe Existence.PRESENT
+    }
+
+    @Test
+    fun `a denied stat is not an absence`(@TempDir tempDir: File) = runTest {
+        val path = LocalPath.build(tempDir, "secret.txt")
+
+        fileSystemOps.classifyExistence(path, AccessDeniedException(path.path)) shouldBe Existence.UNKNOWN
+        fileSystemOps.classifyExistence(path, NoSuchFileException(path.path)) shouldBe Existence.ABSENT
+        fileSystemOps.classifyExistence(path, IOException("I/O error")) shouldBe Existence.UNKNOWN
+        fileSystemOps.classifyExistence(path, SecurityException("no")) shouldBe Existence.UNKNOWN
+    }
+
+    /** The same on a real file system, where the denial comes from the kernel rather than a stub. */
+    @Test
+    fun `a stat denied by the file system is not an absence`(@TempDir tempDir: File) = runTest {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"))
+        val locked = File(tempDir, "locked").apply { mkdirs() }
+        val target = File(locked, "secret.txt").apply { writeText("content") }
+        val originalPermissions = Files.getPosixFilePermissions(locked.toPath())
+
+        try {
+            Files.setPosixFilePermissions(locked.toPath(), emptySet())
+            // Root ignores the permission bits, there is nothing to observe then.
+            assumeTrue(!Files.isReadable(locked.toPath()))
+
+            fileSystemOps.existsStrict(LocalPath.build(target)) shouldBe Existence.UNKNOWN
+        } finally {
+            Files.setPosixFilePermissions(locked.toPath(), originalPermissions)
+        }
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalGatewayExistsStrictTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalGatewayExistsStrictTest.kt
@@ -1,0 +1,254 @@
+package eu.darken.butler.common.files.local
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.darken.butler.common.adb.AdbManager
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.accessibility.LocalPathAccessChecker
+import eu.darken.butler.common.files.local.ipc.FileOpsClient
+import eu.darken.butler.common.files.local.routing.LocalPathRoutingPolicy
+import eu.darken.butler.common.files.local.routing.ModeSessionFactory
+import eu.darken.butler.common.files.local.service.IsolatedServiceClient
+import eu.darken.butler.common.root.RootManager
+import eu.darken.butler.common.root.service.RootServiceClient
+import eu.darken.butler.common.sharedresource.Resource
+import eu.darken.butler.common.storage.StorageManager2
+import eu.darken.butler.common.storage.StorageVolumeX
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.EmptyApp
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.io.File
+import java.io.IOException
+
+/**
+ * Mode selection for the strict existence probe. It cannot ride on the shared mode dispatch:
+ * that escalates on a thrown IOException, while "could not tell" is a return value here.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29], application = EmptyApp::class)
+class LocalGatewayExistsStrictTest : BaseTest() {
+
+    private lateinit var mockFileSystemOps: LocalFileSystemOps
+    private lateinit var mockRootManager: RootManager
+    private lateinit var mockAdbManager: AdbManager
+    private lateinit var mockAccessChecker: LocalPathAccessChecker
+    private lateinit var mockIsolatedServiceClient: IsolatedServiceClient
+    private lateinit var mockStorageManager: StorageManager2
+    private lateinit var mockRoutingPolicy: LocalPathRoutingPolicy
+    private lateinit var mockModeSessionFactory: ModeSessionFactory
+    private lateinit var mockRootServiceClient: RootServiceClient
+    private lateinit var mockRootFileOpsClient: FileOpsClient
+    private lateinit var mockIsolatedFileOpsClient: FileOpsClient
+    private lateinit var gateway: LocalGateway
+
+    @Before
+    fun setup() {
+        mockFileSystemOps = mockk()
+        mockRootManager = mockk()
+        mockAdbManager = mockk()
+        mockAccessChecker = mockk(relaxed = true)
+        mockIsolatedServiceClient = mockk(relaxed = true)
+        mockStorageManager = mockk(relaxed = true)
+        mockRoutingPolicy = mockk(relaxed = true)
+        mockModeSessionFactory = mockk(relaxed = true)
+        mockRootServiceClient = mockk(relaxed = true)
+        mockRootFileOpsClient = mockk()
+        mockIsolatedFileOpsClient = mockk()
+
+        every { mockRootManager.useRoot } returns flowOf(false)
+        every { mockAdbManager.useAdb } returns flowOf(false)
+        every { mockRootManager.serviceClient } returns mockRootServiceClient
+        every { mockAdbManager.serviceClient } returns mockk(relaxed = true)
+        every { mockAccessChecker.shouldTryNormalAccess(any(), any()) } returns true
+        every { mockStorageManager.storageVolumes } returns emptyList()
+
+        coEvery { mockRootServiceClient.get() } answers { rootResource() }
+        coEvery { mockIsolatedServiceClient.get() } answers { isolatedResource() }
+
+        gateway = LocalGateway(
+            appScope = TestScope(),
+            dispatcherProvider = TestDispatcherProvider(),
+            fileSystemOps = mockFileSystemOps,
+            rootManager = mockRootManager,
+            adbManager = mockAdbManager,
+            accessChecker = mockAccessChecker,
+            isolatedServiceClient = mockIsolatedServiceClient,
+            storageManager = mockStorageManager,
+            routingPolicy = mockRoutingPolicy,
+            modeSessionFactory = mockModeSessionFactory,
+        )
+    }
+
+    private fun rootResource(): Resource<RootServiceClient.Connection> {
+        val connection = mockk<RootServiceClient.Connection> {
+            every { clientModules } returns listOf(mockRootFileOpsClient)
+        }
+        return mockk<Resource<RootServiceClient.Connection>> {
+            every { item } returns connection
+            every { close() } just Runs
+        }
+    }
+
+    private fun isolatedResource(): Resource<IsolatedServiceClient.Connection> {
+        val connection = mockk<IsolatedServiceClient.Connection> {
+            every { clientModules } returns listOf(mockIsolatedFileOpsClient)
+        }
+        return mockk<Resource<IsolatedServiceClient.Connection>> {
+            every { item } returns connection
+            every { close() } just Runs
+        }
+    }
+
+    /** Makes [REMOVABLE_PATH] sit on a removable volume. */
+    private fun onRemovableStorage() {
+        val volume = mockk<StorageVolumeX> {
+            every { directory } returns File("/storage/1234-ABCD")
+            every { isRemovable } returns true
+        }
+        every { mockStorageManager.storageVolumes } returns listOf(volume)
+    }
+
+    @Test
+    fun `AUTO takes a definitive direct answer`() = runTest2 {
+        val path = LocalPath.build("/sdcard/gone.txt")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.ABSENT
+
+        gateway.existsStrict(path) shouldBe Existence.ABSENT
+
+        coVerify(exactly = 1) { mockFileSystemOps.existsStrict(path) }
+        coVerify(exactly = 0) { mockRootFileOpsClient.existsStrict(any()) }
+    }
+
+    @Test
+    fun `AUTO escalates when the direct probe cannot tell`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.UNKNOWN
+        every { mockRootManager.useRoot } returns flowOf(true)
+        coEvery { mockRootFileOpsClient.existsStrict(path) } returns Existence.PRESENT
+
+        gateway.existsStrict(path) shouldBe Existence.PRESENT
+
+        coVerify(exactly = 1) { mockFileSystemOps.existsStrict(path) }
+        coVerify(exactly = 1) { mockRootFileOpsClient.existsStrict(path) }
+    }
+
+    @Test
+    fun `AUTO escalates when the direct probe throws`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        coEvery { mockFileSystemOps.existsStrict(path) } throws IOException("Permission denied")
+        every { mockRootManager.useRoot } returns flowOf(true)
+        coEvery { mockRootFileOpsClient.existsStrict(path) } returns Existence.ABSENT
+
+        gateway.existsStrict(path) shouldBe Existence.ABSENT
+    }
+
+    @Test
+    fun `AUTO skips the direct probe where normal access is pointless`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        every { mockAccessChecker.shouldTryNormalAccess(path, false) } returns false
+        every { mockRootManager.useRoot } returns flowOf(true)
+        coEvery { mockRootFileOpsClient.existsStrict(path) } returns Existence.ABSENT
+
+        gateway.existsStrict(path) shouldBe Existence.ABSENT
+
+        coVerify(exactly = 0) { mockFileSystemOps.existsStrict(any()) }
+    }
+
+    /** Nothing left to ask is not an absence, and not a permission error either. */
+    @Test
+    fun `AUTO without an escalation mechanism cannot tell`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.UNKNOWN
+
+        gateway.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `AUTO cannot tell when the escalated service is unreachable`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.UNKNOWN
+        every { mockRootManager.useRoot } returns flowOf(true)
+        coEvery { mockRootServiceClient.get() } throws IOException("host died")
+
+        gateway.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `an escalated answer that cannot tell stays unknown`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.UNKNOWN
+        every { mockRootManager.useRoot } returns flowOf(true)
+        coEvery { mockRootFileOpsClient.existsStrict(path) } returns Existence.UNKNOWN
+
+        gateway.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `an explicit mode that is unavailable cannot tell`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+
+        gateway.existsStrict(path, LocalGateway.Mode.ROOT) shouldBe Existence.UNKNOWN
+
+        coVerify(exactly = 0) { mockFileSystemOps.existsStrict(any()) }
+    }
+
+    @Test
+    fun `an explicit mode answers from that mode alone`() = runTest2 {
+        val path = LocalPath.build("/data/data/com.example")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.PRESENT
+
+        gateway.existsStrict(path, LocalGateway.Mode.DIRECT) shouldBe Existence.PRESENT
+
+        coVerify(exactly = 0) { mockRootFileOpsClient.existsStrict(any()) }
+    }
+
+    /** Crash isolation against a card being pulled mid-probe, as for every other AUTO operation. */
+    @Test
+    fun `removable storage is probed through the isolated service`() = runTest2 {
+        val path = REMOVABLE_PATH
+        onRemovableStorage()
+        coEvery { mockIsolatedFileOpsClient.existsStrict(path) } returns Existence.ABSENT
+
+        gateway.existsStrict(path) shouldBe Existence.ABSENT
+
+        coVerify(exactly = 0) { mockFileSystemOps.existsStrict(any()) }
+    }
+
+    @Test
+    fun `removable storage falls back to direct when the isolated service does not bind`() = runTest2 {
+        val path = REMOVABLE_PATH
+        onRemovableStorage()
+        coEvery { mockIsolatedServiceClient.get() } throws
+            IsolatedServiceClient.ServiceBindException("no service")
+        coEvery { mockFileSystemOps.existsStrict(path) } returns Existence.PRESENT
+
+        gateway.existsStrict(path) shouldBe Existence.PRESENT
+    }
+
+    @Test
+    fun `removable storage cannot tell when the isolated probe fails otherwise`() = runTest2 {
+        val path = REMOVABLE_PATH
+        onRemovableStorage()
+        coEvery { mockIsolatedFileOpsClient.existsStrict(path) } throws IOException("transport gone")
+
+        gateway.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    companion object {
+        private val REMOVABLE_PATH = LocalPath.build("/storage/1234-ABCD/DCIM")
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/FileOpsExistsStrictTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/FileOpsExistsStrictTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.butler.common.files.local.ipc
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalFileSystemOps
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * The existence answer crosses the binder as an int, so both ends have to agree on the mapping and
+ * neither may turn a transport failure into an answer about the path.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FileOpsExistsStrictTest : BaseTest() {
+
+    private val path = LocalPath.build("/data/data/eu.darken.butler")
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val connection = mockk<FileOpsConnection>()
+    private val client = FileOpsClient(connection)
+    private val hostOps = mockk<LocalFileSystemOps>()
+
+    private fun host() = FileOpsHost(
+        context = ApplicationProvider.getApplicationContext<Context>(),
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(),
+        fileSystemOps = hostOps,
+    )
+
+    @After
+    fun teardown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `every answer survives the round trip`() = runTest {
+        Existence.entries.forEach { existence ->
+            coEvery { hostOps.existsStrict(path) } returns existence
+            every { connection.existsStrict(path) } returns host().existsStrict(path)
+
+            client.existsStrict(path) shouldBe existence
+        }
+    }
+
+    /** A host on an older build answering with a code this one does not know is not an answer. */
+    @Test
+    fun `an unknown code reads as unknown`() = runTest {
+        every { connection.existsStrict(path) } returns 42
+
+        client.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `a failed transport is not an answer`() = runTest {
+        every { connection.existsStrict(path) } throws IOException("binder died")
+
+        client.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `cancellation propagates instead of becoming an answer`() = runTest {
+        every { connection.existsStrict(path) } throws CancellationException("cancelled")
+
+        shouldThrow<CancellationException> { client.existsStrict(path) }
+    }
+
+    @Test
+    fun `the host reports a backend failure as unknown instead of throwing`() {
+        coEvery { hostOps.existsStrict(path) } throws IOException("stat blew up")
+
+        host().existsStrict(path) shouldBe Existence.UNKNOWN.ipcCode
+    }
+
+    @Test
+    fun `the host passes a definitive backend answer through`() {
+        coEvery { hostOps.existsStrict(path) } returns Existence.ABSENT
+
+        host().existsStrict(path) shouldBe Existence.ABSENT.ipcCode
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/operations/MockFileSystemOps.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/operations/MockFileSystemOps.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.files.operations
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
@@ -117,9 +118,18 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
     val lookupCalls = mutableListOf<String>()
     val listFilesCalls = mutableListOf<String>()
     val existsCalls = mutableListOf<String>()
+    val existsStrictCalls = mutableListOf<String>()
     val deleteCalls = mutableListOf<String>()
     val createDirCalls = mutableListOf<String>()
     val createFileCalls = mutableListOf<String>()
+
+    /**
+     * Answers for [existsStrict], per path and as a fallback. Deliberately not derived from the
+     * in-memory files: a mock that maps "no such entry" to ABSENT reproduces exactly the conflation
+     * the strict probe exists to avoid, so a test states which of the two it means.
+     */
+    val existsStrictAnswers = mutableMapOf<String, Existence>()
+    var defaultExistsStrict: Existence = Existence.UNKNOWN
 
     /**
      * Failure injection for testing retry scenarios.
@@ -197,6 +207,11 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
     override suspend fun exists(path: P): Boolean {
         existsCalls.add(path.path)
         return files.containsKey(path.path)
+    }
+
+    override suspend fun existsStrict(path: P): Existence {
+        existsStrictCalls.add(path.path)
+        return existsStrictAnswers[path.path] ?: defaultExistsStrict
     }
 
     override suspend fun canWrite(path: P): Boolean {
@@ -605,6 +620,9 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
         lookupCalls.clear()
         listFilesCalls.clear()
         existsCalls.clear()
+        existsStrictCalls.clear()
+        existsStrictAnswers.clear()
+        defaultExistsStrict = Existence.UNKNOWN
         deleteCalls.clear()
         createDirCalls.clear()
         createFileCalls.clear()

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/MockSAFFileSystemOps.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/MockSAFFileSystemOps.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.saf
 
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.SAFPath
@@ -180,6 +181,12 @@ class MockSAFFileSystemOps : MockFileSystemOps<SAFPath, SAFPathLookup>(
         }
 
         return super.exists(path)
+    }
+
+    /** A missing grant means nobody was asked, which is not an absence - as in SAFFileSystemOps. */
+    override suspend fun existsStrict(path: SAFPath): Existence = when {
+        pathsWithoutPermission.contains(path.path) -> Existence.UNKNOWN
+        else -> super.existsStrict(path)
     }
 
     override suspend fun createSymlink(linkPath: SAFPath, targetPath: SAFPath): Boolean {

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
@@ -1,7 +1,14 @@
 package eu.darken.butler.common.files.saf
 
+import android.content.ContentProviderClient
 import android.content.ContentResolver
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.os.RemoteException
+import android.provider.DocumentsContract
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.errors.ReadException
@@ -11,6 +18,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -126,5 +134,95 @@ class SAFFileSystemOpsTest : BaseTest() {
         shouldThrow<ReadException> {
             fileSystemOps.lookup(path, LookupOptions())
         }
+    }
+
+    // ============ STRICT EXISTENCE TESTS ============
+
+    /**
+     * Points [path] at a document whose provider is reached through [client]; a null client is a
+     * provider that could not be reached at all.
+     */
+    private fun probeVia(path: SAFPath, client: ContentProviderClient?) {
+        val resolver = mockk<ContentResolver>(relaxed = true)
+        every { resolver.acquireUnstableContentProviderClient(PROBE_URI) } returns client
+        coEvery { mockLocationManager.getDocFileFor(path) } returns
+            SAFDocFile(mockk(relaxed = true), resolver, PROBE_URI)
+    }
+
+    private fun providerClient(stub: (ContentProviderClient) -> Unit): ContentProviderClient =
+        mockk<ContentProviderClient>(relaxed = true).also(stub)
+
+    private fun docIdCursor(): Cursor = MatrixCursor(arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID))
+        .apply { addRow(arrayOf("doc:probe")) }
+
+    @Test
+    fun `existsStrict reports a document the provider knows as present`() = runTest {
+        val path = SAFPath.build(testTreeUri, "there.txt")
+        probeVia(path, providerClient { every { it.query(PROBE_URI, PROBE_PROJECTION, null, null, null) } returns docIdCursor() })
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.PRESENT
+    }
+
+    /** A live provider answering with no document is the one definitive absence SAF offers. */
+    @Test
+    fun `existsStrict reports a document a live provider denies as absent`() = runTest {
+        val path = SAFPath.build(testTreeUri, "gone.txt")
+        probeVia(path, providerClient { every { it.query(PROBE_URI, PROBE_PROJECTION, null, null, null) } returns null })
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.ABSENT
+    }
+
+    @Test
+    fun `existsStrict cannot tell without a grant`() = runTest {
+        val path = SAFPath.build(testTreeUri, "restricted.txt")
+        coEvery { mockLocationManager.getDocFileFor(path) } throws MissingUriPermissionException(path = path)
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `existsStrict cannot tell when no provider answers`() = runTest {
+        val path = SAFPath.build(testTreeUri, "unreachable.txt")
+        probeVia(path, client = null)
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `existsStrict cannot tell when the provider dies mid-query`() = runTest {
+        val path = SAFPath.build(testTreeUri, "dying.txt")
+        probeVia(path, providerClient {
+            every { it.query(PROBE_URI, PROBE_PROJECTION, null, null, null) } throws RemoteException("died")
+        })
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `existsStrict cannot tell when the provider refuses access`() = runTest {
+        val path = SAFPath.build(testTreeUri, "refused.txt")
+        probeVia(path, providerClient {
+            every { it.query(PROBE_URI, PROBE_PROJECTION, null, null, null) } throws SecurityException("nope")
+        })
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    /** Only the provider quirks that mean "removed" read as absent, other argument errors do not. */
+    @Test
+    fun `existsStrict cannot tell on an unrelated argument error`() = runTest {
+        val path = SAFPath.build(testTreeUri, "odd.txt")
+        probeVia(path, providerClient {
+            every {
+                it.query(PROBE_URI, PROBE_PROJECTION, null, null, null)
+            } throws IllegalArgumentException("Unknown URI")
+        })
+
+        fileSystemOps.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    companion object {
+        private val PROBE_URI: Uri = Uri.parse("content://com.android.externalstorage.documents/document/probe")
+        private val PROBE_PROJECTION = arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/smb/SmbGatewayIntegrationTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/smb/SmbGatewayIntegrationTest.kt
@@ -305,6 +305,18 @@ class SmbGatewayIntegrationTest : BaseTest() {
     }
 
     @Test
+    fun `a location root inside a deleted base path is an absence`() = runTest {
+        assumeTrue(dockerAvailable)
+        val rig = rig(sambaContainer)
+        // Reaching the share says nothing about a directory inside it, which is what a base path is.
+        rig.location.value = rig.location.value.copy(basePath = listOf("no-such-base"))
+
+        rig.ops.existsStrict(path()) shouldBe Existence.ABSENT
+
+        rig.pool.close()
+    }
+
+    @Test
     fun `an unreachable host is never reported as an absence`() = runTest {
         assumeTrue(dockerAvailable)
         val rig = rig(sambaContainer)

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/smb/SmbGatewayIntegrationTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/smb/SmbGatewayIntegrationTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.smb
 
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.SmbPath
@@ -284,6 +285,38 @@ class SmbGatewayIntegrationTest : BaseTest() {
     }
 
     @Test
+    fun `strict existence tells a missing path from an unreachable host`() = runTest {
+        assumeTrue(dockerAvailable)
+        val rig = rig(sambaContainer)
+        val ops = rig.ops
+
+        val dir = path("strict")
+        ops.createDir(dir)
+
+        ops.existsStrict(dir) shouldBe Existence.PRESENT
+        ops.existsStrict(dir.child("nothing-here")) shouldBe Existence.ABSENT
+        // The share root has no path to query, the lease that reached it is the proof.
+        ops.existsStrict(path()) shouldBe Existence.PRESENT
+
+        ops.delete(dir, recursive = true) shouldBe true
+        ops.existsStrict(dir) shouldBe Existence.ABSENT
+
+        rig.pool.close()
+    }
+
+    @Test
+    fun `an unreachable host is never reported as an absence`() = runTest {
+        assumeTrue(dockerAvailable)
+        val rig = rig(sambaContainer)
+        // Nothing is listening there, so the probe cannot reach the share at all.
+        rig.location.value = rig.location.value.copy(port = UNUSED_PORT)
+
+        rig.ops.existsStrict(path("anything")) shouldBe Existence.UNKNOWN
+
+        rig.pool.close()
+    }
+
+    @Test
     fun `an SMB1-only server is rejected instead of downgraded`() = runTest {
         assumeTrue(dockerAvailable)
         val rig = rig(smb1Container)
@@ -302,6 +335,9 @@ class SmbGatewayIntegrationTest : BaseTest() {
 
         /** Well past Int.MAX_VALUE, the offset every 32-bit truncation bug shows up at. */
         private const val LARGE_OFFSET = 3L * 1024 * 1024 * 1024
+
+        /** Reserved by IANA as "do not use", so nothing is listening on it. */
+        private const val UNUSED_PORT = 47
 
         /** Generous room for the shared resource's own stop timeout. */
         private const val RESOURCE_TEARDOWN_TIMEOUT = 30_000L

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
@@ -25,6 +25,7 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.flow.combine
@@ -260,25 +261,28 @@ class AppDetailsWorkspace @AssistedInject constructor(
         .stateIn(scope, SharingStarted.Eagerly, emptyMap())
 
     /**
-     * [eu.darken.butler.common.files.FileSystemOps.exists] answers false both for "not there" and
-     * for "could not look" - a denied stat returns false without throwing - so a false answer is
-     * only worth trusting with root, and only for the user these paths belong to.
+     * An absence is only trusted with root, and only for the user these paths belong to.
      *
-     * TODO A strict IO-layer probe reporting present/absent/could-not-tell per backend would say
-     *  which of the two a false answer is, which is what withholding the external row again needs.
+     * TODO Withholding the external row needs more than a strict probe: from API 30 on the probe
+     *  escalates to the privileged host, which stats in its own mount namespace and launches
+     *  without mount-master, so an ABSENT under `Android/data` says nothing about the app.
      */
     private suspend fun resolveAvailability(candidate: StorageCandidate, hasRoot: Boolean): Availability {
         val path = candidate.path
         if (!candidate.mayBeWithheld) return Availability.UNKNOWN
         if (!hasRoot || !isPrimaryUser) return Availability.UNKNOWN
         return try {
-            val exists = gatewaySwitch.exists(path)
+            val existence = gatewaySwitch.existsStrict(path)
             currentCoroutineContext().ensureActive()
-            if (exists) Availability.EXISTS else Availability.ABSENT
+            when (existence) {
+                Existence.PRESENT -> Availability.EXISTS
+                Existence.ABSENT -> Availability.ABSENT
+                // A probe that could not tell says nothing; absent has to be a positive answer.
+                Existence.UNKNOWN -> Availability.UNKNOWN
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            // A failed probe says nothing; absent has to be a positive answer.
             log(tag, WARN) { "Existence check failed for $path: ${e.asLog()}" }
             Availability.UNKNOWN
         }

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/AppSizeResolutionE2ETest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/AppSizeResolutionE2ETest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.details.AppDetailsWorkspace
 import eu.darken.butler.apps.core.engine.AppsEngine
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.PkgRepo
@@ -196,8 +197,8 @@ class AppSizeResolutionE2ETest : BaseTest() {
         pkgOps = pkgOps,
         apkArchiveParser = mockk(relaxed = true),
         appSizeCache = cache,
-        // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
-        gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+        // Explicit, not relaxed: an ABSENT answer would silently drop rows.
+        gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
         pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
         rootManager = mockk<eu.darken.butler.common.root.RootManager> {
             every { useRoot } returns flowOf(false)

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceArgumentsTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceArgumentsTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.apps.core.details
 
 import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.common.adb.AdbManager
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.features.InstallId
@@ -47,8 +48,8 @@ class AppDetailsWorkspaceArgumentsTest : BaseTest() {
             every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
             every { isAvailable } returns MutableStateFlow(false)
         },
-        // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
-        gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+        // Explicit, not relaxed: an ABSENT answer would silently drop rows.
+        gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
         pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
         rootManager = mockk<RootManager> { every { useRoot } returns flowOf(false) },
         adbManager = mockk<AdbManager> { every { useAdb } returns flowOf(false) },

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceLabelCaptureTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceLabelCaptureTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.PkgRepo
@@ -71,8 +72,8 @@ class AppDetailsWorkspaceLabelCaptureTest {
                 every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
                 every { isAvailable } returns MutableStateFlow(false)
             },
-            // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
-            gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+            // Explicit, not relaxed: an ABSENT answer would silently drop rows.
+            gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
             pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
             rootManager = mockk(relaxed = true),
             adbManager = mockk(relaxed = true),

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceSeedTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceSeedTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.apps.core.details
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.AppSizeCache
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.features.InstallId
@@ -54,8 +55,8 @@ class AppDetailsWorkspaceSeedTest {
                 every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
                 every { isAvailable } returns MutableStateFlow(false)
             },
-            // Explicit, not relaxed: a false exists() would mean ABSENT and silently drop rows.
-            gatewaySwitch = mockk { coEvery { exists(any()) } returns true },
+            // Explicit, not relaxed: an ABSENT answer would silently drop rows.
+            gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
             pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
             rootManager = mockk(relaxed = true),
             adbManager = mockk(relaxed = true),

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceStoragePathsTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceStoragePathsTest.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
 import eu.darken.butler.common.adb.AdbManager
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.pkgs.Pkg
@@ -42,8 +43,8 @@ import java.io.IOException
 
 /**
  * Only the internal data row can ever be withheld, and only when the directory is positively known
- * to be absent, which the gateway can only answer with root: `exists()` returns false for a denied
- * stat too. The external row is always offered, see `the external row is never withheld`.
+ * to be absent, which the gateway can only answer with root. The external row is always offered,
+ * see `the external row is never withheld`.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -55,7 +56,7 @@ class AppDetailsWorkspaceStoragePathsTest {
     private val workProfileInstallId = InstallId(Pkg.Id(PKG), UserHandle2(10))
 
     private val gatewaySwitch = mockk<GatewaySwitch>().apply {
-        coEvery { exists(any()) } returns true
+        coEvery { existsStrict(any()) } returns Existence.PRESENT
     }
     private val pathPermissionCheck = mockk<PathPermissionCheck>().apply {
         every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements())
@@ -101,9 +102,17 @@ class AppDetailsWorkspaceStoragePathsTest {
 
     @Test
     fun `a directory that is not there is not offered`() = runTest {
-        coEvery { gatewaySwitch.exists(match { it.path == INTERNAL }) } returns false
+        coEvery { gatewaySwitch.existsStrict(match { it.path == INTERNAL }) } returns Existence.ABSENT
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
+    }
+
+    /** A probe that could not tell is not an absence, the row stays offered. */
+    @Test
+    fun `a directory the probe could not check is still offered`() = runTest {
+        coEvery { gatewaySwitch.existsStrict(match { it.path == INTERNAL }) } returns Existence.UNKNOWN
+
+        pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
     }
 
     @Test
@@ -115,7 +124,7 @@ class AppDetailsWorkspaceStoragePathsTest {
     @Test
     fun `without root a negative answer is not trusted`() = runTest {
         useRootFlow.value = false
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
     }
@@ -127,10 +136,10 @@ class AppDetailsWorkspaceStoragePathsTest {
      */
     @Test
     fun `the external row is never withheld`() = runTest {
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
-        coVerify(exactly = 0) { gatewaySwitch.exists(match { it.path == EXTERNAL }) }
+        coVerify(exactly = 0) { gatewaySwitch.existsStrict(match { it.path == EXTERNAL }) }
 
         useRootFlow.value = false
 
@@ -140,7 +149,7 @@ class AppDetailsWorkspaceStoragePathsTest {
     @Test
     @Config(sdk = [29])
     fun `the external row is never withheld on older Android versions either`() = runTest {
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
     }
@@ -148,14 +157,14 @@ class AppDetailsWorkspaceStoragePathsTest {
     /** The paths are user 0's, so for another user their absence says nothing. */
     @Test
     fun `a work profile install keeps its rows`() = runTest {
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         pathsOf(createWorkspace(workProfileInstallId)).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
     }
 
     @Test
     fun `a failed probe keeps the rows`() = runTest {
-        coEvery { gatewaySwitch.exists(any()) } throws IOException("nope")
+        coEvery { gatewaySwitch.existsStrict(any()) } throws IOException("nope")
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
     }
@@ -163,7 +172,7 @@ class AppDetailsWorkspaceStoragePathsTest {
     /** Cancellation is not an answer, so it must not be caught and turned into one. */
     @Test
     fun `a cancelled probe resolves nothing`() = runTest {
-        coEvery { gatewaySwitch.exists(any()) } throws CancellationException("cancelled")
+        coEvery { gatewaySwitch.existsStrict(any()) } throws CancellationException("cancelled")
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
 
@@ -173,7 +182,7 @@ class AppDetailsWorkspaceStoragePathsTest {
     @Test
     fun `enabling root re-probes a row that was shown for lack of knowledge`() = runTest {
         useRootFlow.value = false
-        coEvery { gatewaySwitch.exists(match { it.path == INTERNAL }) } returns false
+        coEvery { gatewaySwitch.existsStrict(match { it.path == INTERNAL }) } returns Existence.ABSENT
         val workspace = createWorkspace()
 
         val seen = mutableListOf<AppDetailsWorkspace.State>()
@@ -196,10 +205,10 @@ class AppDetailsWorkspaceStoragePathsTest {
      */
     @Test
     fun `a resumed workspace probes again`() = runTest {
-        coEvery { gatewaySwitch.exists(match { it.path == INTERNAL }) } returns false
+        coEvery { gatewaySwitch.existsStrict(match { it.path == INTERNAL }) } returns Existence.ABSENT
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(EXTERNAL)
 
-        coEvery { gatewaySwitch.exists(any()) } returns true
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.PRESENT
 
         pathsOf(createWorkspace()).map { it.path.path } shouldBe listOf(INTERNAL, EXTERNAL)
     }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoader.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoader.kt
@@ -13,8 +13,8 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
-import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.SmbPath
@@ -136,10 +136,9 @@ class DirectoryLocationLoader @AssistedInject constructor(
     /**
      * Turns "the target is gone" into a state the page can render instead of a failure card.
      *
-     * Restricted to [LocalPath], the only type whose `exists()` reports an actual stat. For SAF a
-     * false answer also covers a provider that is unreachable, crashing or mid-update, and for SMB
-     * and archives it covers an unreachable host or an unreadable container - in each of those the
-     * original error carries the signal the user needs, see `DirectoryLocationLoaderTest`.
+     * Only a probe that positively reports the target as absent qualifies. An unreachable host, an
+     * unresponsive document provider or an unreadable container answer [Existence.UNKNOWN], and
+     * there the original error carries the signal the user needs, see `DirectoryLocationLoaderTest`.
      */
     private suspend fun <T> LocationLoaderContext<ExplorerLocation.Directory>.asNotFoundIfGone(
         block: suspend () -> T,
@@ -150,21 +149,19 @@ class DirectoryLocationLoader @AssistedInject constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (target !is LocalPath) throw e
-
             currentCoroutineContext().ensureActive()
-            val stillThere = try {
-                gatewaySwitch.exists(target)
+            val existence = try {
+                gatewaySwitch.existsStrict(target)
             } catch (probeError: CancellationException) {
                 throw probeError
             } catch (probeError: Exception) {
                 log(tag, WARN) { "asNotFoundIfGone(): Probe failed for $target: ${probeError.asLog()}" }
-                true
+                Existence.UNKNOWN
             }
             // The probe can outlive its coroutine, and a cancelled load must not turn into a
             // "folder gone" state for a target the user has already navigated away from.
             currentCoroutineContext().ensureActive()
-            if (stillThere) throw e
+            if (existence != Existence.ABSENT) throw e
 
             log(tag, INFO) { "asNotFoundIfGone(): $target is gone, original error was ${e.asLog()}" }
             throw PathNotFoundException(target)

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoaderTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/DirectoryLocationLoaderTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.explorer.core.engine
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
@@ -78,7 +79,7 @@ class DirectoryLocationLoaderTest : BaseTest() {
     @Test
     fun `a local target that is gone fails as not found`() = runTest {
         coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         shouldThrow<PathNotFoundException> { loader().loadDirectory(LOCAL_PATH).toList() }
     }
@@ -87,7 +88,16 @@ class DirectoryLocationLoaderTest : BaseTest() {
     fun `a target that is still there keeps its original error`() = runTest {
         val original = IOException("something else")
         coEvery { gatewaySwitch.listFiles(any()) } throws original
-        coEvery { gatewaySwitch.exists(any()) } returns true
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.PRESENT
+
+        shouldThrow<IOException> { loader().loadDirectory(LOCAL_PATH).toList() } shouldBe original
+    }
+
+    @Test
+    fun `a probe that cannot tell keeps the original error`() = runTest {
+        val original = IOException("something else")
+        coEvery { gatewaySwitch.listFiles(any()) } throws original
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.UNKNOWN
 
         shouldThrow<IOException> { loader().loadDirectory(LOCAL_PATH).toList() } shouldBe original
     }
@@ -96,7 +106,7 @@ class DirectoryLocationLoaderTest : BaseTest() {
     fun `a failing existence probe keeps the original error`() = runTest {
         val original = IOException("something else")
         coEvery { gatewaySwitch.listFiles(any()) } throws original
-        coEvery { gatewaySwitch.exists(any()) } throws IOException("probe broke")
+        coEvery { gatewaySwitch.existsStrict(any()) } throws IOException("probe broke")
 
         shouldThrow<IOException> { loader().loadDirectory(LOCAL_PATH).toList() } shouldBe original
     }
@@ -105,7 +115,7 @@ class DirectoryLocationLoaderTest : BaseTest() {
     fun `a target that vanishes after the peek also fails as not found`() = runTest {
         coEvery { gatewaySwitch.listFiles(any()) } returns emptyList()
         coEvery { gatewaySwitch.lookupFiles(any(), any<LookupOptions>()) } throws IOException("no such file")
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         shouldThrow<PathNotFoundException> { loader().loadDirectory(LOCAL_PATH).toList() }
     }
@@ -117,18 +127,18 @@ class DirectoryLocationLoaderTest : BaseTest() {
     @Test
     fun `a cancelled load is never probed`() = runTest {
         coEvery { gatewaySwitch.listFiles(any()) } throws CancellationException("cancelled")
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         loader().loadDirectory(LOCAL_PATH).toList()
 
-        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+        coVerify(exactly = 0) { gatewaySwitch.existsStrict(any()) }
     }
 
     /** A cancelled probe must not fall back to the original error either, see above. */
     @Test
     fun `a cancelled probe ends the load`() = runTest {
         coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
-        coEvery { gatewaySwitch.exists(any()) } throws CancellationException("cancelled")
+        coEvery { gatewaySwitch.existsStrict(any()) } throws CancellationException("cancelled")
 
         loader().loadDirectory(LOCAL_PATH).toList()
     }
@@ -140,44 +150,59 @@ class DirectoryLocationLoaderTest : BaseTest() {
     @Test
     fun `a probe that returns after cancellation is not an answer`() = runTest {
         coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
-        coEvery { gatewaySwitch.exists(any()) } coAnswers {
+        coEvery { gatewaySwitch.existsStrict(any()) } coAnswers {
             currentCoroutineContext().cancel()
-            false
+            Existence.ABSENT
         }
 
         val thrown = runCatching { loader().loadDirectory(LOCAL_PATH).toList() }.exceptionOrNull()
 
         val reported = listOfNotNull(thrown) + thrown?.suppressedExceptions.orEmpty()
         reported.any { it is PathNotFoundException } shouldBe false
-        coVerify(exactly = 1) { gatewaySwitch.exists(any()) }
+        coVerify(exactly = 1) { gatewaySwitch.existsStrict(any()) }
     }
 
     @Test
     fun `an unreachable share is never reported as a missing directory`() = runTest {
         val original = IOException("host unreachable")
         coEvery { gatewaySwitch.listFiles(any()) } throws original
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.UNKNOWN
 
         val path = SmbPath(LOCATION_ID, listOf("media"))
 
         shouldThrow<IOException> { loader().loadDirectory(path).toList() } shouldBe original
-        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
     }
 
-    /**
-     * SAF's exists() is a document-id query whose failures are swallowed, so a false answer covers
-     * a provider that is unreachable, crashing or mid-update just as much as a deleted folder.
-     */
+    @Test
+    fun `a share folder that is gone fails as not found`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such file")
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
+
+        val path = SmbPath(LOCATION_ID, listOf("media"))
+
+        shouldThrow<PathNotFoundException> { loader().loadDirectory(path).toList() }
+    }
+
+    /** A provider that is unreachable, crashing or mid-update answers UNKNOWN, not ABSENT. */
     @Test
     fun `a failing document provider is never reported as a missing directory`() = runTest {
         val original = IOException("provider died")
         coEvery { gatewaySwitch.listFiles(any()) } throws original
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.UNKNOWN
 
         val path = SAFPath(SAF_TREE_ROOT, listOf("Music"))
 
         shouldThrow<IOException> { loader().loadDirectory(path).toList() } shouldBe original
-        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+    }
+
+    @Test
+    fun `a SAF folder that is gone fails as not found`() = runTest {
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("no such document")
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
+
+        val path = SAFPath(SAF_TREE_ROOT, listOf("Music"))
+
+        shouldThrow<PathNotFoundException> { loader().loadDirectory(path).toList() }
     }
 
     @Test
@@ -185,12 +210,22 @@ class DirectoryLocationLoaderTest : BaseTest() {
         val container = LocalPath.build("/storage/emulated/0/Download/archive.zip")
         val original = ArchiveNotSeekableException(container)
         coEvery { gatewaySwitch.listFiles(any()) } throws original
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.UNKNOWN
 
         val path = ArchivePath(container, emptyList())
 
         shouldThrow<ArchiveNotSeekableException> { loader().loadDirectory(path).toList() } shouldBe original
-        coVerify(exactly = 0) { gatewaySwitch.exists(any()) }
+    }
+
+    @Test
+    fun `an archive folder that is gone fails as not found`() = runTest {
+        val container = LocalPath.build("/storage/emulated/0/Download/archive.zip")
+        coEvery { gatewaySwitch.listFiles(any()) } throws IOException("entry not found")
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
+
+        val path = ArchivePath(container, listOf("docs"))
+
+        shouldThrow<PathNotFoundException> { loader().loadDirectory(path).toList() }
     }
 
     companion object {


### PR DESCRIPTION
## What changed

Butler can now tell the difference between a folder that is really gone and one it simply could not check.

Until now those two looked identical. A folder that had been deleted and a folder that was merely unreachable — a network share that is switched off, a storage provider that is not responding, a damaged archive — all produced the same answer. Because of that, the dedicated "This folder is gone" screen only ever appeared for folders on the device's own storage. Everywhere else you got a generic error card, whether the folder had actually been deleted or your NAS was just offline.

Now:

- A deleted folder on a network share, inside an archive, or in storage you added through the system picker shows the "This folder is gone" screen, with a way back.
- A folder that could not be reached still shows the original error, because that error is the one that tells you what to do — reconnect, retry, check the provider.
- In app details, a storage folder is only hidden when Butler can actually prove it is absent. A check that failed no longer counts as proof.

## Technical Context

- The existing existence check answers `false` both for "not there" and "could not look", and each backend arrives there differently: a denied stat returns false without throwing, a document provider that never answered returns null, an unreachable share and an unreadable archive fall into the same catch. This adds a strict sibling that keeps the two apart and leaves the existing check and its ~67 call sites alone, since most callers genuinely want the lenient answer.
- Across the root/ADB boundary the answer travels as a value code rather than an exception. Typed exceptions do not survive that boundary in minified builds — shrinking removes the constructor the reflective unwrap needs — so an exception arrives as an unusable blob while a code arrives intact.
- Worth close review, the SMB path: a connection lease proves the *share* was reached, not that a configured base path inside it still exists. The share-root shortcut is therefore gated on the location having no base path. Without that gate a deleted base folder reports itself as present.
- Also worth review, the local gateway: it escalates to the privileged host when the direct probe cannot answer. The pre-existing escalation triggers on a thrown `IOException`, and "could not tell" is a return value rather than a throw, so this needed its own path — including the removable-storage branch that tries the isolated service first.
- Storage Access Framework absence rests on a null cursor, which Android also uses as a generic failure channel; the two are not distinguishable at that API. Verified on a device that a genuinely deleted document reports itself exactly that way, so treating null as "could not tell" would remove the feature rather than harden it. The residual risk is a third-party provider that returns null on an internal failure instead of throwing.
