### PR TITLE
Workspace: Tighten the spacing on operation details cards

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationAffectedFilesSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationAffectedFilesSection.kt
@@ -1,34 +1,16 @@
 package eu.darken.butler.workspace.ui.operations.details
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.ExpandLess
-import androidx.compose.material.icons.twotone.ExpandMore
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -42,103 +24,57 @@ import eu.darken.butler.workspace.core.operations.Operation
 internal fun OperationAffectedFilesSection(
     affectedPaths: Collection<Operation.Report.PathChange>,
 ) {
-    var isExpanded by remember { mutableStateOf(false) }
     val affectedPathList = remember(affectedPaths) { affectedPaths.toList() }
 
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
+    OperationSection(
+        title = stringResource(
+            R.string.operations_details_affected_paths_with_count,
+            affectedPaths.size,
+        ),
+        initiallyExpanded = false,
     ) {
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                .heightIn(max = 300.dp),
         ) {
-            // Clickable section title with expand/collapse
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { isExpanded = !isExpanded }
-                    .padding(vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(
-                        R.string.operations_details_affected_paths_with_count,
-                        affectedPaths.size
-                    ).uppercase(),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                Icon(
-                    imageVector = if (isExpanded) Icons.TwoTone.ExpandLess else Icons.TwoTone.ExpandMore,
-                    contentDescription = if (isExpanded) "Collapse" else "Expand",
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // Only show divider when expanded
-            AnimatedVisibility(visible = isExpanded) {
-                Column {
-                    HorizontalDivider(
-                        thickness = 0.5.dp,
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            items(
+                items = affectedPathList,
+                key = { "${it.path.path}:${it.change}" },
+            ) { pathChange ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = when (pathChange.change) {
+                            Operation.Report.PathChange.Change.ADDED -> "+"
+                            Operation.Report.PathChange.Change.REMOVED -> "\u2212"
+                            Operation.Report.PathChange.Change.MODIFIED -> "~"
+                            Operation.Report.PathChange.Change.TRASHED -> "\u267B"
+                            Operation.Report.PathChange.Change.MOVED -> "\u2192"
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = when (pathChange.change) {
+                            Operation.Report.PathChange.Change.ADDED -> MaterialTheme.colorScheme.primary
+                            Operation.Report.PathChange.Change.REMOVED -> MaterialTheme.colorScheme.error
+                            Operation.Report.PathChange.Change.MODIFIED -> MaterialTheme.colorScheme.secondary
+                            Operation.Report.PathChange.Change.TRASHED -> MaterialTheme.colorScheme.tertiary
+                            Operation.Report.PathChange.Change.MOVED -> MaterialTheme.colorScheme.primary
+                        },
+                        modifier = Modifier.width(16.dp)
                     )
 
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    // Expandable file list
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 300.dp),
-                    ) {
-                        items(
-                            items = affectedPathList,
-                            key = { "${it.path.path}:${it.change}" },
-                        ) { pathChange ->
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                Text(
-                                    text = when (pathChange.change) {
-                                        Operation.Report.PathChange.Change.ADDED -> "+"
-                                        Operation.Report.PathChange.Change.REMOVED -> "\u2212"
-                                        Operation.Report.PathChange.Change.MODIFIED -> "~"
-                                        Operation.Report.PathChange.Change.TRASHED -> "\u267B"
-                                        Operation.Report.PathChange.Change.MOVED -> "\u2192"
-                                    },
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontFamily = FontFamily.Monospace,
-                                    color = when (pathChange.change) {
-                                        Operation.Report.PathChange.Change.ADDED -> MaterialTheme.colorScheme.primary
-                                        Operation.Report.PathChange.Change.REMOVED -> MaterialTheme.colorScheme.error
-                                        Operation.Report.PathChange.Change.MODIFIED -> MaterialTheme.colorScheme.secondary
-                                        Operation.Report.PathChange.Change.TRASHED -> MaterialTheme.colorScheme.tertiary
-                                        Operation.Report.PathChange.Change.MOVED -> MaterialTheme.colorScheme.primary
-                                    },
-                                    modifier = Modifier.width(16.dp)
-                                )
-
-                                Text(
-                                    text = pathChange.path.userReadablePath.asComposable(),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontFamily = FontFamily.Monospace,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.MiddleEllipsis,
-                                    modifier = Modifier.weight(1f)
-                                )
-                            }
-                        }
-                    }
+                    Text(
+                        text = pathChange.path.userReadablePath.asComposable(),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                        maxLines = 1,
+                        overflow = TextOverflow.MiddleEllipsis,
+                        modifier = Modifier.weight(1f)
+                    )
                 }
             }
         }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationCombinedProgressSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationCombinedProgressSection.kt
@@ -1,34 +1,19 @@
 package eu.darken.butler.workspace.ui.operations.details
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.ExpandLess
-import androidx.compose.material.icons.twotone.ExpandMore
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.ca.CaString
@@ -41,85 +26,26 @@ internal fun OperationCombinedProgressSection(
     primaryProgress: Progress.Data,
     secondaryProgress: Progress.Data?,
 ) {
-    var isExpanded by rememberSaveable { mutableStateOf(true) }
-
-    // Single unified card for all progress
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+    OperationSection(title = stringResource(R.string.operations_details_progress)) {
+        OperationProgressDisplay(
+            progressData = primaryProgress,
+            isPrimary = true,
+            modifier = Modifier.fillMaxWidth()
         )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Clickable section title with expand/collapse
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { isExpanded = !isExpanded }
-                    .padding(vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.operations_details_progress).uppercase(),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
 
-                Icon(
-                    imageVector = if (isExpanded) {
-                        Icons.TwoTone.ExpandLess
-                    } else {
-                        Icons.TwoTone.ExpandMore
-                    },
-                    contentDescription = if (isExpanded) {
-                        "Collapse progress"
-                    } else {
-                        "Expand progress"
-                    },
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+        // Divider and Secondary Progress (if exists)
+        secondaryProgress?.let { secondary ->
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 4.dp),
+                thickness = 0.5.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+            )
 
-            // Content
-            AnimatedVisibility(visible = isExpanded) {
-                Column {
-                    HorizontalDivider(
-                        thickness = 0.5.dp,
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
-                    )
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    // Primary Progress
-                    OperationProgressDisplay(
-                        progressData = primaryProgress,
-                        isPrimary = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-
-                    // Divider and Secondary Progress (if exists)
-                    secondaryProgress?.let { secondary ->
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = 4.dp),
-                            thickness = 0.5.dp,
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                        )
-
-                        OperationProgressDisplay(
-                            progressData = secondary,
-                            isPrimary = false,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                }
-            }
+            OperationProgressDisplay(
+                progressData = secondary,
+                isPrimary = false,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationErrorSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationErrorSection.kt
@@ -1,35 +1,9 @@
 package eu.darken.butler.workspace.ui.operations.details
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.ExpandLess
-import androidx.compose.material.icons.twotone.ExpandMore
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.asComposable
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
@@ -38,69 +12,16 @@ import eu.darken.butler.workspace.ui.operations.OperationDisplay
 internal fun OperationErrorSection(
     state: OperationDisplay.State.Failed,
 ) {
-    var isExpanded by remember { mutableStateOf(true) }
-
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)
-        ),
-        shape = RoundedCornerShape(12.dp)
+    OperationSection(
+        title = stringResource(R.string.operations_details_error),
+        containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f),
+        accentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+        dividerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.3f),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Clickable section title with expand/collapse
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { isExpanded = !isExpanded }
-                    .padding(vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.operations_details_error).uppercase(),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
-                )
-
-                Icon(
-                    imageVector = if (isExpanded) {
-                        Icons.TwoTone.ExpandLess
-                    } else {
-                        Icons.TwoTone.ExpandMore
-                    },
-                    contentDescription = if (isExpanded) {
-                        "Collapse error"
-                    } else {
-                        "Expand error"
-                    },
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
-                )
-            }
-
-            // Content
-            AnimatedVisibility(visible = isExpanded) {
-                Column {
-                    HorizontalDivider(
-                        thickness = 0.5.dp,
-                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.3f)
-                    )
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    Text(
-                        text = state.summary.asComposable(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                }
-            }
-        }
+        Text(
+            text = state.summary.asComposable(),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+        )
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -1,7 +1,5 @@
 package eu.darken.butler.workspace.ui.operations.details
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -9,29 +7,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.ExpandLess
-import androidx.compose.material.icons.twotone.ExpandMore
 import androidx.compose.material.icons.twotone.Handyman
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.ca.toCaString
@@ -101,65 +87,8 @@ internal fun buildOverviewEntries(
 internal fun OperationOverviewSection(
     operation: OperationDisplay,
 ) {
-    var isExpanded by remember { mutableStateOf(true) }
-
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Clickable section title with expand/collapse
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { isExpanded = !isExpanded }
-                    .padding(vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.operations_details_overview).uppercase(),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                Icon(
-                    imageVector = if (isExpanded) {
-                        Icons.TwoTone.ExpandLess
-                    } else {
-                        Icons.TwoTone.ExpandMore
-                    },
-                    contentDescription = if (isExpanded) {
-                        "Collapse overview"
-                    } else {
-                        "Expand overview"
-                    },
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            // Content
-            AnimatedVisibility(visible = isExpanded) {
-                Column {
-                    HorizontalDivider(
-                        thickness = 0.5.dp,
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
-                    )
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    OperationOverviewGrid(operation = operation)
-                }
-            }
-        }
+    OperationSection(title = stringResource(R.string.operations_details_overview)) {
+        OperationOverviewGrid(operation = operation)
     }
 }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
@@ -1,31 +1,7 @@
 package eu.darken.butler.workspace.ui.operations.details
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.ExpandLess
-import androidx.compose.material.icons.twotone.ExpandMore
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
@@ -45,57 +21,10 @@ internal fun OperationPerformanceGraphSection(
     // Return early if no data or insufficient samples
     if (performanceHistory?.canShowGraph != true) return
 
-    var isExpanded by remember { mutableStateOf(false) }
-
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
+    OperationSection(
+        title = stringResource(R.string.workspace_operations_performance_graph_label),
+        initiallyExpanded = false,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Clickable section title with expand/collapse
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { isExpanded = !isExpanded }
-                    .padding(vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.workspace_operations_performance_graph_label),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                Icon(
-                    imageVector = if (isExpanded) {
-                        Icons.TwoTone.ExpandLess
-                    } else {
-                        Icons.TwoTone.ExpandMore
-                    },
-                    contentDescription = if (isExpanded) {
-                        stringResource(R.string.workspace_operation_performance_graph_collapse)
-                    } else {
-                        stringResource(R.string.workspace_operation_performance_graph_expand)
-                    },
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            // Graph content
-            AnimatedVisibility(visible = isExpanded) {
-                Column(modifier = Modifier.padding(vertical = 8.dp)) {
-                    graphContent(performanceHistory)
-                }
-            }
-        }
+        graphContent(performanceHistory)
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationSection.kt
@@ -42,7 +42,8 @@ import eu.darken.butler.workspace.R
  * Card shell shared by every section of the operation details sheet: a clickable title row that
  * toggles [content] behind a divider.
  *
- * [title] is shown uppercased but reaches screen readers as-is, so pass it in natural case.
+ * [title] is uppercased for display and interpolated into the expand/collapse description in the
+ * case it was given, so pass it in natural case.
  */
 @Composable
 internal fun OperationSection(

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationSection.kt
@@ -1,0 +1,147 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ExpandLess
+import androidx.compose.material.icons.twotone.ExpandMore
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.workspace.R
+
+/**
+ * Card shell shared by every section of the operation details sheet: a clickable title row that
+ * toggles [content] behind a divider.
+ *
+ * [title] is shown uppercased but reaches screen readers as-is, so pass it in natural case.
+ */
+@Composable
+internal fun OperationSection(
+    modifier: Modifier = Modifier,
+    title: String,
+    initiallyExpanded: Boolean = true,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    accentColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    dividerColor: Color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
+
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { isExpanded = !isExpanded },
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title.uppercase(),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontFamily = FontFamily.Monospace,
+                    color = accentColor,
+                )
+
+                Icon(
+                    imageVector = if (isExpanded) Icons.TwoTone.ExpandLess else Icons.TwoTone.ExpandMore,
+                    contentDescription = if (isExpanded) {
+                        stringResource(R.string.operations_details_section_collapse, title)
+                    } else {
+                        stringResource(R.string.operations_details_section_expand, title)
+                    },
+                    modifier = Modifier.size(20.dp),
+                    tint = accentColor,
+                )
+            }
+
+            AnimatedVisibility(visible = isExpanded) {
+                Column {
+                    HorizontalDivider(
+                        thickness = 0.5.dp,
+                        color = dividerColor,
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    content()
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationSectionExpandedPreview() {
+    Box(modifier = Modifier.width(360.dp)) {
+        OperationSection(title = "Overview") {
+            Text(text = "Section content")
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationSectionCollapsedPreview() {
+    Box(modifier = Modifier.width(360.dp)) {
+        OperationSection(title = "Overview", initiallyExpanded = false) {
+            Text(text = "Section content")
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationSectionErrorPreview() {
+    Box(modifier = Modifier.width(360.dp)) {
+        OperationSection(
+            title = "Error details",
+            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f),
+            accentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+            dividerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.3f),
+        ) {
+            Text(text = "Section content")
+        }
+    }
+}

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -150,6 +150,8 @@
     <string name="operations_details_destination_folder">Destination folder</string>
     <string name="operations_details_destination_path">Destination path</string>
     <string name="operations_details_affected_paths_with_count">Affected paths (%d)</string>
+    <string name="operations_details_section_expand">Expand %1$s</string>
+    <string name="operations_details_section_collapse">Collapse %1$s</string>
     <string name="workspace_operations_performance_graph_label">Performance graph</string>
 
     <!-- Delete Confirmation Dialog -->
@@ -265,8 +267,6 @@
 
     <!-- Performance Graph -->
     <string name="workspace_operation_performance_not_enough_data">Not enough data</string>
-    <string name="workspace_operation_performance_graph_expand">Expand performance graph</string>
-    <string name="workspace_operation_performance_graph_collapse">Collapse performance graph</string>
     <string name="workspace_operation_performance_unit_bytes">B/s</string>
     <string name="workspace_operation_performance_unit_kilobytes">kB/s</string>
     <string name="workspace_operation_performance_unit_megabytes">MB/s</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
@@ -28,8 +28,9 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
-    private val expandLabel = context.getString(R.string.workspace_operation_performance_graph_expand)
-    private val collapseLabel = context.getString(R.string.workspace_operation_performance_graph_collapse)
+    private val title = context.getString(R.string.workspace_operations_performance_graph_label)
+    private val expandLabel = context.getString(R.string.operations_details_section_expand, title)
+    private val collapseLabel = context.getString(R.string.operations_details_section_collapse, title)
     private val graphTag = "test-graph"
 
     private val startTime = Instant.fromEpochMilliseconds(1000)


### PR DESCRIPTION
## What changed

The expanding cards on the operation details sheet had too much space between their title and their content once opened. They reserved padding that only makes sense while the card is collapsed and kept it after expanding, on top of the gap the divider already provides. Most of these cards open expanded, so this was the state you normally saw.

The gap is now the same above and below the divider, and matches the Actions card, which never expands and already had the right proportions.

Two smaller fixes came with it:

- The expand/collapse buttons announced themselves in English to screen readers regardless of the app language. They are translatable now.
- Four of the cards forgot whether you had opened them when the screen rotated. They remember now.

## Technical Context

- The card shell (card, clickable title row, chevron, divider, spacing) was copy-pasted across five section files, so the padding had five places to drift apart in. It now lives in one `OperationSection` composable that the five sections delegate to, parameterised by title, initial expanded state, and three colors for the error variant.
- The gap came from three independent sources stacking, none conditional on the expanded state: 4dp of vertical padding on the header row, the card column's 8dp `Arrangement.spacedBy`, and an 8dp spacer under the divider. Dropping the header row's padding is what fixes it without a conditional value that would snap mid-animation. The row is ~20dp tall and was already well short of the 48dp touch-target guideline before this change, so that padding was buying appearance, not reach.
- Sharing one shell forced three call sites to converge. The performance graph gains the divider and an uppercase title (it was the only card using a padded column instead of divider plus spacer). Expand state is `rememberSaveable` throughout. Content descriptions come from one generic pair of strings, which let `workspace_operation_performance_graph_expand`/`_collapse` go; they only ever existed in base English, and the performance graph test now builds its expected labels from the generic template.
- Worth a close look: the performance graph card is the one place where the visual result changes beyond spacing.
