### PR TITLE
Workspace: Fix operations bar freezing after an app install

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
@@ -33,7 +33,7 @@ data class OperationDisplay(
         data class Completed(
             val summary: CaString,
             val completedAt: Instant,
-            val report: Operation.Report,
+            val report: Operation.Report?,
             val performanceHistory: PerformanceHistory? = null,
         ) : State
 
@@ -97,7 +97,7 @@ fun ManagedOperation.toDisplayModel(): OperationDisplay {
                         OperationDisplay.State.Completed(
                             summary = state.summary,
                             completedAt = state.completedAt,
-                            report = state.report!!,
+                            report = state.report,
                             performanceHistory = performanceHistory,
                         )
                     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
@@ -110,7 +110,7 @@ private fun OperationDetailsContent(
 
         // Affected Files Section (for completed operations with affected paths)
         val affectedPaths = when (operation.state) {
-            is OperationDisplay.State.Completed -> operation.state.report.affectedPaths
+            is OperationDisplay.State.Completed -> operation.state.report?.affectedPaths ?: emptyList()
             is OperationDisplay.State.Failed -> operation.state.report?.affectedPaths ?: emptyList()
             is OperationDisplay.State.Cancelled -> operation.state.report?.affectedPaths ?: emptyList()
             else -> emptyList()

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -169,7 +169,7 @@ private fun OperationOverviewGrid(
     operation: OperationDisplay,
 ) {
     val reportSummary = when (operation.state) {
-        is OperationDisplay.State.Completed -> operation.state.report.summary
+        is OperationDisplay.State.Completed -> operation.state.report?.summary
         is OperationDisplay.State.Failed -> operation.state.report?.summary
         is OperationDisplay.State.Cancelled -> operation.state.report?.summary
         else -> null

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationDisplayTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationDisplayTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.workspace.ui.operations
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.workspace.core.operations.ManagedOperation
 import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
@@ -44,6 +45,14 @@ class OperationDisplayTest : BaseTest() {
         val display = managedOp(completed(CancellationException("The user declined the install"))).toDisplayModel()
 
         display.state.shouldBeInstanceOf<OperationDisplay.State.Cancelled>()
+    }
+
+    @Test
+    fun `a successful run without a report is completed`() {
+        // An install reports no path changes, so it completes with a null report.
+        val display = managedOp(completed(null)).toDisplayModel()
+
+        display.state.shouldBeInstanceOf<OperationDisplay.State.Completed>().report.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## What changed

Installing an app from a file no longer leaves the operations bar stuck. The install itself always worked, but once it finished, the bar for that tab stopped updating and no longer reflected any further operations until the tab was recreated.

## Technical Context

- A completed operation is allowed to carry no report: the state contract declares it nullable, and an app install produces none because it changes no paths. The display model asserted it non-null, so building the display state for a finished install threw and tore down the operations display flow for that workspace.
- The fix follows the contract rather than the call site: `OperationDisplay.State.Completed.report` is now nullable. The two consumers that read it already handled a null report for the failed and cancelled branches, so they now do the same for the completed one.
- Worth a look: `OperationDisplayTest` gained the case that was missing, a successful run with no report. The existing tests built exactly that state but only asserted the cancelled and failed paths.
