### PR TITLE
Searcher: Fix copy and cut appearing to do nothing

### DIFF
--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleResumeEffect
@@ -122,7 +120,7 @@ fun EditorWorkspacePage(
         onPageAction(EditorPageAction.Navigation.ClearSelection(state.cursorPosition))
     }
 
-    val hasClipboard by remember { derivedStateOf { clipboardState.entries.isNotEmpty() } }
+    val hasClipboard = clipboardState.entries.isNotEmpty()
     val hasActions = state.availableActions.isNotEmpty()
 
     val topBarStackState = rememberPaneFloatingBarStackState(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
@@ -1,7 +1,6 @@
 package eu.darken.butler.explorer.ui.explorer.elements
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -121,17 +120,14 @@ internal fun FloatingBarScope.ExplorerBottomBars(
     initialClipboardExpanded: Boolean,
     onShowOperationDetails: (Operation.Id) -> Unit,
 ) {
-    // Derived states for stable recomposition
-    val hasOperations by derivedStateOf { operationsState.operations.isNotEmpty() }
-    val hasActiveOperations by derivedStateOf {
-        operationsState.operations.any { op ->
-            op.state is OperationDisplay.State.Queued ||
-                op.state is OperationDisplay.State.Running ||
-                op.state is OperationDisplay.State.Waiting
-        }
+    val hasOperations = operationsState.operations.isNotEmpty()
+    val hasActiveOperations = operationsState.operations.any { op ->
+        op.state is OperationDisplay.State.Queued ||
+            op.state is OperationDisplay.State.Running ||
+            op.state is OperationDisplay.State.Waiting
     }
-    val hasClipboard by derivedStateOf { clipboardState.entries.isNotEmpty() }
-    val hasActions by derivedStateOf { state.availableActions.isNotEmpty() }
+    val hasClipboard = clipboardState.entries.isNotEmpty()
+    val hasActions = state.availableActions.isNotEmpty()
 
     // Cache the last non-null favorite feedback so the bar has content to animate out when the
     // underlying state transitions back to null. FloatingBar keeps its content composed during

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -205,22 +205,14 @@ fun SearcherWorkspacePage(
         bottomBarStackState.resetScrollCollapse()
     }
 
-    // Derived states for stable recomposition - at top level for immediate reactivity
-    val hasOperations by remember {
-        derivedStateOf { operationsState.operations.isNotEmpty() }
+    val hasOperations = operationsState.operations.isNotEmpty()
+    val hasActiveOperations = operationsState.operations.any { op ->
+        op.state is OperationDisplay.State.Queued ||
+            op.state is OperationDisplay.State.Running ||
+            op.state is OperationDisplay.State.Waiting
     }
-    val hasActiveOperations by remember {
-        derivedStateOf {
-            operationsState.operations.any { op ->
-                op.state is OperationDisplay.State.Queued ||
-                    op.state is OperationDisplay.State.Running ||
-                    op.state is OperationDisplay.State.Waiting
-            }
-        }
-    }
-    val hasClipboard by remember {
-        derivedStateOf { clipboardState.entries.isNotEmpty() }
-    }
+    val hasClipboard = clipboardState.entries.isNotEmpty()
+
     val hasActions by remember(mainState) {
         derivedStateOf {
             val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf false

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
@@ -1,0 +1,140 @@
+package eu.darken.butler.searcher.ui.search
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import eu.darken.butler.workspace.R as WorkspaceR
+
+/**
+ * The searcher's bottom bars have to react to clipboard and operation updates that arrive while the
+ * page is already composed - a copy in the searcher is exactly that.
+ *
+ * The updates are emitted after the first composition on purpose: it also covers the variant where
+ * the collect seeds its initial value from a StateFlow, as the main state does.
+ */
+class SearcherFloatingBarsTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val stateSource = MutableStateFlow(SearcherMockDataProvider.createMockResultsState())
+    private val clipboardSource = MutableStateFlow<ClipboardDisplayState?>(null)
+    private val operationsSource = MutableStateFlow<OperationsDisplayState?>(null)
+
+    private val pasteLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_open_in_explorer)
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SearcherWorkspacePage(
+                    workspaceId = Workspace.Id(),
+                    // Split-pane layout: keeps the mascot-bearing workspace button, which
+                    // Robolectric cannot rasterise, out of the toolbar cutout.
+                    design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                    stateSource = stateSource,
+                    clipboardStateSource = clipboardSource,
+                    operationsStateSource = operationsSource,
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun scrollResults() {
+        composeTestRule.onRoot().performTouchInput { swipeUp(startY = centerY, endY = top) }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun clip() = ClipboardClip.Paths(
+        origin = Workspace.Id(),
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(
+            LocalPathLookup(
+                lookedUp = LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                fileType = FileType.FILE,
+                size = null,
+                modifiedAt = null,
+            ),
+        ),
+    )
+
+    @Test
+    fun `clipboard bar appears when a clip arrives after first composition`() {
+        setContent()
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertDoesNotExist()
+
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(clip()))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `operations bar appears when an operation arrives after first composition`() {
+        setContent()
+
+        composeTestRule.onNodeWithText(OPERATION_TITLE).assertDoesNotExist()
+
+        operationsSource.value = OperationsDisplayState(
+            operations = listOf(SearcherMockDataProvider.createMockRunningOperation(title = OPERATION_TITLE)),
+        )
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(OPERATION_TITLE).assertIsDisplayed()
+    }
+
+    @Test
+    fun `operations bar stays pinned while an operation is active`() {
+        setContent()
+
+        val operation = SearcherMockDataProvider.createMockRunningOperation(title = OPERATION_TITLE)
+        operationsSource.value = OperationsDisplayState(operations = listOf(operation))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(OPERATION_TITLE).assertIsDisplayed()
+
+        scrollResults()
+        composeTestRule.onNodeWithText(OPERATION_TITLE).assertIsDisplayed()
+
+        operationsSource.value = OperationsDisplayState(
+            operations = listOf(
+                operation.copy(
+                    state = OperationDisplay.State.Cancelled(
+                        completedAt = Clock.System.now(),
+                        report = null,
+                    ),
+                ),
+            ),
+        )
+        composeTestRule.waitForIdle()
+
+        scrollResults()
+        composeTestRule.onNodeWithText(OPERATION_TITLE).assertIsNotDisplayed()
+    }
+
+    companion object {
+        private const val OPERATION_TITLE = "Deleting files"
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WindowSizeInfo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WindowSizeInfo.kt
@@ -1,8 +1,6 @@
 package eu.darken.butler.workspace.ui.manager
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
@@ -47,29 +45,25 @@ fun rememberWindowSizeInfo(): WindowSizeInfo {
     val widthDp = configuration.screenWidthDp.dp
     val heightDp = configuration.screenHeightDp.dp
 
-    // Use derivedStateOf to only recompose when size class changes, not on every dp change
-    val windowSizeInfo by remember {
-        derivedStateOf {
-            val widthSizeClass = when {
-                widthDp < 600.dp -> WindowSizeInfo.SizeClass.COMPACT
-                widthDp < 840.dp -> WindowSizeInfo.SizeClass.MEDIUM
-                else -> WindowSizeInfo.SizeClass.EXPANDED
-            }
-
-            val heightSizeClass = when {
-                heightDp < 480.dp -> WindowSizeInfo.SizeClass.COMPACT
-                heightDp < 900.dp -> WindowSizeInfo.SizeClass.MEDIUM
-                else -> WindowSizeInfo.SizeClass.EXPANDED
-            }
-
-            WindowSizeInfo(
-                widthDp = widthDp,
-                heightDp = heightDp,
-                widthSizeClass = widthSizeClass,
-                heightSizeClass = heightSizeClass,
-            )
+    // Keyed on the measurements so the same instance survives recompositions at an unchanged size
+    return remember(widthDp, heightDp) {
+        val widthSizeClass = when {
+            widthDp < 600.dp -> WindowSizeInfo.SizeClass.COMPACT
+            widthDp < 840.dp -> WindowSizeInfo.SizeClass.MEDIUM
+            else -> WindowSizeInfo.SizeClass.EXPANDED
         }
-    }
 
-    return windowSizeInfo
+        val heightSizeClass = when {
+            heightDp < 480.dp -> WindowSizeInfo.SizeClass.COMPACT
+            heightDp < 900.dp -> WindowSizeInfo.SizeClass.MEDIUM
+            else -> WindowSizeInfo.SizeClass.EXPANDED
+        }
+
+        WindowSizeInfo(
+            widthDp = widthDp,
+            heightDp = heightDp,
+            widthSizeClass = widthSizeClass,
+            heightSizeClass = heightSizeClass,
+        )
+    }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WindowSizeInfoTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WindowSizeInfoTest.kt
@@ -1,0 +1,47 @@
+package eu.darken.butler.workspace.ui.manager
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/** The size class has to follow the window, not the size the caller was first composed at. */
+class WindowSizeInfoTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun sizedConfiguration(widthDp: Int, heightDp: Int) =
+        Configuration(context.resources.configuration).apply {
+            screenWidthDp = widthDp
+            screenHeightDp = heightDp
+        }
+
+    @Test
+    fun `the size class follows a window resize`() {
+        var configuration by mutableStateOf(sizedConfiguration(widthDp = 400, heightDp = 800))
+        lateinit var sizeInfo: WindowSizeInfo
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalConfiguration provides configuration) {
+                sizeInfo = rememberWindowSizeInfo()
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        sizeInfo.widthSizeClass shouldBe WindowSizeInfo.SizeClass.COMPACT
+
+        composeTestRule.runOnIdle { configuration = sizedConfiguration(widthDp = 1000, heightDp = 800) }
+        composeTestRule.waitForIdle()
+
+        sizeInfo.widthDp shouldBe 1000.dp
+        sizeInfo.widthSizeClass shouldBe WindowSizeInfo.SizeClass.EXPANDED
+    }
+}


### PR DESCRIPTION
## What changed

Copying or cutting files in the Searcher now actually shows the clipboard bar, so you can see what you clipped and go paste it. Before this, the copy and cut actions looked completely dead: the files really were being clipped, but nothing appeared on screen and there was no way to reach a paste. This affected every route into the action — the action bar in multi-selection mode, the details sheet on a single result, and the keyboard shortcuts.

The same fault also hid the operations bar in the Searcher, so deleting a file from search results showed no progress and no result row. That is fixed too.

Two related cleanups ride along, neither of them user-visible on its own: the window size class could get stuck at the size the app first measured, and the Explorer and Editor carried the same fragile construct that caused the Searcher bug.

## Technical Context

- Root cause: `SearcherWorkspacePage` collects the clipboard and operations flows and then strips their snapshot delegation with a `?:` null-fallback, leaving plain values. Three bar-visibility flags read those values inside an **unkeyed** `remember { derivedStateOf { … } }`, which pins the lambda to first composition's instances (the `initial = null` fallbacks) and records zero snapshot dependencies, so it never invalidates. All three flags were frozen at `false` for the page's lifetime.
- This is a regression from `ed58a69b7`, which replaced `by collectAsState(initial = X)` with a `Raw` + `?:` pair. The `derivedStateOf` blocks predate it and were correct until the delegation was stripped out from under them. The Explorer received the same edit in that commit but escaped, because its flags later moved to `ExplorerFloatingBars` where `derivedStateOf` is used *without* `remember`.
- `derivedStateOf` earns its keep only when the calculation reads snapshot state. Here the inputs are already plain values from `collectAsState`, and the page body reads the raw snapshot state anyway, so every emission recomposes it regardless — the derived states were narrowing no recomposition scope. Direct computation is what `DeveloperWorkspacePage` already does.
- The Explorer and Editor changes are behaviour-preserving. Neither was broken, but both held the same shape: the Explorer's bare unremembered `derivedStateOf` is lint bait whose obvious correction (adding `remember`) reproduces this exact bug, and the Editor's `remember { derivedStateOf }` was correct only because a delegation nine lines above it survived. After this, no `remember { derivedStateOf }` in the tree depends on a delegation a routine refactor would remove.
- Worth close review: the third test in `SearcherFloatingBarsTest` is the one that distinguishes `hasActiveOperations` from `hasOperations` — it scrolls the result list and asserts an active operation stays pinned while a settled one vanishes. All three tests emit their state *after* first composition on purpose; an initially-populated flow would not exercise the defect.
