### PR TITLE
Workspace: Ask about closing a tab without dimming an unrelated tab

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
@@ -258,9 +258,9 @@ sealed interface WorkspaceAction {
      * Closes [id] and, recursively, everything it owns.
      *
      * @param sourceWorkspaceId the workspace the close was invoked from, when that is not [id]
-     * itself - closing a whole unit from one of its overlays is the case that needs it. A close
-     * confirmation is hosted in its target workspace's pane layer, so it must be anchored to the
-     * workspace the user is actually looking at; anchoring it to [id] would compose the dialog
+     * itself - closing a whole unit from one of its overlays is the case that needs it. It is where
+     * a close confirmation PREFERS to be hosted, and it is used as the host only while it is on
+     * screen and part of what the close removes: anchoring to [id] would compose the dialog
      * underneath the overlay that asked for the close, leaving it invisible and the close pending.
      * Null means the invoking workspace is [id].
      */

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
@@ -259,10 +259,12 @@ sealed interface WorkspaceAction {
      *
      * @param sourceWorkspaceId the workspace the close was invoked from, when that is not [id]
      * itself - closing a whole unit from one of its overlays is the case that needs it. It is where
-     * a close confirmation PREFERS to be hosted, and it is used as the host only while it is on
-     * screen and part of what the close removes: anchoring to [id] would compose the dialog
+     * a close confirmation PREFERS to be hosted: anchoring to [id] would compose the dialog
      * underneath the overlay that asked for the close, leaving it invisible and the close pending.
-     * Null means the invoking workspace is [id].
+     * It hosts unconditionally while it is the workspace a full-screen modal displays, since that
+     * window covers everything else; a pane hosts it only while it is rendered AND part of what the
+     * close removes, and otherwise the confirmation becomes a window dialog. Null means the
+     * invoking workspace is [id].
      */
     data class Close(
         val id: Workspace.Id,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
@@ -13,7 +13,8 @@ sealed interface ManagerDialog {
     val isBlocking: Boolean
 
     /**
-     * Global dialogs that are not targeted to a specific workspace.
+     * Dialogs no workspace hosts: they are composed at screen level, above every pane. Some of them
+     * still name a workspace - what a dialog is about and where it renders are separate questions.
      */
     sealed interface Global : ManagerDialog {
         /**
@@ -31,6 +32,25 @@ sealed interface ManagerDialog {
             val candidates: List<WorkspaceLimitCandidate> = emptyList(),
             val canRecover: Boolean = false,
             val minToClose: Int = 1,
+        ) : Global {
+            override val isBlocking: Boolean = true
+        }
+
+        /**
+         * Confirmation for closing a tab that nothing on screen can host the question for.
+         *
+         * [selectionSourceWorkspaceId] is the pane the jump to [closingWorkspaceId] acts FROM, not
+         * where that tab lands: it protects that pane from eviction and orders the search for an
+         * empty one. Null when nothing on screen can play that part.
+         */
+        data class CloseConfirmation(
+            override val id: String,
+            val closingWorkspaceId: Workspace.Id,
+            val workspaceTitle: CaString,
+            val hasUnsavedChanges: Boolean = false,
+            /** Unsaved members in the closing subtree; [workspaceTitle] names only one of them. */
+            val unsavedCount: Int = 0,
+            val selectionSourceWorkspaceId: Workspace.Id?,
         ) : Global {
             override val isBlocking: Boolean = true
         }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialog.kt
@@ -42,6 +42,9 @@ sealed interface ManagerDialog {
          * [selectionSourceWorkspaceId] is the pane the jump to [closingWorkspaceId] acts FROM, not
          * where that tab lands: it protects that pane from eviction and orders the search for an
          * empty one. Null when nothing on screen can play that part.
+         *
+         * [canGoToWorkspace] is false when [closingWorkspaceId] has no resolvable ownership root -
+         * a broken unit cannot be put on screen, so the jump must not be offered for it.
          */
         data class CloseConfirmation(
             override val id: String,
@@ -51,17 +54,18 @@ sealed interface ManagerDialog {
             /** Unsaved members in the closing subtree; [workspaceTitle] names only one of them. */
             val unsavedCount: Int = 0,
             val selectionSourceWorkspaceId: Workspace.Id?,
+            val canGoToWorkspace: Boolean,
         ) : Global {
             override val isBlocking: Boolean = true
         }
     }
 
     /**
-     * Dialogs that target a specific workspace.
-     * In multi-pane layouts, these appear overlaid on the specific workspace pane.
+     * Dialogs a workspace hosts: they are composed by that workspace's pane, or by the full-screen
+     * modal layer while it is the one displaying that workspace.
      */
     sealed interface WorkspaceTargeted : ManagerDialog {
-        /** The workspace whose pane hosts this dialog, which is not necessarily what it acts on. */
+        /** The workspace whose layer hosts this dialog, which is not necessarily what it acts on. */
         val targetWorkspaceId: Workspace.Id
 
         /**

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialogHost.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/ManagerDialogHost.kt
@@ -5,9 +5,9 @@ import androidx.compose.runtime.Composable
 /**
  * Renders the manager-controlled dialog for one workspace, if there is one.
  *
- * Composed by the pane layer host as its own layer above the workspace content, and deliberately
- * not gated on the workspace's lifecycle state — a close confirmation for a paused workspace must
- * still be reachable.
+ * Composed above the workspace content by whichever layer displays that workspace, the pane layer
+ * host or the full-screen modal one, and deliberately not gated on the workspace's lifecycle state
+ * — a close confirmation for a paused workspace must still be reachable.
  */
 @Composable
 fun ManagerDialogHost(

--- a/app/src/main/java/eu/darken/butler/workspace/core/PendingWorkspaceConfirmation.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/PendingWorkspaceConfirmation.kt
@@ -29,6 +29,11 @@ data class PendingWorkspaceConfirmation(
              * names one of them, so anything above 1 has to be said out loud.
              */
             val unsavedCount: Int = 0,
+            /**
+             * Whether the workspace this confirmation is anchored to ([sourceWorkspaceId]) is one of
+             * the workspaces the close removes. False means the anchor is an unrelated tab's.
+             */
+            val hostInClosingSubtree: Boolean,
         ) : ConfirmationData
 
         /**

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -2239,14 +2239,21 @@ class WorkspaceRepo @Inject constructor(
             return
         }
 
-        // Cancel any pending confirmations for this workspace - both the ones hosted in its pane
-        // and the ones asking about it. A confirmation hosted elsewhere would otherwise survive its
-        // subject: a blocking dialog naming a dead tab, whose confirm re-runs this for a workspace
-        // that no longer exists and emits a second Closed event.
+        // Cancel any pending confirmations for this workspace - both the ones this workspace renders
+        // and the ones asking about it. One asking about it would otherwise survive its subject: a
+        // blocking dialog naming a dead tab, whose confirm re-runs this for a workspace that no
+        // longer exists and emits a second Closed event.
+        //
+        // A close confirmation only renders in its anchor when the anchor goes down with the close;
+        // otherwise the anchor is a placement hint and a window dialog is what shows the question,
+        // so this workspace leaving takes nothing away from it.
         _pendingConfirmations.value
             .filter { (_, confirmation) ->
                 val data = confirmation.data
-                confirmation.sourceWorkspaceId == workspaceId ||
+                val anchoredHere = confirmation.sourceWorkspaceId == workspaceId &&
+                    (data !is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation ||
+                        data.hostInClosingSubtree)
+                anchoredHere ||
                     (data is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation &&
                         data.workspaceId == workspaceId)
             }

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -1854,6 +1854,9 @@ class WorkspaceRepo @Inject constructor(
         // pending, or the screen renders a single dialog for several queued answers and
         // one dismissal only retires one of them.
         val closingIds = closingIdsOf(action.id)
+        // Anchors the dialog to the workspace the close was invoked from, which is the overlay on
+        // top when a unit is closed from one of its children.
+        val hostId = action.sourceWorkspaceId ?: action.id
         val overlapping = _pendingConfirmations.value.filterValues { pending ->
             val data = pending.data
             data is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation &&
@@ -1889,9 +1892,7 @@ class WorkspaceRepo @Inject constructor(
         _pendingConfirmations.update {
             it - overlapping.keys + (confirmationId to PendingWorkspaceConfirmation(
                 id = confirmationId,
-                // Anchors the dialog to the workspace the close was invoked from, which
-                // is the overlay on top when a unit is closed from one of its children.
-                sourceWorkspaceId = action.sourceWorkspaceId ?: action.id,
+                sourceWorkspaceId = hostId,
                 data = PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation(
                     workspaceId = action.id,
                     workspaceTitle = workspaceInfo.displayTitle,
@@ -1899,6 +1900,7 @@ class WorkspaceRepo @Inject constructor(
                     // The close takes the whole subtree, so naming one member while
                     // discarding several would understate what is lost
                     unsavedCount = dirtyMembers.size,
+                    hostInClosingSubtree = hostId in closingIds,
                 ),
             ))
         }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerDialogRouting.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerDialogRouting.kt
@@ -4,17 +4,21 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
 
 /**
- * Which host composes which workspace-targeted dialog.
+ * Which host composes which dialog.
  *
- * The two hosts are the workspace panes and the tab manager overlay. Every dialog appears in
- * exactly one of the two fields, so double composition is not representable rather than merely
- * guarded against.
+ * The four hosts are the full-screen modal window, the tab manager overlay, the workspace panes and
+ * the screen itself. Every dialog appears in exactly one of the fields, so double composition is not
+ * representable rather than merely guarded against.
  */
 internal data class ManagerDialogRouting(
     /** Keyed by the pane that hosts the dialog, which is what a pane looks itself up by. */
     val paneHosted: Map<Workspace.Id, ManagerDialog.WorkspaceTargeted>,
     /** At most one: the manager asks about one tab at a time and takes the next once it resolves. */
     val managerHosted: ManagerDialog.WorkspaceTargeted.CloseConfirmation?,
+    /** At most one: the modal window renders a single workspace and one dialog layer above it. */
+    val modalHosted: ManagerDialog.WorkspaceTargeted.CloseConfirmation?,
+    /** At most one: a window dialog covers the screen, so a second one would render behind it. */
+    val globalHosted: ManagerDialog.Global.CloseConfirmation?,
 )
 
 /**
@@ -22,37 +26,60 @@ internal data class ManagerDialogRouting(
  * it is up, a close confirmation it triggered would render underneath it, or off screen entirely
  * when its host is not the tab on display.
  *
- * [tabOrder] only picks which one the manager asks about first, oldest tab first, so the choice
- * cannot move between recompositions while both are pending.
+ * [fullScreenModalId] wins over the overlay: that modal is a platform window drawn above it, so a
+ * dialog the manager composed would sit behind the very workspace it is anchored to.
+ *
+ * [tabOrder] only picks which one a host asks about first, oldest tab first, so the choice cannot
+ * move between recompositions while several are pending.
  */
 internal fun routeManagerDialogs(
     dialogs: List<ManagerDialog>,
     isManagerOverlayVisible: Boolean,
     tabOrder: List<Workspace.Id>,
+    fullScreenModalId: Workspace.Id? = null,
 ): ManagerDialogRouting {
     val targeted = dialogs.filterIsInstance<ManagerDialog.WorkspaceTargeted>()
 
+    val globalHosted = dialogs
+        .filterIsInstance<ManagerDialog.Global.CloseConfirmation>()
+        .firstToAsk(tabOrder) { it.closingWorkspaceId }
+
+    val modalAnchored = targeted
+        .filterIsInstance<ManagerDialog.WorkspaceTargeted.CloseConfirmation>()
+        .filter { fullScreenModalId != null && it.targetWorkspaceId == fullScreenModalId }
+    val modalAnchoredIds = modalAnchored.mapTo(mutableSetOf()) { it.id }
+    val remaining = targeted.filter { it.id !in modalAnchoredIds }
+
     if (!isManagerOverlayVisible) {
         return ManagerDialogRouting(
-            paneHosted = targeted.associateBy { it.targetWorkspaceId },
+            paneHosted = remaining.associateBy { it.targetWorkspaceId },
             managerHosted = null,
+            modalHosted = modalAnchored.firstToAsk(tabOrder) { it.closingWorkspaceId },
+            globalHosted = globalHosted,
         )
     }
-
-    val closeConfirmations = targeted
-        .filterIsInstance<ManagerDialog.WorkspaceTargeted.CloseConfirmation>()
 
     return ManagerDialogRouting(
         // Batch creation confirmations keep their pane host: they belong to what that pane was
         // doing, and nothing in the manager triggers them.
-        paneHosted = targeted
+        paneHosted = remaining
             .filter { it !is ManagerDialog.WorkspaceTargeted.CloseConfirmation }
             .associateBy { it.targetWorkspaceId },
-        managerHosted = closeConfirmations.minWithOrNull(
-            compareBy(
-                { tabOrder.indexOf(it.closingWorkspaceId).takeIf { index -> index >= 0 } ?: tabOrder.size },
-                { it.id },
-            ),
-        ),
+        managerHosted = remaining
+            .filterIsInstance<ManagerDialog.WorkspaceTargeted.CloseConfirmation>()
+            .firstToAsk(tabOrder) { it.closingWorkspaceId },
+        modalHosted = modalAnchored.firstToAsk(tabOrder) { it.closingWorkspaceId },
+        globalHosted = globalHosted,
     )
 }
+
+/** Oldest tab first, tabs the order does not list last, the confirmation id as the tie-break. */
+private fun <T : ManagerDialog> List<T>.firstToAsk(
+    tabOrder: List<Workspace.Id>,
+    closingWorkspaceId: (T) -> Workspace.Id,
+): T? = minWithOrNull(
+    compareBy(
+        { tabOrder.indexOf(closingWorkspaceId(it)).takeIf { index -> index >= 0 } ?: tabOrder.size },
+        { it.id },
+    ),
+)

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceModalDialog.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceModalDialog.kt
@@ -27,6 +27,8 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
+import eu.darken.butler.workspace.ui.dialogs.ManagerDialogHost
 import eu.darken.butler.workspace.ui.insets.paneHorizontalInsetPadding
 import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -44,6 +46,8 @@ import eu.darken.butler.workspace.ui.modal.PaneLayerRank
  *
  * @param workspace The workspace to display
  * @param design The workspace design/layout configuration from the parent screen
+ * @param managerDialog The manager-level dialog anchored to [workspace], if any
+ * @param onScreenAction Reports what [managerDialog] resolves to
  * @param onDismissRequest Called when the user dismisses the dialog
  * @param onShareError Shares the failure of a workspace that could not initialize
  * @param onCloseWorkspace Closes this workspace, offered by the error placeholder
@@ -53,6 +57,8 @@ import eu.darken.butler.workspace.ui.modal.PaneLayerRank
 fun WorkspaceModalDialog(
     workspace: Workspace.Info,
     design: WorkspaceDesign,
+    managerDialog: ManagerDialog.WorkspaceTargeted? = null,
+    onScreenAction: (WorkspaceScreenAction) -> Unit = {},
     onDismissRequest: () -> Unit,
     onShareError: (Throwable) -> Unit = {},
     onCloseWorkspace: () -> Unit = {},
@@ -111,6 +117,8 @@ fun WorkspaceModalDialog(
                 WorkspaceModalContent(
                     workspace = workspace,
                     design = design,
+                    managerDialog = managerDialog,
+                    onScreenAction = onScreenAction,
                     onShareError = onShareError,
                     onCloseWorkspace = onCloseWorkspace,
                     onResumeWorkspace = onResumeWorkspace,
@@ -135,6 +143,8 @@ fun WorkspaceModalDialog(
 fun WorkspaceModalContent(
     workspace: Workspace.Info,
     design: WorkspaceDesign = WorkspaceDesign(),
+    managerDialog: ManagerDialog.WorkspaceTargeted? = null,
+    onScreenAction: (WorkspaceScreenAction) -> Unit = {},
     onShareError: (Throwable) -> Unit = {},
     onCloseWorkspace: () -> Unit = {},
     onResumeWorkspace: () -> Unit = {},
@@ -187,6 +197,18 @@ fun WorkspaceModalContent(
                     CompositionLocalProvider(LocalPaneLayerRank provides PaneLayerRank.OVERLAY) {
                         entry.Overlays(id = workspace.id, design = design)
                     }
+                }
+            }
+
+            // Depth zero: this window renders one leaf workspace, so there is a single tier of
+            // layers and this is its top one. Outside the lifecycle gate like a pane's, a close
+            // confirmation for a paused workspace must still be answerable.
+            managerDialog?.let { dialog ->
+                PaneLayer(modifier = Modifier.fillMaxSize(), rank = PaneLayerRank.managerAt(0)) {
+                    ManagerDialogHost(
+                        dialog = dialog,
+                        onAction = { onScreenAction(WorkspaceScreenAction.HandleDialog(it)) },
+                    )
                 }
             }
         }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -45,6 +45,7 @@ import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.dialogs.ClearSessionConfirmationDialog
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialogAction
+import eu.darken.butler.workspace.ui.dialogs.WorkspaceCloseConfirmationDialog
 import eu.darken.butler.workspace.ui.dialogs.WorkspaceLimitDialog
 import eu.darken.butler.workspace.ui.dialogs.WorkspaceRenameDialog
 import eu.darken.butler.workspace.ui.feedback.BannerState
@@ -70,6 +71,8 @@ fun WorkspaceScreen(
     bannerStates: Map<Workspace.Id, BannerState> = emptyMap(),
     managerDialogStates: Map<Workspace.Id, ManagerDialog.WorkspaceTargeted>,
     managerDialogs: List<ManagerDialog> = emptyList(),
+    /** The dialog the full-screen modal window hosts, which no pane may compose. */
+    modalDialogState: ManagerDialog.WorkspaceTargeted? = null,
     isOverlayVisible: Boolean = false,
     reviewActivity: Activity? = null,
     onScreenAction: (WorkspaceScreenAction) -> Unit,
@@ -251,6 +254,8 @@ fun WorkspaceScreen(
         WorkspaceModalDialog(
             workspace = fullScreenModal,
             design = design,
+            managerDialog = modalDialogState,
+            onScreenAction = onScreenAction,
             onDismissRequest = {
                 // Dismiss by closing the modal workspace
                 workspaceActionHandler?.executeWorkspaceAction(
@@ -313,14 +318,21 @@ fun WorkspacesScreenHost(
     val managerState by managerVm.state.collectAsState(initial = null)
     val state by vm.state.collectAsState(initial = null)
 
-    // Derive dialog states from unified registry. Both hosts compose here, so this is where the
-    // routing between them belongs.
+    // Derive dialog states from unified registry. Every host is composed from here or from the
+    // screen below it, so this is where the routing between them belongs.
     val tabOrder = state?.tabWorkspaces?.map { it.id }.orEmpty()
-    val dialogRouting = remember(managerDialogs, pageManagerState.isManagerOverlayVisible, tabOrder) {
+    val fullScreenModalId = state?.fullScreenModalWorkspace?.id
+    val dialogRouting = remember(
+        managerDialogs,
+        pageManagerState.isManagerOverlayVisible,
+        tabOrder,
+        fullScreenModalId,
+    ) {
         routeManagerDialogs(
             dialogs = managerDialogs,
             isManagerOverlayVisible = pageManagerState.isManagerOverlayVisible,
             tabOrder = tabOrder,
+            fullScreenModalId = fullScreenModalId,
         )
     }
     val managerDialogStates = dialogRouting.paneHosted
@@ -390,6 +402,7 @@ fun WorkspacesScreenHost(
                 bannerStates = bannerStates,
                 managerDialogStates = managerDialogStates,
                 managerDialogs = managerDialogs,
+                modalDialogState = dialogRouting.modalHosted,
                 isOverlayVisible = pageManagerState.isManagerOverlayVisible,
                 reviewActivity = activity,
                 onScreenAction = { vm.executeScreenAction(it) },
@@ -483,6 +496,47 @@ fun WorkspacesScreenHost(
                 onDismiss = { vm.dismissClearSessionConfirmation() },
                 onConfirm = { vm.confirmClearSession() },
             )
+        }
+
+        // Composed here rather than in a pane, which is what makes it a window dialog: outside every
+        // PaneLayerHost the adaptive renderer resolves to the window one, so the question covers the
+        // screen instead of scrimming a pane that belongs to a tab the close leaves alone.
+        dialogRouting.globalHosted?.let { dialog ->
+            key(dialog.id) {
+                WorkspaceCloseConfirmationDialog(
+                    workspaceTitle = dialog.workspaceTitle,
+                    hasUnsavedChanges = dialog.hasUnsavedChanges,
+                    unsavedCount = dialog.unsavedCount,
+                    onDismiss = {
+                        vm.executeScreenAction(
+                            WorkspaceScreenAction.HandleDialog(
+                                ManagerDialogAction.Resolve(dialog.id, confirmed = false),
+                            ),
+                        )
+                    },
+                    onConfirm = {
+                        vm.executeScreenAction(
+                            WorkspaceScreenAction.HandleDialog(
+                                ManagerDialogAction.Resolve(dialog.id, confirmed = true),
+                            ),
+                        )
+                    },
+                    onGoToWorkspace = {
+                        vm.executeScreenAction(
+                            WorkspaceScreenAction.HandleDialog(
+                                ManagerDialogAction.CancelAndGoToWorkspace(
+                                    confirmationId = dialog.id,
+                                    workspaceId = dialog.closingWorkspaceId,
+                                    sourceWorkspaceId = dialog.selectionSourceWorkspaceId,
+                                    // This dialog can be raised while the manager is up, and hiding
+                                    // one that is already down does nothing.
+                                    hideManagerOverlay = true,
+                                ),
+                            ),
+                        )
+                    },
+                )
+            }
         }
 
         // WorkspaceLimitDialog renders above everything - visible over both workspace and manager

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -521,19 +521,25 @@ fun WorkspacesScreenHost(
                             ),
                         )
                     },
-                    onGoToWorkspace = {
-                        vm.executeScreenAction(
-                            WorkspaceScreenAction.HandleDialog(
-                                ManagerDialogAction.CancelAndGoToWorkspace(
-                                    confirmationId = dialog.id,
-                                    workspaceId = dialog.closingWorkspaceId,
-                                    sourceWorkspaceId = dialog.selectionSourceWorkspaceId,
-                                    // This dialog can be raised while the manager is up, and hiding
-                                    // one that is already down does nothing.
-                                    hideManagerOverlay = true,
+                    // A tab whose ownership chain is broken cannot be brought on screen, so the
+                    // jump is not offered rather than cancelling the close for nothing.
+                    onGoToWorkspace = if (dialog.canGoToWorkspace) {
+                        {
+                            vm.executeScreenAction(
+                                WorkspaceScreenAction.HandleDialog(
+                                    ManagerDialogAction.CancelAndGoToWorkspace(
+                                        confirmationId = dialog.id,
+                                        workspaceId = dialog.closingWorkspaceId,
+                                        sourceWorkspaceId = dialog.selectionSourceWorkspaceId,
+                                        // This dialog can be raised while the manager is up, and
+                                        // hiding one that is already down does nothing.
+                                        hideManagerOverlay = true,
+                                    ),
                                 ),
-                            ),
-                        )
+                            )
+                        }
+                    } else {
+                        null
                     },
                 )
             }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -125,56 +125,87 @@ class WorkspacesViewModel @Inject constructor(
             .onEach { state -> savedStateHandle["workspaceUIState"] = state }
             .launchInViewModel()
 
-        // Observe pending confirmations and populate unified dialog registry
-        workspaceRepo.pendingConfirmations
-            .onEach { confirmations ->
-                log(tag) { "Pending confirmations updated: ${confirmations.size}" }
+        // Observe pending confirmations and populate unified dialog registry. The layout is an input
+        // because who can host a close confirmation changes with it: a pane reassignment, a modal
+        // opening or the anchor closing all move the question to a different host.
+        combine(
+            workspaceRepo.pendingConfirmations,
+            workspacePageManager.state,
+            workspaceRepo.state,
+        ) { confirmations, uiState, repoState ->
+            log(tag) { "Pending confirmations updated: ${confirmations.size}" }
+            val hosts = renderedHosts(infos = repoState.infos, uiState = uiState)
 
-                val dialogs = confirmations.mapNotNull { (confirmationId, confirmation) ->
-                    when (val data = confirmation.data) {
-                        is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceLimitReached -> {
-                            ManagerDialog.Global.WorkspaceLimitReached(
+            confirmations.mapNotNull { (confirmationId, confirmation) ->
+                when (val data = confirmation.data) {
+                    is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceLimitReached -> {
+                        ManagerDialog.Global.WorkspaceLimitReached(
+                            id = confirmationId,
+                            currentCount = data.currentCount,
+                            limit = data.limit,
+                            candidates = data.candidates,
+                            canRecover = data.canRecover,
+                            minToClose = data.minToClose,
+                        )
+                    }
+                    is PendingWorkspaceConfirmation.ConfirmationData.BatchWorkspaceCreation -> {
+                        // Nothing to ask without a pane: the confirmation belongs to what that pane
+                        // was doing, and there is no window variant of it.
+                        val targetId = confirmation.sourceWorkspaceId
+                            ?: uiState.focusedWorkspaceId
+                            ?: run {
+                                log(tag, WARN) { "No target workspace for confirmation $confirmationId" }
+                                return@mapNotNull null
+                            }
+                        ManagerDialog.WorkspaceTargeted.BatchCreationConfirmation(
+                            id = confirmationId,
+                            targetWorkspaceId = targetId,
+                            totalCount = data.totalCount,
+                        )
+                    }
+                    is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation -> {
+                        val anchorId = confirmation.sourceWorkspaceId ?: uiState.focusedWorkspaceId
+                        val anchorRendered = anchorId != null && anchorId in hosts.paneRenderedIds
+                        when {
+                            anchorId != null && anchorId == hosts.fullScreenModalId -> {
+                                ManagerDialog.WorkspaceTargeted.CloseConfirmation(
+                                    id = confirmationId,
+                                    targetWorkspaceId = anchorId,
+                                    closingWorkspaceId = data.workspaceId,
+                                    workspaceTitle = data.workspaceTitle,
+                                    hasUnsavedChanges = data.hasUnsavedChanges,
+                                    unsavedCount = data.unsavedCount,
+                                )
+                            }
+                            // A pane may only ask about a close that takes it down too. Anywhere
+                            // else the pane belongs to a tab the close leaves alone, and a dialog
+                            // scrimming it reads as that tab being the one about to go.
+                            anchorId != null && data.hostInClosingSubtree && anchorRendered -> {
+                                ManagerDialog.WorkspaceTargeted.CloseConfirmation(
+                                    id = confirmationId,
+                                    targetWorkspaceId = anchorId,
+                                    closingWorkspaceId = data.workspaceId,
+                                    workspaceTitle = data.workspaceTitle,
+                                    hasUnsavedChanges = data.hasUnsavedChanges,
+                                    unsavedCount = data.unsavedCount,
+                                )
+                            }
+                            else -> ManagerDialog.Global.CloseConfirmation(
                                 id = confirmationId,
-                                currentCount = data.currentCount,
-                                limit = data.limit,
-                                candidates = data.candidates,
-                                canRecover = data.canRecover,
-                                minToClose = data.minToClose,
-                            )
-                        }
-                        is PendingWorkspaceConfirmation.ConfirmationData.BatchWorkspaceCreation -> {
-                            val targetId = confirmation.sourceWorkspaceId
-                                ?: workspacePageManager.state.value.focusedWorkspaceId
-                                ?: run {
-                                    log(tag, WARN) { "No target workspace for confirmation $confirmationId" }
-                                    return@mapNotNull null
-                                }
-                            ManagerDialog.WorkspaceTargeted.BatchCreationConfirmation(
-                                id = confirmationId,
-                                targetWorkspaceId = targetId,
-                                totalCount = data.totalCount,
-                            )
-                        }
-                        is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation -> {
-                            val targetId = confirmation.sourceWorkspaceId
-                                ?: workspacePageManager.state.value.focusedWorkspaceId
-                                ?: run {
-                                    log(tag, WARN) { "No target workspace for confirmation $confirmationId" }
-                                    return@mapNotNull null
-                                }
-                            ManagerDialog.WorkspaceTargeted.CloseConfirmation(
-                                id = confirmationId,
-                                targetWorkspaceId = targetId,
                                 closingWorkspaceId = data.workspaceId,
                                 workspaceTitle = data.workspaceTitle,
                                 hasUnsavedChanges = data.hasUnsavedChanges,
                                 unsavedCount = data.unsavedCount,
+                                // An anchor nothing renders protects no pane, and naming it would
+                                // make the jump defend a pane that is not there.
+                                selectionSourceWorkspaceId = anchorId?.takeIf { anchorRendered },
                             )
                         }
                     }
                 }
-                _managerDialogs.value = dialogs
             }
+        }
+            .onEach { _managerDialogs.value = it }
             .launchInViewModel()
 
         // Observe workspace events for banner feedback
@@ -243,6 +274,30 @@ class WorkspacesViewModel @Inject constructor(
         } ?: return
 
         workspacePageManager.setLayout(mapOf(0 to targetId), focusedId = targetId)
+    }
+
+    /** What the layout currently on screen can host a workspace-targeted dialog in. */
+    private class RenderedHosts(
+        val fullScreenModalId: Workspace.Id?,
+        val paneRenderedIds: Set<Workspace.Id>,
+    )
+
+    /**
+     * Resolved from the same walk [State] renders by: a pane composes a dialog host for its assigned
+     * tab and for each modal stacked on it, the full-screen modal window only for its leaf.
+     */
+    private fun renderedHosts(
+        infos: List<Workspace.Info>,
+        uiState: WorkspacePageManager.State,
+    ): RenderedHosts {
+        val rendered = WorkspaceStacks(infos).renderedChains(focusedId = uiState.focusedWorkspaceId)
+        return RenderedHosts(
+            fullScreenModalId = rendered.fullScreen?.leaf?.id,
+            paneRenderedIds = uiState.visiblePaneAssignments.values
+                .flatMapTo(mutableSetOf<Workspace.Id>()) { tabId ->
+                    listOf(tabId) + rendered.paneLocal[tabId]?.modals.orEmpty().map { it.id }
+                },
+        )
     }
 
     private val visibleMotd = kotlinx.coroutines.flow.combine(motdRepo.motd, hiddenMotdIds) { motd, hiddenIds ->

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -135,6 +135,7 @@ class WorkspacesViewModel @Inject constructor(
         ) { confirmations, uiState, repoState ->
             log(tag) { "Pending confirmations updated: ${confirmations.size}" }
             val hosts = renderedHosts(infos = repoState.infos, uiState = uiState)
+            val stacks = WorkspaceStacks(repoState.infos)
 
             confirmations.mapNotNull { (confirmationId, confirmation) ->
                 when (val data = confirmation.data) {
@@ -199,6 +200,9 @@ class WorkspacesViewModel @Inject constructor(
                                 // An anchor nothing renders protects no pane, and naming it would
                                 // make the jump defend a pane that is not there.
                                 selectionSourceWorkspaceId = anchorId?.takeIf { anchorRendered },
+                                // Nothing can put a tab on screen whose ownership chain is broken,
+                                // so a jump offered for it would cancel the close and go nowhere.
+                                canGoToWorkspace = stacks.rootOf(data.workspaceId) != null,
                             )
                         }
                     }
@@ -432,10 +436,16 @@ class WorkspacesViewModel @Inject constructor(
                     // selection puts its tab on screen, or the dialog re-renders in that pane, and
                     // the overlay only comes down once the tab it would cover is actually there.
                     workspaceRepo.resolveConfirmation(dialogAction.confirmationId, confirmed = false)
-                    workspacePageManager.handleWorkspaceSelection(
-                        workspaceId = dialogAction.workspaceId,
-                        sourceWorkspaceId = dialogAction.sourceWorkspaceId,
-                    )
+                    // The selection waits for the tab to publish its info, which never happens for
+                    // one whose ownership chain is broken - and the overlay would wait with it.
+                    if (workspaceRepo.peekStacks().rootOf(dialogAction.workspaceId) != null) {
+                        workspacePageManager.handleWorkspaceSelection(
+                            workspaceId = dialogAction.workspaceId,
+                            sourceWorkspaceId = dialogAction.sourceWorkspaceId,
+                        )
+                    } else {
+                        log(tag, WARN) { "No ownership root for ${dialogAction.workspaceId}, not selecting it" }
+                    }
                     if (dialogAction.hideManagerOverlay) workspacePageManager.hideManagerOverlay()
                 }
             }

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -1544,6 +1544,14 @@ class WorkspaceRepoTest : BaseTest() {
                 data.workspaceId == id
         }
 
+    private suspend fun WorkspaceRepo.closeConfirmationData(
+        id: Workspace.Id,
+    ): PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation = pendingConfirmations.first()
+        .values
+        .map { it.data }
+        .filterIsInstance<PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation>()
+        .single { it.workspaceId == id }
+
     @Test
     fun `closing a dirty workspace queues a confirmation instead of closing`() =
         runTest(UnconfinedTestDispatcher()) {
@@ -1847,6 +1855,45 @@ class WorkspaceRepoTest : BaseTest() {
             // Its host pane is gone, so there is nothing left to render it in.
             repo.pendingConfirmations.first() shouldBe emptyMap()
             repo.retrieve(dirty).first() shouldNotBe null
+        }
+
+    @Test
+    fun `a close names its own anchor as part of what it removes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val id = repo.createTab()
+            markDirty(id)
+
+            repo.execute(WorkspaceAction.Close(id))
+
+            repo.closeConfirmationData(id).hostInClosingSubtree shouldBe true
+        }
+
+    @Test
+    fun `a close invoked from a child anchors inside what it removes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(tabId)
+
+            repo.execute(WorkspaceAction.Close(tabId, sourceWorkspaceId = childId))
+
+            // The child goes down with the tab, so the layer it asked from can host the question.
+            repo.closeConfirmationData(tabId).hostInClosingSubtree shouldBe true
+        }
+
+    @Test
+    fun `a close invoked from an unrelated tab anchors outside what it removes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val dirty = repo.createTab()
+            val host = repo.createTab()
+            markDirty(dirty)
+
+            repo.execute(WorkspaceAction.Close(dirty, sourceWorkspaceId = host))
+
+            repo.closeConfirmationData(dirty).hostInClosingSubtree shouldBe false
         }
 
     @Test

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -1841,7 +1841,7 @@ class WorkspaceRepoTest : BaseTest() {
         }
 
     @Test
-    fun `a confirmation dies with the tab whose pane hosts it`() =
+    fun `a confirmation outlives the tab it borrowed as an anchor`() =
         runTest(UnconfinedTestDispatcher()) {
             val repo = createRepo()
             val dirty = repo.createTab()
@@ -1852,9 +1852,27 @@ class WorkspaceRepoTest : BaseTest() {
 
             repo.execute(WorkspaceAction.Close(host))
 
-            // Its host pane is gone, so there is nothing left to render it in.
-            repo.pendingConfirmations.first() shouldBe emptyMap()
+            // The anchor is an unrelated tab, so it never rendered the question - losing it takes
+            // nothing away, while dropping the confirmation would silently abandon the close.
+            repo.pendingConfirmations.first().closeConfirmationsFor(dirty) shouldBe 1
             repo.retrieve(dirty).first() shouldNotBe null
+        }
+
+    @Test
+    fun `a confirmation dies with the child layer that asked it`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val tabId = repo.createTab()
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markDirty(tabId)
+            repo.execute(WorkspaceAction.Close(tabId, sourceWorkspaceId = childId))
+            repo.pendingConfirmations.first().closeConfirmationsFor(tabId) shouldBe 1
+
+            repo.execute(WorkspaceAction.Close(childId))
+
+            // The layer rendering it is gone, so there is nothing left to answer in.
+            repo.pendingConfirmations.first() shouldBe emptyMap()
+            repo.retrieve(tabId).first() shouldNotBe null
         }
 
     @Test

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerDialogRoutingTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerDialogRoutingTest.kt
@@ -38,6 +38,7 @@ class ManagerDialogRoutingTest : BaseTest() {
             workspaceTitle = "notes.txt".toCaString(),
             hasUnsavedChanges = true,
             selectionSourceWorkspaceId = null,
+            canGoToWorkspace = true,
         )
 
     private fun batchConfirmation(host: Workspace.Id) =

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerDialogRoutingTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerDialogRoutingTest.kt
@@ -10,7 +10,8 @@ import testhelpers.BaseTest
 
 /**
  * The tab manager overlay covers every pane, so while it is up it - not the pane - has to host a
- * close confirmation. Exactly one host may compose a given dialog.
+ * close confirmation, and a full-screen modal window covers the overlay in turn. Exactly one host
+ * may compose a given dialog.
  */
 class ManagerDialogRoutingTest : BaseTest() {
 
@@ -29,6 +30,15 @@ class ManagerDialogRoutingTest : BaseTest() {
         workspaceTitle = "notes.txt".toCaString(),
         hasUnsavedChanges = true,
     )
+
+    private fun globalConfirmation(id: String, closing: Workspace.Id) =
+        ManagerDialog.Global.CloseConfirmation(
+            id = id,
+            closingWorkspaceId = closing,
+            workspaceTitle = "notes.txt".toCaString(),
+            hasUnsavedChanges = true,
+            selectionSourceWorkspaceId = null,
+        )
 
     private fun batchConfirmation(host: Workspace.Id) =
         ManagerDialog.WorkspaceTargeted.BatchCreationConfirmation(
@@ -49,6 +59,8 @@ class ManagerDialogRoutingTest : BaseTest() {
 
         routing.paneHosted shouldBe mapOf(tabA to dialog)
         routing.managerHosted.shouldBeNull()
+        routing.modalHosted.shouldBeNull()
+        routing.globalHosted.shouldBeNull()
     }
 
     @Test
@@ -65,6 +77,8 @@ class ManagerDialogRoutingTest : BaseTest() {
         // renders it twice, the other renders it nowhere.
         routing.paneHosted shouldBe emptyMap()
         routing.managerHosted shouldBe dialog
+        routing.modalHosted.shouldBeNull()
+        routing.globalHosted.shouldBeNull()
     }
 
     @Test
@@ -153,7 +167,7 @@ class ManagerDialogRoutingTest : BaseTest() {
     }
 
     @Test
-    fun `global dialogs are not routed to either host`() {
+    fun `the limit dialog is not routed to any workspace host`() {
         val limit = ManagerDialog.Global.WorkspaceLimitReached(
             id = "limit",
             currentCount = 5,
@@ -168,5 +182,110 @@ class ManagerDialogRoutingTest : BaseTest() {
 
         routing.paneHosted shouldBe emptyMap()
         routing.managerHosted.shouldBeNull()
+        routing.modalHosted.shouldBeNull()
+        routing.globalHosted.shouldBeNull()
+    }
+
+    @Test
+    fun `the modal window hosts the confirmation anchored to it, not the manager`() {
+        val modal = Workspace.Id()
+        val dialog = closeConfirmation("c1", closing = tabA, host = modal)
+
+        val routing = routeManagerDialogs(
+            dialogs = listOf(dialog),
+            isManagerOverlayVisible = true,
+            tabOrder = tabOrder,
+            fullScreenModalId = modal,
+        )
+
+        // The modal is a window drawn above the overlay, so a dialog the manager composed would end
+        // up behind the workspace it is anchored to.
+        routing.modalHosted shouldBe dialog
+        routing.managerHosted.shouldBeNull()
+        routing.paneHosted shouldBe emptyMap()
+    }
+
+    @Test
+    fun `the modal window hosts the confirmation anchored to it, not a pane`() {
+        val modal = Workspace.Id()
+        val dialog = closeConfirmation("c1", closing = tabA, host = modal)
+
+        val routing = routeManagerDialogs(
+            dialogs = listOf(dialog),
+            isManagerOverlayVisible = false,
+            tabOrder = tabOrder,
+            fullScreenModalId = modal,
+        )
+
+        routing.modalHosted shouldBe dialog
+        routing.paneHosted shouldBe emptyMap()
+    }
+
+    @Test
+    fun `a confirmation anchored elsewhere stays off the modal`() {
+        val modal = Workspace.Id()
+        val dialog = closeConfirmation("c1", closing = tabA)
+
+        val routing = routeManagerDialogs(
+            dialogs = listOf(dialog),
+            isManagerOverlayVisible = false,
+            tabOrder = tabOrder,
+            fullScreenModalId = modal,
+        )
+
+        routing.modalHosted.shouldBeNull()
+        routing.paneHosted shouldBe mapOf(tabA to dialog)
+    }
+
+    @Test
+    fun `a global close confirmation reaches only the screen`() {
+        val dialog = globalConfirmation("c1", closing = tabA)
+
+        val routing = routeManagerDialogs(
+            dialogs = listOf(dialog),
+            isManagerOverlayVisible = false,
+            tabOrder = tabOrder,
+        )
+
+        routing.globalHosted shouldBe dialog
+        routing.paneHosted shouldBe emptyMap()
+        routing.managerHosted.shouldBeNull()
+        routing.modalHosted.shouldBeNull()
+    }
+
+    @Test
+    fun `the screen asks about one tab at a time`() {
+        val first = globalConfirmation("c2", closing = tabA)
+        val second = globalConfirmation("c1", closing = tabB)
+
+        val routing = routeManagerDialogs(
+            dialogs = listOf(second, first),
+            isManagerOverlayVisible = false,
+            tabOrder = tabOrder,
+        )
+
+        // A window dialog covers the screen, so a second one would render behind the first.
+        routing.globalHosted shouldBe first
+    }
+
+    @Test
+    fun `the overlay does not change who hosts a global close confirmation`() {
+        val dialog = globalConfirmation("c1", closing = tabA)
+
+        val whileVisible = routeManagerDialogs(
+            dialogs = listOf(dialog),
+            isManagerOverlayVisible = true,
+            tabOrder = tabOrder,
+        )
+        val afterHiding = routeManagerDialogs(
+            dialogs = listOf(dialog),
+            isManagerOverlayVisible = false,
+            tabOrder = tabOrder,
+        )
+
+        // A window dialog draws above the overlay, so the manager has nothing to take over.
+        whileVisible.globalHosted shouldBe dialog
+        whileVisible.managerHosted.shouldBeNull()
+        afterHiding.globalHosted shouldBe dialog
     }
 }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceModalManagerDialogTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceModalManagerDialogTest.kt
@@ -1,0 +1,202 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
+import eu.darken.butler.workspace.ui.dialogs.ManagerDialogAction
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialogDefaults
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.modal.LocalLayerActive
+import eu.darken.butler.workspace.ui.modal.LocalPaneLayerState
+import eu.darken.butler.workspace.ui.modal.PaneLayer
+import eu.darken.butler.workspace.ui.modal.PaneLayerState
+import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.TestApplication
+
+/**
+ * A full-screen modal owns its own window and layer stack, so a confirmation anchored to it can only
+ * be asked there: composed anywhere else it would render behind the window it belongs to.
+ *
+ * Drives [WorkspaceModalContent] rather than [WorkspaceModalDialog] - the Dialog wrapper only
+ * reconciles a platform window with the Activity's edge-to-edge setup, and everything under test
+ * lives in the content.
+ */
+@Config(application = TestApplication::class, sdk = [34], qualifiers = "w400dp-h800dp")
+class WorkspaceModalManagerDialogTest : ComposeTest() {
+
+    private val design = WorkspaceDesign()
+
+    /** Stands in for the modal's page, including the overlay slot and back handler a real one has. */
+    private class RecordingHost : WorkspacePageHostEntry {
+
+        val backReceipts = mutableListOf<Workspace.Id>()
+        val overlayLayerActive = mutableMapOf<Workspace.Id, Boolean>()
+        val layerStates = mutableMapOf<Workspace.Id, PaneLayerState?>()
+
+        @Composable
+        override fun Content(id: Workspace.Id, design: WorkspaceDesign) {
+            layerStates[id] = LocalPaneLayerState.current
+            WorkspaceBackHandler { backReceipts += id }
+            Box(modifier = Modifier.fillMaxSize().testTag(PAGE_TAG))
+        }
+
+        @Composable
+        override fun Overlays(id: Workspace.Id, design: WorkspaceDesign) {
+            PaneLayer(modifier = Modifier.fillMaxSize(), modal = false) {
+                overlayLayerActive[id] = LocalLayerActive.current
+            }
+        }
+    }
+
+    private fun modalInfo(
+        lifecycleState: Workspace.LifecycleState = Workspace.LifecycleState.Ready,
+    ) = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "Select Folder".toCaString(),
+        lifecycleState = lifecycleState,
+        callerWorkspaceId = Workspace.Id(),
+    )
+
+    private fun confirmation(anchor: Workspace.Id) = ManagerDialog.WorkspaceTargeted.CloseConfirmation(
+        id = "c1",
+        targetWorkspaceId = anchor,
+        closingWorkspaceId = Workspace.Id(),
+        workspaceTitle = TITLE.toCaString(),
+        hasUnsavedChanges = true,
+    )
+
+    @Composable
+    private fun Content(
+        host: WorkspacePageHostEntry,
+        workspace: Workspace.Info,
+        dialog: ManagerDialog.WorkspaceTargeted?,
+        onScreenAction: (WorkspaceScreenAction) -> Unit = {},
+    ) {
+        PreviewWrapper {
+            CompositionLocalProvider(
+                LocalWorkspacePageHosts provides mapOf(
+                    Workspace.Type.EXPLORER to host,
+                    Workspace.Type.SAVER to host,
+                ),
+            ) {
+                WorkspaceModalContent(
+                    workspace = workspace,
+                    design = design,
+                    managerDialog = dialog,
+                    onScreenAction = onScreenAction,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the confirmation is asked inside the modal, above its page`() {
+        val host = RecordingHost()
+        val workspace = modalInfo()
+
+        composeTestRule.setContent {
+            Content(host = host, workspace = workspace, dialog = confirmation(workspace.id))
+        }
+        composeTestRule.waitForIdle()
+
+        // Pane-bound, not a second platform window: the modal already owns the window, and the
+        // dialog's scrim has to cover the page inside it.
+        composeTestRule.onNodeWithTag(PaneBoundAlertDialogDefaults.SURFACE_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText(TITLE, substring = true).assertIsDisplayed()
+        // Manager rank sits above the overlay tier, so the page's overlays go inactive under it.
+        host.overlayLayerActive[workspace.id] shouldBe false
+    }
+
+    @Test
+    fun `back answers the confirmation instead of reaching the page`() {
+        val host = RecordingHost()
+        val workspace = modalInfo()
+        val actions = mutableListOf<WorkspaceScreenAction>()
+        var dispatcher: OnBackPressedDispatcher? = null
+
+        composeTestRule.setContent {
+            dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+            Content(
+                host = host,
+                workspace = workspace,
+                dialog = confirmation(workspace.id),
+                onScreenAction = { actions += it },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle { dispatcher!!.onBackPressed() }
+        composeTestRule.waitForIdle()
+
+        actions shouldBe listOf(
+            WorkspaceScreenAction.HandleDialog(ManagerDialogAction.Resolve("c1", confirmed = false)),
+        )
+        host.backReceipts shouldBe emptyList()
+    }
+
+    @Test
+    fun `a paused modal can still be asked`() {
+        val host = RecordingHost()
+        val workspace = modalInfo(lifecycleState = Workspace.LifecycleState.Paused())
+
+        composeTestRule.setContent {
+            Content(host = host, workspace = workspace, dialog = confirmation(workspace.id))
+        }
+        composeTestRule.waitForIdle()
+
+        // Nothing else can answer for a paused workspace, so the placeholder still carries its
+        // confirmation.
+        composeTestRule.onNodeWithTag(PaneBoundAlertDialogDefaults.SURFACE_TEST_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun `swapping the workspace rebuilds the confirmation with the new layer stack`() {
+        val host = RecordingHost()
+        val first = modalInfo()
+        val second = modalInfo().copy(type = Workspace.Type.SAVER)
+        var current by mutableStateOf(first)
+
+        composeTestRule.setContent {
+            Content(host = host, workspace = current, dialog = confirmation(current.id))
+        }
+        composeTestRule.waitForIdle()
+
+        val firstStack = host.layerStates[first.id]!!
+
+        composeTestRule.runOnIdle { current = second }
+        composeTestRule.waitForIdle()
+
+        // Unwinding a chain swaps the workspace under this one call site. The dialog belongs to the
+        // stack of the workspace it is anchored to, so that stack going away has to take it along.
+        firstStack.layerCount shouldBe 0
+        host.overlayLayerActive[second.id] shouldBe false
+        composeTestRule.onNodeWithTag(PaneBoundAlertDialogDefaults.SURFACE_TEST_TAG).assertIsDisplayed()
+    }
+
+    companion object {
+        private const val TITLE = "notes.txt"
+        private const val PAGE_TAG = "modal-page-content"
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
@@ -57,7 +57,8 @@ import kotlin.time.Duration.Companion.seconds
 
 /**
  * Who hosts a close confirmation and what it acts on are two different workspaces, and the dialog
- * actions have to keep them apart.
+ * actions have to keep them apart. A pane may only be the host when the close takes that pane's
+ * workspace down too and something on screen renders it; everything else is a window dialog.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = TestApplication::class)
@@ -84,6 +85,9 @@ class WorkspacesViewModelDialogTest : BaseTest() {
         infos: List<Workspace.Info> = emptyList(),
         confirmations: Map<String, PendingWorkspaceConfirmation> = emptyMap(),
         focusedWorkspaceId: Workspace.Id? = null,
+        pageManagerState: MutableStateFlow<WorkspacePageManager.State> = MutableStateFlow(
+            WorkspacePageManager.State(focusedWorkspaceId = focusedWorkspaceId),
+        ),
     ): WorkspacesViewModel {
         every { workspaceRepo.state } returns flowOf(WorkspaceRemote.State(infos = infos))
         every { workspaceRepo.events } returns emptyFlow()
@@ -94,9 +98,7 @@ class WorkspacesViewModelDialogTest : BaseTest() {
             every { onDemandWorkspaceCreation } returns boolSetting(true)
             every { paneClickToFocus } returns boolSetting(true)
         }
-        every { pageManager.state } returns MutableStateFlow(
-            WorkspacePageManager.State(focusedWorkspaceId = focusedWorkspaceId),
-        )
+        every { pageManager.state } returns pageManagerState
         val sessionManager = mockk<WorkspaceSessionManager>(relaxed = true).apply {
             every { state } returns MutableStateFlow(WorkspaceSessionManager.State.Disabled)
         }
@@ -145,46 +147,175 @@ class WorkspacesViewModelDialogTest : BaseTest() {
     private suspend fun WorkspacesViewModel.settledDialogs() =
         withTimeoutOrNull(10.seconds) { managerDialogs.filterNotNull().first { it.isNotEmpty() } }
 
+    /** One instance: a CaString wraps a lambda, so two of them are never equal. */
+    private val closingTitle = "notes.txt".toCaString()
+
     private fun closeConfirmation(
         id: String,
         closing: Workspace.Id,
         host: Workspace.Id?,
+        hostInClosingSubtree: Boolean = host == null || host == closing,
     ) = id to PendingWorkspaceConfirmation(
         id = id,
         sourceWorkspaceId = host,
         data = PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation(
             workspaceId = closing,
-            workspaceTitle = "notes.txt".toCaString(),
+            workspaceTitle = closingTitle,
             hasUnsavedChanges = true,
+            unsavedCount = 2,
+            hostInClosingSubtree = hostInClosingSubtree,
         ),
     )
 
+    private fun tab(id: Workspace.Id) = Workspace.Info(
+        id = id,
+        type = Workspace.Type.EXPLORER,
+        title = "Explorer".toCaString(),
+    )
+
+    /** A modal stacked on [caller], which is what makes it render inside that tab's pane. */
+    private fun stackedChild(id: Workspace.Id, caller: Workspace.Id) = Workspace.Info(
+        id = id,
+        type = Workspace.Type.SAVER,
+        title = "Save as".toCaString(),
+        callerWorkspaceId = caller,
+    )
+
     @Test fun `the mapping keeps the closing tab and its host apart`() = runTest2(context = testDispatcher) {
-        val editor = Workspace.Id()
-        val host = Workspace.Id()
-        val vm = vm(confirmations = mapOf(closeConfirmation("c1", closing = editor, host = host)))
+        val tabId = Workspace.Id()
+        val child = Workspace.Id()
+        val vm = vm(
+            infos = listOf(tab(tabId), stackedChild(child, caller = tabId)),
+            confirmations = mapOf(
+                closeConfirmation("c1", closing = tabId, host = child, hostInClosingSubtree = true),
+            ),
+            pageManagerState = MutableStateFlow(
+                WorkspacePageManager.State(
+                    focusedWorkspaceId = child,
+                    selectedWorkspaces = mapOf(0 to tabId),
+                ),
+            ),
+        )
         advanceUntilIdle()
 
+        // The close takes the child down with it, so the layer it asked from is the right place for
+        // the question.
         val dialog = vm.settledDialogs()!!.single()
             .shouldBeInstanceOf<ManagerDialog.WorkspaceTargeted.CloseConfirmation>()
-        dialog.closingWorkspaceId shouldBe editor
-        dialog.targetWorkspaceId shouldBe host
+        dialog.closingWorkspaceId shouldBe tabId
+        dialog.targetWorkspaceId shouldBe child
     }
 
     @Test fun `a confirmation without a host falls back to the focused workspace`() =
         runTest2(context = testDispatcher) {
-            val editor = Workspace.Id()
-            val focused = Workspace.Id()
+            val tabId = Workspace.Id()
+            val child = Workspace.Id()
             val vm = vm(
-                confirmations = mapOf(closeConfirmation("c1", closing = editor, host = null)),
-                focusedWorkspaceId = focused,
+                infos = listOf(tab(tabId), stackedChild(child, caller = tabId)),
+                confirmations = mapOf(closeConfirmation("c1", closing = tabId, host = null)),
+                pageManagerState = MutableStateFlow(
+                    WorkspacePageManager.State(
+                        focusedWorkspaceId = child,
+                        selectedWorkspaces = mapOf(0 to tabId),
+                    ),
+                ),
             )
             advanceUntilIdle()
 
             val dialog = vm.settledDialogs()!!.single()
                 .shouldBeInstanceOf<ManagerDialog.WorkspaceTargeted.CloseConfirmation>()
-            dialog.closingWorkspaceId shouldBe editor
-            dialog.targetWorkspaceId shouldBe focused
+            dialog.closingWorkspaceId shouldBe tabId
+            dialog.targetWorkspaceId shouldBe child
+        }
+
+    @Test fun `a close of another tab asks in a window dialog`() = runTest2(context = testDispatcher) {
+        val editor = Workspace.Id()
+        val host = Workspace.Id()
+        val vm = vm(
+            infos = listOf(tab(editor), tab(host)),
+            confirmations = mapOf(closeConfirmation("c1", closing = editor, host = host)),
+            pageManagerState = MutableStateFlow(
+                WorkspacePageManager.State(
+                    focusedWorkspaceId = host,
+                    selectedWorkspaces = mapOf(0 to host),
+                ),
+            ),
+        )
+        advanceUntilIdle()
+
+        // Scrimming the host pane would read as that tab being the one about to close.
+        val dialog = vm.settledDialogs()!!.single()
+            .shouldBeInstanceOf<ManagerDialog.Global.CloseConfirmation>()
+        dialog.closingWorkspaceId shouldBe editor
+        dialog.workspaceTitle shouldBe closingTitle
+        dialog.hasUnsavedChanges shouldBe true
+        dialog.unsavedCount shouldBe 2
+        // The host is on screen, so the jump can act from its pane.
+        dialog.selectionSourceWorkspaceId shouldBe host
+    }
+
+    @Test fun `a close whose anchor nothing renders asks in a window dialog`() =
+        runTest2(context = testDispatcher) {
+            val missing = Workspace.Id()
+            val onScreen = Workspace.Id()
+            val vm = vm(
+                infos = listOf(tab(onScreen)),
+                confirmations = mapOf(
+                    closeConfirmation("c1", closing = missing, host = missing),
+                ),
+                pageManagerState = MutableStateFlow(
+                    WorkspacePageManager.State(
+                        focusedWorkspaceId = onScreen,
+                        selectedWorkspaces = mapOf(0 to onScreen),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            // A close of an id no workspace holds still has to be answerable, and no pane can
+            // compose a dialog for an id it does not render.
+            val dialog = vm.settledDialogs()!!.single()
+                .shouldBeInstanceOf<ManagerDialog.Global.CloseConfirmation>()
+            dialog.closingWorkspaceId shouldBe missing
+            // A dead anchor protects no pane from eviction.
+            dialog.selectionSourceWorkspaceId shouldBe null
+        }
+
+    @Test fun `reassigning the host pane moves the question to a window dialog`() =
+        runTest2(context = testDispatcher) {
+            val tabId = Workspace.Id()
+            val child = Workspace.Id()
+            val other = Workspace.Id()
+            val pageManagerState = MutableStateFlow(
+                WorkspacePageManager.State(
+                    focusedWorkspaceId = child,
+                    selectedWorkspaces = mapOf(0 to tabId),
+                ),
+            )
+            val vm = vm(
+                infos = listOf(tab(tabId), stackedChild(child, caller = tabId), tab(other)),
+                confirmations = mapOf(
+                    closeConfirmation("c1", closing = tabId, host = child, hostInClosingSubtree = true),
+                ),
+                pageManagerState = pageManagerState,
+            )
+            advanceUntilIdle()
+
+            vm.settledDialogs()!!.single()
+                .shouldBeInstanceOf<ManagerDialog.WorkspaceTargeted.CloseConfirmation>()
+
+            // The rail stays interactive while the confirmation is up, so the pane hosting it can be
+            // handed to another tab - with nothing pending changing at all.
+            pageManagerState.value = WorkspacePageManager.State(
+                focusedWorkspaceId = other,
+                selectedWorkspaces = mapOf(0 to other),
+            )
+            advanceUntilIdle()
+
+            val dialog = vm.managerDialogs.value.single()
+                .shouldBeInstanceOf<ManagerDialog.Global.CloseConfirmation>()
+            dialog.closingWorkspaceId shouldBe tabId
+            dialog.selectionSourceWorkspaceId shouldBe null
         }
 
     @Test fun `resolving acts on the confirmation id it was given`() = runTest2(context = testDispatcher) {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
+import eu.darken.butler.workspace.core.WorkspaceStacks
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import eu.darken.butler.workspace.ui.WorkspacePageManager
 import eu.darken.butler.workspace.ui.WorkspaceVisibilityTracker
@@ -32,6 +33,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -92,6 +94,7 @@ class WorkspacesViewModelDialogTest : BaseTest() {
         every { workspaceRepo.state } returns flowOf(WorkspaceRemote.State(infos = infos))
         every { workspaceRepo.events } returns emptyFlow()
         every { workspaceRepo.pendingConfirmations } returns flowOf(confirmations)
+        every { workspaceRepo.peekStacks() } answers { WorkspaceStacks(infos) }
 
         val workspaceSettings = mockk<WorkspaceSettings>(relaxed = true).apply {
             every { swipeGesturesEnabled } returns boolSetting(true)
@@ -252,7 +255,32 @@ class WorkspacesViewModelDialogTest : BaseTest() {
         dialog.unsavedCount shouldBe 2
         // The host is on screen, so the jump can act from its pane.
         dialog.selectionSourceWorkspaceId shouldBe host
+        dialog.canGoToWorkspace shouldBe true
     }
+
+    @Test fun `a close of a tab whose owner is gone offers no jump`() =
+        runTest2(context = testDispatcher) {
+            val orphan = Workspace.Id()
+            val onScreen = Workspace.Id()
+            val vm = vm(
+                infos = listOf(tab(onScreen), stackedChild(orphan, caller = Workspace.Id())),
+                confirmations = mapOf(closeConfirmation("c1", closing = orphan, host = onScreen)),
+                pageManagerState = MutableStateFlow(
+                    WorkspacePageManager.State(
+                        focusedWorkspaceId = onScreen,
+                        selectedWorkspaces = mapOf(0 to onScreen),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            // A dirty orphan whose caller is gone is still closable, but nothing can put it on
+            // screen, so the question must not offer to go there.
+            val dialog = vm.settledDialogs()!!.single()
+                .shouldBeInstanceOf<ManagerDialog.Global.CloseConfirmation>()
+            dialog.closingWorkspaceId shouldBe orphan
+            dialog.canGoToWorkspace shouldBe false
+        }
 
     @Test fun `a close whose anchor nothing renders asks in a window dialog`() =
         runTest2(context = testDispatcher) {
@@ -337,7 +365,7 @@ class WorkspacesViewModelDialogTest : BaseTest() {
             every { workspaceRepo.resolveConfirmation(any(), any()) } answers { order += "resolve" }
             coEvery { pageManager.handleWorkspaceSelection(any(), any()) } answers { order += "select" }
 
-            val vm = vm()
+            val vm = vm(infos = listOf(tab(editor), tab(host)))
             vm.executeScreenAction(
                 WorkspaceScreenAction.HandleDialog(
                     ManagerDialogAction.CancelAndGoToWorkspace(
@@ -364,7 +392,7 @@ class WorkspacesViewModelDialogTest : BaseTest() {
             coEvery { pageManager.handleWorkspaceSelection(any(), any()) } answers { order += "select" }
             every { pageManager.hideManagerOverlay() } answers { order += "hide" }
 
-            val vm = vm()
+            val vm = vm(infos = listOf(tab(editor)))
             vm.executeScreenAction(
                 WorkspaceScreenAction.HandleDialog(
                     ManagerDialogAction.CancelAndGoToWorkspace(
@@ -381,11 +409,34 @@ class WorkspacesViewModelDialogTest : BaseTest() {
             order shouldBe listOf("select", "hide")
         }
 
+    @Test fun `the jump to a tab whose owner is gone still takes the overlay down`() =
+        runTest2(context = testDispatcher) {
+            val orphan = Workspace.Id()
+            // What the real selection does with an id the repo never publishes an info for.
+            coEvery { pageManager.handleWorkspaceSelection(any(), any()) } coAnswers { awaitCancellation() }
+
+            val vm = vm()
+            vm.executeScreenAction(
+                WorkspaceScreenAction.HandleDialog(
+                    ManagerDialogAction.CancelAndGoToWorkspace(
+                        confirmationId = "c1",
+                        workspaceId = orphan,
+                        sourceWorkspaceId = null,
+                        hideManagerOverlay = true,
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { pageManager.handleWorkspaceSelection(any(), any()) }
+            verify(exactly = 1) { pageManager.hideManagerOverlay() }
+        }
+
     @Test fun `the jump from a pane leaves the overlay alone`() = runTest2(context = testDispatcher) {
         val editor = Workspace.Id()
         val host = Workspace.Id()
 
-        val vm = vm()
+        val vm = vm(infos = listOf(tab(editor), tab(host)))
         vm.executeScreenAction(
             WorkspaceScreenAction.HandleDialog(
                 ManagerDialogAction.CancelAndGoToWorkspace(


### PR DESCRIPTION
## What changed

Closing a tab that isn't currently on screen used to raise its "Close tab?" question inside whichever pane you were looking at, dimming that pane. Because the question names a different tab than the pane it covers, it read as though that pane was the one about to close. Those confirmations are now an ordinary full-window dialog, like the one you get from long-pressing close on the Butler button. Closing a tab that a pane *is* showing still asks inside that pane, leaving the other panes bright and usable.

Two related problems are fixed along the way. Tapping "Go to tab" for a tab whose ownership is broken used to abandon the close and leave an open tab manager stuck with no way out; the action is no longer offered when the tab cannot be brought on screen. And a confirmation for an off-screen tab no longer disappears when the tab it was raised from happens to close in the background, which silently dropped the close you had asked for.

## Technical Context

- Which host composes a confirmation is decided from two facts combined on every emission, not frozen when the confirmation is created: whether the anchor is inside the closing subtree (only `WorkspaceRepo` knows this, so it is carried on the confirmation) and whether anything currently renders the anchor (only the UI knows, so `WorkspacesViewModel` derives it from live page state). A frozen decision cannot survive a pane being reassigned while a confirmation is pending, and it misclassifies an anchor that no pane can compose.
- `executeClose`'s confirmation cleanup had two cancel legs; the "hosted in its pane" leg is now gated on the anchor actually being part of the close. For a window dialog the anchor is only a placement hint, so a background close of that anchor must not cancel the question.
- The full-screen modal host is wired ahead of any occupant: no production call site passes `ModalPresentationMode.FULL_SCREEN` today. Wiring it now was a deliberate choice made during review, and it is covered by unit and Compose tests only, since no device path can reach it.
- Worth close review: `routeManagerDialogs`' precedence (modal over manager over pane), and the composition point in `WorkspaceModalContent`, which has to stay inside `key(workspace.id)` and inside the existing `PaneLayerHost` or it loses ranking, focus containment and accessibility suppression.
- Manually verified on a three-pane tablet, which CI cannot cover: whole-screen dialog for an off-screen tab with unsaved changes, pane-confined dialog for one that is on screen, and "Go to tab" from both the navigation rail and the tab manager.
