### PR TITLE
General: Share the floating bar packaging across workspaces

### DIFF
--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspacePage.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspacePage.kt
@@ -158,7 +158,7 @@ fun AppsWorkspacePage(
                     WorkspaceActionBar(
                         actions = state.availableActions,
                         onActionClick = { action ->
-                            onPageAction(AppsPageAction.ActionBarClick(action as AppsActionBarItem))
+                            onPageAction(AppsPageAction.ActionBarClick(action))
                         },
                     )
                 }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
@@ -399,7 +399,7 @@ fun AppDetailsWorkspacePage(
                     WorkspaceActionBar(
                         actions = componentActions,
                         onActionClick = { action ->
-                            onPageAction(AppDetailsPageAction.ComponentAction(action as ComponentsActionBarItem))
+                            onPageAction(AppDetailsPageAction.ComponentAction(action))
                         },
                     )
                 }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorBarActionMapping.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorBarActionMapping.kt
@@ -1,0 +1,14 @@
+package eu.darken.butler.editor.ui.editor
+
+import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBarAction
+
+/**
+ * Exhaustiveness guarantees every bar action is handled, not that it is handled correctly: swapping
+ * two same-shaped branches compiles cleanly, so the mapping is pinned by a test instead.
+ */
+internal fun ClipboardBarAction.toPageAction(): EditorPageAction = when (this) {
+    is ClipboardBarAction.Paste -> EditorPageAction.Clipboard.Paste(clip)
+    is ClipboardBarAction.Remove -> EditorPageAction.Clipboard.Remove(clip)
+    is ClipboardBarAction.ShowInfo -> EditorPageAction.Clipboard.ShowInfo(clip)
+    ClipboardBarAction.ClearAll -> EditorPageAction.Clipboard.Clear
+}

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorWorkspacePage.kt
@@ -37,7 +37,7 @@ import eu.darken.butler.editor.ui.editor.text.LazyTextEditor
 import eu.darken.butler.editor.ui.editor.text.SessionDelta
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
-import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBar
+import eu.darken.butler.workspace.ui.clipboard.bar.WorkspaceClipboardFloatingBar
 import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
@@ -120,7 +120,6 @@ fun EditorWorkspacePage(
         onPageAction(EditorPageAction.Navigation.ClearSelection(state.cursorPosition))
     }
 
-    val hasClipboard = clipboardState.entries.isNotEmpty()
     val hasActions = state.availableActions.isNotEmpty()
 
     val topBarStackState = rememberPaneFloatingBarStackState(
@@ -286,21 +285,12 @@ fun EditorWorkspacePage(
                         onReplaceAll = { onPageAction(EditorPageAction.Search.ReplaceAll) },
                     )
                 }
-                FloatingBar(
+                WorkspaceClipboardFloatingBar(
                     key = EditorBarKeys.CLIPBOARD,
-                    visible = hasClipboard,
-                    scrollBehavior = BarScrollBehavior.VanishOnScroll,
-                    animation = BarAnimation.Bouncy,
-                ) {
-                    ClipboardBar(
-                        workspaceType = Workspace.Type.EDITOR,
-                        clipboardEntries = clipboardState.entries,
-                        onPasteClick = { onPageAction(EditorPageAction.Clipboard.Paste(it)) },
-                        onRemoveClick = { onPageAction(EditorPageAction.Clipboard.Remove(it)) },
-                        onEntryClick = { onPageAction(EditorPageAction.Clipboard.ShowInfo(it)) },
-                        onClearAll = { onPageAction(EditorPageAction.Clipboard.Clear) },
-                    )
-                }
+                    workspaceType = Workspace.Type.EDITOR,
+                    clipboardEntries = clipboardState.entries,
+                    onAction = { onPageAction(it.toPageAction()) },
+                )
                 FloatingBar(
                     key = EditorBarKeys.ACTIONS,
                     visible = hasActions,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorActionBar.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorActionBar.kt
@@ -17,7 +17,7 @@ fun EditorActionBar(
     WorkspaceActionBar(
         modifier = modifier,
         actions = actions,
-        onActionClick = { action -> onActionClick(action as EditorActionBarItem) },
+        onActionClick = onActionClick,
     )
 }
 

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorBarActionMappingTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorBarActionMappingTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.butler.editor.ui.editor
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBarAction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Exhaustiveness proves every variant is handled, not that the four same-shaped branches point at
+ * the matching page action.
+ */
+class EditorBarActionMappingTest : BaseTest() {
+
+    private val clip = ClipboardClip.Paths(
+        origin = Workspace.Id(),
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(
+            LocalPathLookup(
+                lookedUp = LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                fileType = FileType.FILE,
+                size = null,
+                modifiedAt = null,
+            ),
+        ),
+    )
+
+    @Test
+    fun `every clipboard bar action maps to its page action`() {
+        val cases = listOf<Pair<ClipboardBarAction, EditorPageAction>>(
+            ClipboardBarAction.Paste(clip) to EditorPageAction.Clipboard.Paste(clip),
+            ClipboardBarAction.Remove(clip) to EditorPageAction.Clipboard.Remove(clip),
+            ClipboardBarAction.ShowInfo(clip) to EditorPageAction.Clipboard.ShowInfo(clip),
+            ClipboardBarAction.ClearAll to EditorPageAction.Clipboard.Clear,
+        )
+
+        cases.forEach { (action, expected) ->
+            withClue(action.toString()) { action.toPageAction() shouldBe expected }
+        }
+    }
+}

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorFloatingBarsTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorFloatingBarsTest.kt
@@ -46,6 +46,10 @@ class EditorFloatingBarsTest : ComposeTest() {
 
     private val pasteLabel: String
         get() = context.getString(WorkspaceR.string.clipboard_paste)
+    private val pasteAsFileLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_text_paste_as_file)
+    private val openInExplorerLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_open_in_explorer)
     private val clipboardHeaderTitle: String
         get() = context.getString(WorkspaceR.string.clipboard_header_title)
     private val searchPlaceholder: String
@@ -71,6 +75,11 @@ class EditorFloatingBarsTest : ComposeTest() {
                 modifiedAt = null,
             ),
         ),
+    )
+
+    private fun textClip() = ClipboardClip.Text(
+        origin = Workspace.Id(),
+        content = "Line 1",
     )
 
     private fun setPage(showSearchBar: Boolean = false) {
@@ -134,6 +143,21 @@ class EditorFloatingBarsTest : ComposeTest() {
         // Filtered: the text editor dispatches navigation actions of its own while it lays out.
         pageActions.filterIsInstance<EditorPageAction.Clipboard>() shouldBe
             listOf(EditorPageAction.Clipboard.Paste(clip))
+    }
+
+    /**
+     * A [ClipboardClip.Paths] clip renders the same paste affordance for every workspace type, so a
+     * text clip is what separates the type this page passes from the Explorer's and the Searcher's.
+     */
+    @Test
+    fun `a text clip keeps the editor's paste affordance`() {
+        setPage()
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(textClip()))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(pasteAsFileLabel).assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription(openInExplorerLabel).assertDoesNotExist()
     }
 
     /**

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorFloatingBarsTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorFloatingBarsTest.kt
@@ -1,0 +1,169 @@
+package eu.darken.butler.editor.ui.editor
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import eu.darken.butler.editor.R as EditorR
+import eu.darken.butler.workspace.R as WorkspaceR
+
+/**
+ * Guards the Editor's call site: the shared wrapper cannot tell whether this page passes the key,
+ * the workspace type and the action mapping the Editor is supposed to pass.
+ */
+@Config(qualifiers = "w400dp-h800dp")
+class EditorFloatingBarsTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val workspaceId = Workspace.Id()
+    private val barCollapseStates = WorkspaceBarCollapseStates()
+    private val clipboardSource = MutableStateFlow(ClipboardDisplayState())
+    private val pageActions = mutableListOf<EditorPageAction>()
+
+    private val pasteLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_paste)
+    private val clipboardHeaderTitle: String
+        get() = context.getString(WorkspaceR.string.clipboard_header_title)
+    private val searchPlaceholder: String
+        get() = context.getString(EditorR.string.editor_search_placeholder)
+
+    private fun state(showSearchBar: Boolean = false) = EditorWorkspaceViewModel.State(
+        id = workspaceId,
+        title = caString("test.txt"),
+        subTitle = caString("/storage/emulated/0/Documents/test.txt"),
+        totalLines = 2,
+        currentContent = "Line 1\nLine 2",
+        showSearchBar = showSearchBar,
+    )
+
+    private fun clip() = ClipboardClip.Paths(
+        origin = Workspace.Id(),
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(
+            LocalPathLookup(
+                lookedUp = LocalPath.build(CLIP_PATH),
+                fileType = FileType.FILE,
+                size = null,
+                modifiedAt = null,
+            ),
+        ),
+    )
+
+    private fun setPage(showSearchBar: Boolean = false) {
+        val stateSource = MutableStateFlow(state(showSearchBar))
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalWorkspaceBarCollapseStates provides barCollapseStates) {
+                    EditorWorkspacePage(
+                        workspaceId = workspaceId,
+                        // Split-pane layout: keeps the mascot-bearing workspace button, which
+                        // Robolectric cannot rasterise, out of the toolbar cutout.
+                        design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                        mainStateSource = stateSource,
+                        clipboardStateSource = clipboardSource,
+                        onPageAction = { pageActions.add(it) },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * The page composes its stacks itself, so the collapse registry it writes its per-bar fractions
+     * into is the read-only route to the keys the bars registered under.
+     */
+    private fun bottomBarKeys(): Set<String> = barCollapseStates
+        .snapshot()[workspaceId]
+        ?.get(BarPosition.BOTTOM.persistedKey)
+        ?.keys
+        .orEmpty()
+
+    @Test
+    fun `the clipboard bar appears when a clip arrives after first composition`() {
+        setPage()
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertDoesNotExist()
+
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(clip()))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the clipboard bar registers under the key the editor persists`() {
+        setPage()
+
+        bottomBarKeys() shouldContain EditorBarKeys.CLIPBOARD
+    }
+
+    @Test
+    fun `the paste affordance dispatches the editor's paste action`() {
+        val clip = clip()
+        setPage()
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(clip))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).performClick()
+
+        // Filtered: the text editor dispatches navigation actions of its own while it lays out.
+        pageActions.filterIsInstance<EditorPageAction.Clipboard>() shouldBe
+            listOf(EditorPageAction.Clipboard.Paste(clip))
+    }
+
+    /**
+     * For a BOTTOM stack the first-declared bar is furthest from the screen edge. Anchored on each
+     * bar's outermost row, since the bars themselves carry no addressable node.
+     */
+    @Test
+    fun `the bars stack in declaration order`() {
+        setPage(showSearchBar = true)
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(clip()))
+        composeTestRule.waitForIdle()
+
+        val actionLabel = state(showSearchBar = true).availableActions
+            .first { it.isVisible && !it.forceOverflow }
+            .label.get(context)
+
+        val searchRow = composeTestRule.onNodeWithText(searchPlaceholder).getUnclippedBoundsInRoot()
+        val clipboardHeader = composeTestRule.onNodeWithText(clipboardHeaderTitle).getUnclippedBoundsInRoot()
+        val clipboardRow = composeTestRule.onNodeWithText(CLIP_PATH).getUnclippedBoundsInRoot()
+        val actionsBar = composeTestRule.onNodeWithContentDescription(actionLabel).getUnclippedBoundsInRoot()
+
+        withClue("search bar sits above the clipboard bar") {
+            (searchRow.bottom <= clipboardHeader.top) shouldBe true
+        }
+        withClue("clipboard bar sits above the actions bar") {
+            (clipboardRow.bottom <= actionsBar.top) shouldBe true
+        }
+    }
+
+    companion object {
+        private const val CLIP_PATH = "/storage/emulated/0/Documents/report.pdf"
+    }
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
@@ -14,7 +14,6 @@ import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.core.favorites.FavoriteFeedback
 import eu.darken.butler.explorer.ui.explorer.ExplorerBarKeys
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
-import eu.darken.butler.explorer.ui.explorer.actions.ExplorerActionBarItem
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
@@ -197,7 +196,7 @@ internal fun FloatingBarScope.ExplorerBottomBars(
     ) {
         WorkspaceActionBar(
             actions = state.availableActions,
-            onActionClick = { action -> vm?.executeAction(action as ExplorerActionBarItem) },
+            onActionClick = { action -> vm?.executeAction(action) },
         )
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
@@ -19,7 +19,8 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
-import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBar
+import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBarAction
+import eu.darken.butler.workspace.ui.clipboard.bar.WorkspaceClipboardFloatingBar
 import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
@@ -27,9 +28,9 @@ import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
-import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
-import eu.darken.butler.workspace.ui.operations.bar.OperationsBar
+import eu.darken.butler.workspace.ui.operations.bar.OperationsBarAction
+import eu.darken.butler.workspace.ui.operations.bar.WorkspaceOperationsFloatingBar
 
 /**
  * The Explorer's top floating bars: toolbar (with breadcrumbs/picker chrome) and info bar.
@@ -119,13 +120,6 @@ internal fun FloatingBarScope.ExplorerBottomBars(
     initialClipboardExpanded: Boolean,
     onShowOperationDetails: (Operation.Id) -> Unit,
 ) {
-    val hasOperations = operationsState.operations.isNotEmpty()
-    val hasActiveOperations = operationsState.operations.any { op ->
-        op.state is OperationDisplay.State.Queued ||
-            op.state is OperationDisplay.State.Running ||
-            op.state is OperationDisplay.State.Waiting
-    }
-    val hasClipboard = clipboardState.entries.isNotEmpty()
     val hasActions = state.availableActions.isNotEmpty()
 
     // Cache the last non-null favorite feedback so the bar has content to animate out when the
@@ -135,43 +129,35 @@ internal fun FloatingBarScope.ExplorerBottomBars(
     state.favoriteFeedback?.let { lastFavoriteFeedback = it }
     val showFavoritesFeedbackBar = state.favoriteFeedback != null && state.pickerConfig == null
 
-    FloatingBar(
+    WorkspaceOperationsFloatingBar(
         key = ExplorerBarKeys.OPERATIONS,
-        visible = hasOperations,
-        scrollBehavior = if (hasActiveOperations) BarScrollBehavior.Static else BarScrollBehavior.VanishOnScroll,
-        animation = BarAnimation.Slide(),
-    ) {
-        OperationsBar(
-            operations = operationsState.operations,
-            onRequestCancelOperation = { id -> vm?.requestCancelOperation(id) },
-            onDismissOperation = { id -> vm?.dismissOperation(id) },
-            onOperationClick = { operation ->
-                when (operation.state) {
-                    is OperationDisplay.State.Waiting -> vm?.showConflictSheet(operation.id)
-                    else -> onShowOperationDetails(operation.id)
-                }
-            },
-            onClearCompleted = { vm?.clearCompletedOperations() },
-            initialExpanded = initialOperationsExpanded,
-        )
-    }
+        operations = operationsState.operations,
+        initialExpanded = initialOperationsExpanded,
+        onAction = { action ->
+            when (action) {
+                is OperationsBarAction.RequestCancel -> vm?.requestCancelOperation(action.id)
+                is OperationsBarAction.Dismiss -> vm?.dismissOperation(action.id)
+                is OperationsBarAction.ShowConflict -> vm?.showConflictSheet(action.id)
+                is OperationsBarAction.ShowDetails -> onShowOperationDetails(action.id)
+                OperationsBarAction.ClearCompleted -> vm?.clearCompletedOperations()
+            }
+        },
+    )
 
-    FloatingBar(
+    WorkspaceClipboardFloatingBar(
         key = ExplorerBarKeys.CLIPBOARD,
-        visible = hasClipboard,
-        scrollBehavior = BarScrollBehavior.VanishOnScroll,
-        animation = BarAnimation.Bouncy,
-    ) {
-        ClipboardBar(
-            workspaceType = Workspace.Type.EXPLORER,
-            clipboardEntries = clipboardState.entries,
-            onPasteClick = { clip -> vm?.pasteClipboard(clip) },
-            onRemoveClick = { clip -> vm?.removeClipboardEntry(clip) },
-            onEntryClick = { clip -> vm?.showClipboardInfo(clip) },
-            onClearAll = { vm?.clearAllClipboard() },
-            initialExpanded = initialClipboardExpanded,
-        )
-    }
+        workspaceType = Workspace.Type.EXPLORER,
+        clipboardEntries = clipboardState.entries,
+        initialExpanded = initialClipboardExpanded,
+        onAction = { action ->
+            when (action) {
+                is ClipboardBarAction.Paste -> vm?.pasteClipboard(action.clip)
+                is ClipboardBarAction.Remove -> vm?.removeClipboardEntry(action.clip)
+                is ClipboardBarAction.ShowInfo -> vm?.showClipboardInfo(action.clip)
+                ClipboardBarAction.ClearAll -> vm?.clearAllClipboard()
+            }
+        },
+    )
 
     FloatingBar(
         key = ExplorerBarKeys.FAVORITES_FEEDBACK,

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBarsTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBarsTest.kt
@@ -1,0 +1,201 @@
+package eu.darken.butler.explorer.ui.explorer.elements
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.explorer.ui.explorer.ExplorerBarKeys
+import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStackState
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
+import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import eu.darken.butler.workspace.R as WorkspaceR
+
+/**
+ * Guards the call site rather than the wrappers: a wrong bar key, a `when` branch pointed at the
+ * wrong handler or a dropped `initialExpanded` are invisible to the shared wrapper tests.
+ */
+@Config(qualifiers = "w400dp-h800dp")
+class ExplorerFloatingBarsTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val state = MockDataProvider.createStateWithSelection()
+    private val detailsShown = mutableListOf<Operation.Id>()
+    private lateinit var stackState: FloatingBarStackState
+
+    private val pasteLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_paste)
+    private val clipboardHeaderTitle: String
+        get() = context.getString(WorkspaceR.string.clipboard_header_title)
+
+    private fun clip(name: String) = MockDataProvider.createMockClipboardCopy(
+        files = listOf(name),
+        basePath = CLIP_DIR,
+    )
+
+    private fun setBars(
+        initialOperationsExpanded: Boolean = false,
+        initialClipboardExpanded: Boolean = false,
+        clipboardState: () -> ClipboardDisplayState = { ClipboardDisplayState(entries = listOf(clip(LATEST_CLIP))) },
+        operationsState: () -> OperationsDisplayState,
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                stackState = rememberFloatingBarStackState(position = BarPosition.BOTTOM)
+                FloatingBarStack(
+                    position = BarPosition.BOTTOM,
+                    state = stackState,
+                ) {
+                    ExplorerBottomBars(
+                        state = state,
+                        vm = null,
+                        operationsState = operationsState(),
+                        clipboardState = clipboardState(),
+                        initialOperationsExpanded = initialOperationsExpanded,
+                        initialClipboardExpanded = initialClipboardExpanded,
+                        onShowOperationDetails = { detailsShown.add(it) },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `the operations and clipboard bars both render`() {
+        setBars { OperationsDisplayState(operations = listOf(MockDataProvider.createMockRunningOperation(title = RUNNING_TITLE))) }
+
+        composeTestRule.onNodeWithText(RUNNING_TITLE).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertIsDisplayed()
+    }
+
+    /**
+     * `collapseTargets` holds every registered non-Static bar, and bars register regardless of their
+     * visibility. The running case is what binds a key to a specific bar: only the operations bar
+     * changes scroll behaviour with operation state, so a swap of the two keys shows up there.
+     */
+    @Test
+    fun `each bar registers under the key its workspace persists`() {
+        var operations by mutableStateOf(
+            OperationsDisplayState(operations = listOf(MockDataProvider.createMockCompletedOperation()))
+        )
+        setBars { operations }
+
+        composeTestRule.runOnIdle {
+            stackState.collapseTargets.keys shouldBe setOf(
+                ExplorerBarKeys.OPERATIONS,
+                ExplorerBarKeys.CLIPBOARD,
+                ExplorerBarKeys.ACTIONS,
+            )
+        }
+
+        operations = OperationsDisplayState(operations = listOf(MockDataProvider.createMockRunningOperation()))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            stackState.collapseTargets.keys shouldBe setOf(
+                ExplorerBarKeys.CLIPBOARD,
+                ExplorerBarKeys.ACTIONS,
+            )
+        }
+    }
+
+    /** `onShowOperationDetails` is a plain parameter, so it stays observable with a null ViewModel. */
+    @Test
+    fun `clicking a finished operation reaches the details handler`() {
+        val completed = MockDataProvider.createMockCompletedOperation(title = COMPLETED_TITLE)
+        setBars { OperationsDisplayState(operations = listOf(completed)) }
+
+        composeTestRule.onNodeWithText(COMPLETED_TITLE).performClick()
+
+        detailsShown shouldBe listOf(completed.id)
+    }
+
+    /**
+     * The two flags are same-typed and adjacent, so both must be asserted from a state where only
+     * one of them is set. Separate compositions per case: both bars seed their expansion from an
+     * unkeyed `remember`, which no longer follows the parameter once composed.
+     */
+    @Test
+    fun `only the operations bar expands when only its flag is set`() {
+        setBars(
+            initialOperationsExpanded = true,
+            initialClipboardExpanded = false,
+            clipboardState = { ClipboardDisplayState(entries = listOf(clip(LATEST_CLIP), clip(OLDER_CLIP))) },
+            operationsState = { twoCompletedOperations() },
+        )
+
+        composeTestRule.onNodeWithText(COMPLETED_TITLE).assertIsDisplayed()
+        composeTestRule.onNodeWithText("$CLIP_DIR/$OLDER_CLIP").assertDoesNotExist()
+    }
+
+    @Test
+    fun `only the clipboard bar expands when only its flag is set`() {
+        setBars(
+            initialOperationsExpanded = false,
+            initialClipboardExpanded = true,
+            clipboardState = { ClipboardDisplayState(entries = listOf(clip(LATEST_CLIP), clip(OLDER_CLIP))) },
+            operationsState = { twoCompletedOperations() },
+        )
+
+        composeTestRule.onNodeWithText(COMPLETED_TITLE).assertDoesNotExist()
+        composeTestRule.onNodeWithText("$CLIP_DIR/$OLDER_CLIP").assertIsDisplayed()
+    }
+
+    /**
+     * For a BOTTOM stack the first-declared bar is furthest from the screen edge, so the declared
+     * order has to read top-to-bottom. Anchored on each bar's outermost row: the operations bar's
+     * last row against the clipboard bar's header, and the clipboard bar's row against the actions.
+     */
+    @Test
+    fun `the bars stack in declaration order`() {
+        setBars { OperationsDisplayState(operations = listOf(MockDataProvider.createMockRunningOperation(title = RUNNING_TITLE))) }
+
+        val actionLabel = state.availableActions.first { it.isVisible && !it.forceOverflow }.label.get(context)
+
+        val operationsRow = composeTestRule.onNodeWithText(RUNNING_TITLE).getUnclippedBoundsInRoot()
+        val clipboardHeader = composeTestRule.onNodeWithText(clipboardHeaderTitle).getUnclippedBoundsInRoot()
+        val clipboardRow = composeTestRule.onNodeWithText("$CLIP_DIR/$LATEST_CLIP").getUnclippedBoundsInRoot()
+        val actionsBar = composeTestRule.onNodeWithContentDescription(actionLabel).getUnclippedBoundsInRoot()
+
+        withClue("operations bar sits above the clipboard bar") {
+            (operationsRow.bottom <= clipboardHeader.top) shouldBe true
+        }
+        withClue("clipboard bar sits above the actions bar") {
+            (clipboardRow.bottom <= actionsBar.top) shouldBe true
+        }
+    }
+
+    private fun twoCompletedOperations() = OperationsDisplayState(
+        operations = listOf(
+            MockDataProvider.createMockCompletedOperation(title = COMPLETED_TITLE, minutesAgo = 9),
+            MockDataProvider.createMockCompletedOperation(title = NEWEST_TITLE, minutesAgo = 1),
+        ),
+    )
+
+    companion object {
+        private const val RUNNING_TITLE = "Deleting files"
+        private const val COMPLETED_TITLE = "Copy operation"
+        private const val NEWEST_TITLE = "Archive created"
+        private const val CLIP_DIR = "/storage/emulated/0/Clips"
+        private const val LATEST_CLIP = "latest.txt"
+        private const val OLDER_CLIP = "older.txt"
+    }
+}

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -784,9 +784,9 @@ fun SearcherWorkspacePage(
                     WorkspaceActionBar(
                         actions = currentState.availableActions,
                         onActionClick = { action ->
-                            when (val searcherAction = action as SearcherActionBarItem) {
+                            when (action) {
                                 is SearcherActionBarItem.DeselectAll -> onPageAction(SearcherPageAction.Results.ExitSelectionMode)
-                                else -> onPageAction(SearcherPageAction.WorkspaceAction(searcherAction))
+                                else -> onPageAction(SearcherPageAction.WorkspaceAction(action))
                             }
                         },
                     )

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -63,10 +63,11 @@ import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
 import eu.darken.butler.searcher.ui.search.util.SearchListItem
 import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
 import eu.darken.butler.searcher.ui.search.util.SearcherPageAction
+import eu.darken.butler.searcher.ui.search.util.toPageAction
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
 import eu.darken.butler.workspace.ui.dnd.rememberWorkspaceDragSource
-import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBar
+import eu.darken.butler.workspace.ui.clipboard.bar.WorkspaceClipboardFloatingBar
 import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.error.ErrorCard
 import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
@@ -78,9 +79,8 @@ import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
-import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
-import eu.darken.butler.workspace.ui.operations.bar.OperationsBar
+import eu.darken.butler.workspace.ui.operations.bar.WorkspaceOperationsFloatingBar
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.preview.ProvideFolderPreviews
 import eu.darken.butler.workspace.ui.scroll.rememberWorkspaceLazyGridState
@@ -204,14 +204,6 @@ fun SearcherWorkspacePage(
         topBarStackState.resetScrollCollapse()
         bottomBarStackState.resetScrollCollapse()
     }
-
-    val hasOperations = operationsState.operations.isNotEmpty()
-    val hasActiveOperations = operationsState.operations.any { op ->
-        op.state is OperationDisplay.State.Queued ||
-            op.state is OperationDisplay.State.Running ||
-            op.state is OperationDisplay.State.Waiting
-    }
-    val hasClipboard = clipboardState.entries.isNotEmpty()
 
     val hasActions by remember(mainState) {
         derivedStateOf {
@@ -729,49 +721,19 @@ fun SearcherWorkspacePage(
             modifier = Modifier.align(Alignment.BottomCenter),
             bars = {
                 // Operations bar - furthest from bottom edge
-                // Static when active operations, VanishOnScroll when only completed
-                FloatingBar(
+                WorkspaceOperationsFloatingBar(
                     key = SearcherBarKeys.OPERATIONS,
-                    visible = hasOperations,
-                    scrollBehavior = if (hasActiveOperations) BarScrollBehavior.Static else BarScrollBehavior.VanishOnScroll,
-                    animation = BarAnimation.Slide(),
-                ) {
-                    OperationsBar(
-                        operations = operationsState.operations,
-                        onRequestCancelOperation = {
-                            onPageAction(SearcherPageAction.Overlays.RequestCancelOperation(it))
-                        },
-                        onDismissOperation = { onPageAction(SearcherPageAction.Operations.Dismiss(it)) },
-                        onOperationClick = { operation ->
-                            when (operation.state) {
-                                is OperationDisplay.State.Waiting -> {
-                                    onPageAction(SearcherPageAction.Operations.ShowConflict(operation.id))
-                                }
-                                else -> {
-                                    onPageAction(SearcherPageAction.Overlays.ShowOperationDetails(operation.id))
-                                }
-                            }
-                        },
-                        onClearCompleted = { onPageAction(SearcherPageAction.Operations.ClearCompleted) },
-                    )
-                }
+                    operations = operationsState.operations,
+                    onAction = { onPageAction(it.toPageAction()) },
+                )
 
-                // Clipboard bar - middle, vanishes on scroll with bouncy animation
-                FloatingBar(
+                // Clipboard bar - middle
+                WorkspaceClipboardFloatingBar(
                     key = SearcherBarKeys.CLIPBOARD,
-                    visible = hasClipboard,
-                    scrollBehavior = BarScrollBehavior.VanishOnScroll,
-                    animation = BarAnimation.Bouncy,
-                ) {
-                    ClipboardBar(
-                        workspaceType = Workspace.Type.SEARCHER,
-                        clipboardEntries = clipboardState.entries,
-                        onPasteClick = { clip -> onPageAction(SearcherPageAction.Clipboard.OpenInExplorer(clip)) },
-                        onRemoveClick = { onPageAction(SearcherPageAction.Clipboard.RemoveEntry(it)) },
-                        onEntryClick = { onPageAction(SearcherPageAction.Clipboard.ClickEntry(it)) },
-                        onClearAll = { onPageAction(SearcherPageAction.Clipboard.ClearAll) },
-                    )
-                }
+                    workspaceType = Workspace.Type.SEARCHER,
+                    clipboardEntries = clipboardState.entries,
+                    onAction = { onPageAction(it.toPageAction()) },
+                )
 
                 // Action bar - closest to bottom edge, hides on scroll
                 FloatingBar(

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherBarActionMapping.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherBarActionMapping.kt
@@ -1,0 +1,24 @@
+package eu.darken.butler.searcher.ui.search.util
+
+import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBarAction
+import eu.darken.butler.workspace.ui.operations.bar.OperationsBarAction
+
+/**
+ * Exhaustiveness guarantees every bar action is handled, not that it is handled correctly, and these
+ * two are the least obvious mappings in the codebase: the Searcher cannot paste in place, and
+ * `Operations.Cancel` would compile just as well as `Overlays.RequestCancelOperation`.
+ */
+internal fun OperationsBarAction.toPageAction(): SearcherPageAction = when (this) {
+    is OperationsBarAction.RequestCancel -> SearcherPageAction.Overlays.RequestCancelOperation(id)
+    is OperationsBarAction.Dismiss -> SearcherPageAction.Operations.Dismiss(id)
+    is OperationsBarAction.ShowConflict -> SearcherPageAction.Operations.ShowConflict(id)
+    is OperationsBarAction.ShowDetails -> SearcherPageAction.Overlays.ShowOperationDetails(id)
+    OperationsBarAction.ClearCompleted -> SearcherPageAction.Operations.ClearCompleted
+}
+
+internal fun ClipboardBarAction.toPageAction(): SearcherPageAction = when (this) {
+    is ClipboardBarAction.Paste -> SearcherPageAction.Clipboard.OpenInExplorer(clip)
+    is ClipboardBarAction.Remove -> SearcherPageAction.Clipboard.RemoveEntry(clip)
+    is ClipboardBarAction.ShowInfo -> SearcherPageAction.Clipboard.ClickEntry(clip)
+    ClipboardBarAction.ClearAll -> SearcherPageAction.Clipboard.ClearAll
+}

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
@@ -1,14 +1,17 @@
 package eu.darken.butler.searcher.ui.search
 
 import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.local.LocalPathLookup
@@ -17,9 +20,14 @@ import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 import testhelpers.ComposeTest
@@ -37,29 +45,46 @@ class SearcherFloatingBarsTest : ComposeTest() {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
+    private val workspaceId = Workspace.Id()
+    private val barCollapseStates = WorkspaceBarCollapseStates()
+
     private val stateSource = MutableStateFlow(SearcherMockDataProvider.createMockResultsState())
     private val clipboardSource = MutableStateFlow<ClipboardDisplayState?>(null)
     private val operationsSource = MutableStateFlow<OperationsDisplayState?>(null)
 
     private val pasteLabel: String
         get() = context.getString(WorkspaceR.string.clipboard_open_in_explorer)
+    private val clipboardHeaderTitle: String
+        get() = context.getString(WorkspaceR.string.clipboard_header_title)
 
     private fun setContent() {
         composeTestRule.setContent {
             PreviewWrapper {
-                SearcherWorkspacePage(
-                    workspaceId = Workspace.Id(),
-                    // Split-pane layout: keeps the mascot-bearing workspace button, which
-                    // Robolectric cannot rasterise, out of the toolbar cutout.
-                    design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
-                    stateSource = stateSource,
-                    clipboardStateSource = clipboardSource,
-                    operationsStateSource = operationsSource,
-                )
+                CompositionLocalProvider(LocalWorkspaceBarCollapseStates provides barCollapseStates) {
+                    SearcherWorkspacePage(
+                        workspaceId = workspaceId,
+                        // Split-pane layout: keeps the mascot-bearing workspace button, which
+                        // Robolectric cannot rasterise, out of the toolbar cutout.
+                        design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                        stateSource = stateSource,
+                        clipboardStateSource = clipboardSource,
+                        operationsStateSource = operationsSource,
+                    )
+                }
             }
         }
         composeTestRule.waitForIdle()
     }
+
+    /**
+     * The page composes its stacks itself, so the collapse registry it writes its per-bar fractions
+     * into is the read-only route to the keys the bars registered under.
+     */
+    private fun bottomBarKeys(): Set<String> = barCollapseStates
+        .snapshot()[workspaceId]
+        ?.get(BarPosition.BOTTOM.persistedKey)
+        ?.keys
+        .orEmpty()
 
     private fun scrollResults() {
         composeTestRule.onRoot().performTouchInput { swipeUp(startY = centerY, endY = top) }
@@ -71,13 +96,23 @@ class SearcherFloatingBarsTest : ComposeTest() {
         mode = ClipboardClip.Paths.Mode.COPY,
         paths = listOf(
             LocalPathLookup(
-                lookedUp = LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                lookedUp = LocalPath.build(CLIP_PATH),
                 fileType = FileType.FILE,
                 size = null,
                 modifiedAt = null,
             ),
         ),
     )
+
+    private fun completedOperation() = SearcherMockDataProvider
+        .createMockRunningOperation(title = OPERATION_TITLE)
+        .copy(
+            state = OperationDisplay.State.Completed(
+                summary = "Done".toCaString(),
+                completedAt = Clock.System.now(),
+                report = null,
+            ),
+        )
 
     @Test
     fun `clipboard bar appears when a clip arrives after first composition`() {
@@ -134,7 +169,69 @@ class SearcherFloatingBarsTest : ComposeTest() {
         composeTestRule.onNodeWithText(OPERATION_TITLE).assertIsNotDisplayed()
     }
 
+    /**
+     * `collapseTargets` holds every registered non-Static bar, and bars register regardless of their
+     * visibility. The running case is what binds a key to a specific bar: only the operations bar
+     * changes scroll behaviour with operation state, so a swap of the two keys shows up there.
+     */
+    @Test
+    fun `each bar registers under the key the searcher persists`() {
+        setContent()
+
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(clip()))
+        operationsSource.value = OperationsDisplayState(operations = listOf(completedOperation()))
+        composeTestRule.waitForIdle()
+
+        bottomBarKeys() shouldBe setOf(
+            SearcherBarKeys.OPERATIONS,
+            SearcherBarKeys.CLIPBOARD,
+            SearcherBarKeys.ACTIONS,
+        )
+
+        operationsSource.value = OperationsDisplayState(
+            operations = listOf(SearcherMockDataProvider.createMockRunningOperation(title = OPERATION_TITLE)),
+        )
+        composeTestRule.waitForIdle()
+
+        bottomBarKeys() shouldBe setOf(
+            SearcherBarKeys.CLIPBOARD,
+            SearcherBarKeys.ACTIONS,
+        )
+    }
+
+    /**
+     * For a BOTTOM stack the first-declared bar is furthest from the screen edge. Anchored on each
+     * bar's outermost row, since the bars themselves carry no addressable node.
+     */
+    @Test
+    fun `the bottom bars stack in declaration order`() {
+        setContent()
+
+        clipboardSource.value = ClipboardDisplayState(entries = listOf(clip()))
+        operationsSource.value = OperationsDisplayState(
+            operations = listOf(SearcherMockDataProvider.createMockRunningOperation(title = OPERATION_TITLE)),
+        )
+        composeTestRule.waitForIdle()
+
+        val actionLabel = stateSource.value.availableActions
+            .first { it.isVisible && !it.forceOverflow }
+            .label.get(context)
+
+        val operationsRow = composeTestRule.onNodeWithText(OPERATION_TITLE).getUnclippedBoundsInRoot()
+        val clipboardHeader = composeTestRule.onNodeWithText(clipboardHeaderTitle).getUnclippedBoundsInRoot()
+        val clipboardRow = composeTestRule.onNodeWithText(CLIP_PATH).getUnclippedBoundsInRoot()
+        val actionsBar = composeTestRule.onNodeWithContentDescription(actionLabel).getUnclippedBoundsInRoot()
+
+        withClue("operations bar sits above the clipboard bar") {
+            (operationsRow.bottom <= clipboardHeader.top) shouldBe true
+        }
+        withClue("clipboard bar sits above the actions bar") {
+            (clipboardRow.bottom <= actionsBar.top) shouldBe true
+        }
+    }
+
     companion object {
         private const val OPERATION_TITLE = "Deleting files"
+        private const val CLIP_PATH = "/storage/emulated/0/Documents/report.pdf"
     }
 }

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/util/SearcherBarActionMappingTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/util/SearcherBarActionMappingTest.kt
@@ -1,0 +1,65 @@
+package eu.darken.butler.searcher.ui.search.util
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.clipboard.bar.ClipboardBarAction
+import eu.darken.butler.workspace.ui.operations.bar.OperationsBarAction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * `Operations.Cancel` and `Overlays.RequestCancelOperation` both exist and both compile here, and
+ * the Searcher answers a paste by opening the target in the Explorer. Neither is guessable.
+ */
+class SearcherBarActionMappingTest : BaseTest() {
+
+    private val id = Operation.Id()
+
+    private val clip = ClipboardClip.Paths(
+        origin = Workspace.Id(),
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(
+            LocalPathLookup(
+                lookedUp = LocalPath.build("/storage/emulated/0/Documents/report.pdf"),
+                fileType = FileType.FILE,
+                size = null,
+                modifiedAt = null,
+            ),
+        ),
+    )
+
+    @Test
+    fun `every operations bar action maps to its page action`() {
+        val cases = listOf<Pair<OperationsBarAction, SearcherPageAction>>(
+            OperationsBarAction.RequestCancel(id) to SearcherPageAction.Overlays.RequestCancelOperation(id),
+            OperationsBarAction.Dismiss(id) to SearcherPageAction.Operations.Dismiss(id),
+            OperationsBarAction.ShowConflict(id) to SearcherPageAction.Operations.ShowConflict(id),
+            OperationsBarAction.ShowDetails(id) to SearcherPageAction.Overlays.ShowOperationDetails(id),
+            OperationsBarAction.ClearCompleted to SearcherPageAction.Operations.ClearCompleted,
+        )
+
+        cases.forEach { (action, expected) ->
+            withClue(action.toString()) { action.toPageAction() shouldBe expected }
+        }
+    }
+
+    @Test
+    fun `every clipboard bar action maps to its page action`() {
+        val cases = listOf<Pair<ClipboardBarAction, SearcherPageAction>>(
+            ClipboardBarAction.Paste(clip) to SearcherPageAction.Clipboard.OpenInExplorer(clip),
+            ClipboardBarAction.Remove(clip) to SearcherPageAction.Clipboard.RemoveEntry(clip),
+            ClipboardBarAction.ShowInfo(clip) to SearcherPageAction.Clipboard.ClickEntry(clip),
+            ClipboardBarAction.ClearAll to SearcherPageAction.Clipboard.ClearAll,
+        )
+
+        cases.forEach { (action, expected) ->
+            withClue(action.toString()) { action.toPageAction() shouldBe expected }
+        }
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
@@ -401,9 +401,7 @@ fun ViewerWorkspacePage(
                         ) {
                             WorkspaceActionBar(
                                 actions = state.actions,
-                                // The bar is generic over all workspaces; only our own items can
-                                // reach it here, and anything else would have no handler anyway.
-                                onActionClick = { clicked -> (clicked as? ViewerActionBarItem)?.let(onAction) },
+                                onActionClick = onAction,
                             )
                         }
                     },

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/WorkspaceActionBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/WorkspaceActionBar.kt
@@ -74,9 +74,9 @@ import eu.darken.butler.workspace.ui.modal.DismissWhenPaneUnfocused
  * @param modifier Modifier to apply to the action bar
  */
 @Composable
-fun WorkspaceActionBar(
-    actions: List<WorkspaceActionBarItem>,
-    onActionClick: (WorkspaceActionBarItem) -> Unit,
+fun <T : WorkspaceActionBarItem> WorkspaceActionBar(
+    actions: List<T>,
+    onActionClick: (T) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardBarAction.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/ClipboardBarAction.kt
@@ -1,0 +1,16 @@
+package eu.darken.butler.workspace.ui.clipboard.bar
+
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+
+/**
+ * What the user did on a [WorkspaceClipboardFloatingBar], as a single typed channel.
+ *
+ * The names describe the gesture on the bar, not any workspace's handling of it: the Searcher
+ * answers [Paste] by opening the target in the Explorer, which is a handler decision.
+ */
+sealed interface ClipboardBarAction {
+    data class Paste(val clip: ClipboardClip) : ClipboardBarAction
+    data class Remove(val clip: ClipboardClip) : ClipboardBarAction
+    data class ShowInfo(val clip: ClipboardClip) : ClipboardBarAction
+    data object ClearAll : ClipboardBarAction
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/WorkspaceClipboardFloatingBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/clipboard/bar/WorkspaceClipboardFloatingBar.kt
@@ -1,0 +1,79 @@
+package eu.darken.butler.workspace.ui.clipboard.bar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.clipboard.mockFileLookup
+import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Packages [ClipboardBar] as a floating bar: it owns the visibility rule, the scroll behaviour and
+ * the animation, so every workspace's clipboard bar behaves the same way.
+ *
+ * [key] has no default because it is a per-workspace persistence contract: sharing one literal
+ * would tie two workspaces' stored collapse fractions to each other.
+ */
+@Composable
+fun FloatingBarScope.WorkspaceClipboardFloatingBar(
+    key: String,
+    workspaceType: Workspace.Type,
+    clipboardEntries: List<ClipboardClip>,
+    onAction: (ClipboardBarAction) -> Unit,
+    initialExpanded: Boolean = false,
+) {
+    FloatingBar(
+        key = key,
+        visible = clipboardEntries.isNotEmpty(),
+        scrollBehavior = BarScrollBehavior.VanishOnScroll,
+        animation = BarAnimation.Bouncy,
+    ) {
+        ClipboardBar(
+            workspaceType = workspaceType,
+            initialExpanded = initialExpanded,
+            clipboardEntries = clipboardEntries,
+            onPasteClick = { onAction(ClipboardBarAction.Paste(it)) },
+            onRemoveClick = { onAction(ClipboardBarAction.Remove(it)) },
+            onEntryClick = { onAction(ClipboardBarAction.ShowInfo(it)) },
+            onClearAll = { onAction(ClipboardBarAction.ClearAll) },
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceClipboardFloatingBarPreview() {
+    PreviewWrapper {
+        val stackState = rememberFloatingBarStackState(position = BarPosition.BOTTOM)
+        FloatingBarStack(
+            state = stackState,
+            position = BarPosition.BOTTOM,
+            bars = {
+                WorkspaceClipboardFloatingBar(
+                    key = "clipboard",
+                    workspaceType = Workspace.Type.EXPLORER,
+                    clipboardEntries = listOf(
+                        ClipboardClip.Paths(
+                            origin = Workspace.Id(),
+                            mode = ClipboardClip.Paths.Mode.COPY,
+                            paths = listOf(mockFileLookup("/storage/emulated/0/Documents/report.pdf")),
+                            clippedAt = Clock.System.now() - 2.minutes,
+                        ),
+                    ),
+                    onAction = {},
+                )
+            },
+        )
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/BarPosition.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/BarPosition.kt
@@ -19,7 +19,7 @@ enum class BarPosition(val persistedKey: String) {
 
     /**
      * Bars stack from the bottom edge upward.
-     * First declared bar is closest to the bottom edge.
+     * First declared bar is furthest from the bottom edge, last declared bar sits at it.
      */
     BOTTOM("BOTTOM"),
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/FloatingBarScope.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/FloatingBarScope.kt
@@ -28,7 +28,7 @@ abstract class FloatingBarScope {
      *
      * Bars are rendered in declaration order:
      * - For [BarPosition.TOP]: first bar is closest to top edge
-     * - For [BarPosition.BOTTOM]: first bar is closest to bottom edge
+     * - For [BarPosition.BOTTOM]: first bar is furthest from bottom edge, last bar is at it
      *
      * @param modifier Modifier for the bar container.
      * @param key Stable identity of this bar within its stack, e.g. "toolbar". Required rather than

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/FloatingBarStack.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/FloatingBarStack.kt
@@ -46,7 +46,7 @@ import kotlin.math.roundToInt
  * - Reactive content padding based on visible bars (use [FloatingBarStackState.contentPaddingDp])
  * - Coordinated scroll behaviors (static, collapse, hide)
  * - Gap-filling animations when bars show/hide
- * - Edge-first ordering (first bar closest to screen edge)
+ * - Bars render in declared top-to-bottom visual order, for both positions
  *
  * Content should be rendered separately, using [FloatingBarStackState.nestedScrollConnection]
  * for scroll coordination and [contentPaddingDp] for padding.

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBarAction.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBarAction.kt
@@ -1,0 +1,17 @@
+package eu.darken.butler.workspace.ui.operations.bar
+
+import eu.darken.butler.workspace.core.operations.Operation
+
+/**
+ * What the user did on a [WorkspaceOperationsFloatingBar], as a single typed channel.
+ *
+ * [ShowConflict] and [ShowDetails] are produced by the wrapper's own routing, never passed in: the
+ * waiting-to-conflict decision stays in the one place that owns it.
+ */
+sealed interface OperationsBarAction {
+    data class RequestCancel(val id: Operation.Id) : OperationsBarAction
+    data class Dismiss(val id: Operation.Id) : OperationsBarAction
+    data class ShowConflict(val id: Operation.Id) : OperationsBarAction
+    data class ShowDetails(val id: Operation.Id) : OperationsBarAction
+    data object ClearCompleted : OperationsBarAction
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBar.kt
@@ -1,0 +1,107 @@
+package eu.darken.butler.workspace.ui.operations.bar
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ContentCopy
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.progress.Progress
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import kotlin.time.Clock
+
+/**
+ * Packages [OperationsBar] as a floating bar: it owns the visibility rule, the active-vs-terminal
+ * classification that picks the scroll behaviour, the animation, and the routing of a click on a
+ * waiting operation to [OperationsBarAction.ShowConflict] instead of [OperationsBarAction.ShowDetails].
+ *
+ * [key] has no default because it is a per-workspace persistence contract: sharing one literal
+ * would tie two workspaces' stored collapse fractions to each other.
+ */
+@Composable
+fun FloatingBarScope.WorkspaceOperationsFloatingBar(
+    key: String,
+    operations: List<OperationDisplay>,
+    onAction: (OperationsBarAction) -> Unit,
+    initialExpanded: Boolean = false,
+) {
+    // Exhaustive rather than an is-chain: a future subtype would silently classify as terminal and
+    // make an in-progress bar vanish on scroll with no compiler error.
+    val hasActive = operations.any { op ->
+        when (op.state) {
+            is OperationDisplay.State.Queued,
+            is OperationDisplay.State.Running,
+            is OperationDisplay.State.Waiting -> true
+
+            is OperationDisplay.State.Completed,
+            is OperationDisplay.State.Failed,
+            is OperationDisplay.State.Cancelled -> false
+        }
+    }
+
+    FloatingBar(
+        key = key,
+        visible = operations.isNotEmpty(),
+        scrollBehavior = if (hasActive) BarScrollBehavior.Static else BarScrollBehavior.VanishOnScroll,
+        animation = BarAnimation.Slide(),
+    ) {
+        OperationsBar(
+            operations = operations,
+            onRequestCancelOperation = { onAction(OperationsBarAction.RequestCancel(it)) },
+            onDismissOperation = { onAction(OperationsBarAction.Dismiss(it)) },
+            onOperationClick = { operation ->
+                when (operation.state) {
+                    is OperationDisplay.State.Waiting -> onAction(OperationsBarAction.ShowConflict(operation.id))
+                    else -> onAction(OperationsBarAction.ShowDetails(operation.id))
+                }
+            },
+            onClearCompleted = { onAction(OperationsBarAction.ClearCompleted) },
+            initialExpanded = initialExpanded,
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceOperationsFloatingBarPreview() {
+    PreviewWrapper {
+        val stackState = rememberFloatingBarStackState(position = BarPosition.BOTTOM)
+        FloatingBarStack(
+            state = stackState,
+            position = BarPosition.BOTTOM,
+            bars = {
+                WorkspaceOperationsFloatingBar(
+                    key = "operations",
+                    operations = listOf(
+                        OperationDisplay(
+                            id = Operation.Id(),
+                            title = "Copying files".toCaString(),
+                            description = "2 files remaining".toCaString(),
+                            icon = Icons.TwoTone.ContentCopy,
+                            state = OperationDisplay.State.Running(
+                                primaryProgress = Progress.Data(
+                                    primary = "Copying files".toCaString(),
+                                    secondary = "Processing...".toCaString(),
+                                    count = Progress.Count.Percent(8, 10),
+                                ),
+                            ),
+                            canCancel = true,
+                            startedAt = Clock.System.now(),
+                        ),
+                    ),
+                    onAction = {},
+                )
+            },
+        )
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/bar/WorkspaceClipboardFloatingBarTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/bar/WorkspaceClipboardFloatingBarTest.kt
@@ -1,0 +1,192 @@
+package eu.darken.butler.workspace.ui.clipboard.bar
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.clipboard.ClipboardClip
+import eu.darken.butler.workspace.ui.clipboard.mockFileLookup
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStackState
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import eu.darken.butler.workspace.R as WorkspaceR
+
+/**
+ * The wrapper concentrates the clipboard-bar packaging that used to be copied per workspace, so a
+ * wrong default or an inverted conditional here regresses Explorer, Searcher and Editor at once.
+ */
+@Config(qualifiers = "w400dp-h800dp")
+class WorkspaceClipboardFloatingBarTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val emitted = mutableListOf<ClipboardBarAction>()
+    private lateinit var stackState: FloatingBarStackState
+
+    private val pasteLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_paste)
+    private val openInExplorerLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_open_in_explorer)
+    private val clearAllLabel: String
+        get() = context.getString(WorkspaceR.string.clipboard_clear_all)
+
+    /** A single-path clip renders that path as its description, which is what addresses the row. */
+    private fun clip(path: String, minutesAgo: Long = 1) = ClipboardClip.Paths(
+        origin = Workspace.Id(),
+        mode = ClipboardClip.Paths.Mode.COPY,
+        paths = listOf(mockFileLookup(path)),
+        clippedAt = Clock.System.now() - minutesAgo.minutes,
+    )
+
+    private fun setBar(
+        workspaceType: Workspace.Type = Workspace.Type.EXPLORER,
+        initialExpanded: Boolean = false,
+        clips: () -> List<ClipboardClip>,
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                stackState = rememberFloatingBarStackState(position = BarPosition.BOTTOM)
+                FloatingBarStack(
+                    position = BarPosition.BOTTOM,
+                    state = stackState,
+                ) {
+                    WorkspaceClipboardFloatingBar(
+                        key = KEY,
+                        workspaceType = workspaceType,
+                        clipboardEntries = clips(),
+                        initialExpanded = initialExpanded,
+                        onAction = { emitted.add(it) },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * An empty list composes no row at all, so its absence - not a hidden node - is the observable.
+     */
+    @Test
+    fun `the bar appears only once there is a clip`() {
+        var clips by mutableStateOf(emptyList<ClipboardClip>())
+        setBar { clips }
+
+        composeTestRule.onNodeWithText(FIRST_PATH).assertDoesNotExist()
+
+        clips = listOf(clip(FIRST_PATH))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(FIRST_PATH).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the bar vanishes on scroll`() {
+        setBar { listOf(clip(FIRST_PATH)) }
+
+        composeTestRule.onNodeWithText(FIRST_PATH).assertIsDisplayed()
+
+        runBlocking { stackState.applyCollapse(mapOf(KEY to 1f)) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(FIRST_PATH).assertIsNotDisplayed()
+    }
+
+    @Test
+    fun `an expanded bar shows the older clips too`() {
+        setBar(initialExpanded = true) {
+            listOf(clip(FIRST_PATH, minutesAgo = 1), clip(SECOND_PATH, minutesAgo = 5))
+        }
+
+        composeTestRule.onNodeWithText(FIRST_PATH).assertIsDisplayed()
+        composeTestRule.onNodeWithText(SECOND_PATH).assertIsDisplayed()
+    }
+
+    /**
+     * A separate composition from the expanded case: `isExpanded` is seeded by an unkeyed `remember`
+     * in `ClipboardBar`, so flipping the parameter in place deliberately does not update it.
+     */
+    @Test
+    fun `a collapsed bar shows only the latest clip`() {
+        setBar(initialExpanded = false) {
+            listOf(clip(FIRST_PATH, minutesAgo = 1), clip(SECOND_PATH, minutesAgo = 5))
+        }
+
+        composeTestRule.onNodeWithText(FIRST_PATH).assertIsDisplayed()
+        composeTestRule.onNodeWithText(SECOND_PATH).assertDoesNotExist()
+    }
+
+    /**
+     * Clear-all runs collapsed: expanded it is deferred behind the cascading dismiss animation.
+     */
+    @Test
+    fun `the paste button, the row and clear-all emit their actions`() {
+        val clip = clip(FIRST_PATH)
+        setBar { listOf(clip) }
+
+        composeTestRule.onNodeWithContentDescription(pasteLabel).performClick()
+        emitted shouldBe listOf(ClipboardBarAction.Paste(clip))
+
+        emitted.clear()
+        composeTestRule.onNodeWithText(FIRST_PATH).performClick()
+        emitted shouldBe listOf(ClipboardBarAction.ShowInfo(clip))
+
+        emitted.clear()
+        composeTestRule.onNodeWithText(clearAllLabel).performClick()
+        emitted shouldBe listOf(ClipboardBarAction.ClearAll)
+    }
+
+    /**
+     * `workspaceType` is not cosmetic: `ClipboardEntryRow` picks the row's action label from it, and
+     * the Searcher opens the clip's location instead of pasting it.
+     */
+    @Test
+    fun `the workspace type selects the row's action label`() {
+        val clip = clip(FIRST_PATH)
+        composeTestRule.setContent {
+            PreviewWrapper {
+                FloatingBarStack(position = BarPosition.BOTTOM) {
+                    WorkspaceClipboardFloatingBar(
+                        key = "explorer-clipboard",
+                        workspaceType = Workspace.Type.EXPLORER,
+                        clipboardEntries = listOf(clip),
+                        onAction = {},
+                    )
+                    WorkspaceClipboardFloatingBar(
+                        key = "searcher-clipboard",
+                        workspaceType = Workspace.Type.SEARCHER,
+                        clipboardEntries = listOf(clip),
+                        onAction = {},
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithContentDescription(pasteLabel).assertCountEquals(1)
+        composeTestRule.onAllNodesWithContentDescription(openInExplorerLabel).assertCountEquals(1)
+    }
+
+    companion object {
+        private const val KEY = "clipboard"
+        private const val FIRST_PATH = "/storage/emulated/0/Documents/report.pdf"
+        private const val SECOND_PATH = "/storage/emulated/0/Pictures/photo.jpg"
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/bar/WorkspaceClipboardFloatingBarTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/clipboard/bar/WorkspaceClipboardFloatingBarTest.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -83,6 +81,10 @@ class WorkspaceClipboardFloatingBarTest : ComposeTest() {
 
     /**
      * An empty list composes no row at all, so its absence - not a hidden node - is the observable.
+     *
+     * Collapsing while empty is what tells the two candidates apart: `FloatingBarStack` snaps the
+     * collapse fraction back to 0 only when a bar's visibility actually flips, so a bar that was
+     * never hidden stays collapsed and keeps the path off-screen.
      */
     @Test
     fun `the bar appears only once there is a clip`() {
@@ -90,6 +92,9 @@ class WorkspaceClipboardFloatingBarTest : ComposeTest() {
         setBar { clips }
 
         composeTestRule.onNodeWithText(FIRST_PATH).assertDoesNotExist()
+
+        runBlocking { stackState.applyCollapse(mapOf(KEY to 1f)) }
+        composeTestRule.waitForIdle()
 
         clips = listOf(clip(FIRST_PATH))
         composeTestRule.waitForIdle()
@@ -160,18 +165,13 @@ class WorkspaceClipboardFloatingBarTest : ComposeTest() {
     @Test
     fun `the workspace type selects the row's action label`() {
         val clip = clip(FIRST_PATH)
+        var workspaceType by mutableStateOf(Workspace.Type.EXPLORER)
         composeTestRule.setContent {
             PreviewWrapper {
                 FloatingBarStack(position = BarPosition.BOTTOM) {
                     WorkspaceClipboardFloatingBar(
-                        key = "explorer-clipboard",
-                        workspaceType = Workspace.Type.EXPLORER,
-                        clipboardEntries = listOf(clip),
-                        onAction = {},
-                    )
-                    WorkspaceClipboardFloatingBar(
-                        key = "searcher-clipboard",
-                        workspaceType = Workspace.Type.SEARCHER,
+                        key = KEY,
+                        workspaceType = workspaceType,
                         clipboardEntries = listOf(clip),
                         onAction = {},
                     )
@@ -180,8 +180,14 @@ class WorkspaceClipboardFloatingBarTest : ComposeTest() {
         }
         composeTestRule.waitForIdle()
 
-        composeTestRule.onAllNodesWithContentDescription(pasteLabel).assertCountEquals(1)
-        composeTestRule.onAllNodesWithContentDescription(openInExplorerLabel).assertCountEquals(1)
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(openInExplorerLabel).assertDoesNotExist()
+
+        workspaceType = Workspace.Type.SEARCHER
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(openInExplorerLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(pasteLabel).assertDoesNotExist()
     }
 
     companion object {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBarTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBarTest.kt
@@ -1,0 +1,251 @@
+package eu.darken.butler.workspace.ui.operations.bar
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ContentCopy
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.progress.Progress
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStackState
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import eu.darken.butler.workspace.R as WorkspaceR
+
+/**
+ * The wrapper concentrates the operations-bar packaging that used to be copied per workspace, so a
+ * wrong default or an inverted conditional here regresses Explorer, Searcher and Editor at once.
+ */
+@Config(qualifiers = "w400dp-h800dp")
+class WorkspaceOperationsFloatingBarTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val emitted = mutableListOf<OperationsBarAction>()
+    private lateinit var stackState: FloatingBarStackState
+
+    private val defaultStartedAt = Clock.System.now() - 5.minutes
+
+    /**
+     * A collapsed row renders a running operation's progress primary instead of its title
+     * (`OperationEntryRow`), so both carry [title] and one finder works in either expansion state.
+     */
+    private fun operation(
+        title: String,
+        state: OperationDisplay.State = running(title),
+        id: Operation.Id = Operation.Id(),
+        startedAt: Instant = defaultStartedAt,
+    ) = OperationDisplay(
+        id = id,
+        title = title.toCaString(),
+        description = "$title details".toCaString(),
+        icon = Icons.TwoTone.ContentCopy,
+        state = state,
+        canCancel = true,
+        startedAt = startedAt,
+    )
+
+    private fun running(primary: String) = OperationDisplay.State.Running(
+        primaryProgress = Progress.Data(
+            primary = primary.toCaString(),
+            secondary = "Working".toCaString(),
+            count = Progress.Count.Percent(5, 10),
+        ),
+    )
+
+    private fun completed() = OperationDisplay.State.Completed(
+        summary = "Done".toCaString(),
+        completedAt = Clock.System.now(),
+        report = null,
+    )
+
+    private fun setBar(
+        initialExpanded: Boolean = false,
+        operations: () -> List<OperationDisplay>,
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                stackState = rememberFloatingBarStackState(position = BarPosition.BOTTOM)
+                FloatingBarStack(
+                    position = BarPosition.BOTTOM,
+                    state = stackState,
+                ) {
+                    WorkspaceOperationsFloatingBar(
+                        key = KEY,
+                        operations = operations(),
+                        initialExpanded = initialExpanded,
+                        onAction = { emitted.add(it) },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun collapseBar(fraction: Float) {
+        runBlocking { stackState.applyCollapse(mapOf(KEY to fraction)) }
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * An empty list composes no row at all, so its absence - not a hidden node - is the observable.
+     */
+    @Test
+    fun `the bar appears only once there is an operation`() {
+        var operations by mutableStateOf(emptyList<OperationDisplay>())
+        setBar { operations }
+
+        composeTestRule.onNodeWithText(FIRST_TITLE).assertDoesNotExist()
+
+        operations = listOf(operation(FIRST_TITLE))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(FIRST_TITLE).assertIsDisplayed()
+    }
+
+    /**
+     * `applyCollapse` skips [eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior.Static] bars
+     * by construction, which is exactly the distinction the active-state classifier decides.
+     */
+    @Test
+    fun `an active operation pins the bar against scroll while a terminal one lets it vanish`() {
+        var state: OperationDisplay.State by mutableStateOf(running(FIRST_TITLE))
+        setBar { listOf(operation(FIRST_TITLE, state)) }
+
+        val cases = listOf(
+            OperationDisplay.State.Queued to true,
+            running(FIRST_TITLE) to true,
+            OperationDisplay.State.Waiting("Name conflict".toCaString()) to true,
+            completed() to false,
+            OperationDisplay.State.Failed(
+                summary = "Failed".toCaString(),
+                completedAt = Clock.System.now(),
+                report = null,
+            ) to false,
+            OperationDisplay.State.Cancelled(
+                completedAt = Clock.System.now(),
+                report = null,
+            ) to false,
+        )
+
+        cases.forEach { (operationState, staysPinned) ->
+            state = operationState
+            composeTestRule.waitForIdle()
+            collapseBar(1f)
+
+            withClue(operationState.toString()) {
+                if (staysPinned) {
+                    composeTestRule.onNodeWithText(FIRST_TITLE).assertIsDisplayed()
+                } else {
+                    composeTestRule.onNodeWithText(FIRST_TITLE).assertIsNotDisplayed()
+                }
+            }
+
+            collapseBar(0f)
+        }
+    }
+
+    @Test
+    fun `an expanded bar shows every operation`() {
+        setBar(initialExpanded = true) {
+            listOf(
+                operation(FIRST_TITLE, completed(), startedAt = defaultStartedAt),
+                operation(SECOND_TITLE, completed(), startedAt = defaultStartedAt + 1.minutes),
+            )
+        }
+
+        composeTestRule.onNodeWithText(FIRST_TITLE).assertIsDisplayed()
+        composeTestRule.onNodeWithText(SECOND_TITLE).assertIsDisplayed()
+    }
+
+    /**
+     * A separate composition from the expanded case: `isExpanded` is seeded by an unkeyed `remember`
+     * in `OperationsBar`, so flipping the parameter in place deliberately does not update it.
+     *
+     * With nothing active, the collapsed branch renders the most recently started operation only.
+     */
+    @Test
+    fun `a collapsed bar shows only the most recently started operation`() {
+        setBar(initialExpanded = false) {
+            listOf(
+                operation(FIRST_TITLE, completed(), startedAt = defaultStartedAt),
+                operation(SECOND_TITLE, completed(), startedAt = defaultStartedAt + 1.minutes),
+            )
+        }
+
+        composeTestRule.onNodeWithText(SECOND_TITLE).assertIsDisplayed()
+        composeTestRule.onNodeWithText(FIRST_TITLE).assertDoesNotExist()
+    }
+
+    /** The waiting-to-conflict decision is the only branching logic either wrapper owns. */
+    @Test
+    fun `a waiting operation routes to the conflict sheet and any other to the details`() {
+        val waitingId = Operation.Id()
+        val completedId = Operation.Id()
+        setBar(initialExpanded = true) {
+            listOf(
+                operation(FIRST_TITLE, OperationDisplay.State.Waiting("Name conflict".toCaString()), waitingId),
+                operation(SECOND_TITLE, completed(), completedId),
+            )
+        }
+
+        composeTestRule.onNodeWithText(FIRST_TITLE).performClick()
+        emitted shouldBe listOf(OperationsBarAction.ShowConflict(waitingId))
+
+        emitted.clear()
+        composeTestRule.onNodeWithText(SECOND_TITLE).performClick()
+        emitted shouldBe listOf(OperationsBarAction.ShowDetails(completedId))
+    }
+
+    /**
+     * Both affordances are plain buttons, and clear-completed only forwards straight through while
+     * the bar is collapsed - expanded it waits out the cascading dismiss animation first.
+     */
+    @Test
+    fun `the cancel and clear-completed buttons emit their actions`() {
+        val runningId = Operation.Id()
+        setBar {
+            listOf(
+                operation(FIRST_TITLE, running(FIRST_TITLE), runningId),
+                operation(SECOND_TITLE, completed()),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(WorkspaceR.string.operations_cancel_operation))
+            .performClick()
+        emitted shouldBe listOf(OperationsBarAction.RequestCancel(runningId))
+
+        emitted.clear()
+        composeTestRule
+            .onNodeWithText(context.getString(WorkspaceR.string.operations_clear_completed))
+            .performClick()
+        emitted shouldBe listOf(OperationsBarAction.ClearCompleted)
+    }
+
+    companion object {
+        private const val KEY = "operations"
+        private const val FIRST_TITLE = "Copying files"
+        private const val SECOND_TITLE = "Moving documents"
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBarTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBarTest.kt
@@ -109,6 +109,12 @@ class WorkspaceOperationsFloatingBarTest : ComposeTest() {
 
     /**
      * An empty list composes no row at all, so its absence - not a hidden node - is the observable.
+     *
+     * Collapsing while empty is what tells the two candidates apart: `FloatingBarStack` snaps the
+     * collapse fraction back to 0 only when a bar's visibility actually flips, so a bar that was
+     * never hidden stays collapsed and keeps the title off-screen. The operation has to be terminal,
+     * an active one makes the bar [eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior.Static]
+     * and a static bar ignores the collapse fraction.
      */
     @Test
     fun `the bar appears only once there is an operation`() {
@@ -117,7 +123,8 @@ class WorkspaceOperationsFloatingBarTest : ComposeTest() {
 
         composeTestRule.onNodeWithText(FIRST_TITLE).assertDoesNotExist()
 
-        operations = listOf(operation(FIRST_TITLE))
+        collapseBar(1f)
+        operations = listOf(operation(FIRST_TITLE, completed()))
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText(FIRST_TITLE).assertIsDisplayed()


### PR DESCRIPTION
## What changed

No user-facing behavior change. The Explorer, Searcher and Editor each built their own version of the
clipboard bar and the operations bar: when it is visible, whether it pins or slides away as you
scroll, which animation it uses, and where a tap on a conflicted operation goes. Those rules were
copied per workspace, so they could and did drift apart. They now come from one place, and the bars
behave identically everywhere by construction rather than by coincidence.

The shared action bar also stops discarding the type of the actions handed to it, which removes an
unchecked cast from every screen that uses one.

## Technical Context

- The duplicated packaging is what hid the Searcher regression fixed in `521383755`: `ed58a69b7`
  swapped a delegated `collectAsState` for a `Raw` + `?:` pair, which froze three remembered
  `derivedStateOf` flags to `false` and made the clipboard bar stop appearing. Only one workspace's
  copy of the policy broke, and nothing noticed. Consolidating it means there is a single place for
  that policy to be right.
- `WorkspaceOperationsFloatingBar` and `WorkspaceClipboardFloatingBar` take a sealed action
  (`OperationsBarAction`, `ClipboardBarAction`) rather than a set of callbacks, so each call site
  handles them in an exhaustive `when` and a future affordance is a compile error at every workspace
  instead of a lambda someone forgets to wire. The waiting-to-conflict routing now lives in the
  wrapper and emits an already-routed action. `key` is deliberately required with no default: bar keys
  are per-workspace persistence contracts for stored collapse fractions, and sharing one literal would
  couple two independently-evolvable contracts.
- The active-operation classifier is an exhaustive `when` over `OperationDisplay.State` rather than an
  `is`-chain. An `is`-chain silently treats a future subtype as terminal, which would make an
  in-progress bar vanish on scroll with no compiler error.
- `WorkspaceActionBar` is now generic over `T : WorkspaceActionBarItem`. Every workspace's state
  already held the concrete list type, so the type parameter recovers it with no state changes and the
  `action as XActionBarItem` cast disappears at all seven call sites. Worth close review: the seven
  sites are in Explorer, Searcher, Editor, Apps, App Details, Viewer and the workspace manager screen.
- `BarPosition`, `FloatingBarScope` and `FloatingBarStack` each documented the bottom-stack
  declaration order backwards. Declaration order determines rendering order, so these were a live trap
  for exactly the mistake this change could have made. Corrected in all three.
