### PR TITLE
General: Fix root setup showing as not installed while root works

### DIFF
--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootServiceState.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootServiceState.kt
@@ -25,4 +25,13 @@ sealed interface RootServiceState {
      * logs the exception, and nothing downstream reads it.
      */
     data object Failed : RootServiceState
+
+    /**
+     * The connect attempt spent its whole budget without the binder resolving.
+     *
+     * Distinct from [Failed]: nothing said no, we simply stopped waiting. Acquiring the host can sit on
+     * an unanswered su prompt indefinitely, and a pending message that never resolves is worse than an
+     * answer.
+     */
+    data object TimedOut : RootServiceState
 }

--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootServiceState.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootServiceState.kt
@@ -1,0 +1,28 @@
+package eu.darken.butler.setup.core.root
+
+/**
+ * Why our privileged root service is (not) usable.
+ *
+ * Exists because a bare Boolean cannot tell "still connecting" apart from "we tried and there is no
+ * service", and acquiring the root host can cold-bind an su session, so the setup card sits in that
+ * window long enough for the difference to be visible.
+ */
+sealed interface RootServiceState {
+
+    /** Root is not enabled, nothing has probed. */
+    data object NotChecked : RootServiceState
+
+    /** The binder has not resolved yet. */
+    data object Connecting : RootServiceState
+
+    /** Our service is up and answering with the identity the connection was gated on. */
+    data object Available : RootServiceState
+
+    /**
+     * The binder resolved to nothing, the probe threw, or the reply came from another installation.
+     *
+     * Carries no [Throwable] on purpose: it gets cached in long-lived UI state, the module already
+     * logs the exception, and nothing downstream reads it.
+     */
+    data object Failed : RootServiceState
+}

--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
@@ -18,15 +18,18 @@ import eu.darken.butler.common.root.RootSettings
 import eu.darken.butler.setup.core.SetupModule
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
@@ -43,6 +46,9 @@ class RootSetupModule @Inject constructor(
 
     private val refreshTrigger = MutableStateFlow(rngString)
 
+    /** Overridden in tests to keep the timeout case fast, never in production. */
+    internal var connectTimeoutMs: Long = CONNECT_TIMEOUT_MS
+
     // Last known concrete Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
     // immediately instead of regressing to Loading and flickering the setup card while the availability
     // probe re-runs (acquiring the root host can cold-bind a su session). Only ever holds a real Result.
@@ -57,36 +63,49 @@ class RootSetupModule @Inject constructor(
 
         if (useRoot != true) return@combine flowOf(baseState)
 
-        rootManager.binder
-            .map { connection ->
-                val serviceState = if (connection == null) {
-                    RootServiceState.Failed
-                } else {
-                    try {
-                        // The round-trip is the liveness proof; the identity in its reply must still
-                        // be the one the connection was gated on.
-                        val ours = IpcContract.decode(connection.ipc.checkBase()) == connection.hostIdentity
-                        if (ours) RootServiceState.Available else RootServiceState.Failed
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Error while checking for root: $e" }
-                        RootServiceState.Failed
-                    }
-                }
-
-                @Suppress("USELESS_CAST")
-                baseState.copy(serviceState = serviceState) as SetupModule.State
-            }
+        channelFlow<SetupModule.State> {
             // Resolving the connection can cold-bind an su session, so there is a window in which we
             // know nothing yet. It is a connecting state, not a failed one.
-            .onStart { emit(baseState.copy(serviceState = RootServiceState.Connecting)) }
-            // The service client rejects a host left over from an older app installation, so obtaining
-            // the binder itself can fail. Report "no service" rather than erroring the whole setup flow.
-            .catch { e ->
-                log(TAG, WARN) { "Root service unavailable: $e" }
-                emit(baseState.copy(serviceState = RootServiceState.Failed) as SetupModule.State)
+            send(baseState.copy(serviceState = RootServiceState.Connecting))
+
+            val timeout = launch {
+                delay(connectTimeoutMs)
+                log(TAG, WARN) { "Root service did not connect within ${connectTimeoutMs}ms" }
+                send(baseState.copy(serviceState = RootServiceState.TimedOut))
             }
+
+            rootManager.binder
+                .map { connection ->
+                    val serviceState = if (connection == null) {
+                        RootServiceState.Failed
+                    } else {
+                        try {
+                            // The round-trip is the liveness proof; the identity in its reply must still
+                            // be the one the connection was gated on.
+                            val ours = IpcContract.decode(connection.ipc.checkBase()) == connection.hostIdentity
+                            if (ours) RootServiceState.Available else RootServiceState.Failed
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            log(TAG, WARN) { "Error while checking for root: $e" }
+                            RootServiceState.Failed
+                        }
+                    }
+
+                    @Suppress("USELESS_CAST")
+                    baseState.copy(serviceState = serviceState) as SetupModule.State
+                }
+                // The service client rejects a host left over from an older app installation, so obtaining
+                // the binder itself can fail. Report "no service" rather than erroring the whole setup flow.
+                .catch { e ->
+                    log(TAG, WARN) { "Root service unavailable: $e" }
+                    emit(baseState.copy(serviceState = RootServiceState.Failed))
+                }
+                .collect {
+                    timeout.cancel()
+                    send(it)
+                }
+        }
     }
         .flatMapLatest { it }
         .onEach { if (it is Result) lastResult = it }
@@ -150,5 +169,9 @@ class RootSetupModule @Inject constructor(
 
     companion object {
         private val TAG = logTag("Setup", "Root", "Module")
+
+        // Generous on purpose: acquiring the host can wait on a user answering an su prompt, and a false
+        // timeout would report working root as unavailable.
+        internal const val CONNECT_TIMEOUT_MS = 60 * 1000L
     }
 }

--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
@@ -58,29 +58,34 @@ class RootSetupModule @Inject constructor(
         if (useRoot != true) return@combine flowOf(baseState)
 
         rootManager.binder
-            .onStart { emit(null) }
             .map { connection ->
-                if (connection == null) return@map baseState
-
-                @Suppress("USELESS_CAST")
-                baseState.copy(
-                    ourService = try {
+                val serviceState = if (connection == null) {
+                    RootServiceState.Failed
+                } else {
+                    try {
                         // The round-trip is the liveness proof; the identity in its reply must still
                         // be the one the connection was gated on.
-                        IpcContract.decode(connection.ipc.checkBase()) == connection.hostIdentity
+                        val ours = IpcContract.decode(connection.ipc.checkBase()) == connection.hostIdentity
+                        if (ours) RootServiceState.Available else RootServiceState.Failed
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
                         log(TAG, WARN) { "Error while checking for root: $e" }
-                        false
-                    },
-                ) as SetupModule.State
+                        RootServiceState.Failed
+                    }
+                }
+
+                @Suppress("USELESS_CAST")
+                baseState.copy(serviceState = serviceState) as SetupModule.State
             }
+            // Resolving the connection can cold-bind an su session, so there is a window in which we
+            // know nothing yet. It is a connecting state, not a failed one.
+            .onStart { emit(baseState.copy(serviceState = RootServiceState.Connecting)) }
             // The service client rejects a host left over from an older app installation, so obtaining
             // the binder itself can fail. Report "no service" rather than erroring the whole setup flow.
             .catch { e ->
                 log(TAG, WARN) { "Root service unavailable: $e" }
-                emit(baseState as SetupModule.State)
+                emit(baseState.copy(serviceState = RootServiceState.Failed) as SetupModule.State)
             }
     }
         .flatMapLatest { it }
@@ -120,8 +125,11 @@ class RootSetupModule @Inject constructor(
     data class Result(
         val useRoot: Boolean?,
         override val isInstalled: Boolean = false,
-        val ourService: Boolean = false,
+        val serviceState: RootServiceState = RootServiceState.NotChecked,
     ) : SetupModule.State.Current {
+
+        val ourService: Boolean
+            get() = serviceState is RootServiceState.Available
 
         override val type: SetupModule.Type = SetupModule.Type.ROOT
 

--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
@@ -18,6 +18,7 @@ import eu.darken.butler.common.root.RootSettings
 import eu.darken.butler.setup.core.SetupModule
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -92,8 +93,7 @@ class RootSetupModule @Inject constructor(
                         }
                     }
 
-                    @Suppress("USELESS_CAST")
-                    baseState.copy(serviceState = serviceState) as SetupModule.State
+                    baseState.copy(serviceState = serviceState)
                 }
                 // The service client rejects a host left over from an older app installation, so obtaining
                 // the binder itself can fail. Report "no service" rather than erroring the whole setup flow.
@@ -102,7 +102,7 @@ class RootSetupModule @Inject constructor(
                     emit(baseState.copy(serviceState = RootServiceState.Failed))
                 }
                 .collect {
-                    timeout.cancel()
+                    timeout.cancelAndJoin()
                     send(it)
                 }
         }

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootCardStatus.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootCardStatus.kt
@@ -1,0 +1,27 @@
+package eu.darken.butler.setup.ui.items
+
+import eu.darken.butler.setup.core.root.RootServiceState
+import eu.darken.butler.setup.core.root.RootSetupModule
+
+/** What the root setup card tells the user, resolved once for every surface that renders it. */
+enum class RootCardStatus {
+    DISABLED,
+    CONNECTING,
+    CONNECTED,
+    NOT_INSTALLED,
+    NOT_CONNECTED,
+}
+
+/**
+ * The installed-manager lookup only knows a handful of package ids, so it says nothing about a
+ * device whose root manager is not one of them. It is consulted after the probe concluded it failed,
+ * never as a reason to contradict a service that is answering.
+ */
+fun RootSetupModule.Result?.toCardStatus(): RootCardStatus = when {
+    this == null || useRoot != true -> RootCardStatus.DISABLED
+    else -> when (serviceState) {
+        is RootServiceState.Available -> RootCardStatus.CONNECTED
+        is RootServiceState.NotChecked, is RootServiceState.Connecting -> RootCardStatus.CONNECTING
+        is RootServiceState.Failed -> if (isInstalled) RootCardStatus.NOT_CONNECTED else RootCardStatus.NOT_INSTALLED
+    }
+}

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootCardStatus.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootCardStatus.kt
@@ -10,6 +10,7 @@ enum class RootCardStatus {
     CONNECTED,
     NOT_INSTALLED,
     NOT_CONNECTED,
+    CONNECTION_FAILED,
 }
 
 /**
@@ -23,5 +24,6 @@ fun RootSetupModule.Result?.toCardStatus(): RootCardStatus = when {
         is RootServiceState.Available -> RootCardStatus.CONNECTED
         is RootServiceState.NotChecked, is RootServiceState.Connecting -> RootCardStatus.CONNECTING
         is RootServiceState.Failed -> if (isInstalled) RootCardStatus.NOT_CONNECTED else RootCardStatus.NOT_INSTALLED
+        is RootServiceState.TimedOut -> RootCardStatus.CONNECTION_FAILED
     }
 }

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -50,6 +50,7 @@ fun RootShizukuActions(
                     RootCardStatus.CONNECTING -> stringResource(R.string.setup_status_connecting)
                     RootCardStatus.NOT_INSTALLED -> stringResource(R.string.setup_status_not_installed)
                     RootCardStatus.NOT_CONNECTED -> stringResource(R.string.setup_status_not_connected)
+                    RootCardStatus.CONNECTION_FAILED -> stringResource(R.string.setup_status_connection_failed)
                 }
             }
             SetupModule.Type.SHIZUKU -> {
@@ -191,6 +192,27 @@ private fun RootActionsConnectingPreview() {
                 useRoot = true,
                 isInstalled = true,
                 serviceState = RootServiceState.Connecting,
+            ),
+            isRequired = true,
+            priority = 5,
+        ),
+        onExecuteAction = {},
+        switchLabel = "Use Root"
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun RootActionsConnectionFailedPreview() {
+    RootShizukuActions(
+        item = SetupItem(
+            type = SetupModule.Type.ROOT,
+            state = RootSetupModule.Result(
+                useRoot = true,
+                isInstalled = true,
+                // The su prompt was never answered, so the handshake ran out its budget.
+                serviceState = RootServiceState.TimedOut,
             ),
             isRequired = true,
             priority = 5,

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -24,6 +24,7 @@ import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.setup.core.SetupAction
 import eu.darken.butler.setup.core.SetupItem
 import eu.darken.butler.setup.core.SetupModule
+import eu.darken.butler.setup.core.root.RootServiceState
 import eu.darken.butler.setup.core.root.RootSetupModule
 import eu.darken.butler.setup.core.shizuku.ShizukuSetupModule
 
@@ -43,11 +44,12 @@ fun RootShizukuActions(
         val connectionStatus = when (item.type) {
             SetupModule.Type.ROOT -> {
                 val rootState = state as? RootSetupModule.Result
-                when {
-                    rootState?.useRoot != true -> null
-                    !rootState.isInstalled -> stringResource(R.string.setup_status_not_installed)
-                    rootState.ourService -> stringResource(R.string.setup_status_connected)
-                    else -> stringResource(R.string.setup_status_not_connected)
+                when (rootState.toCardStatus()) {
+                    RootCardStatus.DISABLED -> null
+                    RootCardStatus.CONNECTED -> stringResource(R.string.setup_status_connected)
+                    RootCardStatus.CONNECTING -> stringResource(R.string.setup_status_connecting)
+                    RootCardStatus.NOT_INSTALLED -> stringResource(R.string.setup_status_not_installed)
+                    RootCardStatus.NOT_CONNECTED -> stringResource(R.string.setup_status_not_connected)
                 }
             }
             SetupModule.Type.SHIZUKU -> {
@@ -147,7 +149,48 @@ private fun RootActionsEnabledPreview() {
             state = RootSetupModule.Result(
                 useRoot = true,
                 isInstalled = true,
-                ourService = true,
+                serviceState = RootServiceState.Available,
+            ),
+            isRequired = true,
+            priority = 5,
+        ),
+        onExecuteAction = {},
+        switchLabel = "Use Root"
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun RootActionsConnectedWithoutManagerPreview() {
+    RootShizukuActions(
+        item = SetupItem(
+            type = SetupModule.Type.ROOT,
+            state = RootSetupModule.Result(
+                useRoot = true,
+                // A rooted device whose root manager is none of the ones we can look up.
+                isInstalled = false,
+                serviceState = RootServiceState.Available,
+            ),
+            isRequired = true,
+            priority = 5,
+        ),
+        onExecuteAction = {},
+        switchLabel = "Use Root"
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun RootActionsConnectingPreview() {
+    RootShizukuActions(
+        item = SetupItem(
+            type = SetupModule.Type.ROOT,
+            state = RootSetupModule.Result(
+                useRoot = true,
+                isInstalled = true,
+                serviceState = RootServiceState.Connecting,
             ),
             isRequired = true,
             priority = 5,

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/SetupStateIndicator.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/SetupStateIndicator.kt
@@ -50,6 +50,9 @@ fun SetupStateIndicator(
                         RootCardStatus.NOT_CONNECTED -> {
                             Icons.TwoTone.Error to MaterialTheme.colorScheme.tertiary
                         }
+                        RootCardStatus.CONNECTION_FAILED -> {
+                            Icons.TwoTone.Error to MaterialTheme.colorScheme.error
+                        }
                     }
                 }
                 SetupModule.Type.SHIZUKU -> {

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/SetupStateIndicator.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/SetupStateIndicator.kt
@@ -33,17 +33,21 @@ fun SetupStateIndicator(
             val (icon, tint) = when (state.type) {
                 SetupModule.Type.ROOT -> {
                     val rootState = state as? RootSetupModule.Result
-                    when {
-                        rootState?.useRoot != true -> {
+                    when (rootState.toCardStatus()) {
+                        RootCardStatus.DISABLED -> {
                             Icons.TwoTone.PauseCircle to MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
                         }
-                        !rootState.isInstalled -> {
-                            Icons.TwoTone.Error to MaterialTheme.colorScheme.error
-                        }
-                        rootState.ourService -> {
+                        RootCardStatus.CONNECTED -> {
                             Icons.TwoTone.CheckCircle to MaterialTheme.colorScheme.primary
                         }
-                        else -> {
+                        // The same pending indicator the Shizuku card uses while it connects.
+                        RootCardStatus.CONNECTING -> {
+                            Icons.TwoTone.RadioButtonUnchecked to MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                        }
+                        RootCardStatus.NOT_INSTALLED -> {
+                            Icons.TwoTone.Error to MaterialTheme.colorScheme.error
+                        }
+                        RootCardStatus.NOT_CONNECTED -> {
                             Icons.TwoTone.Error to MaterialTheme.colorScheme.tertiary
                         }
                     }

--- a/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
@@ -154,4 +154,58 @@ class RootSetupModuleTest : BaseTest() {
 
         collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>().ourService shouldBe false
     }
+
+    @Test fun `an answering host counts even if we cannot name the root manager`() {
+        // The installed-manager lookup only knows a handful of package ids; a device rooted with
+        // anything else still has a working service, and the service is what root access needs.
+        coEvery { rootManager.isInstalled() } returns false
+        val mod = module()
+
+        val collector = mod.state.test(tag = "unknown-manager", scope = scope)
+        val state = collector.await { _, value -> value is RootSetupModule.Result && value.ourService }
+
+        val result = state.shouldBeInstanceOf<RootSetupModule.Result>()
+        result.serviceState shouldBe RootServiceState.Available
+        result.isInstalled shouldBe false
+        result.isComplete shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `an unknown root manager without a matching host stays incomplete`() {
+        coEvery { rootManager.isInstalled() } returns false
+        val leftover = hostIdentity.copy(lastUpdateTime = hostIdentity.lastUpdateTime - 5000)
+        every { ipc.checkBase() } answers { probeCount++; "${leftover.encode()}\nok" }
+        val mod = module()
+
+        val collector = mod.state.test(tag = "unknown-manager-no-host", scope = scope)
+        collector.await { _, value ->
+            value is RootSetupModule.Result && value.serviceState is RootServiceState.Failed
+        }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
+        result.serviceState shouldBe RootServiceState.Failed
+        result.ourService shouldBe false
+        result.isComplete shouldBe false
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `the connecting state precedes the connected one`() {
+        // Obtaining the connection can cold-bind an su session. The card needs something to show for
+        // that window that isn't "no root".
+        val mod = module()
+
+        val collector = mod.state.test(tag = "connecting", scope = scope)
+        collector.await { _, value -> value is RootSetupModule.Result && value.ourService }
+
+        val results = collector.latestValues.filterIsInstance<RootSetupModule.Result>()
+        val connecting = results.indexOfFirst { it.serviceState is RootServiceState.Connecting }
+        val available = results.indexOfFirst { it.serviceState is RootServiceState.Available }
+
+        (connecting >= 0) shouldBe true
+        (connecting < available) shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
+    }
 }

--- a/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
@@ -139,7 +139,9 @@ class RootSetupModuleTest : BaseTest() {
         val mod = module()
 
         val collector = mod.state.test(tag = "no-identity", scope = scope)
-        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        collector.await { _, value ->
+            value is RootSetupModule.Result && value.serviceState is RootServiceState.Failed
+        }
 
         collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>().ourService shouldBe false
     }
@@ -151,7 +153,9 @@ class RootSetupModuleTest : BaseTest() {
         val mod = module()
 
         val collector = mod.state.test(tag = "stale-host", scope = scope)
-        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        collector.await { _, value ->
+            value is RootSetupModule.Result && value.serviceState is RootServiceState.Failed
+        }
 
         collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>().ourService shouldBe false
     }

--- a/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/core/root/RootSetupModuleTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -185,6 +186,25 @@ class RootSetupModuleTest : BaseTest() {
 
         val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
         result.serviceState shouldBe RootServiceState.Failed
+        result.ourService shouldBe false
+        result.isComplete shouldBe false
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `a binder that never resolves times out instead of staying pending`() {
+        // An su prompt the user never answers leaves the binder flow silent forever. Without a budget
+        // the card sits on "Connecting..." for the rest of the session.
+        every { rootManager.binder } returns MutableSharedFlow()
+
+        val mod = module().apply { connectTimeoutMs = 250L }
+
+        val collector = mod.state.test(tag = "timeout", scope = scope)
+        val state = collector.await(timeout = 10_000) { _, value ->
+            value is RootSetupModule.Result && value.serviceState is RootServiceState.TimedOut
+        }
+
+        val result = state.shouldBeInstanceOf<RootSetupModule.Result>()
         result.ourService shouldBe false
         result.isComplete shouldBe false
 

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootCardStatusTest.kt
@@ -10,7 +10,7 @@ import testhelpers.BaseTest
  * The card's headline, its sub-line and its icon each render the same decision, so the decision is
  * made once, here, rather than re-derived per surface.
  */
-class RootServiceStatusTest : BaseTest() {
+class RootCardStatusTest : BaseTest() {
 
     private fun result(
         useRoot: Boolean?,

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootServiceStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootServiceStatusTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.butler.setup.ui.items
+
+import eu.darken.butler.setup.core.root.RootServiceState
+import eu.darken.butler.setup.core.root.RootSetupModule
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The card's headline, its sub-line and its icon each render the same decision, so the decision is
+ * made once, here, rather than re-derived per surface.
+ */
+class RootServiceStatusTest : BaseTest() {
+
+    private fun result(
+        useRoot: Boolean?,
+        isInstalled: Boolean,
+        serviceState: RootServiceState,
+    ) = RootSetupModule.Result(
+        useRoot = useRoot,
+        isInstalled = isInstalled,
+        serviceState = serviceState,
+    )
+
+    @Test fun `root not configured is disabled`() {
+        result(null, isInstalled = true, RootServiceState.Available).toCardStatus() shouldBe RootCardStatus.DISABLED
+        result(null, isInstalled = false, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.DISABLED
+    }
+
+    @Test fun `root turned off is disabled`() {
+        result(false, isInstalled = true, RootServiceState.Available).toCardStatus() shouldBe RootCardStatus.DISABLED
+        result(false, isInstalled = false, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.DISABLED
+    }
+
+    @Test fun `no state at all is disabled`() {
+        val noState: RootSetupModule.Result? = null
+        noState.toCardStatus() shouldBe RootCardStatus.DISABLED
+    }
+
+    /**
+     * The reported defect: a rooted device whose root manager is none of the package ids we can look
+     * up. The service is answering, so that is what the card has to say.
+     */
+    @Test fun `an answering service outranks an unknown root manager`() {
+        result(true, isInstalled = false, RootServiceState.Available).toCardStatus() shouldBe RootCardStatus.CONNECTED
+    }
+
+    @Test fun `an answering service with a known manager is connected`() {
+        result(true, isInstalled = true, RootServiceState.Available).toCardStatus() shouldBe RootCardStatus.CONNECTED
+    }
+
+    /** The handshake window: nothing has concluded yet, so nothing may be reported as missing. */
+    @Test fun `a pending probe is connecting`() {
+        result(true, isInstalled = true, RootServiceState.Connecting).toCardStatus() shouldBe RootCardStatus.CONNECTING
+        result(true, isInstalled = false, RootServiceState.Connecting).toCardStatus() shouldBe RootCardStatus.CONNECTING
+    }
+
+    @Test fun `an unprobed service is connecting`() {
+        result(true, isInstalled = true, RootServiceState.NotChecked).toCardStatus() shouldBe RootCardStatus.CONNECTING
+    }
+
+    @Test fun `a failed probe without a known manager is not installed`() {
+        result(true, isInstalled = false, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.NOT_INSTALLED
+    }
+
+    @Test fun `a failed probe with a known manager is not connected`() {
+        result(true, isInstalled = true, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.NOT_CONNECTED
+    }
+}

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootServiceStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootServiceStatusTest.kt
@@ -66,4 +66,15 @@ class RootServiceStatusTest : BaseTest() {
     @Test fun `a failed probe with a known manager is not connected`() {
         result(true, isInstalled = true, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.NOT_CONNECTED
     }
+
+    /**
+     * A timeout says nothing about the manager, only that the handshake never finished, so the
+     * installed-manager lookup does not get to change the answer here.
+     */
+    @Test fun `a handshake that ran out of time is a connection failure`() {
+        result(true, isInstalled = true, RootServiceState.TimedOut)
+            .toCardStatus() shouldBe RootCardStatus.CONNECTION_FAILED
+        result(true, isInstalled = false, RootServiceState.TimedOut)
+            .toCardStatus() shouldBe RootCardStatus.CONNECTION_FAILED
+    }
 }

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootSetupCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootSetupCardStatusTest.kt
@@ -1,0 +1,66 @@
+package eu.darken.butler.setup.ui.items
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.setup.core.SetupItem
+import eu.darken.butler.setup.core.SetupModule
+import eu.darken.butler.setup.core.root.RootServiceState
+import eu.darken.butler.setup.core.root.RootSetupModule
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The card is where the headline and the connection sub-line meet, so this is what catches them
+ * disagreeing about one state. The icon is not asserted: it carries no content description and
+ * Robolectric cannot draw, [RootServiceStatusTest] covers the decision both of them render.
+ */
+class RootSetupCardStatusTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun renderCard(serviceState: RootServiceState) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RootShizukuActions(
+                    item = SetupItem(
+                        type = SetupModule.Type.ROOT,
+                        state = RootSetupModule.Result(
+                            useRoot = true,
+                            isInstalled = false,
+                            serviceState = serviceState,
+                        ),
+                        isRequired = false,
+                        priority = 5,
+                    ),
+                    onExecuteAction = {},
+                    switchLabel = context.getString(R.string.setup_use_root_label),
+                )
+            }
+        }
+    }
+
+    private fun assertNotShown(text: String) = composeTestRule.onAllNodesWithText(text).assertCountEquals(0)
+
+    @Test
+    fun `an answering service is reported as connected`() {
+        renderCard(RootServiceState.Available)
+
+        composeTestRule.onNodeWithText(context.getString(R.string.setup_status_connected)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.setup_status_completed)).assertIsDisplayed()
+        assertNotShown(context.getString(R.string.setup_status_not_installed))
+    }
+
+    @Test
+    fun `a pending probe is reported as connecting`() {
+        renderCard(RootServiceState.Connecting)
+
+        composeTestRule.onNodeWithText(context.getString(R.string.setup_status_connecting)).assertIsDisplayed()
+        assertNotShown(context.getString(R.string.setup_status_not_installed))
+    }
+}

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootSetupCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootSetupCardStatusTest.kt
@@ -18,7 +18,7 @@ import testhelpers.ComposeTest
 /**
  * The card is where the headline and the connection sub-line meet, so this is what catches them
  * disagreeing about one state. The icon is not asserted: it carries no content description and
- * Robolectric cannot draw, [RootServiceStatusTest] covers the decision both of them render.
+ * Robolectric cannot draw, [RootCardStatusTest] covers the decision both of them render.
  */
 class RootSetupCardStatusTest : ComposeTest() {
 


### PR DESCRIPTION
## What changed

On a rooted device whose root manager app isn't one of the three the app knows how to look for, the Root setup card contradicted itself: a red error icon and "Not installed" sat right next to the headline "Configured", while root access worked normally the whole time. The card now reports what the privileged service is actually doing, so a working root reads as connected regardless of which root manager is installed.

Two related improvements to the same card:

- It no longer flashes a red error while the root connection is being established. That window can be long, because acquiring root may involve starting a new su session, and it now shows a pending state instead.
- It no longer waits indefinitely when the root prompt is never answered. After a bounded wait it reports a connection failure, instead of sitting on a pending message forever.

## Technical Context

- Root cause: `RootSetupModule.Result` carried `isInstalled` (a `PackageManager` lookup over three hardcoded root-manager package ids) and `ourService` (a live identity-checked IPC round-trip) as unreconciled fields. `RootShizukuActions` and `SetupStateIndicator` each re-derived the card's status from those booleans in their own branch order, both testing `!isInstalled` before `ourService`, which made the "Connected" branch unreachable whenever the package lookup missed. The headline came from `isComplete`, computed independently — hence the contradiction.
- Rather than reorder both `when` blocks, the ordering decision was extracted into a single `toCardStatus()` resolver that both surfaces consume through exhaustive `when`s over an enum, so the two cannot drift apart again and a new state becomes a compile error rather than a silent fall-through. The package lookup is now consulted only after the service probe has concluded that it failed.
- The service check became a `RootServiceState` sealed type instead of a Boolean, mirroring the existing `ShizukuServiceState`, which exists for the same reason: a Boolean cannot distinguish "still connecting" from "tried and failed". `Result.ourService` is kept as a derived property, so `isComplete` and its readers are untouched. `Result.isAvailable` deliberately still returns `isInstalled` — changing it was considered and dropped, since it feeds `PathPermissionCheck` and tracing every consumer showed it would change no access verdict.
- Rejected alternative: extending the hardcoded `KNOWN_ROOT_MANAGERS` set. That would fix only devices whose manager uses a newly added id and leave every non-stock id broken, and the id on the reporting device is unknown.
- Worth close review: the `channelFlow` in `RootSetupModule` has two producers, the block body and the launched timeout job. `cancelAndJoin`, not `cancel`, is load-bearing there — `cancel` is non-suspending, so a timeout child already inside its buffered `send` could land `TimedOut` after a good state and leave a working root showing "Connection failed".
- Manual testing covered something CI cannot: the change was exercised on a rooted physical device (Android 12), confirming the card settles on "Configured"/"Connected" and that the connection handshake renders a pending state rather than an error.
