### PR TITLE
IO: Report the real cause when a root or ADB file operation fails

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/CopyOperationEvent.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/CopyOperationEvent.kt
@@ -97,7 +97,7 @@ sealed interface CopyOperationEvent : Parcelable {
     /**
      * Emitted when operation fails or is cancelled.
      *
-     * @param error Error message
+     * @param error An `IpcErrorCodec` carrier when the host encoded the failure, a plain message otherwise
      * @param cancelled True if user cancelled, false if error
      */
     @Parcelize

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/DeleteOperationEvent.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/DeleteOperationEvent.kt
@@ -86,7 +86,7 @@ sealed interface DeleteOperationEvent : Parcelable {
     /**
      * Emitted when operation fails or is cancelled.
      *
-     * @param error Error message
+     * @param error An `IpcErrorCodec` carrier when the host encoded the failure, a plain message otherwise
      * @param cancelled True if user cancelled, false if error
      */
     @Parcelize

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsClient.kt
@@ -26,7 +26,6 @@ import eu.darken.butler.common.ipc.IpcClientModule
 import eu.darken.butler.common.ipc.fileHandle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import okio.FileHandle
 import okio.buffer
@@ -112,16 +111,18 @@ class FileOpsClient @AssistedInject constructor(
                 when (event) {
                     is WalkEvent.Item -> emit(event.lookup)
                     is WalkEvent.DirError -> {
-                        val error = ReadException(
-                            message = event.message ?: "Failed to read directory",
-                            path = event.lookup.lookedUp,
-                        )
+                        // onError takes an Exception; every type the codec rebuilds is one.
+                        val error = (decodeStreamError(event.message) as? Exception)
+                            ?: ReadException(
+                                message = event.message ?: "Failed to read directory",
+                                path = event.lookup.lookedUp,
+                            )
                         val continueWalk = walkOptions.onError?.invoke(event.lookup, error) ?: true
                         if (!continueWalk) throw error
                     }
                     is WalkEvent.FatalError -> {
                         terminated = true
-                        throw ReadException(
+                        throw decodeStreamError(event.message) ?: ReadException(
                             message = event.message ?: "Walk failed",
                             path = event.path ?: path,
                         )
@@ -256,19 +257,25 @@ class FileOpsClient @AssistedInject constructor(
         )
 
         // Convert RemoteInputStream to Flow<DeleteOperationEvent>
-        remoteInputStream.toEventFlow(DeleteOperationEvent.CREATOR)
-            .map { event ->
-                // Handle Error events by throwing appropriate exception
-                if (event is DeleteOperationEvent.Error) {
-                    if (event.cancelled) {
-                        throw CancellationException(event.error)
-                    } else {
-                        throw IOException(event.error)
+        flow {
+            var terminated = false
+            remoteInputStream.toEventFlow(DeleteOperationEvent.CREATOR).collect { event ->
+                when (event) {
+                    is DeleteOperationEvent.Error -> {
+                        terminated = true
+                        val decoded = decodeStreamError(event.error)
+                        if (event.cancelled) throw CancellationException(decoded?.message ?: event.error)
+                        throw decoded ?: IOException(event.error)
                     }
+                    is DeleteOperationEvent.Result -> {
+                        terminated = true
+                        emit(event.toDeleteActionState())
+                    }
+                    else -> emit(event.toDeleteActionState())
                 }
-                // Convert each event to DeleteAction.State
-                event.toDeleteActionState()
             }
+            if (!terminated) throw IOException("Delete stream truncated")
+        }
     } catch (e: Exception) {
         throw e.refineException()
     }
@@ -319,19 +326,25 @@ class FileOpsClient @AssistedInject constructor(
         )
 
         // Convert RemoteInputStream to Flow<CopyOperationEvent>
-        remoteInputStream.toEventFlow(CopyOperationEvent.CREATOR)
-            .map { event ->
-                // Handle Error events by throwing appropriate exception
-                if (event is CopyOperationEvent.Error) {
-                    if (event.cancelled) {
-                        throw CancellationException(event.error)
-                    } else {
-                        throw IOException(event.error)
+        flow {
+            var terminated = false
+            remoteInputStream.toEventFlow(CopyOperationEvent.CREATOR).collect { event ->
+                when (event) {
+                    is CopyOperationEvent.Error -> {
+                        terminated = true
+                        val decoded = decodeStreamError(event.error)
+                        if (event.cancelled) throw CancellationException(decoded?.message ?: event.error)
+                        throw decoded ?: IOException(event.error)
                     }
+                    is CopyOperationEvent.Result -> {
+                        terminated = true
+                        emit(event.toCopyActionState())
+                    }
+                    else -> emit(event.toCopyActionState())
                 }
-                // Convert each event to CopyAction.State
-                event.toCopyActionState()
             }
+            if (!terminated) throw IOException("Copy stream truncated")
+        }
     } catch (e: Exception) {
         throw e.refineException()
     }
@@ -382,19 +395,25 @@ class FileOpsClient @AssistedInject constructor(
         )
 
         // Convert RemoteInputStream to Flow<MoveOperationEvent>
-        remoteInputStream.toEventFlow(MoveOperationEvent.CREATOR)
-            .map { event ->
-                // Handle Error events by throwing appropriate exception
-                if (event is MoveOperationEvent.Error) {
-                    if (event.cancelled) {
-                        throw CancellationException(event.error)
-                    } else {
-                        throw IOException(event.error)
+        flow {
+            var terminated = false
+            remoteInputStream.toEventFlow(MoveOperationEvent.CREATOR).collect { event ->
+                when (event) {
+                    is MoveOperationEvent.Error -> {
+                        terminated = true
+                        val decoded = decodeStreamError(event.error)
+                        if (event.cancelled) throw CancellationException(decoded?.message ?: event.error)
+                        throw decoded ?: IOException(event.error)
                     }
+                    is MoveOperationEvent.Result -> {
+                        terminated = true
+                        emit(event.toMoveActionState())
+                    }
+                    else -> emit(event.toMoveActionState())
                 }
-                // Convert each event to MoveAction.State
-                event.toMoveActionState()
             }
+            if (!terminated) throw IOException("Move stream truncated")
+        }
     } catch (e: Exception) {
         throw e.refineException()
     }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/FileOpsHost.kt
@@ -28,15 +28,19 @@ import eu.darken.butler.common.files.local.walkers.DirectLocalWalker
 import eu.darken.butler.common.files.metadata.FileSystem
 import eu.darken.butler.common.files.metadata.Ownership
 import eu.darken.butler.common.files.metadata.Permissions
+import eu.darken.butler.common.ipc.IpcErrorCodec
 import eu.darken.butler.common.ipc.IpcHostModule
 import eu.darken.butler.common.ipc.RemoteFileHandle
 import eu.darken.butler.common.ipc.RemoteInputStream
 import eu.darken.butler.common.ipc.remoteFileHandle
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
@@ -118,7 +122,7 @@ class FileOpsHost @Inject constructor(
                     true
                 },
                 onError = { lookup, e ->
-                    emit(WalkEvent.DirError(lookup, e.message ?: e.toString()))
+                    emit(WalkEvent.DirError(lookup, IpcErrorCodec.encodeCompact(e)))
                     true
                 },
                 followSymlinks = spec.followSymlinks,
@@ -127,9 +131,8 @@ class FileOpsHost @Inject constructor(
         }.catch { e ->
             if (e is kotlinx.coroutines.CancellationException) throw e
             log(TAG, ERROR) { "walkStreamV2($path) fatal: ${e.asLog()}" }
-            // Only the message crosses here, not the exception itself: the client rebuilds a fresh
-            // ReadException from it, so type, cause chain and host stack are lost on this path.
-            emit(WalkEvent.FatalError(path, e.message ?: e.toString()))
+            // Full payload for the one terminal failure, the per-directory errors go compact.
+            emit(WalkEvent.FatalError(path, IpcErrorCodec.encode(e)))
         }
         events.toEventRemoteStream(appScope + dispatcherProvider.IO)
     } catch (e: Exception) {
@@ -330,11 +333,16 @@ class FileOpsHost @Inject constructor(
                 log(TAG, VERBOSE) { "deleteStream() completed successfully" }
             } catch (e: Exception) {
                 log(TAG, ERROR) { "deleteStream() operation failed: ${e.asLog()}" }
-                // Send error event instead of throwing. Only the message crosses, so type, cause
-                // chain and host stack are lost on this path.
+                if (e is CancellationException) {
+                    // A cancelled scope has to unwind; a cancelled operation is a terminal event.
+                    if (!currentCoroutineContext().isActive) throw e
+                    send(DeleteOperationEvent.Error(error = e.message ?: "Cancelled", cancelled = true))
+                    return@channelFlow
+                }
+                // Send error event instead of throwing
                 send(
                     DeleteOperationEvent.Error(
-                        error = e.message ?: "Unknown error",
+                        error = IpcErrorCodec.encode(e),
                         cancelled = false
                     )
                 )
@@ -400,10 +408,16 @@ class FileOpsHost @Inject constructor(
                 log(TAG, VERBOSE) { "copyStream() completed successfully" }
             } catch (e: Exception) {
                 log(TAG, ERROR) { "copyStream() operation failed: ${e.asLog()}" }
+                if (e is CancellationException) {
+                    // A cancelled scope has to unwind; a cancelled operation is a terminal event.
+                    if (!currentCoroutineContext().isActive) throw e
+                    send(CopyOperationEvent.Error(error = e.message ?: "Cancelled", cancelled = true))
+                    return@channelFlow
+                }
                 // Send error event instead of throwing
                 send(
                     CopyOperationEvent.Error(
-                        error = e.message ?: "Unknown error",
+                        error = IpcErrorCodec.encode(e),
                         cancelled = false
                     )
                 )
@@ -469,10 +483,16 @@ class FileOpsHost @Inject constructor(
                 log(TAG, VERBOSE) { "moveStream() completed successfully" }
             } catch (e: Exception) {
                 log(TAG, ERROR) { "moveStream() operation failed: ${e.asLog()}" }
+                if (e is CancellationException) {
+                    // A cancelled scope has to unwind; a cancelled operation is a terminal event.
+                    if (!currentCoroutineContext().isActive) throw e
+                    send(MoveOperationEvent.Error(error = e.message ?: "Cancelled", cancelled = true))
+                    return@channelFlow
+                }
                 // Send error event instead of throwing
                 send(
                     MoveOperationEvent.Error(
-                        error = e.message ?: "Unknown error",
+                        error = IpcErrorCodec.encode(e),
                         cancelled = false
                     )
                 )

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/MoveOperationEvent.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/MoveOperationEvent.kt
@@ -97,7 +97,7 @@ sealed interface MoveOperationEvent : Parcelable {
     /**
      * Emitted when operation fails or is cancelled.
      *
-     * @param error Error message
+     * @param error An `IpcErrorCodec` carrier when the host encoded the failure, a plain message otherwise
      * @param cancelled True if user cancelled, false if error
      */
     @Parcelize

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.files.permissions
 
 import eu.darken.butler.common.ElevatedAccessUnavailableException
 import eu.darken.butler.common.error.causeChain
+import eu.darken.butler.common.files.errors.PathAlreadyExistsException
 import eu.darken.butler.common.files.errors.PathException
 import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
@@ -35,7 +36,16 @@ object PermissionErrorClassifier {
             val r = t.matchMessage()
             if (r != null) return r
         }
-        // Pass 3: Generic permission-style exception types without a more specific message.
+        // Pass 3: Positive evidence of a different failure beats pass 4 inferring a denial from a
+        // generic wrapper. A named non-permission kernel error anywhere in the chain settles it,
+        // and so does the PathAlreadyExistsException type: "the target is already there" is as
+        // plain a non-denial as the errno strings are. Escalation changes only for failures root
+        // access cannot fix anyway: it frees no disk space and unmakes no existing file.
+        for (t in error.causeChain) {
+            if (t is PathAlreadyExistsException) return null
+            if (t.matchesNonPermissionError()) return null
+        }
+        // Pass 4: Generic permission-style exception types without a more specific message.
         for (t in error.causeChain) {
             when (t) {
                 // A path that isn't there is not a path we were kept out of.
@@ -52,15 +62,7 @@ object PermissionErrorClassifier {
     fun isPermissionError(error: Throwable): Boolean = classify(error) != null
 
     private fun Throwable.matchMessage(): Reason? {
-        // For IOException we trust the message directly (kernel-level errno strings).
-        // For other types we only match if the message looks like a flattened cause chain
-        // (e.g. RemoteException from Binder includes "Caused by: java.io.IOException: ...").
-        val msg = message.orEmpty()
-        val isFlattenedIo = msg.contains("Caused by:") &&
-            msg.contains("java.io.IOException", ignoreCase = true)
-        if (this !is IOException && !isFlattenedIo) return null
-
-        val haystack = msg.lowercase()
+        val haystack = errnoHaystack(message) ?: return null
         return when {
             "read-only file system" in haystack -> Reason.READONLY_FILESYSTEM
             "operation not permitted" in haystack -> Reason.NOT_PERMITTED
@@ -68,4 +70,47 @@ object PermissionErrorClassifier {
             else -> null
         }
     }
+
+    private fun Throwable.matchesNonPermissionError(): Boolean {
+        val haystack = suppressionHaystack() ?: return false
+        return NON_PERMISSION_ERRORS.any { it in haystack }
+    }
+
+    /**
+     * Suppression only ever removes a verdict, so it matches on text a file name cannot reach —
+     * otherwise a denial on a path called "file exists" would silence itself.
+     * [java.nio.file.FileSystemException] keeps the errno in `reason`, while its message also
+     * renders the file and otherFile it failed on.
+     */
+    private fun Throwable.suppressionHaystack(): String? = when (this) {
+        is java.nio.file.FileSystemException -> reason?.lowercase()
+        else -> errnoHaystack(pathlessMessage())
+    }
+
+    /** [PathException] appends ` <-> path` to its message, and no errno lives in that suffix. */
+    private fun Throwable.pathlessMessage(): String? {
+        val path = (this as? PathException)?.path ?: return message
+        return message?.removeSuffix(" <-> ${path.path}")
+    }
+
+    private fun Throwable.errnoHaystack(text: String?): String? {
+        // For IOException we trust the message directly (kernel-level errno strings).
+        // For other types we only match if the message looks like a flattened cause chain
+        // (e.g. RemoteException from Binder includes "Caused by: java.io.IOException: ...").
+        val msg = text.orEmpty()
+        val isFlattenedIo = msg.contains("Caused by:") &&
+            msg.contains("java.io.IOException", ignoreCase = true)
+        if (this !is IOException && !isFlattenedIo) return null
+
+        return msg.lowercase()
+    }
+
+    /** Failures the kernel names, none of which is us being kept out. */
+    private val NON_PERMISSION_ERRORS = listOf(
+        "no space left on device",
+        "disk quota exceeded",
+        "input/output error",
+        "invalid cross-device link",
+        "file exists",
+    )
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcClientModule.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcClientModule.kt
@@ -20,15 +20,19 @@ interface IpcClientModule {
      * says an exception actually came from a host, so anything without it is handed back untouched.
      */
     fun Throwable.unwrapPropagation(): Throwable {
-        val carried = (this as? UnsupportedOperationException)
-            ?.message
-            ?.takeIf { it.startsWith(IpcErrorCodec.MARKER) }
-            ?: return this
+        val carrier = (this as? UnsupportedOperationException)?.message ?: return this
 
-        return IpcErrorCodec.decode(carried, stackTrace).also {
+        return IpcErrorCodec.decodeIfMarked(carrier, stackTrace)?.also {
             log(TAG, VERBOSE) { "Propagating unwrapped exception: $it" }
-        }
+        } ?: this
     }
+
+    /**
+     * The stream counterpart: those events carry the host error in a [String] field instead of a
+     * binder exception. Null means nothing was encoded, so the caller keeps the raw text.
+     */
+    fun decodeStreamError(carrier: String?): Throwable? =
+        IpcErrorCodec.decodeIfMarked(carrier, Throwable().stackTrace)
 
     companion object {
         private val TAG = logTag("IPC", "Module")

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCode.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCode.kt
@@ -1,20 +1,21 @@
 package eu.darken.butler.common.ipc
 
 /**
- * The exception types a privileged host (root, ADB/Shizuku, isolated file service) can throw out of
- * a *synchronous* binder call, i.e. what [IpcErrorCodec] is able to rebuild by type on the other
- * side.
+ * The exception types a privileged host (root, ADB/Shizuku, isolated file service) can fail with,
+ * both out of a synchronous binder call and inside a streamed event, i.e. what [IpcErrorCodec] is
+ * able to rebuild by type on the other side.
  *
  * Exceptions that are constructed in the app-side facades after the transaction already returned
  * (`ShellOpsException`, `PkgOpsException`, the root/ADB connection failures) never cross the binder
  * and deliberately have no code here.
  *
- * The enum entry NAME is the wire identity, never the ordinal: a host process can outlive an
- * in-place app update, so both sides of a transaction may come from different builds.
+ * The enum entry NAME is the wire identity, never the ordinal. Build skew between the two sides does
+ * not arise: every host reaching `FileOpsClient` belongs to this installation. Root and ADB hosts
+ * are checked against our own identity on connect (`gateOnHostIdentity`), and the isolated service
+ * runs in `:isolated`, a process of this package that dies when the package is replaced.
  *
- * That holds only while both sides speak the marker format. A host from a build predating it emits
- * no marker, and markerless carriers are passed through untouched, so such a host's errors surface
- * unrecognized until it restarts.
+ * A carrier without the marker is passed through untouched, so a null or plain-string error field
+ * stays the message it was.
  */
 enum class IpcErrorCode {
     PATH_READ,

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCodec.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCodec.kt
@@ -53,11 +53,12 @@ data class IpcStackFrame(
 )
 
 /**
- * Carries a host-side exception through a synchronous binder call.
+ * Carries a host-side exception across the IPC boundary, either as the exception of a synchronous
+ * binder call or in the error field of a streamed event.
  *
  * A `Parcel` transports only an exception's message, and only for the handful of types
  * `Parcel.writeException` knows about, so everything the app needs (type, path, causes, host stack)
- * is packed into that message as JSON behind [MARKER].
+ * is packed into that message as JSON behind [MARKER]. [encodeCompact] leaves out `hostStack`.
  */
 object IpcErrorCodec {
 
@@ -67,8 +68,16 @@ object IpcErrorCodec {
      */
     const val MARKER = "#BTLR_IPC_ERROR_V1#"
 
-    fun encode(error: Throwable): String {
-        val encoded = runCatching { MARKER + json.encodeToString(SERIALIZER, error.toPayload()) }
+    fun encode(error: Throwable): String = encodePayload(error, includeHostStack = true)
+
+    /**
+     * Without the host stack, for carriers a single operation can emit many of: one per unreadable
+     * directory of a walk. Everything else, including the cause chain, still crosses.
+     */
+    fun encodeCompact(error: Throwable): String = encodePayload(error, includeHostStack = false)
+
+    private fun encodePayload(error: Throwable, includeHostStack: Boolean): String {
+        val encoded = runCatching { MARKER + json.encodeToString(SERIALIZER, error.toPayload(includeHostStack)) }
             .onFailure { log(TAG, WARN) { "Failed to encode $error: ${it.asLog()}" } }
             .getOrNull()
 
@@ -80,6 +89,12 @@ object IpcErrorCodec {
         if (minimal != null && minimal.toByteArray().size <= MAX_PAYLOAD_BYTES) return minimal
 
         return MARKER + UNENCODABLE
+    }
+
+    /** Null when there is nothing encoded to decode, i.e. the carrier is a plain message or absent. */
+    fun decodeIfMarked(carrier: String?, localStack: Array<StackTraceElement>): Throwable? {
+        if (carrier == null || !carrier.startsWith(MARKER)) return null
+        return decode(carrier, localStack)
     }
 
     fun decode(carrierMessage: String, localStack: Array<StackTraceElement>): Throwable {
@@ -110,20 +125,23 @@ object IpcErrorCodec {
         return rebuilt
     }
 
-    private fun Throwable.toPayload() = IpcErrorPayload(
+    private fun Throwable.toPayload(includeHostStack: Boolean) = IpcErrorPayload(
         code = classify(),
         className = javaClass.name.truncate(),
         rawMessage = rawMessage()?.truncate(),
         rawPath = (this as? PathException)?.path?.path?.truncate(),
         extras = extras(),
         causeChain = boundedCauses().map { it.toString().truncate() },
-        hostStack = stackTrace.take(MAX_STACK_FRAMES).map {
-            IpcStackFrame(
-                className = it.className.truncate(),
-                methodName = it.methodName.truncate(),
-                fileName = it.fileName?.truncate(),
-                lineNumber = it.lineNumber,
-            )
+        hostStack = when {
+            includeHostStack -> stackTrace.take(MAX_STACK_FRAMES).map {
+                IpcStackFrame(
+                    className = it.className.truncate(),
+                    methodName = it.methodName.truncate(),
+                    fileName = it.fileName?.truncate(),
+                    lineNumber = it.lineNumber,
+                )
+            }
+            else -> emptyList()
         },
     )
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/FileOpsClientOperationErrorTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/FileOpsClientOperationErrorTest.kt
@@ -1,0 +1,328 @@
+package eu.darken.butler.common.files.local.ipc
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.actions.CopyAction
+import eu.darken.butler.common.files.actions.DeleteAction
+import eu.darken.butler.common.files.actions.MoveAction
+import eu.darken.butler.common.files.errors.PathPermissionDeniedException
+import eu.darken.butler.common.files.local.LocalFileSystemOps
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.ipc.IpcErrorCodec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * How the delete/copy/move streams report a failed operation: the error event carries an
+ * [IpcErrorCodec] payload the client rebuilds by type, `cancelled` is the only cancellation signal,
+ * and a stream ending without a terminal event is truncation rather than success. The connection is
+ * mocked with a real [toRemoteInputStream] pipe, and the host round trips drive a [FileOpsHost] over
+ * a mocked backend so both ends of the protocol are covered.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FileOpsClientOperationErrorTest : BaseTest() {
+
+    private val target = LocalPath.build("/data/subtree/target.txt")
+    private val destination = LocalPath.build("/data/other")
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val connection = mockk<FileOpsConnection>()
+    private val client = FileOpsClient(connection)
+    private val hostOps = mockk<LocalFileSystemOps>()
+
+    private fun denial(operation: String) = PathPermissionDeniedException(
+        path = target,
+        operation = operation,
+        reason = PathPermissionDeniedException.Reason.NOT_PERMITTED,
+    )
+
+    private fun host() = FileOpsHost(
+        context = ApplicationProvider.getApplicationContext<Context>(),
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        fileSystemOps = hostOps,
+    )
+
+    @After
+    fun teardown() {
+        scope.cancel()
+    }
+
+    private fun lookup(path: LocalPath) = LocalPathLookup(
+        lookedUp = path,
+        fileType = FileType.FILE,
+        size = 0L,
+        modifiedAt = null,
+    )
+
+    private fun deleteStreams(vararg events: DeleteOperationEvent) {
+        every { connection.deleteStream(any(), any(), any(), any()) } answers {
+            events.asList().asFlow().toRemoteInputStream(scope)
+        }
+    }
+
+    private fun copyStreams(vararg events: CopyOperationEvent) {
+        every { connection.copyStream(any(), any(), any(), any(), any(), any()) } answers {
+            events.asList().asFlow().toRemoteInputStream(scope)
+        }
+    }
+
+    private fun moveStreams(vararg events: MoveOperationEvent) {
+        every { connection.moveStream(any(), any(), any(), any(), any(), any()) } answers {
+            events.asList().asFlow().toRemoteInputStream(scope)
+        }
+    }
+
+    private suspend fun collectDelete() = withTimeout(10_000) {
+        client.delete(setOf(target), DeleteAction.Options(recursive = true)).toList()
+    }
+
+    private suspend fun collectCopy() = withTimeout(10_000) {
+        client.copy(setOf(target), destination, null, CopyAction.Options()).toList()
+    }
+
+    private suspend fun collectMove() = withTimeout(10_000) {
+        client.move(setOf(target), destination, null, MoveAction.Options()).toList()
+    }
+
+    @Test
+    fun `an encoded delete error surfaces as the host type`() {
+        deleteStreams(DeleteOperationEvent.Error(IpcErrorCodec.encode(denial("delete")), cancelled = false))
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { collectDelete() }
+            thrown.path!!.path shouldBe target.path
+            thrown.operation shouldBe "delete"
+        }
+    }
+
+    @Test
+    fun `a markerless delete error surfaces as an IOException with the host message`() {
+        deleteStreams(DeleteOperationEvent.Error("Backend went away", cancelled = false))
+
+        runBlocking {
+            shouldThrow<IOException> { collectDelete() }.message shouldBe "Backend went away"
+        }
+    }
+
+    @Test
+    fun `a cancelled delete surfaces as cancellation, encoded or not`() {
+        deleteStreams(DeleteOperationEvent.Error("Stopped by user", cancelled = true))
+        runBlocking {
+            shouldThrow<CancellationException> { collectDelete() }.message shouldContain "Stopped by user"
+        }
+
+        deleteStreams(DeleteOperationEvent.Error(IpcErrorCodec.encode(denial("delete")), cancelled = true))
+        runBlocking { shouldThrow<CancellationException> { collectDelete() } }
+    }
+
+    @Test
+    fun `a delete stream without a terminal event is reported as truncation`() {
+        deleteStreams(DeleteOperationEvent.ScanProgress(1L, lookup(target)))
+
+        runBlocking {
+            shouldThrow<IOException> { collectDelete() }.message!! shouldContain "truncated"
+        }
+    }
+
+    @Test
+    fun `an encoded copy error surfaces as the host type`() {
+        copyStreams(CopyOperationEvent.Error(IpcErrorCodec.encode(denial("copy")), cancelled = false))
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { collectCopy() }
+            thrown.path!!.path shouldBe target.path
+            thrown.operation shouldBe "copy"
+        }
+    }
+
+    @Test
+    fun `a markerless copy error surfaces as an IOException with the host message`() {
+        copyStreams(CopyOperationEvent.Error("Backend went away", cancelled = false))
+
+        runBlocking {
+            shouldThrow<IOException> { collectCopy() }.message shouldBe "Backend went away"
+        }
+    }
+
+    @Test
+    fun `a cancelled copy surfaces as cancellation, encoded or not`() {
+        copyStreams(CopyOperationEvent.Error("Stopped by user", cancelled = true))
+        runBlocking {
+            shouldThrow<CancellationException> { collectCopy() }.message shouldContain "Stopped by user"
+        }
+
+        copyStreams(CopyOperationEvent.Error(IpcErrorCodec.encode(denial("copy")), cancelled = true))
+        runBlocking { shouldThrow<CancellationException> { collectCopy() } }
+    }
+
+    @Test
+    fun `a copy stream without a terminal event is reported as truncation`() {
+        copyStreams(CopyOperationEvent.ScanProgress(1L, 0L, lookup(target)))
+
+        runBlocking {
+            shouldThrow<IOException> { collectCopy() }.message!! shouldContain "truncated"
+        }
+    }
+
+    @Test
+    fun `an encoded move error surfaces as the host type`() {
+        moveStreams(MoveOperationEvent.Error(IpcErrorCodec.encode(denial("move")), cancelled = false))
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { collectMove() }
+            thrown.path!!.path shouldBe target.path
+            thrown.operation shouldBe "move"
+        }
+    }
+
+    @Test
+    fun `a markerless move error surfaces as an IOException with the host message`() {
+        moveStreams(MoveOperationEvent.Error("Backend went away", cancelled = false))
+
+        runBlocking {
+            shouldThrow<IOException> { collectMove() }.message shouldBe "Backend went away"
+        }
+    }
+
+    @Test
+    fun `a cancelled move surfaces as cancellation, encoded or not`() {
+        moveStreams(MoveOperationEvent.Error("Stopped by user", cancelled = true))
+        runBlocking {
+            shouldThrow<CancellationException> { collectMove() }.message shouldContain "Stopped by user"
+        }
+
+        moveStreams(MoveOperationEvent.Error(IpcErrorCodec.encode(denial("move")), cancelled = true))
+        runBlocking { shouldThrow<CancellationException> { collectMove() } }
+    }
+
+    @Test
+    fun `a move stream without a terminal event is reported as truncation`() {
+        moveStreams(MoveOperationEvent.ScanProgress(1L, 0L, lookup(target)))
+
+        runBlocking {
+            shouldThrow<IOException> { collectMove() }.message!! shouldContain "truncated"
+        }
+    }
+
+    @Test
+    fun `a host side delete failure crosses as its own type`() {
+        val hostError = denial("delete").apply {
+            stackTrace = arrayOf(StackTraceElement("com.host.Delete", "deleteStart", "Delete.kt", 42))
+        }
+        coEvery { hostOps.lookup(target, LookupOptions.BASE) } returns lookup(target)
+        coEvery { hostOps.exists(target) } returns true
+        coEvery { hostOps.delete(target, any()) } throws hostError
+        every { connection.deleteStream(any(), any(), any(), any()) } answers {
+            host().deleteStream(listOf(target), true, true, null)
+        }
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { collectDelete() }
+            thrown.path!!.path shouldBe target.path
+            thrown.reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+            thrown.stackTrace.any { it.className == "com.host.Delete" } shouldBe true
+        }
+    }
+
+    @Test
+    fun `a host side cancellation crosses as cancellation, not as a failure`() {
+        coEvery { hostOps.lookup(target, LookupOptions.BASE) } returns lookup(target)
+        coEvery { hostOps.exists(target) } returns true
+        coEvery { hostOps.delete(target, any()) } throws CancellationException("Stopped by user")
+        every { connection.deleteStream(any(), any(), any(), any()) } answers {
+            host().deleteStream(listOf(target), true, true, null)
+        }
+
+        runBlocking {
+            shouldThrow<CancellationException> { collectDelete() }.message shouldContain "Stopped by user"
+        }
+    }
+
+    @Test
+    fun `a host side copy failure crosses as its own type`() {
+        val hostError = denial("copy").apply {
+            stackTrace = arrayOf(StackTraceElement("com.host.Copy", "copyStart", "Copy.kt", 42))
+        }
+        coEvery { hostOps.lookup(destination, any()) } throws hostError
+        every { connection.copyStream(any(), any(), any(), any(), any(), any()) } answers {
+            host().copyStream(listOf(target), destination, false, false, false, null)
+        }
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { collectCopy() }
+            thrown.path!!.path shouldBe target.path
+            thrown.operation shouldBe "copy"
+            thrown.reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+            thrown.stackTrace.any { it.className == "com.host.Copy" } shouldBe true
+        }
+    }
+
+    @Test
+    fun `a host side copy cancellation crosses as cancellation, not as a failure`() {
+        coEvery { hostOps.lookup(destination, any()) } throws CancellationException("Stopped by user")
+        every { connection.copyStream(any(), any(), any(), any(), any(), any()) } answers {
+            host().copyStream(listOf(target), destination, false, false, false, null)
+        }
+
+        runBlocking {
+            shouldThrow<CancellationException> { collectCopy() }.message shouldContain "Stopped by user"
+        }
+    }
+
+    @Test
+    fun `a host side move failure crosses as its own type`() {
+        val hostError = denial("move").apply {
+            stackTrace = arrayOf(StackTraceElement("com.host.Move", "moveStart", "Move.kt", 42))
+        }
+        coEvery { hostOps.lookup(destination, any()) } throws hostError
+        every { connection.moveStream(any(), any(), any(), any(), any(), any()) } answers {
+            host().moveStream(listOf(target), destination, false, false, false, null)
+        }
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { collectMove() }
+            thrown.path!!.path shouldBe target.path
+            thrown.operation shouldBe "move"
+            thrown.reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+            thrown.stackTrace.any { it.className == "com.host.Move" } shouldBe true
+        }
+    }
+
+    @Test
+    fun `a host side move cancellation crosses as cancellation, not as a failure`() {
+        coEvery { hostOps.lookup(destination, any()) } throws CancellationException("Stopped by user")
+        every { connection.moveStream(any(), any(), any(), any(), any(), any()) } answers {
+            host().moveStream(listOf(target), destination, false, false, false, null)
+        }
+
+        runBlocking {
+            shouldThrow<CancellationException> { collectMove() }.message shouldContain "Stopped by user"
+        }
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/FileOpsClientWalkTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/ipc/FileOpsClientWalkTest.kt
@@ -1,16 +1,25 @@
 package eu.darken.butler.common.files.local.ipc
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.files.APathGateway
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.common.files.local.LocalFileSystemOps
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.ipc.IpcErrorCodec
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -29,11 +38,15 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
 
 /**
  * Client-side mapping of the walkStreamV2 event protocol in [FileOpsClient.walk]: Item emission,
- * DirError-to-onError routing, FatalError propagation and truncation detection. The connection is
- * mocked with a real [toEventRemoteStream] pipe, so the full chunked wire format is exercised.
+ * DirError-to-onError routing, FatalError propagation, decoding of the error carriers and
+ * truncation detection. The connection is mocked with a real [toEventRemoteStream] pipe, so the
+ * full chunked wire format is exercised, and the host round trip drives a [FileOpsHost] over a
+ * mocked backend.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -43,6 +56,14 @@ class FileOpsClientWalkTest : BaseTest() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val connection = mockk<FileOpsConnection>()
     private val client = FileOpsClient(connection)
+    private val hostOps = mockk<LocalFileSystemOps>()
+
+    private fun host() = FileOpsHost(
+        context = ApplicationProvider.getApplicationContext<Context>(),
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+        fileSystemOps = hostOps,
+    )
 
     @After
     fun teardown() {
@@ -68,6 +89,15 @@ class FileOpsClientWalkTest : BaseTest() {
     ): List<LocalPathLookup> = withTimeout(10_000) {
         client.walk(path, LookupOptions.BASE, walkOptions, excludeSubtrees).toList()
     }
+
+    private suspend fun walkCollectingErrors(errors: MutableList<Exception>): List<LocalPathLookup> = walk(
+        walkOptions = APathGateway.WalkOptions(
+            onError = { _, e ->
+                errors += e
+                true
+            },
+        ),
+    )
 
     @Test
     fun `Item events emit lookups and Done ends the walk cleanly`() {
@@ -183,6 +213,141 @@ class FileOpsClientWalkTest : BaseTest() {
         runBlocking {
             val thrown = shouldThrow<ReadException> { walk() }
             thrown.message shouldContain "truncated"
+        }
+    }
+
+    @Test
+    fun `an encoded DirError reaches onError as the host type`() {
+        val denied = lookup("/data/subtree/denied", FileType.DIRECTORY)
+        val hostError = PathPermissionDeniedException(
+            path = denied.lookedUp,
+            operation = "lookupFiles",
+            reason = PathPermissionDeniedException.Reason.NOT_PERMITTED,
+        )
+        connectionStreams(
+            listOf(
+                WalkEvent.DirError(denied, IpcErrorCodec.encodeCompact(hostError)),
+                WalkEvent.Done,
+            )
+        )
+        val errors = mutableListOf<Exception>()
+
+        runBlocking { walkCollectingErrors(errors).shouldBeEmpty() }
+
+        errors.single().shouldBeTypeOf<PathPermissionDeniedException>().apply {
+            path!!.path shouldBe denied.lookedUp.path
+            operation shouldBe "lookupFiles"
+            reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+        }
+    }
+
+    @Test
+    fun `an encoded FatalError keeps its cause chain and the host frames`() {
+        val hostError = ReadException(
+            message = "Can't read from path.",
+            path = path,
+            cause = IOException("ENOENT (No such file or directory)"),
+        ).apply {
+            stackTrace = arrayOf(StackTraceElement("com.host.Walker", "list", "Walker.kt", 42))
+        }
+        connectionStreams(listOf(WalkEvent.FatalError(path, IpcErrorCodec.encode(hostError))))
+
+        runBlocking {
+            val thrown = shouldThrow<ReadException> { walk() }
+            thrown.cause!!.message!! shouldContain "ENOENT"
+            thrown.stackTrace.any { it.className == "com.host.Walker" } shouldBe true
+        }
+    }
+
+    @Test
+    fun `a markerless DirError message survives verbatim`() {
+        val denied = lookup("/data/subtree/denied", FileType.DIRECTORY)
+        connectionStreams(
+            listOf(
+                WalkEvent.DirError(denied, "EACCES (Permission denied)"),
+                WalkEvent.Done,
+            )
+        )
+        val errors = mutableListOf<Exception>()
+
+        runBlocking { walkCollectingErrors(errors).shouldBeEmpty() }
+
+        val message = errors.single().shouldBeTypeOf<ReadException>().message!!
+        message shouldContain "EACCES (Permission denied)"
+        message shouldNotContain "Undecodable"
+    }
+
+    @Test
+    fun `a full chunk of encoded directory errors crosses the wire`() {
+        val deep = lookup(
+            "/data/subtree/" + (0 until 20).joinToString("/") { "level$it" },
+            FileType.DIRECTORY,
+        )
+        val hostError = ReadException(
+            message = "Can't read from path.",
+            path = deep.lookedUp,
+            cause = IOException("EACCES (Permission denied)"),
+        ).apply {
+            stackTrace = Array(100) { StackTraceElement("com.host.Walker", "list$it", "Walker.kt", it) }
+        }
+        val carrier = IpcErrorCodec.encodeCompact(hostError)
+        carrier.toByteArray().size shouldBeLessThan 2048
+
+        connectionStreams(List(100) { WalkEvent.DirError(deep, carrier) } + WalkEvent.Done)
+        val errors = mutableListOf<Exception>()
+
+        runBlocking { walkCollectingErrors(errors).shouldBeEmpty() }
+
+        errors.size shouldBe 100
+        errors.all { it is ReadException } shouldBe true
+    }
+
+    @Test
+    fun `a host side listing denial reaches onError as its own type`() {
+        val start = lookup(path.path, FileType.DIRECTORY)
+        val hostError = PathPermissionDeniedException(
+            path = path,
+            operation = "lookupFiles",
+            reason = PathPermissionDeniedException.Reason.NOT_PERMITTED,
+        )
+        coEvery { hostOps.lookup(path, LookupOptions.BASE) } returns start
+        coEvery { hostOps.lookupFiles(path, LookupOptions.BASE) } throws hostError
+        every { connection.walkStreamV2(any(), any(), any()) } answers {
+            host().walkStreamV2(path, LookupOptions.BASE, WalkSpec())
+        }
+        val errors = mutableListOf<Exception>()
+
+        runBlocking { walkCollectingErrors(errors).shouldBeEmpty() }
+
+        errors.single().shouldBeTypeOf<PathPermissionDeniedException>().apply {
+            path!!.path shouldBe hostError.path!!.path
+            operation shouldBe "lookupFiles"
+            reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+        }
+    }
+
+    @Test
+    fun `a host side walk failure crosses with its cause chain and the host frames`() {
+        val hostError = PathPermissionDeniedException(
+            path = path,
+            operation = "lookup",
+            reason = PathPermissionDeniedException.Reason.NOT_PERMITTED,
+            cause = IOException("EACCES (Permission denied)"),
+        ).apply {
+            stackTrace = arrayOf(StackTraceElement("com.host.Walker", "lookupStart", "Walker.kt", 42))
+        }
+        coEvery { hostOps.lookup(path, LookupOptions.BASE) } throws hostError
+        every { connection.walkStreamV2(any(), any(), any()) } answers {
+            host().walkStreamV2(path, LookupOptions.BASE, WalkSpec())
+        }
+
+        runBlocking {
+            val thrown = shouldThrow<PathPermissionDeniedException> { walk() }
+            thrown.path!!.path shouldBe path.path
+            thrown.operation shouldBe "lookup"
+            thrown.reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+            thrown.cause!!.message!! shouldContain "EACCES (Permission denied)"
+            thrown.stackTrace.any { it.className == "com.host.Walker" } shouldBe true
         }
     }
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
@@ -2,9 +2,11 @@ package eu.darken.butler.common.files.permissions
 
 import eu.darken.butler.common.ElevatedAccessUnavailableException
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathAlreadyExistsException
 import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
+import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.WriteException
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -87,8 +89,92 @@ class PermissionErrorClassifierTest : BaseTest() {
     }
 
     @Test
+    fun `a full disk is not a permission failure`() {
+        val wrapped = WriteException(
+            path = LocalPath.build("/sdcard/foo"),
+            cause = IOException("No space left on device"),
+        )
+
+        PermissionErrorClassifier.classify(wrapped) shouldBe null
+        PermissionErrorClassifier.isPermissionError(wrapped) shouldBe false
+    }
+
+    @Test
+    fun `a named non-permission errno wins over the generic wrapper type`() {
+        listOf(
+            "Disk quota exceeded",
+            "Input/output error",
+            "Invalid cross-device link",
+            "File exists",
+        ).forEach { errno ->
+            val wrapped = WriteException(path = LocalPath.build("/sdcard/foo"), cause = IOException(errno))
+
+            PermissionErrorClassifier.classify(wrapped) shouldBe null
+        }
+    }
+
+    @Test
+    fun `a path named after an errno does not suppress the denial`() {
+        val bare = WriteException(path = LocalPath.build("/sdcard/file exists"))
+
+        PermissionErrorClassifier.classify(bare) shouldBe Reason.ACCESS_DENIED
+        PermissionErrorClassifier.isPermissionError(bare) shouldBe true
+    }
+
+    @Test
+    fun `a path named after an errno does not suppress the nio denial`() {
+        val e = java.nio.file.AccessDeniedException("/sdcard/file exists")
+
+        PermissionErrorClassifier.classify(e) shouldBe Reason.ACCESS_DENIED
+        PermissionErrorClassifier.isPermissionError(e) shouldBe true
+    }
+
+    @Test
+    fun `an errno in the wrapper message still suppresses the denial`() {
+        val e = WriteException(message = "No space left on device", path = LocalPath.build("/sdcard/foo"))
+
+        PermissionErrorClassifier.classify(e) shouldBe null
+        PermissionErrorClassifier.isPermissionError(e) shouldBe false
+    }
+
+    @Test
+    fun `an errno in the nio reason still suppresses the denial`() {
+        val e = java.nio.file.AccessDeniedException("/sdcard/foo", null, "No space left on device")
+
+        PermissionErrorClassifier.classify(e) shouldBe null
+        PermissionErrorClassifier.isPermissionError(e) shouldBe false
+    }
+
+    @Test
+    fun `a wrapper without a named errno still reads as a denial`() {
+        val bare = ReadException(path = LocalPath.build("/data/data/eu.darken.butler"))
+
+        PermissionErrorClassifier.classify(bare) shouldBe Reason.ACCESS_DENIED
+        PermissionErrorClassifier.isPermissionError(bare) shouldBe true
+    }
+
+    @Test
     fun `a missing path is not a permission failure`() {
         val e = PathNotFoundException(LocalPath.build("/data/data/eu.darken.butler"))
+
+        PermissionErrorClassifier.classify(e) shouldBe null
+        PermissionErrorClassifier.isPermissionError(e) shouldBe false
+    }
+
+    @Test
+    fun `an existing path is not a permission failure`() {
+        val e = PathAlreadyExistsException(path = LocalPath.build("/sdcard/foo"))
+
+        PermissionErrorClassifier.classify(e) shouldBe null
+        PermissionErrorClassifier.isPermissionError(e) shouldBe false
+    }
+
+    @Test
+    fun `an existing path is not a permission failure - with the cause the gateway attaches`() {
+        val e = PathAlreadyExistsException(
+            path = LocalPath.build("/sdcard/foo"),
+            cause = java.nio.file.FileAlreadyExistsException("/sdcard/foo"),
+        )
 
         PermissionErrorClassifier.classify(e) shouldBe null
         PermissionErrorClassifier.isPermissionError(e) shouldBe false

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/ExceptionPropagationTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/ExceptionPropagationTest.kt
@@ -303,6 +303,49 @@ class ExceptionPropagationTest : BaseTest(), IpcHostModule, IpcClientModule {
     }
 
     @Test
+    fun `compact - keeps the type and its extras but not the host stack`() {
+        val original = PathPermissionDeniedException(
+            path = filePath,
+            operation = "createFile",
+            reason = PathPermissionDeniedException.Reason.NOT_PERMITTED,
+        ).apply {
+            stackTrace = arrayOf(StackTraceElement("com.host.Native", "nativeCall", null, -2))
+        }
+
+        val decoded = IpcErrorCodec.decode(IpcErrorCodec.encodeCompact(original), Throwable().stackTrace)
+
+        decoded.shouldBeTypeOf<PathPermissionDeniedException>().apply {
+            message shouldBe original.message
+            this.path!!.path shouldBe original.path!!.path
+            operation shouldBe "createFile"
+            reason shouldBe PathPermissionDeniedException.Reason.NOT_PERMITTED
+        }
+        decoded.stackTrace.none { it.className == "com.host.Native" } shouldBe true
+    }
+
+    @Test
+    fun `compact - cause chain survives so EROFS is not reclassified as a plain denial`() {
+        val original = ReadException("Can't read from path.", filePath, IOException("Read-only file system"))
+
+        val decoded = IpcErrorCodec.decode(IpcErrorCodec.encodeCompact(original), Throwable().stackTrace)
+
+        decoded.shouldBeTypeOf<ReadException>().cause!!.message!! shouldContain "Read-only file system"
+        PermissionErrorClassifier.classify(decoded) shouldBe PathPermissionDeniedException.Reason.READONLY_FILESYSTEM
+    }
+
+    @Test
+    fun `decodeIfMarked - only a carrier starting with the marker is decoded`() {
+        val stack = Throwable().stackTrace
+
+        IpcErrorCodec.decodeIfMarked(null, stack) shouldBe null
+        IpcErrorCodec.decodeIfMarked("Permission denied", stack) shouldBe null
+        IpcErrorCodec.decodeIfMarked("EACCES ${IpcErrorCodec.MARKER}{}", stack) shouldBe null
+
+        IpcErrorCodec.decodeIfMarked(IpcErrorCodec.encode(IOException("boom")), stack)
+            .shouldBeTypeOf<IOException>().message shouldBe "boom"
+    }
+
+    @Test
     fun `decoded ReadException renders its localized error`() {
         val original = ReadException("Can't read from path.", filePath, IOException("Read-only file system"))
 


### PR DESCRIPTION
## What changed

When a file operation running with root or ADB access failed, the reason often got lost on its way back to the app. A permission problem during a folder scan, delete, copy or move arrived as a generic "can't read" or "can't write" error, so error reports about the longest-running and most failure-prone operations said very little about what actually went wrong. Those errors now keep their real identity, including what the privileged helper was doing when it failed.

Two problems that surfaced alongside this are fixed as well:

- Cancelling a delete, copy or move that was running with root or ADB access was reported as a failure rather than a cancellation. A cancelled operation could also end quietly enough to look like it had finished successfully.
- Running out of disk space during a root copy would have been presented as "Permission denied", complete with an offer to fix permissions that could not have helped. The same wrong message applied to copying onto a file that already exists, which was already the case before this change.

## Technical Context

- Root cause: the four streaming binder methods carried failures as a bare message string, so type, cause chain and host stack were destroyed at every crossing. The synchronous binder path already had a working mechanism for this (#99); these methods were explicitly outside its scope. They now reuse the same codec, and the client only decodes carriers that actually bear its marker, so a plain or absent message passes through as the text it was.
- Per-directory walk errors use a reduced payload that omits the host stack, because a scan of a permission-dense tree emits one per unreadable directory and the walk protocol packs 100 events into a single parcel. The cause chain is kept in both payload shapes: the permission classifier reads kernel error text out of it, and the gateway attaches that text to the inner exception rather than the wrapper.
- Making cancellation distinguishable required the host to rethrow on genuine scope cancellation, which ends a stream with no terminal event. The three operation streams had no truncation detection, so that path would have read as success. They now track their terminal event, which also closes the pre-existing case of the helper process dying mid-operation.
- The permission classifier treated any path exception as "access denied", which is what the local filesystem layer wraps every failure in. Feeding it correctly typed errors would have turned a full disk into a permission dialog, so it now returns no verdict when the cause chain carries positive evidence of a non-permission failure. That matching deliberately ignores rendered path text, otherwise a file named after a kernel error could silence a real denial and suppress the automatic retry with root.
- Worth close review: the restructure of the three operation streams in `FileOpsClient`, since it changes how each one terminates; and the ordering of the new classifier pass, which must stay subtractive so the auto-escalation decisions that read it are unaffected. One deliberate behaviour change is not covered by tests: walk failures that decode to a security or argument error are no longer retried under a stronger access mode, because escalating cannot cure either.
