### PR TITLE
General: Fix content hidden behind the operations bar

### DIFF
--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperPersistedKeys.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperPersistedKeys.kt
@@ -1,0 +1,12 @@
+package eu.darken.butler.developer.ui
+
+/**
+ * Floating bar keys for the Developer workspace.
+ *
+ * These are persisted in the workspace session's UI state blob as part of the bar collapse
+ * fractions: renaming one orphans the stored fraction for that bar, so it comes back expanded while
+ * the rest of its stack stays as it was.
+ */
+internal object DeveloperBarKeys {
+    const val OPERATIONS = "operations"
+}

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
@@ -33,7 +33,7 @@ import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.DeveloperTab
 import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.Factory
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
-import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarContentPadding
 import eu.darken.butler.workspace.ui.insets.paneInsets
 import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
@@ -173,8 +173,7 @@ fun DeveloperWorkspacePage(
         estimatedContentPadding = 80.dp,
     )
 
-    // Calculate bottom padding for content sections
-    val bottomPadding = bottomBarStackState.contentPaddingDp()
+    val contentPadding = rememberFloatingBarContentPadding(bottomStackState = bottomBarStackState)
 
     // A different tab is fresh content; reset scroll-collapse so the bar doesn't stay hidden over it.
     // Guarded on the transition: firing on initial composition would undo the restored collapse state.
@@ -233,11 +232,11 @@ fun DeveloperWorkspacePage(
             when (state.selectedTab) {
                 DeveloperTab.SYSTEM -> SystemInfoSection(
                     systemInfo = state.systemInfo,
-                    bottomPadding = bottomPadding,
+                    contentPadding = contentPadding,
                 )
                 DeveloperTab.OPTIONS -> OptionsSection(
                     optionsState = state.optionsState,
-                    bottomPadding = bottomPadding,
+                    contentPadding = contentPadding,
                     onToggleDebugMode = onToggleDebugMode,
                     onToggleTraceMode = onToggleTraceMode,
                     onToggleFloatingLog = onToggleFloatingLog,
@@ -248,13 +247,13 @@ fun DeveloperWorkspacePage(
                 DeveloperTab.LOGS -> LogsSection(
                     logs = state.logLines,
                     isPaused = state.isLogPaused,
-                    bottomPadding = bottomPadding,
+                    contentPadding = contentPadding,
                     onTogglePause = onToggleLogPause,
                     onClear = onClearLogs,
                 )
                 DeveloperTab.TEST_DATA -> TestDataSection(
                     testDataState = state.testDataState,
-                    bottomPadding = bottomPadding,
+                    contentPadding = contentPadding,
                     onAddPath = onAddPath,
                     onRemovePath = onRemovePath,
                     onLargeFilesToggled = onLargeFilesToggled,

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -21,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.compose.ButlerChip
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.OnValueChange
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.navigation.NavigationEventHandler
 import androidx.compose.runtime.collectAsState
@@ -29,7 +31,11 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.DeveloperTab
 import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.Factory
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
 import eu.darken.butler.workspace.ui.insets.paneInsets
+import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
 import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.OptionsState
 import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.State
@@ -48,7 +54,8 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.operations.details.OperationDialogHost
 import eu.darken.butler.workspace.ui.operations.details.OperationDialogState
-import eu.darken.butler.workspace.ui.operations.bar.OperationsBar
+import eu.darken.butler.workspace.ui.operations.bar.OperationsBarAction
+import eu.darken.butler.workspace.ui.operations.bar.WorkspaceOperationsFloatingBar
 
 @Composable
 fun DeveloperWorkspacePageHost(
@@ -155,11 +162,23 @@ fun DeveloperWorkspacePage(
 ) {
     val paneInsets = design.paneInsets()
     val statusBarInset = paneInsets.top
-    val navBarInset = paneInsets.bottom
+
+    val bottomBarStackState = rememberPaneFloatingBarStackState(
+        position = BarPosition.BOTTOM,
+        workspaceId = workspaceId,
+        design = design,
+        defaultSpacing = 8.dp,
+        edgePadding = 8.dp,
+        contentPadding = 16.dp,
+        estimatedContentPadding = 80.dp,
+    )
 
     // Calculate bottom padding for content sections
-    val hasOperations = operationsState.operations.isNotEmpty()
-    val bottomPadding = navBarInset + if (hasOperations) 80.dp else 16.dp
+    val bottomPadding = bottomBarStackState.contentPaddingDp()
+
+    // A different tab is fresh content; reset scroll-collapse so the bar doesn't stay hidden over it.
+    // Guarded on the transition: firing on initial composition would undo the restored collapse state.
+    OnValueChange(state.selectedTab) { _, _ -> bottomBarStackState.resetScrollCollapse() }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -208,6 +227,7 @@ fun DeveloperWorkspacePage(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .nestedScroll(bottomBarStackState.nestedScrollConnection)
                 .padding(horizontal = WorkspacePaddings.ContentHorizontal)
         ) {
             when (state.selectedTab) {
@@ -248,19 +268,28 @@ fun DeveloperWorkspacePage(
         }
 
         // Operations bar at bottom
-        if (operationsState.operations.isNotEmpty()) {
-            OperationsBar(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = navBarInset + 16.dp),
-                operations = operationsState.operations,
-                onRequestCancelOperation = onRequestCancelOperation,
-                onDismissOperation = onDismissOperation,
-                onOperationClick = { onShowOperationDetails(it.id) },
-                onClearCompleted = onClearCompletedOperations,
-            )
-        }
+        FloatingBarStack(
+            state = bottomBarStackState,
+            position = BarPosition.BOTTOM,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            bars = {
+                WorkspaceOperationsFloatingBar(
+                    key = DeveloperBarKeys.OPERATIONS,
+                    operations = operationsState.operations,
+                    onAction = { action ->
+                        when (action) {
+                            is OperationsBarAction.RequestCancel -> onRequestCancelOperation(action.id)
+                            is OperationsBarAction.Dismiss -> onDismissOperation(action.id)
+                            // No conflict sheet in this workspace, so a waiting operation opens details,
+                            // which is what the bar did before it moved onto the shared stack.
+                            is OperationsBarAction.ShowConflict -> onShowOperationDetails(action.id)
+                            is OperationsBarAction.ShowDetails -> onShowOperationDetails(action.id)
+                            OperationsBarAction.ClearCompleted -> onClearCompletedOperations()
+                        }
+                    },
+                )
+            },
+        )
     }
 }
 

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/LogsSection.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/LogsSection.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -33,7 +32,7 @@ import eu.darken.butler.developer.R
 internal fun LogsSection(
     logs: List<String>,
     isPaused: Boolean,
-    bottomPadding: Dp = 0.dp,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     onTogglePause: () -> Unit,
     onClear: () -> Unit,
 ) {
@@ -75,7 +74,7 @@ internal fun LogsSection(
                 modifier = Modifier
                     .fillMaxSize()
                     .horizontalScroll(horizontalScrollState),
-                contentPadding = PaddingValues(bottom = bottomPadding),
+                contentPadding = contentPadding,
             ) {
                 items(logs) { line ->
                     Text(

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/OptionsSection.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/OptionsSection.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -36,7 +35,7 @@ import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.ShizukuTestResu
 @Composable
 internal fun OptionsSection(
     optionsState: OptionsState,
-    bottomPadding: Dp = 0.dp,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     onToggleDebugMode: (Boolean) -> Unit,
     onToggleTraceMode: (Boolean) -> Unit,
     onToggleFloatingLog: (Boolean) -> Unit,
@@ -46,7 +45,7 @@ internal fun OptionsSection(
 ) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(bottom = bottomPadding),
+        contentPadding = contentPadding,
     ) {
         // Debug Options Card
         item {

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/SystemInfoSection.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/SystemInfoSection.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -25,11 +24,11 @@ import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.SystemInfo
 @Composable
 internal fun SystemInfoSection(
     systemInfo: SystemInfo,
-    bottomPadding: Dp = 0.dp,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(bottom = bottomPadding),
+        contentPadding = contentPadding,
     ) {
         // Device Section
         item {

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/TestDataSection.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/TestDataSection.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.developer.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -41,7 +41,7 @@ import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.*
 @Composable
 internal fun TestDataSection(
     testDataState: TestDataState,
-    bottomPadding: Dp = 0.dp,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     onAddPath: () -> Unit,
     onRemovePath: (APath<*>) -> Unit,
     onLargeFilesToggled: (Boolean) -> Unit,
@@ -143,7 +143,7 @@ internal fun TestDataSection(
         Button(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = bottomPadding),
+                .padding(contentPadding),
             onClick = onGenerateTestHistory,
         ) {
             Text(text = stringResource(R.string.developer_testdata_history_generate_action))

--- a/app-workspace-developer/src/test/java/eu/darken/butler/developer/ui/DeveloperFloatingBarsTest.kt
+++ b/app-workspace-developer/src/test/java/eu/darken/butler/developer/ui/DeveloperFloatingBarsTest.kt
@@ -46,11 +46,9 @@ import eu.darken.butler.workspace.R as WorkspaceR
  * The developer page's operations bar sits on the shared floating bar stack, which owns both the
  * bar's own geometry and the bottom content padding the four sections are laid out with.
  *
- * A bar that turns visible only after the first composition is not picked up by FloatingBarStack in
- * any Robolectric test that is not the first one executed in its class, because the stack
- * subcomposes its bars inside the SubcomposeLayout measure lambda, so they re-run only when a
- * re-measure is scheduled - which a device's frame loop always does and Robolectric's manual clock
- * need not. Arrival of a first operation is therefore untested here; it was verified on a device.
+ * Arrival of a first operation is not covered here. A test for it reproducibly failed in this
+ * harness whenever it did not run first in the class, and passed when it did; the cause was never
+ * diagnosed. The behaviour itself was verified on a device.
  */
 class DeveloperFloatingBarsTest : ComposeTest() {
 

--- a/app-workspace-developer/src/test/java/eu/darken/butler/developer/ui/DeveloperFloatingBarsTest.kt
+++ b/app-workspace-developer/src/test/java/eu/darken/butler/developer/ui/DeveloperFloatingBarsTest.kt
@@ -1,0 +1,214 @@
+package eu.darken.butler.developer.ui
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.developer.R
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.DeveloperTab
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.OptionsState
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.State
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.StorageVolumeInfo
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.SystemInfo
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.TargetPathInfo
+import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.TestDataState
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import eu.darken.butler.workspace.R as WorkspaceR
+
+/**
+ * The developer page's operations bar sits on the shared floating bar stack, which owns both the
+ * bar's own geometry and the bottom content padding the four sections are laid out with.
+ */
+class DeveloperFloatingBarsTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val workspaceId = Workspace.Id()
+    private val barCollapseStates = WorkspaceBarCollapseStates()
+
+    private val stateSource = MutableStateFlow(systemState())
+    private val operationsSource = MutableStateFlow(OperationsDisplayState())
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalWorkspaceBarCollapseStates provides barCollapseStates) {
+                    val state by stateSource.collectAsState()
+                    val operationsState by operationsSource.collectAsState()
+                    DeveloperWorkspacePage(
+                        workspaceId = workspaceId,
+                        // Split-pane layout: keeps the mascot-bearing workspace button, which
+                        // Robolectric cannot rasterise, out of the header cutout.
+                        design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                        state = state,
+                        operationsState = operationsState,
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * The page composes its stack itself, so the collapse registry it writes its per-bar fractions
+     * into is the read-only route to the key the bar registered under.
+     */
+    private fun bottomBarKeys(): Set<String> = barCollapseStates
+        .snapshot()[workspaceId]
+        ?.get(BarPosition.BOTTOM.persistedKey)
+        ?.keys
+        .orEmpty()
+
+    private fun systemState(volumeCount: Int = 1) = State(
+        id = workspaceId,
+        selectedTab = DeveloperTab.SYSTEM,
+        systemInfo = SystemInfo(
+            deviceModel = "Pixel 8 Pro",
+            deviceManufacturer = "Google",
+            apiLevel = 34,
+            versionName = "1.0.0-dev",
+            versionCode = 100,
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            gitSha = "abc123",
+            memoryAvailable = "4.2 GB",
+            memoryTotal = "8.0 GB",
+            storageVolumes = List(volumeCount) { index ->
+                StorageVolumeInfo(
+                    name = "Volume $index",
+                    path = "/storage/volume-$index",
+                    freeSpace = "$index GB",
+                    totalSpace = "128 GB",
+                )
+            },
+        ),
+        logLines = emptyList(),
+        isLogPaused = false,
+        testDataState = TestDataState(
+            targetPaths = listOf(
+                TargetPathInfo(
+                    path = LocalPath.build("/storage/emulated/0"),
+                    displayPath = "/storage/emulated/0",
+                ),
+            ),
+            largeFilesEnabled = false,
+            nestedStructureEnabled = false,
+            textFilesEnabled = true,
+            canGenerate = true,
+        ),
+        optionsState = OptionsState(
+            isDebugMode = true,
+            isTraceMode = false,
+            isFloatingLogEnabled = false,
+            rootTestResult = null,
+            isRootTesting = false,
+            shizukuTestResult = null,
+            isShizukuTesting = false,
+            canHideDeveloperMode = false,
+        ),
+    )
+
+    /** The last line the storage section renders for [volumeIndex], and with it the last of the page. */
+    private fun lastRowText(volumeIndex: Int) = "$volumeIndex GB free of 128 GB"
+
+    private fun runningOperation(title: String = OPERATION_TITLE) = OperationDisplay(
+        id = Operation.Id(),
+        startedAt = Clock.System.now(),
+        icon = Icons.TwoTone.Delete,
+        title = title.toCaString(),
+        description = "3 of 10".toCaString(),
+        canCancel = true,
+        state = OperationDisplay.State.Running(),
+    )
+
+    private fun completedOperation(title: String = OPERATION_TITLE) = runningOperation(title).copy(
+        state = OperationDisplay.State.Completed(
+            summary = "Done".toCaString(),
+            completedAt = Clock.System.now(),
+            report = null,
+        ),
+    )
+
+    /**
+     * `collapseTargets` holds every registered non-Static bar, and the operations bar is Static
+     * while any operation is still active - hence the terminal fixture.
+     */
+    @Test
+    fun `the operations bar registers under the key the developer workspace persists`() {
+        operationsSource.value = OperationsDisplayState(operations = listOf(completedOperation()))
+        setContent()
+
+        bottomBarKeys() shouldBe setOf(DeveloperBarKeys.OPERATIONS)
+    }
+
+    /**
+     * Scrolled to its end, the last row of the system section has to sit above the bar. The fixture
+     * makes the bar taller than the fixed 80.dp of padding the page used to reserve, which the first
+     * assertion pins - a shorter bar would fit inside that reservation and prove nothing.
+     */
+    @Test
+    fun `content scrolls clear of the operations bar`() {
+        stateSource.value = systemState(volumeCount = 2)
+        operationsSource.value = OperationsDisplayState(
+            operations = List(4) { completedOperation(title = "Operation $it") },
+        )
+        setContent()
+
+        val barTop = composeTestRule
+            .onNodeWithText(context.getString(WorkspaceR.string.operations_header_title) + " (4)")
+            .getUnclippedBoundsInRoot()
+            .top
+        val rootBottom = composeTestRule.onRoot().getUnclippedBoundsInRoot().bottom
+
+        withClue("the bar has to be taller than the page's former fixed reservation") {
+            (rootBottom - barTop > 80.dp) shouldBe true
+        }
+
+        composeTestRule
+            .onNode(hasScrollAction() and hasAnyDescendant(hasText(deviceSectionHeader)))
+            .performScrollToIndex(LAST_SECTION_INDEX)
+        composeTestRule.waitForIdle()
+
+        val lastRow = composeTestRule.onNodeWithText(lastRowText(1)).getUnclippedBoundsInRoot()
+        withClue("the last row of the section sits above the bar") {
+            (lastRow.bottom <= barTop) shouldBe true
+        }
+    }
+
+    private val deviceSectionHeader: String
+        get() = context.getString(R.string.developer_system_device_header)
+
+    companion object {
+        private const val OPERATION_TITLE = "Generating test data"
+
+        /** Device, build, memory, storage - the storage section is last. */
+        private const val LAST_SECTION_INDEX = 3
+    }
+}

--- a/app-workspace-developer/src/test/java/eu/darken/butler/developer/ui/DeveloperFloatingBarsTest.kt
+++ b/app-workspace-developer/src/test/java/eu/darken/butler/developer/ui/DeveloperFloatingBarsTest.kt
@@ -45,6 +45,12 @@ import eu.darken.butler.workspace.R as WorkspaceR
 /**
  * The developer page's operations bar sits on the shared floating bar stack, which owns both the
  * bar's own geometry and the bottom content padding the four sections are laid out with.
+ *
+ * A bar that turns visible only after the first composition is not picked up by FloatingBarStack in
+ * any Robolectric test that is not the first one executed in its class, because the stack
+ * subcomposes its bars inside the SubcomposeLayout measure lambda, so they re-run only when a
+ * re-measure is scheduled - which a device's frame loop always does and Robolectric's manual clock
+ * need not. Arrival of a first operation is therefore untested here; it was verified on a device.
  */
 class DeveloperFloatingBarsTest : ComposeTest() {
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -2,7 +2,6 @@ package eu.darken.butler.searcher.ui.search
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -67,7 +66,7 @@ import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.error.ErrorCard
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
-import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarContentPadding
 import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
@@ -257,12 +256,11 @@ fun SearcherWorkspacePage(
             }
         }
 
-        // Content padding - automatically calculated by FloatingBarStack
-        val contentPaddingValues = PaddingValues(
+        val contentPaddingValues = rememberFloatingBarContentPadding(
+            topStackState = topBarStackState,
+            bottomStackState = bottomBarStackState,
             start = WorkspacePaddings.ContentHorizontal,
             end = WorkspacePaddings.ContentHorizontal,
-            top = topBarStackState.contentPaddingDp(),
-            bottom = bottomBarStackState.contentPaddingDp(),
         )
 
         // Conditional rendering: Idle state (templates + history) vs Results mode

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,10 +50,9 @@ import eu.darken.butler.searcher.core.SearcherWorkspace
 import eu.darken.butler.searcher.core.resultKey
 import eu.darken.butler.searcher.ui.search.dnd.SearcherDragPayloadFactory
 import eu.darken.butler.searcher.ui.search.elements.PermissionSetupCard
-import eu.darken.butler.searcher.ui.search.elements.SearchProgressCard
 import eu.darken.butler.searcher.ui.search.elements.SearchTargetsEmptyStateCard
-import eu.darken.butler.searcher.ui.search.elements.SearchToolbarCard
-import eu.darken.butler.searcher.ui.search.elements.SearcherInfoBar
+import eu.darken.butler.searcher.ui.search.elements.SearcherBottomBars
+import eu.darken.butler.searcher.ui.search.elements.SearcherTopBars
 import eu.darken.butler.searcher.ui.search.elements.TemplatesCard
 import eu.darken.butler.searcher.ui.search.elements.searchHistorySection
 import eu.darken.butler.searcher.ui.search.items.SelectableFileGrid
@@ -63,16 +61,11 @@ import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
 import eu.darken.butler.searcher.ui.search.util.SearchListItem
 import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
 import eu.darken.butler.searcher.ui.search.util.SearcherPageAction
-import eu.darken.butler.searcher.ui.search.util.toPageAction
 import eu.darken.butler.workspace.core.Workspace
-import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
 import eu.darken.butler.workspace.ui.dnd.rememberWorkspaceDragSource
-import eu.darken.butler.workspace.ui.clipboard.bar.WorkspaceClipboardFloatingBar
 import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.error.ErrorCard
-import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
-import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
 import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
@@ -80,7 +73,6 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
-import eu.darken.butler.workspace.ui.operations.bar.WorkspaceOperationsFloatingBar
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.preview.ProvideFolderPreviews
 import eu.darken.butler.workspace.ui.scroll.rememberWorkspaceLazyGridState
@@ -203,69 +195,6 @@ fun SearcherWorkspacePage(
         }
         topBarStackState.resetScrollCollapse()
         bottomBarStackState.resetScrollCollapse()
-    }
-
-    val hasActions by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf false
-            val showingHistory = !currentState.hasResults && currentState.searchHistory.isNotEmpty()
-
-            currentState.selectionState.selectedResultIds.isNotEmpty() ||
-                (!showingHistory && currentState.listItems.isNotEmpty())
-        }
-    }
-
-    // Determine if progress card should be visible
-    val showProgressCard by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf false
-            currentState.workspaceState.targetProgress.isNotEmpty() &&
-                currentState.workspaceState.searchStatus != SearcherWorkspace.State.SearchStatus.IDLE
-        }
-    }
-
-    // Determine if info bar should be visible (when there are results OR selection)
-    val showInfoBar by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf false
-            currentState.selectionState.selectionCount > 0 || currentState.hasResults
-        }
-    }
-
-    // Calculate results info for info bar
-    val foldersCount by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf 0
-            currentState.listItems.count {
-                it is SearchListItem.Result && it.searchItem is SearchItem.Directory
-            }
-        }
-    }
-
-    val filesCount by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf 0
-            currentState.listItems.count {
-                it is SearchListItem.Result && it.searchItem is SearchItem.File
-            }
-        }
-    }
-
-    val totalSize by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf 0L
-            currentState.listItems
-                .filterIsInstance<SearchListItem.Result>()
-                .sumOf { it.searchItem.size ?: 0L }
-        }
-    }
-
-    val selectedSize by remember(mainState) {
-        derivedStateOf {
-            val currentState = mainState as? SearcherWorkspaceViewModel.State.Ready ?: return@derivedStateOf 0L
-            currentState.selectionState.selectedResults
-                .sumOf { it.size ?: 0L }
-        }
     }
 
     // Only render when Ready - WorkspaceMapper handles Init/Error overlays
@@ -648,69 +577,12 @@ fun SearcherWorkspacePage(
             position = BarPosition.TOP,
             modifier = Modifier.align(Alignment.TopCenter),
             bars = {
-                // Toolbar - closest to top edge, collapses on scroll
-                FloatingBar(
-                    key = SearcherBarKeys.TOOLBAR,
-                    visible = true,
-                    scrollBehavior = BarScrollBehavior.CollapseOnScroll,
-                    animation = BarAnimation.Slide(),
-                ) {
-                    SearchToolbarCard(
-                        workspaceId = workspaceId,
-                        state = currentState,
-                        design = design,
-                        collapsedFraction = collapsedFraction,
-                        onAction = onPageAction,
-                    )
-                }
-
-                // Progress card - vanishes on scroll
-                FloatingBar(
-                    key = SearcherBarKeys.PROGRESS,
-                    visible = showProgressCard,
-                    scrollBehavior = BarScrollBehavior.VanishOnScroll,
-                    animation = BarAnimation.Slide(),
-                ) {
-                    SearchProgressCard(
-                        targetProgress = currentState.workspaceState.targetProgress,
-                        overallProgress = currentState.workspaceState.progress,
-                        searchStatus = currentState.workspaceState.searchStatus,
-                        resultCount = currentState.workspaceState.results.size,
-                        limitReached = currentState.workspaceState.limitReached,
-                        onAccessErrorsClick = { onPageAction(SearcherPageAction.Overlays.ShowAccessErrors) },
-                        onCancel = { onPageAction(SearcherPageAction.Search.Cancel) },
-                        onClear = { onPageAction(SearcherPageAction.Search.ClearResults) },
-                        onErrorClick = { path, exception ->
-                            onPageAction(SearcherPageAction.Overlays.ShowTargetError(path, exception))
-                        },
-                    )
-                }
-
-                // Info bar - static (stays visible when results or selection)
-                FloatingBar(
-                    key = SearcherBarKeys.INFOBAR,
-                    visible = showInfoBar,
-                    scrollBehavior = BarScrollBehavior.Static,
-                    animation = BarAnimation.Slide(),
-                ) {
-                    SearcherInfoBar(
-                        foldersCount = foldersCount,
-                        filesCount = filesCount,
-                        totalSize = totalSize,
-                        selectedCount = currentState.selectionState.selectionCount,
-                        selectedSize = selectedSize,
-                        onSelectAllFolders = {
-                            onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.SelectAllFolders))
-                        },
-                        onSelectAllFiles = {
-                            onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.SelectAllFiles))
-                        },
-                        onSelectAll = {
-                            onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.SelectAll))
-                        },
-                        onClearSelection = { onPageAction(SearcherPageAction.Results.ExitSelectionMode) },
-                    )
-                }
+                SearcherTopBars(
+                    workspaceId = workspaceId,
+                    design = design,
+                    state = currentState,
+                    onPageAction = onPageAction,
+                )
             },
         )
 
@@ -720,39 +592,12 @@ fun SearcherWorkspacePage(
             position = BarPosition.BOTTOM,
             modifier = Modifier.align(Alignment.BottomCenter),
             bars = {
-                // Operations bar - furthest from bottom edge
-                WorkspaceOperationsFloatingBar(
-                    key = SearcherBarKeys.OPERATIONS,
-                    operations = operationsState.operations,
-                    onAction = { onPageAction(it.toPageAction()) },
+                SearcherBottomBars(
+                    state = currentState,
+                    operationsState = operationsState,
+                    clipboardState = clipboardState,
+                    onPageAction = onPageAction,
                 )
-
-                // Clipboard bar - middle
-                WorkspaceClipboardFloatingBar(
-                    key = SearcherBarKeys.CLIPBOARD,
-                    workspaceType = Workspace.Type.SEARCHER,
-                    clipboardEntries = clipboardState.entries,
-                    onAction = { onPageAction(it.toPageAction()) },
-                )
-
-                // Action bar - closest to bottom edge, hides on scroll
-                FloatingBar(
-                    key = SearcherBarKeys.ACTIONS,
-                    visible = hasActions,
-                    scrollBehavior = BarScrollBehavior.HideOnScroll,
-                    animation = BarAnimation.Slide(),
-                    revealOn = currentState.selectionState.selectedResultIds,
-                ) {
-                    WorkspaceActionBar(
-                        actions = currentState.availableActions,
-                        onActionClick = { action ->
-                            when (action) {
-                                is SearcherActionBarItem.DeselectAll -> onPageAction(SearcherPageAction.Results.ExitSelectionMode)
-                                else -> onPageAction(SearcherPageAction.WorkspaceAction(action))
-                            }
-                        },
-                    )
-                }
             },
         )
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearcherFloatingBars.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearcherFloatingBars.kt
@@ -1,0 +1,229 @@
+package eu.darken.butler.searcher.ui.search.elements
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.searcher.core.SearchItem
+import eu.darken.butler.searcher.core.SearcherWorkspace
+import eu.darken.butler.searcher.ui.search.SearcherBarKeys
+import eu.darken.butler.searcher.ui.search.SearcherWorkspaceViewModel
+import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
+import eu.darken.butler.searcher.ui.search.util.SearchListItem
+import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
+import eu.darken.butler.searcher.ui.search.util.SearcherPageAction
+import eu.darken.butler.searcher.ui.search.util.toPageAction
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
+import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.ui.clipboard.bar.WorkspaceClipboardFloatingBar
+import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
+import eu.darken.butler.workspace.ui.operations.bar.WorkspaceOperationsFloatingBar
+
+/**
+ * The Searcher's top floating bars: toolbar, search progress card and info bar.
+ *
+ * Must stay a [FloatingBarScope] extension with the nested [FloatingBarScope.FloatingBar] calls
+ * intact — `collapsedFraction` resolves from the inner bar's `FloatingBarContentScope` receiver.
+ */
+@Composable
+internal fun FloatingBarScope.SearcherTopBars(
+    workspaceId: Workspace.Id,
+    design: WorkspaceDesign,
+    state: SearcherWorkspaceViewModel.State.Ready,
+    onPageAction: (SearcherPageAction) -> Unit,
+) {
+    val showProgressCard = state.workspaceState.targetProgress.isNotEmpty() &&
+        state.workspaceState.searchStatus != SearcherWorkspace.State.SearchStatus.IDLE
+
+    val showInfoBar = state.selectionState.selectionCount > 0 || state.hasResults
+
+    val foldersCount = remember(state) {
+        state.listItems.count {
+            it is SearchListItem.Result && it.searchItem is SearchItem.Directory
+        }
+    }
+
+    val filesCount = remember(state) {
+        state.listItems.count {
+            it is SearchListItem.Result && it.searchItem is SearchItem.File
+        }
+    }
+
+    val totalSize = remember(state) {
+        state.listItems
+            .filterIsInstance<SearchListItem.Result>()
+            .sumOf { it.searchItem.size ?: 0L }
+    }
+
+    val selectedSize = remember(state) {
+        state.selectionState.selectedResults
+            .sumOf { it.size ?: 0L }
+    }
+
+    // Toolbar - closest to top edge, collapses on scroll
+    FloatingBar(
+        key = SearcherBarKeys.TOOLBAR,
+        visible = true,
+        scrollBehavior = BarScrollBehavior.CollapseOnScroll,
+        animation = BarAnimation.Slide(),
+    ) {
+        SearchToolbarCard(
+            workspaceId = workspaceId,
+            state = state,
+            design = design,
+            collapsedFraction = collapsedFraction,
+            onAction = onPageAction,
+        )
+    }
+
+    // Progress card - vanishes on scroll
+    FloatingBar(
+        key = SearcherBarKeys.PROGRESS,
+        visible = showProgressCard,
+        scrollBehavior = BarScrollBehavior.VanishOnScroll,
+        animation = BarAnimation.Slide(),
+    ) {
+        SearchProgressCard(
+            targetProgress = state.workspaceState.targetProgress,
+            overallProgress = state.workspaceState.progress,
+            searchStatus = state.workspaceState.searchStatus,
+            resultCount = state.workspaceState.results.size,
+            limitReached = state.workspaceState.limitReached,
+            onAccessErrorsClick = { onPageAction(SearcherPageAction.Overlays.ShowAccessErrors) },
+            onCancel = { onPageAction(SearcherPageAction.Search.Cancel) },
+            onClear = { onPageAction(SearcherPageAction.Search.ClearResults) },
+            onErrorClick = { path, exception ->
+                onPageAction(SearcherPageAction.Overlays.ShowTargetError(path, exception))
+            },
+        )
+    }
+
+    // Info bar - static (stays visible when results or selection)
+    FloatingBar(
+        key = SearcherBarKeys.INFOBAR,
+        visible = showInfoBar,
+        scrollBehavior = BarScrollBehavior.Static,
+        animation = BarAnimation.Slide(),
+    ) {
+        SearcherInfoBar(
+            foldersCount = foldersCount,
+            filesCount = filesCount,
+            totalSize = totalSize,
+            selectedCount = state.selectionState.selectionCount,
+            selectedSize = selectedSize,
+            onSelectAllFolders = {
+                onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.SelectAllFolders))
+            },
+            onSelectAllFiles = {
+                onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.SelectAllFiles))
+            },
+            onSelectAll = {
+                onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.SelectAll))
+            },
+            onClearSelection = { onPageAction(SearcherPageAction.Results.ExitSelectionMode) },
+        )
+    }
+}
+
+/**
+ * The Searcher's bottom floating bars: operations, clipboard and actions.
+ */
+@Composable
+internal fun FloatingBarScope.SearcherBottomBars(
+    state: SearcherWorkspaceViewModel.State.Ready,
+    operationsState: OperationsDisplayState,
+    clipboardState: ClipboardDisplayState,
+    onPageAction: (SearcherPageAction) -> Unit,
+) {
+    val showingHistory = !state.hasResults && state.searchHistory.isNotEmpty()
+    val hasActions = state.selectionState.selectedResultIds.isNotEmpty() ||
+        (!showingHistory && state.listItems.isNotEmpty())
+
+    // Operations bar - furthest from bottom edge
+    WorkspaceOperationsFloatingBar(
+        key = SearcherBarKeys.OPERATIONS,
+        operations = operationsState.operations,
+        onAction = { onPageAction(it.toPageAction()) },
+    )
+
+    // Clipboard bar - middle
+    WorkspaceClipboardFloatingBar(
+        key = SearcherBarKeys.CLIPBOARD,
+        workspaceType = Workspace.Type.SEARCHER,
+        clipboardEntries = clipboardState.entries,
+        onAction = { onPageAction(it.toPageAction()) },
+    )
+
+    // Action bar - closest to bottom edge, hides on scroll
+    FloatingBar(
+        key = SearcherBarKeys.ACTIONS,
+        visible = hasActions,
+        scrollBehavior = BarScrollBehavior.HideOnScroll,
+        animation = BarAnimation.Slide(),
+        revealOn = state.selectionState.selectedResultIds,
+    ) {
+        WorkspaceActionBar(
+            actions = state.availableActions,
+            onActionClick = { action ->
+                when (action) {
+                    is SearcherActionBarItem.DeselectAll -> onPageAction(SearcherPageAction.Results.ExitSelectionMode)
+                    else -> onPageAction(SearcherPageAction.WorkspaceAction(action))
+                }
+            },
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun SearcherTopBarsPreview() {
+    PreviewWrapper {
+        val stackState = rememberFloatingBarStackState(position = BarPosition.TOP)
+        FloatingBarStack(
+            state = stackState,
+            position = BarPosition.TOP,
+            bars = {
+                SearcherTopBars(
+                    workspaceId = Workspace.Id(),
+                    design = WorkspaceDesign(),
+                    state = SearcherMockDataProvider.createMockResultsState(),
+                    onPageAction = {},
+                )
+            },
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun SearcherBottomBarsPreview() {
+    PreviewWrapper {
+        val stackState = rememberFloatingBarStackState(position = BarPosition.BOTTOM)
+        FloatingBarStack(
+            state = stackState,
+            position = BarPosition.BOTTOM,
+            bars = {
+                SearcherBottomBars(
+                    state = SearcherMockDataProvider.createMockResultsState(),
+                    operationsState = OperationsDisplayState(
+                        operations = listOf(SearcherMockDataProvider.createMockRunningOperation()),
+                    ),
+                    clipboardState = ClipboardDisplayState(),
+                    onPageAction = {},
+                )
+            },
+        )
+    }
+}

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
@@ -16,10 +16,12 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.searcher.core.SearcherWorkspace
 import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.contracts.searcher.SearchTarget
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.floatingbar.WorkspaceBarCollapseStates
@@ -32,6 +34,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 import testhelpers.ComposeTest
 import kotlin.time.Clock
+import eu.darken.butler.common.R as CommonR
 import eu.darken.butler.workspace.R as WorkspaceR
 
 /**
@@ -56,6 +59,10 @@ class SearcherFloatingBarsTest : ComposeTest() {
         get() = context.getString(WorkspaceR.string.clipboard_open_in_explorer)
     private val clipboardHeaderTitle: String
         get() = context.getString(WorkspaceR.string.clipboard_header_title)
+    private val foldersLabel: String
+        get() = context.resources.getQuantityString(CommonR.plurals.common_folders_count, FOLDER_COUNT, FOLDER_COUNT)
+    private val filesLabel: String
+        get() = context.resources.getQuantityString(CommonR.plurals.common_files_count, FILE_COUNT, FILE_COUNT)
 
     private fun setContent() {
         composeTestRule.setContent {
@@ -80,11 +87,15 @@ class SearcherFloatingBarsTest : ComposeTest() {
      * The page composes its stacks itself, so the collapse registry it writes its per-bar fractions
      * into is the read-only route to the keys the bars registered under.
      */
-    private fun bottomBarKeys(): Set<String> = barCollapseStates
+    private fun barKeys(position: BarPosition): Set<String> = barCollapseStates
         .snapshot()[workspaceId]
-        ?.get(BarPosition.BOTTOM.persistedKey)
+        ?.get(position.persistedKey)
         ?.keys
         .orEmpty()
+
+    private fun bottomBarKeys(): Set<String> = barKeys(BarPosition.BOTTOM)
+
+    private fun topBarKeys(): Set<String> = barKeys(BarPosition.TOP)
 
     private fun scrollResults() {
         composeTestRule.onRoot().performTouchInput { swipeUp(startY = centerY, endY = top) }
@@ -101,6 +112,20 @@ class SearcherFloatingBarsTest : ComposeTest() {
                 size = null,
                 modifiedAt = null,
             ),
+        ),
+    )
+
+    /** A result set whose folder and file counts differ from each other and from the selection. */
+    private fun mixedResultsState() = SearcherWorkspaceViewModel.State.Ready(
+        filenameQuery = "config",
+        workspaceState = SearcherWorkspace.State(
+            searchTargets = listOf(SearchTarget.Path.from(LocalPath.build("/storage/emulated/0"))),
+            searchStatus = SearcherWorkspace.State.SearchStatus.IDLE,
+            results = List(FOLDER_COUNT) { index ->
+                SearcherMockDataProvider.createMockDirectory(name = "config-dir-$index")
+            } + List(FILE_COUNT) { index ->
+                SearcherMockDataProvider.createMockTextFile(name = "config-$index.txt")
+            },
         ),
     )
 
@@ -230,8 +255,34 @@ class SearcherFloatingBarsTest : ComposeTest() {
         }
     }
 
+    /**
+     * The info bar's scroll behaviour is Static and so never a collapse target, which is why only
+     * the toolbar and the progress card can show up here.
+     */
+    @Test
+    fun `the top bars register under the keys the searcher persists`() {
+        setContent()
+
+        topBarKeys() shouldBe setOf(
+            SearcherBarKeys.TOOLBAR,
+            SearcherBarKeys.PROGRESS,
+        )
+    }
+
+    /** Pins the folder/file/size aggregates the info bar is fed with. */
+    @Test
+    fun `the info bar counts folders and files separately`() {
+        stateSource.value = mixedResultsState()
+        setContent()
+
+        composeTestRule.onNodeWithText(foldersLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText(filesLabel).assertIsDisplayed()
+    }
+
     companion object {
         private const val OPERATION_TITLE = "Deleting files"
         private const val CLIP_PATH = "/storage/emulated/0/Documents/report.pdf"
+        private const val FOLDER_COUNT = 2
+        private const val FILE_COUNT = 3
     }
 }

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherFloatingBarsTest.kt
@@ -16,8 +16,12 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.formatFileSize
+import eu.darken.butler.searcher.core.SearchItem
 import eu.darken.butler.searcher.core.SearcherWorkspace
+import eu.darken.butler.searcher.core.resultKey
 import eu.darken.butler.searcher.ui.search.preview.SearcherMockDataProvider
+import eu.darken.butler.searcher.ui.search.util.SearcherSelectionState
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
@@ -63,6 +67,10 @@ class SearcherFloatingBarsTest : ComposeTest() {
         get() = context.resources.getQuantityString(CommonR.plurals.common_folders_count, FOLDER_COUNT, FOLDER_COUNT)
     private val filesLabel: String
         get() = context.resources.getQuantityString(CommonR.plurals.common_files_count, FILE_COUNT, FILE_COUNT)
+    private val totalSizeLabel: String
+        get() = formatFileSize(context, TOTAL_SIZE)
+    private val selectedSizeLabel: String
+        get() = formatFileSize(context, SELECTED_SIZE)
 
     private fun setContent() {
         composeTestRule.setContent {
@@ -115,17 +123,25 @@ class SearcherFloatingBarsTest : ComposeTest() {
         ),
     )
 
+    private val mixedFolders: List<SearchItem> = List(FOLDER_COUNT) { index ->
+        SearcherMockDataProvider.createMockDirectory(name = "config-dir-$index")
+    }
+
+    private val mixedFiles: List<SearchItem> = FILE_SIZES_KB.mapIndexed { index, sizeKB ->
+        SearcherMockDataProvider.createMockTextFile(name = "config-$index.txt", sizeKB = sizeKB)
+    }
+
     /** A result set whose folder and file counts differ from each other and from the selection. */
-    private fun mixedResultsState() = SearcherWorkspaceViewModel.State.Ready(
+    private fun mixedResultsState(selection: List<SearchItem> = emptyList()) = SearcherWorkspaceViewModel.State.Ready(
         filenameQuery = "config",
         workspaceState = SearcherWorkspace.State(
             searchTargets = listOf(SearchTarget.Path.from(LocalPath.build("/storage/emulated/0"))),
             searchStatus = SearcherWorkspace.State.SearchStatus.IDLE,
-            results = List(FOLDER_COUNT) { index ->
-                SearcherMockDataProvider.createMockDirectory(name = "config-dir-$index")
-            } + List(FILE_COUNT) { index ->
-                SearcherMockDataProvider.createMockTextFile(name = "config-$index.txt")
-            },
+            results = mixedFolders + mixedFiles,
+        ),
+        selectionState = SearcherSelectionState(
+            selectableResults = mixedFolders + mixedFiles,
+            selectedResultIds = selection.map { it.resultKey }.toSet(),
         ),
     )
 
@@ -269,7 +285,10 @@ class SearcherFloatingBarsTest : ComposeTest() {
         )
     }
 
-    /** Pins the folder/file/size aggregates the info bar is fed with. */
+    /**
+     * Pins the folder/file/size aggregates the info bar is fed with. The size chip has two mutually
+     * exclusive branches, so the selected size needs its own test rather than a second assertion.
+     */
     @Test
     fun `the info bar counts folders and files separately`() {
         stateSource.value = mixedResultsState()
@@ -277,12 +296,29 @@ class SearcherFloatingBarsTest : ComposeTest() {
 
         composeTestRule.onNodeWithText(foldersLabel).assertIsDisplayed()
         composeTestRule.onNodeWithText(filesLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText(totalSizeLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the info bar sizes only the selection while a selection exists`() {
+        stateSource.value = mixedResultsState(selection = mixedFiles.take(SELECTED_FILE_COUNT))
+        setContent()
+
+        composeTestRule.onNodeWithText(selectedSizeLabel).assertIsDisplayed()
     }
 
     companion object {
         private const val OPERATION_TITLE = "Deleting files"
         private const val CLIP_PATH = "/storage/emulated/0/Documents/report.pdf"
         private const val FOLDER_COUNT = 2
-        private const val FILE_COUNT = 3
+        private const val KB = 1024L
+
+        /** Distinct enough that neither aggregate can be confused with a single result's own size. */
+        private val FILE_SIZES_KB = listOf(1024L, 2048L, 4096L)
+        private val FILE_COUNT = FILE_SIZES_KB.size
+        private val TOTAL_SIZE = FILE_SIZES_KB.sumOf { it * KB }
+
+        private const val SELECTED_FILE_COUNT = 2
+        private val SELECTED_SIZE = FILE_SIZES_KB.take(SELECTED_FILE_COUNT).sumOf { it * KB }
     }
 }


### PR DESCRIPTION
## What changed

The Developer workspace set aside a fixed amount of room for the operations bar at the bottom of the page — a guess, not a measurement. Whenever the bar was taller than that guess, with several operations at once or the bar expanded, page content ended up underneath it. The page now reserves exactly the space the bar actually takes up.

Both the Developer and the Searcher pages also redrew their whole contents on every frame of a bar sliding in or out. They now work out the bar's size while laying the page out instead, so an animating bar no longer drags the rest of the page through the animation with it.

Internally the Searcher's six floating bars moved out of the page file into their own file, matching how the Explorer is already organised. Nothing about how they look or behave changes.

## Technical Context

- The Developer page adopts `FloatingBarStack` and `WorkspaceOperationsFloatingBar`, replacing hand-rolled `Alignment.BottomCenter` placement and a fixed `navBarInset + 80.dp` reservation with the stack's measured content padding. It was the last page still positioning a bar by hand.
- That padding comes from `rememberFloatingBarContentPadding`, not `contentPaddingDp()`. The latter reads a `derivedStateOf` over per-frame animated bar heights in the page's composable body, which invalidates the entire page scope every frame; the helper defers the read to measure time. Explorer, Editor and Apps already use it. The Searcher's call site is corrected here too — that one is pre-existing and the only part of this PR outside its original scope.
- `ShowConflict` maps to the details dialog on the Developer page deliberately: that workspace has no conflict sheet (`onHandleIssue = {}`), so this preserves current behaviour instead of routing to a dead handler.
- Two intended behaviour changes: with no operations present, the Developer page's bottom content padding goes from `navBarInset + 16.dp` to `navBarInset + 8.dp`, adopting the `edgePadding` value the other workspaces already use; and switching Developer tabs now resets the bar's scroll-collapse, matching the guarded idiom in Explorer, Searcher and Editor.
- Worth a close look: `DeveloperFloatingBarsTest` covers bar registration and non-occlusion, but not the bar appearing when an operation arrives after first composition. That case fails under Robolectric whenever its test is not the first in its class, and the cause was not diagnosed — the class KDoc records exactly that and claims no mechanism. The behaviour itself was verified on a device.
