### PR TITLE
General: Fix flaky shell test deadlocking under system load

### DIFF
--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/FlowShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/FlowShellTest.kt
@@ -117,16 +117,23 @@ class FlowShellTest : BaseTest() {
 
         val session = sharedSession.first()
 
-        (1..loop).forEach {
-            val data = "$it# ${Uuid.random()}"
-            session.write("echo $data")
-            expected.add(data)
+        // Writing without a consumer deadlocks once OS pipe buffers fill, so the producer runs concurrently
+        val headStart = CompletableDeferred<Unit>()
+        val writer = launch(Dispatchers.IO) {
+            (1..loop).forEach {
+                val data = "$it# ${Uuid.random()}"
+                session.write("echo $data")
+                expected.add(data)
+                if (it == 50) headStart.complete(Unit)
+            }
+            session.close()
         }
-        session.close()
 
+        headStart.await()
         session.output.collect { output.add(it) }
+        writer.join()
 
-        sharedSession.first().waitFor() shouldBe FlowProcess.ExitCode.OK
+        session.waitFor() shouldBe FlowProcess.ExitCode.OK
         output shouldBe expected
         output.size shouldBe loop
     }


### PR DESCRIPTION
## What changed

No user-facing behavior change. The `FlowShellTest > slow consumer` unit test deadlocked and timed out after 60 seconds when the machine was under heavy load (it fails identically on unmodified `main`), while passing on an idle machine. The test is restructured so it can no longer deadlock, without weakening what it verifies.

## Technical Context

- Root cause: the test wrote 1000 echo commands (~48KB stdin, ~43KB stdout) from the test body before anything collected the shell's output, relying on OS pipe buffers to absorb it all. When the per-user pipe-buffer soft limit is exhausted (many gradle workers plus emulators), Linux shrinks new pipes to a single 4KB page: the shell blocks writing stdout, stops reading stdin, and the test's `write()` blocks forever in `flush()`, producing the observed `UncompletedCoroutinesError` with a suppressed broken pipe from the teardown kill.
- Fix: the writes and `close()` run in a concurrent `Dispatchers.IO` job, so shell backpressure can never block the test body.
- The slow-consumer property is preserved: collection starts only once the producer is 50 lines ahead, so a backlog exists and backpressure is still exercised. Assertions are unchanged (all 1000 lines arrive, in order, exit code 0).
- On-device/CI note per repo policy: verified locally with two back-to-back `--rerun-tasks` runs under load average 12+, the original trigger condition CI may not reproduce.
