### PR TITLE
General: Fix invisible text in dark theme

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/ComposePreviewHelpers.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/ComposePreviewHelpers.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -22,6 +21,7 @@ import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.tour.LocalGuidedTourController
 import eu.darken.butler.common.compose.tour.NoOpGuidedTourAccess
+import eu.darken.butler.common.theming.ButlerRootSurface
 import eu.darken.butler.common.theming.ButlerTheme
 import eu.darken.butler.common.theming.ThemeMode
 import eu.darken.butler.common.theming.ThemeState
@@ -74,9 +74,7 @@ fun PreviewWrapper(
     ButlerTheme(
         state = theme,
     ) {
-        Surface(
-            color = MaterialTheme.colorScheme.background
-        ) {
+        ButlerRootSurface {
             // LocalGuidedTourController has no default (a missing provider must fail loudly in the
             // real app), so anything previewed/tested outside MainActivity needs the no-op stand-in.
             CompositionLocalProvider(LocalGuidedTourController provides NoOpGuidedTourAccess) {

--- a/app-common/src/main/java/eu/darken/butler/common/theming/ButlerRootSurface.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/theming/ButlerRootSurface.kt
@@ -9,7 +9,7 @@ import eu.darken.butler.common.compose.SampleContent
 
 /**
  * Root of a composition: `MaterialTheme` provides no `LocalContentColor`, so without a surface at
- * the top everything falls back to the `Color.Black` sentinel. [contentColor] is passed explicitly
+ * the top everything falls back to the `Color.Black` sentinel. `contentColor` is passed explicitly
  * instead of letting [Surface] derive it, so the result does not depend on `contentColorFor`
  * matching `background` before `surface`.
  */

--- a/app-common/src/main/java/eu/darken/butler/common/theming/ButlerRootSurface.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/theming/ButlerRootSurface.kt
@@ -1,0 +1,38 @@
+package eu.darken.butler.common.theming
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.SampleContent
+
+/**
+ * Root of a composition: `MaterialTheme` provides no `LocalContentColor`, so without a surface at
+ * the top everything falls back to the `Color.Black` sentinel. [contentColor] is passed explicitly
+ * instead of letting [Surface] derive it, so the result does not depend on `contentColorFor`
+ * matching `background` before `surface`.
+ */
+@Composable
+fun ButlerRootSurface(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+    ) {
+        content()
+    }
+}
+
+@Preview2
+@Composable
+private fun ButlerRootSurfacePreview() {
+    ButlerTheme {
+        ButlerRootSurface {
+            SampleContent()
+        }
+    }
+}

--- a/app-common/src/test/java/eu/darken/butler/common/theming/ButlerRootSurfaceTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/theming/ButlerRootSurfaceTest.kt
@@ -39,6 +39,7 @@ class ButlerRootSurfaceTest : ComposeTest() {
         composeTestRule.runOnIdle {
             contentColor shouldNotBe null
             contentColor shouldBe onBackground
+            // Dark-only: black is the material3 sentinel and invisible here, light onBackground may be near-black.
             contentColor shouldNotBe Color.Black
         }
     }

--- a/app-common/src/test/java/eu/darken/butler/common/theming/ButlerRootSurfaceTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/theming/ButlerRootSurfaceTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.butler.common.theming
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * Robolectric has no native bitmap and `captureToImage()` deadlocks, so the provided colour is read
+ * out of the composition instead of off a pixel.
+ */
+class ButlerRootSurfaceTest : ComposeTest() {
+
+    private var contentColor: Color? = null
+    private var onBackground: Color? = null
+    private var onSurface: Color? = null
+
+    @Composable
+    private fun ColorProbe(theme: ThemeState) {
+        ButlerTheme(state = theme) {
+            ButlerRootSurface {
+                contentColor = LocalContentColor.current
+                onBackground = MaterialTheme.colorScheme.onBackground
+                onSurface = MaterialTheme.colorScheme.onSurface
+            }
+        }
+    }
+
+    @Test
+    fun `dark theme content color is onBackground, not the black fallback`() {
+        composeTestRule.setContent {
+            ColorProbe(ThemeState(mode = ThemeMode.DARK))
+        }
+
+        composeTestRule.runOnIdle {
+            contentColor shouldNotBe null
+            contentColor shouldBe onBackground
+            contentColor shouldNotBe Color.Black
+        }
+    }
+
+    @Test
+    fun `light theme content color is onBackground`() {
+        composeTestRule.setContent {
+            ColorProbe(ThemeState(mode = ThemeMode.LIGHT))
+        }
+
+        composeTestRule.runOnIdle {
+            contentColor shouldNotBe null
+            contentColor shouldBe onBackground
+        }
+    }
+
+    @Test
+    fun `onBackground wins over onSurface where the two schemes diverge`() {
+        composeTestRule.setContent {
+            ColorProbe(
+                ThemeState(
+                    mode = ThemeMode.DARK,
+                    style = ThemeStyle.HIGH_CONTRAST,
+                    color = ThemeColor.AMOLED,
+                ),
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            contentColor shouldBe onBackground
+            contentColor shouldNotBe onSurface
+        }
+    }
+}

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -580,6 +580,7 @@ private fun EmptyState(modifier: Modifier = Modifier) {
         Text(
             text = stringResource(R.string.bugreport_empty_title),
             style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
         Text(

--- a/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
@@ -57,6 +57,7 @@ import eu.darken.butler.common.navigation.NavigationDestination
 import eu.darken.butler.common.navigation.NavigationEntry
 import eu.darken.butler.common.navigation.NavigationEventHandler
 import eu.darken.butler.common.navigation.onboarding
+import eu.darken.butler.common.theming.ButlerRootSurface
 import eu.darken.butler.common.theming.ButlerTheme
 import eu.darken.butler.common.ui.Activity2
 import eu.darken.butler.common.hasApiLevel
@@ -158,38 +159,40 @@ class MainActivity : Activity2() {
                     window.decorView.setBackgroundColor(backgroundColor.toArgb())
                 }
 
-                CompositionLocalProvider(
-                    LocalNavigationController provides navCtrl,
-                    LocalUserActivity provides userActivityTracker,
-                ) {
-                    ErrorEventHandler(vm)
-                    NavigationEventHandler(vm)
+                ButlerRootSurface {
+                    CompositionLocalProvider(
+                        LocalNavigationController provides navCtrl,
+                        LocalUserActivity provides userActivityTracker,
+                    ) {
+                        ErrorEventHandler(vm)
+                        NavigationEventHandler(vm)
 
-                    vmState?.let { mainState ->
-                        LaunchedEffect(mainState) {
-                            log(TAG) { "Main state: $mainState" }
-                        }
-                        CompositionLocalProvider(
-                            LocalAvoidDisplayCutout provides mainState.avoidDisplayCutout,
-                        ) {
-                            Navigation(mainState)
+                        vmState?.let { mainState ->
+                            LaunchedEffect(mainState) {
+                                log(TAG) { "Main state: $mainState" }
+                            }
+                            CompositionLocalProvider(
+                                LocalAvoidDisplayCutout provides mainState.avoidDisplayCutout,
+                            ) {
+                                Navigation(mainState)
 
-                            // During onboarding the arrival stays pending: the dialog shows up once
-                            // the user is through and the workspace UI can actually take the file.
-                            val externalOpen by vm.externalOpen.collectAsState()
-                            externalOpen
-                                ?.takeIf { mainState.startScreen == MainViewModel.State.StartScreen.HOME }
-                                ?.let { arrival ->
-                                    ExternalOpenDialog(
-                                        displayName = arrival.displayName,
-                                        mime = arrival.mime,
-                                        sizeBytes = arrival.sizeBytes,
-                                        previewUri = arrival.originalUri.takeIf { arrival.mime.isImage },
-                                        options = arrival.options,
-                                        onOption = { vm.onExternalOpenAction(it) },
-                                        onDismiss = { vm.onExternalOpenDismiss() },
-                                    )
-                                }
+                                // During onboarding the arrival stays pending: the dialog shows up once
+                                // the user is through and the workspace UI can actually take the file.
+                                val externalOpen by vm.externalOpen.collectAsState()
+                                externalOpen
+                                    ?.takeIf { mainState.startScreen == MainViewModel.State.StartScreen.HOME }
+                                    ?.let { arrival ->
+                                        ExternalOpenDialog(
+                                            displayName = arrival.displayName,
+                                            mime = arrival.mime,
+                                            sizeBytes = arrival.sizeBytes,
+                                            previewUri = arrival.originalUri.takeIf { arrival.mime.isImage },
+                                            options = arrival.options,
+                                            onOption = { vm.onExternalOpenAction(it) },
+                                            onDismiss = { vm.onExternalOpenDismiss() },
+                                        )
+                                    }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCaptureService.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/preview/WorkspacePreviewCaptureService.kt
@@ -14,6 +14,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.theming.ButlerRootSurface
 import eu.darken.butler.common.theming.ButlerTheme
 import eu.darken.butler.main.core.GeneralSettings
 import eu.darken.butler.main.core.themeStateBlocking
@@ -105,21 +106,23 @@ class WorkspacePreviewCaptureService @Inject constructor(
                         workspaceTitles = workspaceTitles,
                     ) {
                         ButlerTheme(state = themeState) {
-                            WorkspaceMapper(
-                                info = WorkspacePaneInfo(
-                                    id = workspaceId,
-                                    type = workspaceType,
-                                    lifecycleState = Workspace.LifecycleState.Ready,
-                                    // Only Ready is composed here, which draws the page, not a title
-                                    title = workspaceType.label,
-                                ),
-                                design = WorkspaceDesign(
-                                    layout = WorkspaceDesign.Layout.SINGLE
-                                ),
-                                onShareError = { /* No-op for preview */ },
-                                onCloseWorkspace = { /* No-op for preview */ },
-                                onResumeWorkspace = { /* No-op for preview */ },
-                            )
+                            ButlerRootSurface {
+                                WorkspaceMapper(
+                                    info = WorkspacePaneInfo(
+                                        id = workspaceId,
+                                        type = workspaceType,
+                                        lifecycleState = Workspace.LifecycleState.Ready,
+                                        // Only Ready is composed here, which draws the page, not a title
+                                        title = workspaceType.label,
+                                    ),
+                                    design = WorkspaceDesign(
+                                        layout = WorkspaceDesign.Layout.SINGLE
+                                    ),
+                                    onShareError = { /* No-op for preview */ },
+                                    onCloseWorkspace = { /* No-op for preview */ },
+                                    onResumeWorkspace = { /* No-op for preview */ },
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## What changed

Some text was drawn in near-black no matter which theme was active, so it disappeared against dark backgrounds. The clearest case was the bug report screen: in dark mode its "No reports" heading was invisible while the subtitle right below it stayed readable. Text now takes its colour from the active theme, so it stays legible in both light and dark.

Only the single-pane layout was affected. Multi-pane layouts already rendered these screens correctly, which is why the problem looked intermittent.

## Technical Context

- Root cause: Material 3 leaves `LocalContentColor` at a `Color.Black` sentinel unless a `Surface` establishes one, and nothing above the page did so on the single-pane path. Any text without an explicit colour inherited that sentinel, which happens to look fine on a light background and vanishes on a dark one.
- The fix adds a small root-surface composable and applies it at both composition roots, the activity and the offscreen renderer that produces tab thumbnails, plus the preview wrapper. The theme itself stays layout-neutral: a `Surface` is a layout node, so folding it into the theme would quietly impose a single-child contract on every caller.
- The content colour is passed explicitly instead of being derived. `contentColorFor` matches on colour value, and this project assigns `background` and `surface` the same value in every scheme, so the derived result would depend on the branch order inside Material's lookup rather than on intent.
- Previews were already the only place following this shape, which is exactly why they rendered correctly while the real screens did not. The preview wrapper now shares the same composable, and its tree structure is unchanged.
- Worth a close look: the re-indentation in `MainActivity` is large but content-identical, and on multi-pane layouts the new surface nests inside the existing per-pane one. Tonal elevation stays at zero there, so pane colours are unaffected.
