### PR TITLE
Bugreport: Include root and Shizuku logs in recordings

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbHost.kt
@@ -7,7 +7,8 @@ import dagger.Lazy
 import eu.darken.butler.common.BuildConfigWrap
 import eu.darken.butler.common.adb.service.internal.BaseAdbHost
 import eu.darken.butler.common.debug.Bugs
-import eu.darken.butler.common.debug.logging.FileLogger
+import eu.darken.butler.common.debug.HostRecorderLog
+import eu.darken.butler.common.debug.bugreport.BugReportStorage
 import eu.darken.butler.common.debug.logging.LogCatLogger
 import eu.darken.butler.common.debug.logging.Logging
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
@@ -21,7 +22,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
-import java.io.File
 import javax.inject.Inject
 
 @Keep
@@ -58,7 +58,7 @@ class AdbHost(
 
         keepAliveToken = sharedResource.get()
 
-        var currentFileLogger: FileLogger? = null
+        val recorderLog = HostRecorderLog(BugReportStorage.ADB_LOG_FILE, TAG)
 
         currentOptions
             .onEach { options ->
@@ -71,19 +71,7 @@ class AdbHost(
                     Logging.remove(logCatLogger)
                 }
 
-                if (options.recorderPath != null && currentFileLogger == null) {
-                    val path = File(options.recorderPath!!, "adb.log")
-                    val logger = FileLogger(path).also {
-                        currentFileLogger = it
-                        it.start()
-                    }
-                    Logging.install(logger)
-                    log(TAG) { "FileLogger installed" }
-                } else if (options.recorderPath == null && currentFileLogger != null) {
-                    log(TAG) { "Removing FileLogger: $currentFileLogger" }
-                    currentFileLogger?.let { Logging.remove(it) }
-                    currentFileLogger = null
-                }
+                recorderLog.update(options.recorderPath)
 
                 Bugs.isDebug = options.isDebug
                 Bugs.isTrace = options.isTrace

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/service/AdbServiceClient.kt
@@ -12,6 +12,7 @@ import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.DebugSettings
+import eu.darken.butler.common.debug.bugreport.RecorderPathPublisher
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
@@ -51,6 +52,7 @@ class AdbServiceClient @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val adbSettings: AdbSettings,
     private val debugSettings: DebugSettings,
+    private val recorderPathPublisher: RecorderPathPublisher,
     private val fileOpsClientFactory: FileOpsClient.Factory,
     private val pkgOpsClientFactory: PkgOpsClient.Factory,
     private val shellOpsClientFactory: ShellOpsClient.Factory,
@@ -68,7 +70,7 @@ class AdbServiceClient @Inject constructor(
         val optionsInitial = AdbHostOptions(
             isDebug = debugSettings.isDebugMode.value(),
             isTrace = debugSettings.isTraceMode.value(),
-            recorderPath = debugSettings.recorderPath.value(),
+            recorderPath = recorderPathPublisher.path.value,
             // Shizuku has no init args, so this initial push doubles as the host's launch arguments.
             hostIdentity = IpcContract.current(context).encode(),
         )
@@ -87,7 +89,7 @@ class AdbServiceClient @Inject constructor(
         combine(
             debugSettings.isDebugMode.flow,
             debugSettings.isTraceMode.flow,
-            debugSettings.recorderPath.flow,
+            recorderPathPublisher.path,
             lastInternal.filterNotNull(),
         ) { isDebug, isTrace, recorderPath, lastConnection ->
             val optionsDynamic = AdbHostOptions(

--- a/app-common-io/src/main/java/eu/darken/butler/common/debug/HostRecorderLog.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/debug/HostRecorderLog.kt
@@ -1,0 +1,63 @@
+package eu.darken.butler.common.debug
+
+import eu.darken.butler.common.debug.logging.FileLogger
+import eu.darken.butler.common.debug.logging.Logging
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.asLog
+import eu.darken.butler.common.debug.logging.log
+import java.io.File
+
+/**
+ * Host-side sink for the main process's bug-report recording: keeps a [FileLogger] writing to
+ * `<recorderPath>/<logName>` in step with the report directory the main process pushes along with
+ * the host options.
+ *
+ * The path is a level, not an edge. A host generation outlives a single recording, so it can go
+ * straight from one report directory to the next without passing through null; every transition is
+ * derived from the difference to the currently active path.
+ *
+ * [update] never throws — a failure here must not terminate the host's option collection for the
+ * rest of the process.
+ */
+class HostRecorderLog(
+    private val logName: String,
+    private val tag: String,
+) {
+
+    private var activePath: String? = null
+    private var activeLogger: FileLogger? = null
+
+    @Synchronized
+    fun update(recorderPath: String?) {
+        if (recorderPath == activePath) return
+        try {
+            detach()
+            if (recorderPath != null) attach(recorderPath)
+        } catch (e: Throwable) {
+            log(tag, ERROR) { "Failed to switch the recorder log to $recorderPath: ${e.asLog()}" }
+        }
+    }
+
+    private fun detach() {
+        val logger = activeLogger ?: return
+        log(tag) { "Removing recorder log: $logger" }
+        Logging.remove(logger)
+        // Also stop it: removing alone leaks the writer and its report never gets the END marker.
+        logger.stop()
+        activeLogger = null
+        activePath = null
+    }
+
+    private fun attach(recorderPath: String) {
+        val logFile = File(recorderPath, logName)
+        val logger = FileLogger(logFile)
+        if (!logger.start()) {
+            log(tag, ERROR) { "Recorder log failed to start: $logFile" }
+            return
+        }
+        Logging.install(logger)
+        activeLogger = logger
+        activePath = recorderPath
+        log(tag) { "Recorder log installed: $logFile" }
+    }
+}

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootHost.kt
@@ -5,7 +5,8 @@ import android.util.Log
 import androidx.annotation.Keep
 import dagger.Lazy
 import eu.darken.butler.common.debug.Bugs
-import eu.darken.butler.common.debug.logging.FileLogger
+import eu.darken.butler.common.debug.HostRecorderLog
+import eu.darken.butler.common.debug.bugreport.BugReportStorage
 import eu.darken.butler.common.debug.logging.Logging
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
@@ -19,7 +20,6 @@ import eu.darken.butler.common.sharedresource.adoptChildResource
 import eu.darken.butler.common.shell.SharedShell
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import java.io.File
 import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
@@ -57,7 +57,7 @@ class RootHost(_args: List<String>) : HasSharedResource<Any>, BaseRootHost("$TAG
         )
         log(iTag) { "IPC created: $ipc" }
 
-        var currentFileLogger: FileLogger? = null
+        val recorderLog = HostRecorderLog(BugReportStorage.ROOT_LOG_FILE, TAG)
 
         ipc.hostOptions
             .onEach { options ->
@@ -70,19 +70,7 @@ class RootHost(_args: List<String>) : HasSharedResource<Any>, BaseRootHost("$TAG
                     Logging.remove(logCatLogger)
                 }
 
-                if (options.recorderPath != null && currentFileLogger == null) {
-                    val path = File(options.recorderPath!!, "root.log")
-                    val logger = FileLogger(path).also {
-                        currentFileLogger = it
-                        it.start()
-                    }
-                    Logging.install(logger)
-                    log(TAG) { "FileLogger installed" }
-                } else if (options.recorderPath == null && currentFileLogger != null) {
-                    log(TAG) { "Removing FileLogger: $currentFileLogger" }
-                    currentFileLogger?.let { Logging.remove(it) }
-                    currentFileLogger = null
-                }
+                recorderLog.update(options.recorderPath)
 
                 Bugs.isDebug = options.isDebug
                 Bugs.isTrace = options.isTrace

--- a/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/root/service/RootServiceClient.kt
@@ -6,6 +6,7 @@ import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.DebugSettings
+import eu.darken.butler.common.debug.bugreport.RecorderPathPublisher
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
@@ -47,6 +48,7 @@ class RootServiceClient @Inject constructor(
     private val rootHostLauncher: RootHostLauncher,
     private val rootSettings: RootSettings,
     private val debugSettings: DebugSettings,
+    private val recorderPathPublisher: RecorderPathPublisher,
     private val fileOpsClientFactory: FileOpsClient.Factory,
     private val pkgOpsClientFactory: PkgOpsClient.Factory,
     private val shellOpsClientFactory: ShellOpsClient.Factory,
@@ -63,7 +65,7 @@ class RootServiceClient @Inject constructor(
         val initialOptions = RootHostOptions(
             isDebug = debugSettings.isDebugMode.value(),
             isTrace = debugSettings.isTraceMode.value(),
-            recorderPath = debugSettings.recorderPath.value(),
+            recorderPath = recorderPathPublisher.path.value,
         )
 
         val lastInternal = MutableStateFlow<RootConnection?>(null)
@@ -83,7 +85,7 @@ class RootServiceClient @Inject constructor(
         combine(
             debugSettings.isDebugMode.flow,
             debugSettings.isTraceMode.flow,
-            debugSettings.recorderPath.flow,
+            recorderPathPublisher.path,
             lastInternal.filterNotNull(),
         ) { isDebug, isTrace, recorderPath, lastConnection ->
             val dynamicOptions = RootHostOptions(

--- a/app-common-io/src/test/java/eu/darken/butler/common/debug/HostRecorderLogTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/debug/HostRecorderLogTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.butler.common.debug
+
+import eu.darken.butler.common.debug.logging.Logging
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.io.File
+
+/**
+ * Drives the path state machine through `null → A → B → null` plus a failed start, the sequence a
+ * privileged host sees when it outlives more than one recording.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class HostRecorderLogTest : BaseTest() {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private fun hostLog(dir: File) = File(dir, LOG_NAME).readText()
+
+    @Test
+    fun `the log follows the published path and every switch closes the previous one`() {
+        val dirA = tempFolder.newFolder("report_a")
+        val dirB = tempFolder.newFolder("report_b")
+        val loggersBefore = Logging.loggers
+        val recorderLog = HostRecorderLog(LOG_NAME, TAG)
+
+        try {
+            recorderLog.update(null)
+            File(dirA, LOG_NAME).exists() shouldBe false
+
+            recorderLog.update(dirA.path)
+            log(TAG, INFO) { "line-a" }
+            hostLog(dirA) shouldContain "line-a"
+
+            // Straight from one report to the next, without passing through null.
+            recorderLog.update(dirB.path)
+            log(TAG, INFO) { "line-b" }
+
+            // The END marker is only written by stop(), so it proves the old logger was closed and
+            // not merely detached from the bus.
+            hostLog(dirA) shouldContain "=== END ==="
+            hostLog(dirA) shouldNotContain "line-b"
+            hostLog(dirB) shouldContain "line-b"
+
+            recorderLog.update(null)
+            log(TAG, INFO) { "line-c" }
+
+            hostLog(dirB) shouldContain "=== END ==="
+            hostLog(dirB) shouldNotContain "line-c"
+            Logging.loggers shouldBe loggersBefore
+        } finally {
+            recorderLog.update(null)
+        }
+    }
+
+    @Test
+    fun `a logger that cannot start is not installed and does not wedge the next report`() {
+        val dirA = tempFolder.newFolder("report_a")
+        // A directory where the log file belongs: the writer cannot be opened on it.
+        File(dirA, LOG_NAME).mkdirs()
+        val dirB = tempFolder.newFolder("report_b")
+        val loggersBefore = Logging.loggers
+        val recorderLog = HostRecorderLog(LOG_NAME, TAG)
+
+        try {
+            recorderLog.update(dirA.path)
+
+            Logging.loggers shouldBe loggersBefore
+
+            recorderLog.update(dirB.path)
+            log(TAG, INFO) { "line-b" }
+
+            hostLog(dirB) shouldContain "line-b"
+        } finally {
+            recorderLog.update(null)
+        }
+
+        Logging.loggers shouldBe loggersBefore
+    }
+
+    companion object {
+        private const val LOG_NAME = "root.log"
+        private val TAG = logTag("Test", "HostRecorderLog")
+    }
+}

--- a/app-common/src/main/java/eu/darken/butler/common/debug/DebugSettings.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/DebugSettings.kt
@@ -31,8 +31,4 @@ class DebugSettings @Inject constructor(
         "debug.logview.floating.visible",
         false,
     )
-    val recorderPath = dataStore.createValue<String?>(
-        "recorder.log.path",
-        null
-    )
 }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
@@ -59,6 +59,7 @@ class BugReportRecorder @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val butlerId: ButlerId,
     private val json: Json,
+    private val storageLayout: BugReportStorageLayout,
     // Multibound set, never a single binding: the implementations live in the flavor source sets of
     // :app, and app-common must build (and record) whether or not one was contributed.
     private val upgradeDiagnostics: Set<@JvmSuppressWildcards UpgradeDiagnostics>,
@@ -87,8 +88,6 @@ class BugReportRecorder @Inject constructor(
     private val internalState = MutableStateFlow(State())
     val state: StateFlow<State> = internalState.asStateFlow()
 
-    private val reportsDir: File get() = BugReportStorage.reportsDir(context)
-
     /** Begin a recording. Idempotent (no-op if already recording). Never throws. */
     suspend fun start() = mutex.withLock {
         try {
@@ -100,7 +99,7 @@ class BugReportRecorder @Inject constructor(
             // setup time from the measured duration, changing what the existing heuristic measures.
             val startedAtMonotonic = monotonicClock()
             val id = "${BugReportStorage.RECORDING_ID_PREFIX}${now.toEpochMilliseconds()}_${Uuid.random().toString().take(8)}"
-            val reportDir = File(reportsDir, id)
+            val reportDir = File(storageLayout.writeRoot, id)
             reportDir.mkdirs()
 
             // meta.json first: a crash mid-recording still leaves a complete, surfaceable report.
@@ -168,7 +167,7 @@ class BugReportRecorder @Inject constructor(
         startedAtMonotonicMs = 0L
         val id = internalState.value.recordingId
         if (id != null) {
-            runCatching { File(File(reportsDir, id), BugReportStorage.RECORDING_SENTINEL).delete() }
+            runCatching { File(File(storageLayout.writeRoot, id), BugReportStorage.RECORDING_SENTINEL).delete() }
         }
         internalState.value = State()
     }
@@ -197,22 +196,26 @@ class BugReportRecorder @Inject constructor(
     suspend fun sweepOrphanedSentinels() = mutex.withLock {
         if (!isMainProcess()) return@withLock
         val activeId = internalState.value.recordingId
-        reportsDir.listFiles()?.forEach { dir ->
-            if (!dir.isDirectory) return@forEach
-            if (dir.name.startsWith(BugReportStorage.TMP_PREFIX)) return@forEach
-            if (!dir.name.startsWith(BugReportStorage.RECORDING_ID_PREFIX)) return@forEach
-            if (dir.name == activeId) return@forEach
-            val logFile = File(dir, BugReportStorage.LOG_FILE)
-            if (logFile.exists()) {
-                val sentinel = File(dir, BugReportStorage.RECORDING_SENTINEL)
-                if (sentinel.exists()) {
-                    runCatching { sentinel.delete() }
-                    log(TAG, WARN) { "Finalized interrupted recording: ${dir.name}" }
+        // Every root: a sentinel left behind by a version that still wrote to the private root would
+        // otherwise stay forever, and a sentinel-bearing directory is skipped by deleteAll().
+        storageLayout.roots.forEach { root ->
+            root.listFiles()?.forEach { dir ->
+                if (!dir.isDirectory) return@forEach
+                if (dir.name.startsWith(BugReportStorage.TMP_PREFIX)) return@forEach
+                if (!dir.name.startsWith(BugReportStorage.RECORDING_ID_PREFIX)) return@forEach
+                if (dir.name == activeId) return@forEach
+                val logFile = File(dir, BugReportStorage.LOG_FILE)
+                if (logFile.exists()) {
+                    val sentinel = File(dir, BugReportStorage.RECORDING_SENTINEL)
+                    if (sentinel.exists()) {
+                        runCatching { sentinel.delete() }
+                        log(TAG, WARN) { "Finalized interrupted recording: ${dir.name}" }
+                    }
+                } else {
+                    // Died between meta.json and report.log creation — incomplete, never surfaceable.
+                    runCatching { dir.deleteRecursively() }
+                    log(TAG, WARN) { "Dropped incomplete recording dir: ${dir.name}" }
                 }
-            } else {
-                // Died between meta.json and report.log creation — incomplete, never surfaceable.
-                runCatching { dir.deleteRecursively() }
-                log(TAG, WARN) { "Dropped incomplete recording dir: ${dir.name}" }
             }
         }
     }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
@@ -60,6 +60,7 @@ class BugReportRecorder @Inject constructor(
     private val butlerId: ButlerId,
     private val json: Json,
     private val storageLayout: BugReportStorageLayout,
+    private val recorderPathPublisher: RecorderPathPublisher,
     // Multibound set, never a single binding: the implementations live in the flavor source sets of
     // :app, and app-common must build (and record) whether or not one was contributed.
     private val upgradeDiagnostics: Set<@JvmSuppressWildcards UpgradeDiagnostics>,
@@ -118,6 +119,7 @@ class BugReportRecorder @Inject constructor(
             fileLogger = logger
 
             File(reportDir, BugReportStorage.RECORDING_SENTINEL).createNewFile()
+            recorderPathPublisher.publish(reportDir.path)
 
             logSessionInfos()
 
@@ -164,6 +166,7 @@ class BugReportRecorder @Inject constructor(
             it.stop()
         }
         fileLogger = null
+        recorderPathPublisher.publish(null)
         startedAtMonotonicMs = 0L
         val id = internalState.value.recordingId
         if (id != null) {

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
@@ -121,8 +121,8 @@ class BugReportRecorder @Inject constructor(
             File(reportDir, BugReportStorage.RECORDING_SENTINEL).createNewFile()
             recorderPathPublisher.publish(reportDir.path)
 
-            logSessionInfos()
-
+            // Committed before the session infos are logged: those reads take seconds, and until the
+            // id is published the finished report directory on disk has nothing marking it as live.
             startedAtMonotonicMs = startedAtMonotonic
             internalState.value = State(
                 isRecording = true,
@@ -131,6 +131,9 @@ class BugReportRecorder @Inject constructor(
                 currentLogSize = File(reportDir, BugReportStorage.LOG_FILE).length(),
             )
             startLogSizeUpdates(reportDir)
+
+            logSessionInfos()
+
             log(TAG, INFO) { "Recording started: $id" }
         } catch (e: Throwable) {
             log(TAG, ERROR) { "start() failed: ${e.asLog()}" }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
@@ -162,6 +162,15 @@ class BugReportRecorder @Inject constructor(
         id?.let { StopResult.Stopped(it) }
     }
 
+    /**
+     * Whether [id] is the recording this recorder currently owns. Takes [mutex] rather than reading
+     * [state] directly: [start] runs wholly under the lock, so a caller blocks until a start in
+     * flight has either published its id or rolled back, instead of observing the window in between.
+     */
+    internal suspend fun isActiveOrStarting(id: String): Boolean = mutex.withLock {
+        internalState.value.recordingId == id
+    }
+
     private fun stopInternal() {
         fileLogger?.let {
             log(TAG, INFO) { "Stopping recording logger: $it" }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -130,16 +130,10 @@ class BugReportRepo @Inject constructor(
     }
 
     suspend fun delete(id: String) = withContext(dispatcherProvider.IO) {
-        require(id != bugReportRecorder.state.value.recordingId) { "Cannot delete an active recording" }
+        require(!bugReportRecorder.isActiveOrStarting(id)) { "Cannot delete an active recording" }
         // Every copy, not just the one scan() lists: dropping only the listed copy would let the
         // shadowed one take its place in the very next scan.
-        val dirs = storageLayout.allReportDirs(id)
-        // A live `.recording` sentinel counts as active too, same guard deleteAll() applies: the
-        // published id alone does not cover a recording whose start is still in progress.
-        require(dirs.none { File(it, BugReportStorage.RECORDING_SENTINEL).exists() }) {
-            "Cannot delete an active recording"
-        }
-        dirs.forEach { it.deleteRecursively() }
+        storageLayout.allReportDirs(id).forEach { it.deleteRecursively() }
         File(shareDir, "$id.zip").delete()
         refresh()
     }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
@@ -195,19 +196,43 @@ class BugReportRepo @Inject constructor(
      * (Re)create the report's share zip under the cache dir and return a [FileProvider] uri. Used both
      * by [buildShareIntent] and by the support contact form when attaching a report to an email.
      */
-    suspend fun buildShareUri(id: String): Uri = withContext(dispatcherProvider.IO) {
+    suspend fun buildShareUri(id: String): Uri {
+        val zip = buildShareZip(id)
+        return FileProvider.getUriForFile(context, "${BuildConfigWrap.APPLICATION_ID}.provider", zip)
+    }
+
+    /**
+     * (Re)create the report's share zip: `meta.json`, `report.log` and the helper logs the privileged
+     * hosts wrote during a recording ([BugReportStorage.payloadFiles]).
+     *
+     * Built under a temporary name and renamed on success, because [Zipper] leaves its output behind
+     * when compression throws — a half-written `<id>.zip` would then be shared as if it were whole.
+     */
+    suspend fun buildShareZip(id: String): File = withContext(dispatcherProvider.IO) {
         require(id != bugReportRecorder.state.value.recordingId) { "Cannot share an active recording" }
-        val reportDir = resolveReportDir(id)
-        val files = reportDir?.let { listOf(File(it, BugReportStorage.META_FILE), File(it, BugReportStorage.LOG_FILE)) }
-            ?.filter { it.exists() }
-            ?: emptyList()
+        val files = resolveReportDir(id)?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
         require(files.isNotEmpty()) { "No report files for $id" }
 
         if (!shareDir.exists()) shareDir.mkdirs()
-        val zip = File(shareDir, "$id.zip")
-        Zipper().zip(files.map { it.path }, zip.path)
+        val payloadSize = files.sumOf { it.length() }
+        val usableSpace = shareDir.usableSpace
+        // A recording can be tens of MB and the zip is a second copy of it. Failing here is a message
+        // the user can act on; filling the cache volume instead breaks unrelated features.
+        check(usableSpace > payloadSize) {
+            "Not enough space for the share zip of $id: needs up to $payloadSize bytes, $usableSpace available"
+        }
 
-        FileProvider.getUriForFile(context, "${BuildConfigWrap.APPLICATION_ID}.provider", zip)
+        val zip = File(shareDir, "$id.zip")
+        val tmpZip = File(shareDir, "$id.zip${BugReportStorage.TMP_SUFFIX}")
+        try {
+            Zipper().zip(files.map { it.path }, tmpZip.path)
+            zip.delete()
+            if (!tmpZip.renameTo(zip)) throw IOException("Could not finalize the share zip for $id")
+        } catch (t: Throwable) {
+            runCatching { tmpZip.delete() }
+            throw t
+        }
+        zip
     }
 
     /**

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -52,9 +52,9 @@ class BugReportRepo @Inject constructor(
     private val bugReportRecorder: BugReportRecorder,
     private val butlerId: ButlerId,
     private val json: Json,
+    private val storageLayout: BugReportStorageLayout,
 ) {
 
-    private val reportsDir = BugReportStorage.reportsDir(context)
     private val shareDir = BugReportStorage.shareDir(context)
     private val refreshTrigger = MutableStateFlow(0)
 
@@ -121,8 +121,7 @@ class BugReportRepo @Inject constructor(
     }
 
     suspend fun markSeen(id: String) = withContext(dispatcherProvider.IO) {
-        val dir = File(reportsDir, id)
-        if (dir.isDirectory) {
+        resolveReportDir(id)?.let { dir ->
             val marker = File(dir, BugReportStorage.SEEN_MARKER)
             if (!marker.exists()) runCatching { marker.createNewFile() }
         }
@@ -131,7 +130,9 @@ class BugReportRepo @Inject constructor(
 
     suspend fun delete(id: String) = withContext(dispatcherProvider.IO) {
         require(id != bugReportRecorder.state.value.recordingId) { "Cannot delete an active recording" }
-        File(reportsDir, id).deleteRecursively()
+        // Every copy, not just the one scan() lists: dropping only the listed copy would let the
+        // shadowed one take its place in the very next scan.
+        storageLayout.allReportDirs(id).forEach { it.deleteRecursively() }
         File(shareDir, "$id.zip").delete()
         refresh()
     }
@@ -142,10 +143,12 @@ class BugReportRepo @Inject constructor(
         // before publishing the id to recorder state, so the sentinel check also covers a recording
         // that is mid-start when delete-all fires.
         val activeId = bugReportRecorder.state.value.recordingId
-        reportsDir.listFiles()?.forEach { entry ->
-            if (entry.name == activeId) return@forEach
-            if (entry.isDirectory && File(entry, BugReportStorage.RECORDING_SENTINEL).exists()) return@forEach
-            if (entry.isDirectory) entry.deleteRecursively() else entry.delete()
+        storageLayout.roots.forEach { root ->
+            root.listFiles()?.forEach { entry ->
+                if (entry.name == activeId) return@forEach
+                if (entry.isDirectory && File(entry, BugReportStorage.RECORDING_SENTINEL).exists()) return@forEach
+                if (entry.isDirectory) entry.deleteRecursively() else entry.delete()
+            }
         }
         shareDir.listFiles()?.forEach { zip ->
             if (activeId != null && zip.name == "$activeId.zip") return@forEach
@@ -156,7 +159,8 @@ class BugReportRepo @Inject constructor(
 
     /** Full log trail; loaded on demand because it can be large. Kept for callers needing the whole log. */
     suspend fun readLog(id: String): String = withContext(dispatcherProvider.IO) {
-        File(File(reportsDir, id), BugReportStorage.LOG_FILE).takeIf { it.exists() }?.readText() ?: ""
+        val dir = resolveReportDir(id) ?: return@withContext ""
+        File(dir, BugReportStorage.LOG_FILE).takeIf { it.exists() }?.readText() ?: ""
     }
 
     /**
@@ -166,7 +170,8 @@ class BugReportRepo @Inject constructor(
      */
     suspend fun readLogTail(id: String, maxLines: Int): LogTail = withContext(dispatcherProvider.IO) {
         require(maxLines > 0) { "maxLines must be > 0, was $maxLines" }
-        val file = File(File(reportsDir, id), BugReportStorage.LOG_FILE)
+        val dir = resolveReportDir(id) ?: return@withContext LogTail(emptyList(), 0)
+        val file = File(dir, BugReportStorage.LOG_FILE)
         if (!file.exists()) return@withContext LogTail(emptyList(), 0)
         val ring = ArrayDeque<String>(maxLines)
         var total = 0
@@ -192,9 +197,10 @@ class BugReportRepo @Inject constructor(
      */
     suspend fun buildShareUri(id: String): Uri = withContext(dispatcherProvider.IO) {
         require(id != bugReportRecorder.state.value.recordingId) { "Cannot share an active recording" }
-        val reportDir = File(reportsDir, id)
-        val files = listOf(File(reportDir, BugReportStorage.META_FILE), File(reportDir, BugReportStorage.LOG_FILE))
-            .filter { it.exists() }
+        val reportDir = resolveReportDir(id)
+        val files = reportDir?.let { listOf(File(it, BugReportStorage.META_FILE), File(it, BugReportStorage.LOG_FILE)) }
+            ?.filter { it.exists() }
+            ?: emptyList()
         require(files.isNotEmpty()) { "No report files for $id" }
 
         if (!shareDir.exists()) shareDir.mkdirs()
@@ -244,8 +250,9 @@ class BugReportRepo @Inject constructor(
 
     /** Two-phase write: build under `.tmp-<id>`, then atomically rename so the scanner never sees a partial dir. */
     private fun writeReport(report: BugReport, logSnapshot: String) {
-        val tmpDir = File(reportsDir, "${BugReportStorage.TMP_PREFIX}${report.id}")
-        val finalDir = File(reportsDir, report.id)
+        val writeRoot = storageLayout.writeRoot
+        val tmpDir = File(writeRoot, "${BugReportStorage.TMP_PREFIX}${report.id}")
+        val finalDir = File(writeRoot, report.id)
         try {
             if (tmpDir.exists()) tmpDir.deleteRecursively()
             tmpDir.mkdirs()
@@ -263,56 +270,81 @@ class BugReportRepo @Inject constructor(
         }
     }
 
+    /**
+     * The copy of [id] that [scan] surfaced: the first root holding a valid report directory. A
+     * corrupt external copy must not shadow the readable private one the list is showing.
+     */
+    private fun resolveReportDir(id: String): File? = storageLayout
+        .allReportDirs(id)
+        .firstOrNull { readReport(it) != null }
+
+    /** Parses a report directory, or null if it is a temp dir, incomplete, unreadable or mislabelled. */
+    private fun readReport(dir: File): BugReport? {
+        if (!dir.isDirectory) return null
+        // Skip (never delete) in-progress temp dirs — deleting here would race a concurrent
+        // write. Stale temp dirs are reaped on init via reapStaleTempDirs().
+        if (dir.name.startsWith(BugReportStorage.TMP_PREFIX)) return null
+        val meta = File(dir, BugReportStorage.META_FILE)
+        // Require both files so a partially-written/copied dir is never treated as complete.
+        // (An ongoing recording always has both: meta.json + report.log are created before the
+        // .recording sentinel.)
+        if (!meta.exists() || !File(dir, BugReportStorage.LOG_FILE).exists()) return null
+        val report = try {
+            json.decodeFromString(BugReport.serializer(), meta.readText())
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Skipping unreadable report ${dir.name}: ${e.message}" }
+            return null
+        }
+        // id doubles as the storage path for delete/prune/share — reject any mismatch.
+        if (report.id != dir.name) {
+            log(TAG, WARN) { "Skipping report with id/dir mismatch: ${report.id} vs ${dir.name}" }
+            return null
+        }
+        return report
+    }
+
     private fun scan(): List<BugReportInfo> {
-        val children = reportsDir.listFiles() ?: return emptyList()
-        return children.mapNotNull { dir ->
-            if (!dir.isDirectory) return@mapNotNull null
-            // Skip (never delete) in-progress temp dirs — deleting here would race a concurrent
-            // write. Stale temp dirs are reaped on init via reapStaleTempDirs().
-            if (dir.name.startsWith(BugReportStorage.TMP_PREFIX)) return@mapNotNull null
-            val meta = File(dir, BugReportStorage.META_FILE)
-            val logFile = File(dir, BugReportStorage.LOG_FILE)
-            // Require both files so a partially-written/copied dir is never treated as complete.
-            // (An ongoing recording always has both: meta.json + report.log are created before the
-            // .recording sentinel.)
-            if (!meta.exists() || !logFile.exists()) return@mapNotNull null
-            val report = try {
-                json.decodeFromString(BugReport.serializer(), meta.readText())
-            } catch (e: Exception) {
-                log(TAG, WARN) { "Skipping unreadable report ${dir.name}: ${e.message}" }
-                return@mapNotNull null
+        // Keyed by id: the same report can exist under both roots, and two entries with the same key
+        // would crash the workspace list. First root wins, matching resolveReportDir().
+        val byId = LinkedHashMap<String, BugReportInfo>()
+        storageLayout.roots.forEach { root ->
+            root.listFiles()?.forEach { dir ->
+                val report = readReport(dir) ?: return@forEach
+                if (byId.containsKey(report.id)) {
+                    log(TAG, WARN) { "Duplicate report id ${report.id}, ignoring the copy in ${dir.path}" }
+                    return@forEach
+                }
+                val logFile = File(dir, BugReportStorage.LOG_FILE)
+                // "Ongoing" is tied to the live recorder, not just the sentinel: a recording interrupted
+                // by process death keeps a stale sentinel until the init sweep clears it, but it is a
+                // complete, surfaceable report — so it shows as a normal report immediately instead of
+                // vanishing from the list during the brief startup-cleanup window.
+                val isOngoing = File(dir, BugReportStorage.RECORDING_SENTINEL).exists() &&
+                    dir.name == bugReportRecorder.state.value.recordingId
+                byId[report.id] = BugReportInfo(
+                    report = report,
+                    // Ongoing recordings are implicitly "seen" — they never count as an unseen crash.
+                    isSeen = isOngoing || File(dir, BugReportStorage.SEEN_MARKER).exists(),
+                    isOngoingRecording = isOngoing,
+                    recordingLogSize = if (isOngoing) logFile.length() else 0L,
+                    logSizeBytes = logFile.length(),
+                )
             }
-            // id doubles as the storage path for delete/prune/share — reject any mismatch.
-            if (report.id != dir.name) {
-                log(TAG, WARN) { "Skipping report with id/dir mismatch: ${report.id} vs ${dir.name}" }
-                return@mapNotNull null
-            }
-            // "Ongoing" is tied to the live recorder, not just the sentinel: a recording interrupted
-            // by process death keeps a stale sentinel until the init sweep clears it, but it is a
-            // complete, surfaceable report — so it shows as a normal report immediately instead of
-            // vanishing from the list during the brief startup-cleanup window.
-            val isOngoing = File(dir, BugReportStorage.RECORDING_SENTINEL).exists() &&
-                dir.name == bugReportRecorder.state.value.recordingId
-            BugReportInfo(
-                report = report,
-                // Ongoing recordings are implicitly "seen" — they never count as an unseen crash.
-                isSeen = isOngoing || File(dir, BugReportStorage.SEEN_MARKER).exists(),
-                isOngoingRecording = isOngoing,
-                recordingLogSize = if (isOngoing) logFile.length() else 0L,
-                logSizeBytes = logFile.length(),
-            )
-        }.sortedByDescending { it.report.createdAt }
+        }
+        return byId.values.sortedByDescending { it.report.createdAt }
     }
 
     /** Remove temp dirs left by interrupted writes, but only past the write grace window. */
     private fun reapStaleTempDirs() {
         val now = System.currentTimeMillis()
-        reportsDir.listFiles()?.forEach { dir ->
-            if (dir.isDirectory &&
-                dir.name.startsWith(BugReportStorage.TMP_PREFIX) &&
-                now - dir.lastModified() > TMP_GRACE_MS
-            ) {
-                runCatching { dir.deleteRecursively() }
+        storageLayout.roots.forEach { root ->
+            root.listFiles()?.forEach { dir ->
+                if (dir.isDirectory &&
+                    dir.name.startsWith(BugReportStorage.TMP_PREFIX) &&
+                    now - dir.lastModified() > TMP_GRACE_MS
+                ) {
+                    runCatching { dir.deleteRecursively() }
+                }
             }
         }
     }
@@ -322,7 +354,7 @@ class BugReportRepo @Inject constructor(
         val valid = scan().filter { !it.isOngoingRecording }
         if (valid.size <= MAX_REPORTS) return
         valid.drop(MAX_REPORTS).forEach { stale ->
-            File(reportsDir, stale.id).deleteRecursively()
+            storageLayout.allReportDirs(stale.id).forEach { it.deleteRecursively() }
             File(shareDir, "${stale.id}.zip").delete()
             log(TAG) { "Pruned old report: ${stale.id}" }
         }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -133,7 +133,13 @@ class BugReportRepo @Inject constructor(
         require(id != bugReportRecorder.state.value.recordingId) { "Cannot delete an active recording" }
         // Every copy, not just the one scan() lists: dropping only the listed copy would let the
         // shadowed one take its place in the very next scan.
-        storageLayout.allReportDirs(id).forEach { it.deleteRecursively() }
+        val dirs = storageLayout.allReportDirs(id)
+        // A live `.recording` sentinel counts as active too, same guard deleteAll() applies: the
+        // published id alone does not cover a recording whose start is still in progress.
+        require(dirs.none { File(it, BugReportStorage.RECORDING_SENTINEL).exists() }) {
+            "Cannot delete an active recording"
+        }
+        dirs.forEach { it.deleteRecursively() }
         File(shareDir, "$id.zip").delete()
         refresh()
     }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
@@ -2,25 +2,36 @@ package eu.darken.butler.common.debug.bugreport
 
 import android.content.Context
 import java.io.File
+import java.nio.file.Files
 
 /**
  * Shared on-disk layout for the unified bug-report store, used by both [BugReportRepo] (crashes +
  * manual snapshots) and [BugReportRecorder] (ongoing recordings) so the two never drift.
  *
  * ```
- * <root>/bugreports/<id>/   meta.json | report.log | .seen? | .recording (while live)
+ * <root>/bugreports/<id>/   meta.json | report.log | root.log? | adb.log? | .seen? | .recording (while live)
  * <root>/bugreports/.tmp-<id>/   snapshot two-phase writes
  * cacheDir/bugreports_share/<id>.zip
  * ```
  *
  * `<root>` is resolved by [BugReportStorageLayout], which owns the order of the two report roots.
  */
-internal object BugReportStorage {
+object BugReportStorage {
     const val REPORTS_DIRNAME = "bugreports"
     const val SHARE_DIRNAME = "bugreports_share"
     const val TMP_PREFIX = ".tmp-"
+
+    /** Suffix of a share zip that is still being written. */
+    const val TMP_SUFFIX = ".tmp"
     const val META_FILE = "meta.json"
     const val LOG_FILE = "report.log"
+
+    /** Written by the root helper process while a recording is active. */
+    const val ROOT_LOG_FILE = "root.log"
+
+    /** Written by the Shizuku/ADB helper process while a recording is active. */
+    const val ADB_LOG_FILE = "adb.log"
+
     const val SEEN_MARKER = ".seen"
 
     /** Present only while a [BugReport.Type.RECORDING] report is actively being written. */
@@ -31,4 +42,13 @@ internal object BugReportStorage {
     fun reportsDir(context: Context): File = File(context.filesDir, REPORTS_DIRNAME)
 
     fun shareDir(context: Context): File = File(context.cacheDir, SHARE_DIRNAME)
+
+    /**
+     * The files that may leave the device in a share zip, in a fixed order. An allowlist rather than
+     * a directory listing: the helper processes write into the report directory, so anything not
+     * named here — including a symlink pointing somewhere else entirely — is never packaged.
+     */
+    fun payloadFiles(reportDir: File): List<File> = listOf(META_FILE, LOG_FILE, ROOT_LOG_FILE, ADB_LOG_FILE)
+        .map { File(reportDir, it) }
+        .filter { it.isFile && !Files.isSymbolicLink(it.toPath()) }
 }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
@@ -8,10 +8,12 @@ import java.io.File
  * manual snapshots) and [BugReportRecorder] (ongoing recordings) so the two never drift.
  *
  * ```
- * filesDir/bugreports/<id>/   meta.json | report.log | .seen? | .recording (while live)
- * filesDir/bugreports/.tmp-<id>/   snapshot two-phase writes
+ * <root>/bugreports/<id>/   meta.json | report.log | .seen? | .recording (while live)
+ * <root>/bugreports/.tmp-<id>/   snapshot two-phase writes
  * cacheDir/bugreports_share/<id>.zip
  * ```
+ *
+ * `<root>` is resolved by [BugReportStorageLayout], which owns the order of the two report roots.
  */
 internal object BugReportStorage {
     const val REPORTS_DIRNAME = "bugreports"

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorageLayout.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorageLayout.kt
@@ -1,0 +1,36 @@
+package eu.darken.butler.common.debug.bugreport
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The resolved roots of the bug-report store, shared by [BugReportRepo] and [BugReportRecorder]:
+ * external app-specific storage first (new reports go there, because the root and ADB helpers append
+ * their own logs into the report directory and cannot write into `filesDir`), the private `filesDir`
+ * second (reports from older versions, and the write root while no external volume is mounted).
+ *
+ * Resolved once here so every consumer agrees on the same roots. Accepted limitation: an external
+ * volume that only becomes available mid-process is not picked up until the next start.
+ */
+@Singleton
+class BugReportStorageLayout @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+
+    /** Read order: the first root holding a report wins. */
+    val roots: List<File> = listOfNotNull(
+        context.getExternalFilesDir(null)?.let { File(it, BugReportStorage.REPORTS_DIRNAME) },
+        BugReportStorage.reportsDir(context),
+    )
+
+    /** Where new reports are written. */
+    val writeRoot: File = roots.first()
+
+    fun findReportDir(id: String): File? = roots.map { File(it, id) }.firstOrNull { it.isDirectory }
+
+    /** Every physical copy of [id], so a delete cannot leave a shadowed one behind. */
+    fun allReportDirs(id: String): List<File> = roots.map { File(it, id) }.filter { it.isDirectory }
+}

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/RecorderPathPublisher.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/RecorderPathPublisher.kt
@@ -1,0 +1,28 @@
+package eu.darken.butler.common.debug.bugreport
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The report directory of the recording that is running right now, handed to the root and ADB
+ * service clients so they can forward it to their host processes, which append their own log next to
+ * `report.log`.
+ *
+ * An output channel, never a resume marker: [BugReportRecorder] alone decides whether a recording is
+ * live, via the `.recording` sentinel. Deliberately process-local and never persisted, so a fresh
+ * process starts at `null` even if a recording was interrupted by process death, and so publishing
+ * can neither suspend nor fail (a write that throws would abort an otherwise working recording).
+ */
+@Singleton
+class RecorderPathPublisher @Inject constructor() {
+
+    private val internalPath = MutableStateFlow<String?>(null)
+    val path: StateFlow<String?> = internalPath.asStateFlow()
+
+    fun publish(path: String?) {
+        internalPath.value = path
+    }
+}

--- a/app-common/src/main/java/eu/darken/butler/common/debug/logging/FileLogger.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/logging/FileLogger.kt
@@ -11,7 +11,8 @@ import kotlin.time.Clock
 
 /**
  * @param worldReadable when true the log file is made world read/writable (needed for the legacy
- *   external-storage debug logs). Bug-report recordings live in private `filesDir` and pass `false`.
+ *   external-storage debug logs). Bug-report recordings pass `false`; their files leave the device
+ *   only inside the packaged share zip.
  */
 class FileLogger(
     private val logFile: File,

--- a/app-common/src/main/java/eu/darken/butler/common/debug/logging/FileLogger.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/logging/FileLogger.kt
@@ -11,8 +11,8 @@ import kotlin.time.Clock
 
 /**
  * @param worldReadable when true the log file is made world read/writable (needed for the legacy
- *   external-storage debug logs). Bug-report recordings pass `false`; their files leave the device
- *   only inside the packaged share zip.
+ *   external-storage debug logs). Bug-report recordings pass `false`, so `FileLogger` does not make
+ *   their log files world readable or writable.
  */
 class FileLogger(
     private val logFile: File,

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
@@ -37,7 +37,9 @@ import kotlin.time.Instant
 class BugReportRecorderTest : BaseTest() {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()
-    private val reportsDir get() = File(context.filesDir, "bugreports")
+    private val storageLayout by lazy { BugReportStorageLayout(context) }
+    private val reportsDir get() = storageLayout.writeRoot
+    private val privateReportsDir get() = File(context.filesDir, "bugreports")
 
     /**
      * Test-controlled clocks, handed to the recorder's two seams. The durations under test are
@@ -60,6 +62,7 @@ class BugReportRecorderTest : BaseTest() {
         dispatcherProvider = TestDispatcherProvider(),
         butlerId = ButlerId(context),
         json = Json { ignoreUnknownKeys = true },
+        storageLayout = storageLayout,
         upgradeDiagnostics = upgradeDiagnostics,
     ).apply {
         wallClock = { clocks.wall }
@@ -337,6 +340,21 @@ class BugReportRecorderTest : BaseTest() {
         interrupted.exists() shouldBe true
         File(interrupted, ".recording").exists() shouldBe false
         incomplete.exists() shouldBe false
+    }
+
+    @Test
+    fun `sweep finalizes an interrupted recording in the legacy root`() = runTest {
+        // Written by a version that still recorded into filesDir: deleteAll() skips a directory with a
+        // sentinel, so a sweep that only looks at the write root would leave this one undeletable.
+        val interrupted = File(privateReportsDir, "recording_5_eeee").apply { mkdirs() }
+        File(interrupted, "meta.json").writeText("{}")
+        File(interrupted, "report.log").writeText("x")
+        File(interrupted, ".recording").createNewFile()
+
+        createRecorder(CoroutineScope(Dispatchers.Unconfined), TestClocks()).sweepOrphanedSentinels()
+
+        interrupted.exists() shouldBe true
+        File(interrupted, ".recording").exists() shouldBe false
     }
 
     private class RecordingLogger : Logging.Logger {

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
@@ -260,6 +260,28 @@ class BugReportRecorderTest : BaseTest() {
     }
 
     @Test
+    fun `the recording id is published before the session infos are logged`() {
+        // Deletion keys "active recording" on the published id, and the report directory is already
+        // on disk while the session infos are being collected — a null id there is a deletable report.
+        var started: BugReportRecorder? = null
+        var idDuringDiagnostics: String? = null
+        val provider = object : UpgradeDiagnostics {
+            override suspend fun debugInfo(): String {
+                idDuringDiagnostics = started!!.state.value.recordingId
+                return "info"
+            }
+        }
+
+        withRecorder(upgradeDiagnostics = setOf(provider)) { recorder ->
+            started = recorder
+            recorder.start()
+
+            idDuringDiagnostics shouldNotBe null
+            idDuringDiagnostics shouldBe recorder.state.value.recordingId
+        }
+    }
+
+    @Test
     fun `force stop bypasses the duration threshold`() {
         // "Stop anyway" — the answer to the short-recording warning in the banner, the contact form
         // and the bug-report workspace dialog. It must stop a recording the threshold would reject.

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
@@ -38,6 +38,7 @@ class BugReportRecorderTest : BaseTest() {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()
     private val storageLayout by lazy { BugReportStorageLayout(context) }
+    private val recorderPathPublisher = RecorderPathPublisher()
     private val reportsDir get() = storageLayout.writeRoot
     private val privateReportsDir get() = File(context.filesDir, "bugreports")
 
@@ -63,6 +64,7 @@ class BugReportRecorderTest : BaseTest() {
         butlerId = ButlerId(context),
         json = Json { ignoreUnknownKeys = true },
         storageLayout = storageLayout,
+        recorderPathPublisher = recorderPathPublisher,
         upgradeDiagnostics = upgradeDiagnostics,
     ).apply {
         wallClock = { clocks.wall }
@@ -125,6 +127,39 @@ class BugReportRecorderTest : BaseTest() {
         File(dir, ".recording").exists() shouldBe false
         File(dir, "meta.json").exists() shouldBe true
         File(dir, "report.log").exists() shouldBe true
+    }
+
+    @Test
+    fun `start publishes the report directory to the privileged helpers`() = withRecorder { recorder ->
+        recorder.start()
+
+        val id = recorder.state.value.recordingId!!
+        recorderPathPublisher.path.value shouldBe File(reportsDir, id).path
+    }
+
+    @Test
+    fun `stopping retracts the published path`() = withRecorder { recorder ->
+        recorder.start()
+        recorderPathPublisher.path.value shouldNotBe null
+
+        recorder.forceStop()
+
+        recorderPathPublisher.path.value shouldBe null
+    }
+
+    @Test
+    fun `a start that cannot set up its files publishes no path`() {
+        // A plain file where the report root belongs: the report directory cannot be created, so
+        // start() rolls back before it would publish.
+        reportsDir.parentFile!!.mkdirs()
+        reportsDir.writeText("not a directory")
+
+        withRecorder { recorder ->
+            recorder.start()
+
+            recorder.state.value.isRecording shouldBe false
+            recorderPathPublisher.path.value shouldBe null
+        }
     }
 
     @Test

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ButlerId
 import eu.darken.butler.common.debug.logging.RingLogBuffer
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -24,6 +25,7 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -271,6 +273,42 @@ class BugReportRepoTest : BaseTest() {
 
         repo.reports.first().single().id shouldBe "dupe_3"
         repo.readLog("dupe_3") shouldBe "legacy log"
+        // Sharing must follow the same copy the list shows, not the corrupt one it skipped.
+        ZipFile(repo.buildShareZip("dupe_3")).use { zip ->
+            zip.getInputStream(zip.getEntry("report.log")).readBytes().decodeToString()
+        } shouldBe "legacy log"
+    }
+
+    @Test
+    fun `buildShareZip packages the report payload and nothing else`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_1", logText = "report log")
+        val dir = File(reportsDir, "share_1")
+        File(dir, "root.log").writeText("root log")
+        File(dir, "adb.log").writeText("adb log")
+        File(dir, ".seen").createNewFile()
+        File(dir, ".recording").createNewFile()
+        File(dir, "injected.txt").writeText("not mine")
+
+        val zip = repo.buildShareZip("share_1")
+
+        ZipFile(zip).use { it.entries().toList().map { entry -> entry.name } } shouldContainExactly
+            listOf("meta.json", "report.log", "root.log", "adb.log")
+    }
+
+    @Test
+    fun `a failed buildShareZip leaves no zip behind`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_2")
+        val shareDir = File(context.cacheDir, "bugreports_share")
+        // The zip is built under this name before being renamed into place; an (empty) directory
+        // sitting there makes the compression fail on its very first write.
+        File(shareDir, "share_2.zip.tmp").mkdirs()
+
+        shouldThrow<Exception> { repo.buildShareZip("share_2") }
+
+        File(shareDir, "share_2.zip").exists() shouldBe false
+        File(shareDir, "share_2.zip.tmp").exists() shouldBe false
     }
 
     @Test

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ButlerId
 import eu.darken.butler.common.debug.logging.RingLogBuffer
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -23,13 +24,19 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [29])
 class BugReportRepoTest : BaseTest() {
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()
-    private val reportsDir get() = File(context.filesDir, "bugreports")
+    private val storageLayout by lazy { BugReportStorageLayout(context) }
+
+    /** Where new reports go (external app-specific storage), and the legacy root older ones live in. */
+    private val reportsDir get() = storageLayout.writeRoot
+    private val privateReportsDir get() = File(context.filesDir, "bugreports")
     private val json = Json { ignoreUnknownKeys = true }
     private val recorderState = MutableStateFlow(BugReportRecorder.State())
 
@@ -48,14 +55,22 @@ class BugReportRepoTest : BaseTest() {
             bugReportRecorder = recorder,
             butlerId = ButlerId(context),
             json = json,
+            storageLayout = storageLayout,
         )
     }
 
-    private fun writeReportDir(id: String, type: BugReport.Type, ongoing: Boolean) {
-        val dir = File(reportsDir, id).apply { mkdirs() }
+    private fun writeReportDir(
+        id: String,
+        type: BugReport.Type = BugReport.Type.REPORTED,
+        ongoing: Boolean = false,
+        root: File = reportsDir,
+        logText: String = "rec log",
+        createdAt: Instant = kotlin.time.Clock.System.now(),
+    ) {
+        val dir = File(root, id).apply { mkdirs() }
         val report = BugReport(
             id = id,
-            createdAt = kotlin.time.Clock.System.now(),
+            createdAt = createdAt,
             type = type,
             appVersion = "1.0",
             deviceFingerprint = "fp",
@@ -66,7 +81,7 @@ class BugReportRepoTest : BaseTest() {
             locale = "en",
         )
         File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
-        File(dir, "report.log").writeText("rec log")
+        File(dir, "report.log").writeText(logText)
         if (ongoing) File(dir, ".recording").createNewFile()
     }
 
@@ -187,8 +202,7 @@ class BugReportRepoTest : BaseTest() {
     @Test
     fun `readLogTail returns all lines for a short log`() = runTest {
         val repo = createRepo()
-        File(reportsDir, "tail_short").mkdirs()
-        File(File(reportsDir, "tail_short"), "report.log").writeText("a\nb\nc")
+        writeReportDir("tail_short", logText = "a\nb\nc")
 
         val tail = repo.readLogTail("tail_short", maxLines = 10)
         tail.totalLines shouldBe 3
@@ -198,8 +212,7 @@ class BugReportRepoTest : BaseTest() {
     @Test
     fun `readLogTail returns only the tail for a long log`() = runTest {
         val repo = createRepo()
-        File(reportsDir, "tail_long").mkdirs()
-        File(File(reportsDir, "tail_long"), "report.log").writeText((1..100).joinToString("\n") { "line$it" })
+        writeReportDir("tail_long", logText = (1..100).joinToString("\n") { "line$it" })
 
         val tail = repo.readLogTail("tail_long", maxLines = 10)
         tail.totalLines shouldBe 100
@@ -215,5 +228,91 @@ class BugReportRepoTest : BaseTest() {
         val tail = repo.readLogTail("does_not_exist", maxLines = 10)
         tail.totalLines shouldBe 0
         tail.lines shouldHaveSize 0
+    }
+
+    @Test
+    fun `reports from both roots are listed`() = runTest {
+        val repo = createRepo()
+        writeReportDir("external_1")
+        writeReportDir("legacy_1", root = privateReportsDir)
+
+        repo.reports.first().map { it.id } shouldContainExactlyInAnyOrder listOf("external_1", "legacy_1")
+    }
+
+    @Test
+    fun `an id present in both roots is listed once, from the external root`() = runTest {
+        val repo = createRepo()
+        writeReportDir("dupe_1", logText = "external log")
+        writeReportDir("dupe_1", root = privateReportsDir, logText = "legacy log")
+
+        repo.reports.first() shouldHaveSize 1
+        repo.readLog("dupe_1") shouldBe "external log"
+    }
+
+    @Test
+    fun `delete removes every physical copy of an id`() = runTest {
+        val repo = createRepo()
+        writeReportDir("dupe_2")
+        writeReportDir("dupe_2", root = privateReportsDir)
+
+        repo.delete("dupe_2")
+
+        File(reportsDir, "dupe_2").exists() shouldBe false
+        File(privateReportsDir, "dupe_2").exists() shouldBe false
+        repo.reports.first() shouldHaveSize 0
+    }
+
+    @Test
+    fun `a corrupt external copy does not shadow the readable legacy one`() = runTest {
+        val repo = createRepo()
+        writeReportDir("dupe_3", logText = "external log")
+        File(File(reportsDir, "dupe_3"), "meta.json").writeText("{ not valid json")
+        writeReportDir("dupe_3", root = privateReportsDir, logText = "legacy log")
+
+        repo.reports.first().single().id shouldBe "dupe_3"
+        repo.readLog("dupe_3") shouldBe "legacy log"
+    }
+
+    @Test
+    fun `markSeen, readLog and readLogTail work on a report in the legacy root`() = runTest {
+        val repo = createRepo()
+        writeReportDir("legacy_2", root = privateReportsDir, logText = "l1\nl2")
+
+        repo.markSeen("legacy_2")
+
+        repo.reports.first().single { it.id == "legacy_2" }.isSeen shouldBe true
+        repo.readLog("legacy_2") shouldBe "l1\nl2"
+        repo.readLogTail("legacy_2", maxLines = 10).lines shouldBe listOf("l1", "l2")
+    }
+
+    @Test
+    fun `retention also prunes reports in the legacy root`() = runTest {
+        val repo = createRepo()
+        val base = kotlin.time.Clock.System.now()
+        repeat(30) { index ->
+            writeReportDir(
+                id = "legacy_prune_$index",
+                root = privateReportsDir,
+                createdAt = base - (30 - index).seconds,
+            )
+        }
+
+        // captureReport writes a fresh report and prunes afterwards.
+        repo.captureReport(IllegalStateException("boom"))
+
+        repo.reports.first() shouldHaveSize 25
+        File(privateReportsDir, "legacy_prune_0").exists() shouldBe false
+        File(privateReportsDir, "legacy_prune_29").exists() shouldBe true
+    }
+
+    @Test
+    fun `stale temp dirs are reaped in the legacy root`() = runTest {
+        val stale = File(privateReportsDir, ".tmp-legacy").apply { mkdirs() }
+        stale.setLastModified(System.currentTimeMillis() - 5 * 60_000L)
+
+        // The init cleanup runs the reaper.
+        createRepo()
+
+        stale.exists() shouldBe false
     }
 }

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -193,6 +193,19 @@ class BugReportRepoTest : BaseTest() {
     }
 
     @Test
+    fun `delete refuses a report carrying a live recording sentinel`() = runTest {
+        val repo = createRepo()
+        // Mid-start: the directory and its sentinel exist while the recorder has not published the
+        // id yet, so the id check alone would let this delete through.
+        writeReportDir("recording_6_ffff", BugReport.Type.RECORDING, ongoing = true)
+        recorderState.value = BugReportRecorder.State()
+
+        shouldThrow<IllegalArgumentException> { repo.delete("recording_6_ffff") }
+
+        File(reportsDir, "recording_6_ffff").exists() shouldBe true
+    }
+
+    @Test
     fun `logSizeBytes reflects the on-disk log size`() = runTest {
         val repo = createRepo()
         repo.captureCrashBlocking(IllegalStateException("boom"), Thread.currentThread())

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -42,12 +43,19 @@ class BugReportRepoTest : BaseTest() {
     private val json = Json { ignoreUnknownKeys = true }
     private val recorderState = MutableStateFlow(BugReportRecorder.State())
 
+    /** Ids the recorder double reports as active-or-starting on top of the published recordingId. */
+    private val startingRecordingIds = mutableSetOf<String>()
+
     private fun createRepo(): BugReportRepo {
         val buffer = RingLogBuffer().apply {
             log(eu.darken.butler.common.debug.logging.Logging.Priority.INFO, "Test", "log line", null)
         }
         val recorder = mockk<BugReportRecorder>(relaxed = true) {
             every { state } returns recorderState
+            coEvery { isActiveOrStarting(any()) } answers {
+                val id = firstArg<String>()
+                id == recorderState.value.recordingId || id in startingRecordingIds
+            }
         }
         return BugReportRepo(
             context = context,
@@ -193,16 +201,30 @@ class BugReportRepoTest : BaseTest() {
     }
 
     @Test
-    fun `delete refuses a report carrying a live recording sentinel`() = runTest {
+    fun `delete refuses a recording whose start has not published its id yet`() = runTest {
         val repo = createRepo()
-        // Mid-start: the directory and its sentinel exist while the recorder has not published the
-        // id yet, so the id check alone would let this delete through.
+        // Mid-start: the directory exists while the recorder has not published the id yet, so the
+        // published id alone would let this delete through.
         writeReportDir("recording_6_ffff", BugReport.Type.RECORDING, ongoing = true)
         recorderState.value = BugReportRecorder.State()
+        startingRecordingIds += "recording_6_ffff"
 
         shouldThrow<IllegalArgumentException> { repo.delete("recording_6_ffff") }
 
         File(reportsDir, "recording_6_ffff").exists() shouldBe true
+    }
+
+    @Test
+    fun `delete removes a report with a stale recording sentinel`() = runTest {
+        val repo = createRepo()
+        // Sentinel left behind by a stop that could not remove it (or by process death after the
+        // startup sweep): the recorder is idle, so the report is finished and must be deletable.
+        writeReportDir("recording_7_gggg", BugReport.Type.RECORDING, ongoing = true)
+
+        repo.delete("recording_7_gggg")
+
+        File(reportsDir, "recording_7_gggg").exists() shouldBe false
+        repo.reports.first() shouldHaveSize 0
     }
 
     @Test

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportStorageLayoutTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportStorageLayoutTest.kt
@@ -1,0 +1,50 @@
+package eu.darken.butler.common.debug.bugreport
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class BugReportStorageLayoutTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val externalRoot get() = File(context.getExternalFilesDir(null), "bugreports")
+    private val privateRoot get() = File(context.filesDir, "bugreports")
+
+    @Test
+    fun `external storage comes first and is the write root`() {
+        val layout = BugReportStorageLayout(context)
+
+        layout.roots shouldBe listOf(externalRoot, privateRoot)
+        layout.writeRoot shouldBe externalRoot
+    }
+
+    @Test
+    fun `findReportDir searches both roots`() {
+        val layout = BugReportStorageLayout(context)
+        File(externalRoot, "external_1").mkdirs()
+        File(privateRoot, "legacy_1").mkdirs()
+
+        layout.findReportDir("external_1") shouldBe File(externalRoot, "external_1")
+        layout.findReportDir("legacy_1") shouldBe File(privateRoot, "legacy_1")
+        layout.findReportDir("unknown") shouldBe null
+    }
+
+    @Test
+    fun `findReportDir prefers the external copy, allReportDirs returns both`() {
+        val layout = BugReportStorageLayout(context)
+        File(externalRoot, "dupe_1").mkdirs()
+        File(privateRoot, "dupe_1").mkdirs()
+
+        layout.findReportDir("dupe_1") shouldBe File(externalRoot, "dupe_1")
+        layout.allReportDirs("dupe_1") shouldBe listOf(File(externalRoot, "dupe_1"), File(privateRoot, "dupe_1"))
+        layout.allReportDirs("unknown") shouldBe emptyList()
+    }
+}

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportStorageTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportStorageTest.kt
@@ -1,0 +1,58 @@
+package eu.darken.butler.common.debug.bugreport
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.io.File
+import java.nio.file.Files
+
+class BugReportStorageTest : BaseTest() {
+
+    @Test
+    fun `payloadFiles returns the known report files in a fixed order`(@TempDir tempDir: File) {
+        val reportDir = File(tempDir, "report").apply { mkdirs() }
+        listOf("adb.log", "report.log", "meta.json", "root.log").forEach {
+            File(reportDir, it).writeText(it)
+        }
+
+        BugReportStorage.payloadFiles(reportDir) shouldBe listOf(
+            File(reportDir, "meta.json"),
+            File(reportDir, "report.log"),
+            File(reportDir, "root.log"),
+            File(reportDir, "adb.log"),
+        )
+    }
+
+    @Test
+    fun `payloadFiles skips markers and anything not on the allowlist`(@TempDir tempDir: File) {
+        val reportDir = File(tempDir, "report").apply { mkdirs() }
+        File(reportDir, "meta.json").writeText("{}")
+        File(reportDir, "report.log").writeText("log")
+        File(reportDir, ".recording").createNewFile()
+        File(reportDir, ".seen").createNewFile()
+        File(reportDir, "injected.txt").writeText("not mine")
+
+        BugReportStorage.payloadFiles(reportDir) shouldBe listOf(
+            File(reportDir, "meta.json"),
+            File(reportDir, "report.log"),
+        )
+    }
+
+    @Test
+    fun `payloadFiles skips an allowlisted name that is a symlink`(@TempDir tempDir: File) {
+        val reportDir = File(tempDir, "report").apply { mkdirs() }
+        File(reportDir, "meta.json").writeText("{}")
+        val elsewhere = File(tempDir, "secret.txt").apply { writeText("secret") }
+        // The helper processes write into the report directory as uid 0 / uid 2000, so a report file
+        // may be a symlink someone else planted rather than a log we produced.
+        Files.createSymbolicLink(File(reportDir, "root.log").toPath(), elsewhere.toPath())
+
+        BugReportStorage.payloadFiles(reportDir) shouldBe listOf(File(reportDir, "meta.json"))
+    }
+
+    @Test
+    fun `payloadFiles is empty for an empty directory`(@TempDir tempDir: File) {
+        BugReportStorage.payloadFiles(tempDir) shouldBe emptyList()
+    }
+}


### PR DESCRIPTION
## What changed

Bug report recordings now include the logs from Butler's privileged helper processes. Record a bug report with root or Shizuku enabled and the helpers' own logs are captured alongside the app's, and all of them are included when the report is shared. Previously those helper logs were never created at all, so a report from a device using root or Shizuku carried nothing about what those processes were doing.

Bug reports are also stored in the app's external files directory now, rather than private internal storage. That is what lets the helper processes, which run as different system users, write their logs into a report's folder. Reports created by earlier versions stay where they are and remain listed and deletable.

Two further fixes in the same area: a recording could be deleted during the first seconds after starting it, silently discarding the recording in progress, and a report whose recording marker was left behind by a failed cleanup could not be deleted at all.

## Technical Context

- Root cause: `recorder.log.path` was declared in `DebugSettings` and read by both service clients, but nothing ever wrote it, so both hosts always saw null and took their logger removal branch. The recorder now publishes through a process-local `StateFlow` instead of restoring the DataStore write, because `DataStoreValue.value(x)` awaits `updateData()`, which can throw and would then abort an otherwise working recording in `start()` or break `forceStop()`'s documented "never throws" contract. The setting is deleted rather than left dead.
- The storage move is what makes the ADB half possible at all: `filesDir` is mode 0700 app-uid-only, so the Shizuku/ADB helper (uid 2000) could never write there. Confirmed on device that a uid-2000 process can create and append a file under the app's external files directory and the app reads it back, on both API 29 and API 37.
- Worth close review: the two-root handling in `BugReportRepo`. `scan()` dedupes by report id with the external copy winning, since two entries sharing an id would crash the workspace list that keys its items by id; reads and sharing resolve through the same validated copy `scan()` selected, so a corrupt external copy cannot route reads to itself while the list shows a readable private one; delete and prune remove every physical copy.
- The share zip is a fixed allowlist rather than a directory listing, because uid 0 and uid 2000 write into that directory too and a file there may be a symlink pointing anywhere. It builds under a temporary name and renames on success, since `Zipper` neither closes nor removes its output when compression throws, which would otherwise leave a truncated archive to be shared as if whole.
- Known limitation, deliberate: a report shared in the moment right after stopping may be missing the last lines of a helper log, because the helpers learn the recording ended asynchronously. Guaranteeing those lines needs a cross-process acknowledgement protocol, which was judged disproportionate to the payoff. Separately, on API 26 to 29 these files become readable by any app holding `READ_EXTERNAL_STORAGE`; that is accepted here and will be addressed on its own.
