### PR TITLE
Workspace: Explain the tab manager's drag and long-press gestures

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourController.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourController.kt
@@ -32,10 +32,11 @@ class GuidedTourController @Inject constructor(
     @Volatile private var currentTopRoute: NavKey? = null
     @Volatile private var routeAtStart: NavKey? = null
 
-    // Whether the active session has had at least one step actually rendered (anchored or
-    // centerless). Reset on start, flipped by the host via [markStepRendered]. Guards against
-    // persisting "completed" for a tour that fell through entirely on missing-target grace-skips.
-    @Volatile private var sessionStepRendered: Boolean = false
+    // Step ids of the active session that actually rendered (anchored or centerless). Reset on
+    // start, filled by the host via [markStepRendered]. A tour is only persisted as "completed"
+    // once every one of its steps is in here: a missing one means that step's target never
+    // registered, and burning the tour on that would hide steps the user never saw.
+    private val sessionRenderedStepIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // Singleton-scoped, so this resets on app restart — which is exactly what "skip for now" means:
     // suppress the tour for the current process lifetime, not persistently.
@@ -72,7 +73,7 @@ class GuidedTourController @Inject constructor(
             log(TAG) { "start(${definition.id.raw}): no steps, ignoring" }
             return false
         }
-        sessionStepRendered = false
+        sessionRenderedStepIds.clear()
         firstStep.prepareTarget?.invoke()
         log(TAG) { "start(${definition.id.raw})" }
         _session.value = TourSession(definition, stepIndex = 0)
@@ -166,23 +167,34 @@ class GuidedTourController @Inject constructor(
     }
 
     /**
-     * Signal from the host that the session for [tourId] has shown at least one step (anchored or
-     * centerless). Lets [completeLocked] tell "user walked the whole tour" apart from "every step
-     * grace-skipped because its target never registered". The id guard rejects a late callback
+     * Signal from the host that [stepId] of [tourId]'s session has been shown (anchored or
+     * centerless). Lets [completeLocked] tell "user walked the whole tour" apart from steps that
+     * grace-skipped because their target never registered. The id guard rejects a late callback
      * from a previous session that already ended (e.g. tour A's render arriving after tour B start).
      */
-    fun markStepRendered(tourId: TourId) {
-        if (_session.value?.definition?.id == tourId) sessionStepRendered = true
+    fun markStepRendered(tourId: TourId, stepId: String) {
+        if (_session.value?.definition?.id == tourId) sessionRenderedStepIds += stepId
     }
 
     private suspend fun completeLocked(): (suspend () -> Unit)? {
         val s = _session.value ?: return null
-        if (!sessionStepRendered) {
+        val renderedCount = sessionRenderedStepIds.size
+        if (renderedCount == 0) {
             // The whole tour fell through on missing-target grace-skips without a single step ever
             // being shown (anchors not registered yet, wrong target ids, or a transient layout
             // race). Persisting "completed" would burn the tour forever for something the user
             // never saw — treat it as skip-for-now instead, so it stays eligible after a restart.
             log(TAG, WARN) { "complete(${s.definition.id.raw}): no step ever rendered, skipping instead" }
+            skippedThisSession += s.definition.id.raw
+            _session.value = null
+            routeAtStart = null
+            return null
+        }
+        if (renderedCount < s.definition.steps.size) {
+            log(TAG, WARN) {
+                "complete(${s.definition.id.raw}): only $renderedCount of ${s.definition.steps.size} " +
+                    "steps rendered ($sessionRenderedStepIds), skipping instead"
+            }
             skippedThisSession += s.definition.id.raw
             _session.value = null
             routeAtStart = null

--- a/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourHost.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourHost.kt
@@ -91,7 +91,7 @@ fun GuidedTourHost(
     onDisableAllTours: () -> Unit,
     modifier: Modifier = Modifier,
     registry: TourTargetRegistry = remember { TourTargetRegistry() },
-    onStepRendered: (TourId) -> Unit = {},
+    onStepRendered: (TourId, String) -> Unit = { _, _ -> },
     content: @Composable () -> Unit,
 ) {
     val current by session.collectAsState()
@@ -100,12 +100,13 @@ fun GuidedTourHost(
     // host is mounted at the Compose root.
     val layout = step?.let { resolveStepLayout(it, registry) }
 
-    // Tell the controller a step actually became visible. A tour that grace-skips every step
-    // (no target ever registers) must not be persisted as "completed" — see completeLocked().
+    // Tell the controller which step actually became visible. A tour whose steps grace-skip for
+    // want of a registered target must not be persisted as "completed" — see completeLocked().
     val stepRendered = layout is StepLayout.Anchored || layout is StepLayout.Centerless
     val activeTourId = current?.definition?.id
     LaunchedEffect(activeTourId?.raw, step?.stepId, stepRendered) {
-        if (stepRendered && activeTourId != null) onStepRendered(activeTourId)
+        val stepId = step?.stepId
+        if (stepRendered && activeTourId != null && stepId != null) onStepRendered(activeTourId, stepId)
     }
 
     // Deliberately NOT debounced like the bubble's Next below: this path is programmatic, already

--- a/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourControllerTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourControllerTest.kt
@@ -252,7 +252,7 @@ class GuidedTourControllerTest : BaseTest() {
     fun `a stale next on the last step does not complete the tour`() = runTest {
         val ctrl = controller()
         ctrl.start(basicDefinition)
-        ctrl.markStepRendered(basicDefinition.id)
+        ctrl.markAllStepsRendered(basicDefinition)
         ctrl.nextFromCurrent()
         ctrl.nextFromCurrent() // now on the last step "c"
         ctrl.next(basicDefinition.id, "b")
@@ -264,7 +264,7 @@ class GuidedTourControllerTest : BaseTest() {
     fun `next from last step completes tour and persists completed`() = runTest {
         val ctrl = controller()
         ctrl.start(basicDefinition)
-        ctrl.markStepRendered(basicDefinition.id) // host showed a step — a real walkthrough, persists
+        ctrl.markAllStepsRendered(basicDefinition) // host showed every step — a real walkthrough, persists
         ctrl.nextFromCurrent()
         ctrl.nextFromCurrent()
         ctrl.nextFromCurrent() // last → complete
@@ -287,7 +287,7 @@ class GuidedTourControllerTest : BaseTest() {
         )
         ctrl = controller()
         ctrl.start(def)
-        ctrl.markStepRendered(def.id)
+        ctrl.markAllStepsRendered(def)
 
         ctrl.nextFromCurrent()
         ctrl.nextFromCurrent()
@@ -348,6 +348,30 @@ class GuidedTourControllerTest : BaseTest() {
         // Suppressed in-memory for this process, but eligible again after an app restart.
         ctrl.shouldStart(basicDefinition) shouldBe false
         controller().shouldStart(basicDefinition) shouldBe true
+    }
+
+    @Test
+    fun `complete with a step that never rendered does not persist and stays eligible after restart`() = runTest {
+        val ctrl = controller()
+        ctrl.start(basicDefinition)
+        // The user walked the first two steps; the third grace-skipped for want of an anchor.
+        ctrl.markStepRendered(basicDefinition.id, "a")
+        ctrl.markStepRendered(basicDefinition.id, "b")
+        ctrl.complete()
+        ctrl.session.value shouldBe null
+        prefsFlow.value.completed shouldBe emptySet()
+        prefsFlow.value.dismissed shouldBe emptySet()
+        ctrl.shouldStart(basicDefinition) shouldBe false
+        controller().shouldStart(basicDefinition) shouldBe true
+    }
+
+    @Test
+    fun `a repeated render of the same step does not stand in for the missing ones`() = runTest {
+        val ctrl = controller()
+        ctrl.start(basicDefinition)
+        repeat(3) { ctrl.markStepRendered(basicDefinition.id, "a") }
+        ctrl.complete()
+        prefsFlow.value.completed shouldBe emptySet()
     }
 
     @Test
@@ -426,7 +450,7 @@ class GuidedTourControllerTest : BaseTest() {
     fun `complete persists to completed and clears session`() = runTest {
         val ctrl = controller()
         ctrl.start(basicDefinition)
-        ctrl.markStepRendered(basicDefinition.id)
+        ctrl.markAllStepsRendered(basicDefinition)
         ctrl.complete()
         ctrl.session.value shouldBe null
         prefsFlow.value.completed shouldBe setOf(basicDefinition.id.raw)
@@ -448,7 +472,7 @@ class GuidedTourControllerTest : BaseTest() {
         val ctrl = controller()
         ctrl.start(basicDefinition)
         // A late render callback for a different (already-ended) tour must not mark this session.
-        ctrl.markStepRendered(TourId("some.other.tour"))
+        basicDefinition.steps.forEach { ctrl.markStepRendered(TourId("some.other.tour"), it.stepId) }
         ctrl.complete()
         prefsFlow.value.completed shouldBe emptySet()
         controller().shouldStart(basicDefinition) shouldBe true
@@ -472,7 +496,7 @@ class GuidedTourControllerTest : BaseTest() {
         // Simulate MainActivity emitting the current route BEFORE the screen auto-starts the tour.
         ctrl.onRouteChanged(routeA)
         ctrl.start(unprotectedDefinition)
-        ctrl.markStepRendered(unprotectedDefinition.id) // a step was shown before navigating away
+        ctrl.markAllStepsRendered(unprotectedDefinition) // the whole tour was walked before navigating away
         ctrl.session.value shouldBe TourSession(unprotectedDefinition, 0)
         // User navigates away → the controller must auto-complete (regression for the stale-seed bug).
         ctrl.onRouteChanged(routeB)
@@ -589,6 +613,11 @@ class GuidedTourControllerTest : BaseTest() {
 
 @Serializable
 private data class TestRoute(val tag: String) : NavKey
+
+/** Report every step as rendered — what the host sends when the user walks the whole tour. */
+private fun GuidedTourController.markAllStepsRendered(definition: TourDefinition) {
+    definition.steps.forEach { markStepRendered(definition.id, it.stepId) }
+}
 
 /** Advance from whatever step is current — the identity the real bubble would send. */
 private suspend fun GuidedTourController.nextFromCurrent() {

--- a/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourHostTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourHostTest.kt
@@ -266,41 +266,44 @@ class GuidedTourHostTest : ComposeTest() {
     }
 
     @Test
-    fun `onStepRendered fires when an anchored step becomes visible`() {
+    fun `onStepRendered reports the anchored step that became visible`() {
         val sessionFlow = MutableStateFlow<TourSession?>(TourSession(protectedDef, 0))
-        var rendered = 0
+        val rendered = mutableListOf<Pair<TourId, String>>()
         composeTestRule.setHostContent(
             sessionFlow,
             preregister = mapOf("first" to targetRect),
-            onStepRendered = { rendered++ },
+            onStepRendered = { tourId, stepId -> rendered += tourId to stepId },
         ) {
             Text("CONTENT_MARKER")
         }
-        (rendered > 0) shouldBe true
+        rendered.distinct() shouldBe listOf(protectedDef.id to "first")
     }
 
     @Test
-    fun `onStepRendered fires for a centerless step`() {
+    fun `onStepRendered reports a centerless step`() {
         val sessionFlow = MutableStateFlow<TourSession?>(TourSession(centerlessDef, 0))
-        var rendered = 0
-        composeTestRule.setHostContent(sessionFlow, onStepRendered = { rendered++ }) {
+        val rendered = mutableListOf<Pair<TourId, String>>()
+        composeTestRule.setHostContent(
+            sessionFlow,
+            onStepRendered = { tourId, stepId -> rendered += tourId to stepId },
+        ) {
             Text("CONTENT_MARKER")
         }
-        (rendered > 0) shouldBe true
+        rendered.distinct() shouldBe listOf(centerlessDef.id to "overview")
     }
 
     @Test
     fun `onStepRendered does not fire while the target is still pending`() {
         // protectedDef step 0 target "first" is never registered → layout stays Pending.
         val sessionFlow = MutableStateFlow<TourSession?>(TourSession(protectedDef, 0))
-        var rendered = 0
+        val rendered = mutableListOf<String>()
         composeTestRule.mainClock.autoAdvance = false
-        composeTestRule.setHostContent(sessionFlow, onStepRendered = { rendered++ }) {
+        composeTestRule.setHostContent(sessionFlow, onStepRendered = { _, stepId -> rendered += stepId }) {
             Text("CONTENT_MARKER")
         }
         composeTestRule.mainClock.advanceTimeBy(100)
         composeTestRule.mainClock.autoAdvance = true
-        rendered shouldBe 0
+        rendered shouldBe emptyList()
     }
 
     @Test
@@ -673,7 +676,7 @@ private fun ComposeContentTestRule.setHostContent(
     onPrevious: () -> Unit = {},
     onDontShowAgain: () -> Unit = {},
     onDisableAllTours: () -> Unit = {},
-    onStepRendered: (TourId) -> Unit = {},
+    onStepRendered: (TourId, String) -> Unit = { _, _ -> },
     onBackOwner: (OnBackPressedDispatcherOwner) -> Unit = {},
     content: @Composable () -> Unit,
 ) {

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/AdaptiveWorkspaceManagerContent.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/AdaptiveWorkspaceManagerContent.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +38,7 @@ fun AdaptiveWorkspaceManagerContent(
     onClearSelection: () -> Unit = {},
     onOperationsFilterClick: () -> Unit = {},
     onAttentionFilterClick: () -> Unit = {},
+    lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
     BoxWithConstraints(
         modifier = modifier.fillMaxSize()
@@ -70,6 +73,7 @@ fun AdaptiveWorkspaceManagerContent(
             onClearSelection = onClearSelection,
             onOperationsFilterClick = onOperationsFilterClick,
             onAttentionFilterClick = onAttentionFilterClick,
+            lazyGridState = lazyGridState,
         )
     }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
@@ -6,8 +6,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -31,6 +32,11 @@ import eu.darken.butler.workspace.ui.manager.rows.WorkspaceStatusCard
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyGridState
 
+object WorkspaceManagerGridDefaults {
+    /** The status card occupies grid slot 0 whenever there is at least one tab. */
+    const val FIRST_WORKSPACE_CARD_INDEX = 1
+}
+
 @Composable
 fun WorkspaceManagerGridLayout(
     modifier: Modifier = Modifier,
@@ -50,6 +56,7 @@ fun WorkspaceManagerGridLayout(
     onClearSelection: () -> Unit = {},
     onOperationsFilterClick: () -> Unit = {},
     onAttentionFilterClick: () -> Unit = {},
+    lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
     val tag = logTag("Workspace", "Manager", "GridLayout")
     var localWorkspaceItems by remember { mutableStateOf(state.filteredWorkspaces) }
@@ -69,7 +76,6 @@ fun WorkspaceManagerGridLayout(
     // Calculate span for explanation cards - use 2 columns on large screens, full width otherwise
     val explanationSpan = if (columns == 3) 2 else columns
 
-    val lazyGridState = rememberLazyGridState()
     val reorderableLazyGridState = rememberReorderableLazyGridState(
         lazyGridState = lazyGridState
     ) { from, to ->
@@ -135,11 +141,11 @@ fun WorkspaceManagerGridLayout(
                 WorkspaceManagerEmptyState()
             }
         } else {
-            items(
+            itemsIndexed(
                 items = localWorkspaceItems,
-                key = { workspace -> WorkspaceManagerColumnItemKey.Workspace.Standard(workspace.id) },
-                span = { GridItemSpan(1) }
-            ) { workspace ->
+                key = { _, workspace -> WorkspaceManagerColumnItemKey.Workspace.Standard(workspace.id) },
+                span = { _, _ -> GridItemSpan(1) }
+            ) { index, workspace ->
                 ReorderableItem(
                     reorderableLazyGridState,
                     key = WorkspaceManagerColumnItemKey.Workspace.Standard(workspace.id)
@@ -166,6 +172,7 @@ fun WorkspaceManagerGridLayout(
                         isVisibleInPane = workspace.isVisibleInPane,
                         isSelectionActive = state.isSelectionActive,
                         isChecked = state.selectedIds?.contains(workspace.id) == true,
+                        isTourAnchor = index == 0,
                         currentPaneCount = state.currentPaneCount,
                     )
                 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Workspaces
@@ -80,6 +82,7 @@ fun WorkspaceManagerScreen(
     onTabsClick: () -> Unit = {},
     onOperationsFilterClick: () -> Unit = {},
     onAttentionFilterClick: () -> Unit = {},
+    lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
     var showCloseAllDialog by remember { mutableStateOf(false) }
     var showCloseSelectedDialog by remember { mutableStateOf(false) }
@@ -172,6 +175,7 @@ fun WorkspaceManagerScreen(
                 onClearSelection = onClearSelection,
                 onOperationsFilterClick = onOperationsFilterClick,
                 onAttentionFilterClick = onAttentionFilterClick,
+                lazyGridState = lazyGridState,
             )
 
             FloatingBarStack(

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItem.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItem.kt
@@ -55,11 +55,13 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.asComposable
+import eu.darken.butler.common.compose.tour.guidedTourTarget
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.icon
 import eu.darken.butler.workspace.core.label
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
 import eu.darken.butler.workspace.ui.manager.rows.preview.WorkspacePreview
+import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
 import eu.darken.butler.common.R as CommonR
 import eu.darken.butler.workspace.R as WorkspaceR
 
@@ -86,6 +88,7 @@ fun WorkspaceGridItem(
     isVisibleInPane: Boolean = false,
     isSelectionActive: Boolean = false,
     isChecked: Boolean = false,
+    isTourAnchor: Boolean = false,
     currentPaneCount: Int = 1,
 ) {
     val haptic = LocalHapticFeedback.current
@@ -102,6 +105,19 @@ fun WorkspaceGridItem(
     val needsAttention = workspace.attentionCount > 0
     val attentionColor = MaterialTheme.colorScheme.error
     var showOverflowMenu by remember { mutableStateOf(false) }
+
+    // The tour cuts out the header and the preview separately, because the same long press means
+    // reorder on one and select on the other.
+    val reorderTourAnchor = if (isTourAnchor) {
+        Modifier.guidedTourTarget(WorkspaceManagerTour.REORDER_TARGET)
+    } else {
+        Modifier
+    }
+    val selectTourAnchor = if (isTourAnchor) {
+        Modifier.guidedTourTarget(WorkspaceManagerTour.SELECT_TARGET)
+    } else {
+        Modifier
+    }
 
     val glowModifier = if (needsAttention) {
         Modifier.drawBehind {
@@ -164,6 +180,7 @@ fun WorkspaceGridItem(
                                     haptic.performHapticFeedback(HapticFeedbackType.GestureEnd)
                                 },
                             )
+                            .then(reorderTourAnchor)
                     },
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -322,7 +339,8 @@ fun WorkspaceGridItem(
                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                 if (isSelectionActive) onToggleSelection() else onStartSelection()
                             },
-                        ),
+                        )
+                        .then(selectTourAnchor),
                 ) {
                     WorkspacePreview(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTour.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTour.kt
@@ -8,18 +8,33 @@ import eu.darken.butler.common.compose.tour.TourId
 import eu.darken.butler.common.compose.tour.TourStep
 
 /**
- * Points at the tab manager's add-tab button, whose long-press shortcut is otherwise unadvertised.
+ * Walks the tab manager: the add-tab button, then the two card long-presses that are otherwise
+ * undiscoverable — the title row reorders, the preview below it starts a selection.
  *
- * No `prepareTarget`: the button hides itself while the grid scrolls down, but the overlay always
- * opens unscrolled, so the anchor is registered by the time the tour starts.
+ * [REORDER_TARGET] and [SELECT_TARGET] are registered by exactly one card, the first in the grid.
+ * That is what keeps the ids unique: tagging every card would file one rect per tab under a single
+ * id, and the last one positioned would win.
+ *
+ * The tour only starts once the grid holds at least one card, so those two anchors exist.
+ *
+ * Every step carries a `prepareTarget`. The status card above the cards is a wrapping `FlowRow` of
+ * chips and each preview is a fixed 160dp, so in a short window at large font scale the first
+ * card's preview sits below the viewport and never registers. The add-tab step prepares in the
+ * other direction: its button hides on scroll, so stepping back to it has to restore the top of
+ * the grid.
  */
 object WorkspaceManagerTour : GuidedTour {
 
     override val id: TourId = TourId("tour.workspace.manager")
 
     const val ADD_TAB_TARGET = "workspaceManager.addTab"
+    const val REORDER_TARGET = "workspaceManager.cardHeader"
+    const val SELECT_TARGET = "workspaceManager.cardPreview"
 
-    val definition: TourDefinition = TourDefinition(
+    fun definition(
+        prepareAddTab: suspend () -> Unit,
+        prepareFirstCard: suspend () -> Unit,
+    ): TourDefinition = TourDefinition(
         id = id,
         clickProtection = true,
         steps = listOf(
@@ -28,6 +43,21 @@ object WorkspaceManagerTour : GuidedTour {
                 targetId = ADD_TAB_TARGET,
                 title = R.string.tour_manager_add_tab_title.toCaString(),
                 body = R.string.tour_manager_add_tab_body.toCaString(),
+                prepareTarget = prepareAddTab,
+            ),
+            TourStep(
+                stepId = "reorder",
+                targetId = REORDER_TARGET,
+                title = R.string.tour_manager_reorder_title.toCaString(),
+                body = R.string.tour_manager_reorder_body.toCaString(),
+                prepareTarget = prepareFirstCard,
+            ),
+            TourStep(
+                stepId = "select",
+                targetId = SELECT_TARGET,
+                title = R.string.tour_manager_select_title.toCaString(),
+                body = R.string.tour_manager_select_body.toCaString(),
+                prepareTarget = prepareFirstCard,
             ),
         ),
     )

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -54,6 +55,7 @@ import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonViewModel
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerScreen
+import eu.darken.butler.workspace.ui.manager.WorkspaceManagerGridDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
 import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
@@ -358,16 +360,31 @@ fun WorkspacesScreenHost(
     }
 
     val tourController = LocalGuidedTourController.current
+    // Hoisted out of the grid so the tour's prepareTarget hooks can scroll an anchor into the
+    // viewport before the step it belongs to is published.
+    val managerGridState = rememberLazyGridState()
+    val managerTourDefinition = remember(managerGridState) {
+        WorkspaceManagerTour.definition(
+            prepareAddTab = { managerGridState.scrollToItem(0) },
+            prepareFirstCard = {
+                managerGridState.scrollToItem(WorkspaceManagerGridDefaults.FIRST_WORKSPACE_CARD_INDEX)
+            },
+        )
+    }
     // Gated on the manager's own state, not just the overlay flag: a restored session makes the
-    // overlay visible before that state arrives, and the manager - with the tour's only anchor -
-    // is composed no earlier than the state is non-null. A tour started in that window finds no
-    // anchor, grace-skips its single step, and suppresses itself for the rest of the process.
-    val managerTourReady = pageManagerState.isManagerOverlayVisible && managerState != null
+    // overlay visible before that state arrives, and the manager - with the tour's anchors - is
+    // composed no earlier than the state is non-null. A tour started in that window finds no
+    // anchor, grace-skips every step, and suppresses itself for the rest of the process.
+    // The grid also has to hold a card: the manager is reachable with zero tabs, and there the two
+    // card steps have nothing to anchor on while the add-tab step still renders - enough for
+    // completion to be persisted, burning a tour whose gestures were never shown.
+    val managerTourReady = pageManagerState.isManagerOverlayVisible &&
+        managerState?.filteredWorkspaces?.isNotEmpty() == true
     LaunchedEffect(managerTourReady) {
         if (!managerTourReady) return@LaunchedEffect
         // No attempted-flag: this key already runs the body once per open, and tryStart itself
         // refuses a tour that is completed, dismissed, or skipped this process.
-        tourController.tryStart(WorkspaceManagerTour.definition)
+        tourController.tryStart(managerTourDefinition)
     }
 
     // Selection mode is a state inside the overlay, so back leaves it first; dismissing the manager
@@ -423,6 +440,7 @@ fun WorkspacesScreenHost(
             managerState?.let { currentManagerState ->
                 WorkspaceManagerScreen(
                     state = currentManagerState,
+                    lazyGridState = managerGridState,
                     closeConfirmation = managerCloseConfirmation,
                     onCloseConfirmationResolve = { confirmed ->
                         managerCloseConfirmation?.let {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -321,6 +321,10 @@
     <string name="tour_first_tab_body">Butler works in tabs, like a browser: each one is a tool of its own — Explorer, Searcher, Editor, and more. Create your first tab.</string>
     <string name="tour_manager_add_tab_title">Add a tab</string>
     <string name="tour_manager_add_tab_body">Tap this to pick a tool for a new tab. Long-press it instead for a shortcut list of the tools you use most, and for closing every tab at once.</string>
+    <string name="tour_manager_reorder_title">Reorder your tabs</string>
+    <string name="tour_manager_reorder_body">Press and hold a tab\'s title bar, then drag it where you want it. This is the order your tabs appear in everywhere else.</string>
+    <string name="tour_manager_select_title">Work on several tabs</string>
+    <string name="tour_manager_select_body">Press and hold a tab\'s preview to start picking tabs. Then tap the rest and close or pause them all in one go.</string>
 
     <string name="workspace_creating_placeholder">Creating tab…</string>
     <string name="workspace_ondemand_swipe_title">Swipe to create new tab</string>

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItemTourAnchorTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceGridItemTourAnchorTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.butler.workspace.ui.manager.rows
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.tour.LocalTourTargetRegistry
+import eu.darken.butler.common.compose.tour.TourTargetRegistry
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
+import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import sh.calvin.reorderable.DragGestureDetector
+import sh.calvin.reorderable.ReorderableCollectionItemScope
+import testhelpers.ComposeTest
+
+/**
+ * The two card gestures live on different halves of the same card, so the tour's cutouts have to
+ * land on different rects: the title row it reorders from, the preview it starts a selection from.
+ */
+class WorkspaceGridItemTourAnchorTest : ComposeTest() {
+
+    private val noopReorderableScope = object : ReorderableCollectionItemScope {
+        override fun Modifier.draggableHandle(
+            enabled: Boolean,
+            interactionSource: MutableInteractionSource?,
+            onDragStarted: (Offset) -> Unit,
+            onDragStopped: () -> Unit,
+            dragGestureDetector: DragGestureDetector,
+        ): Modifier = this
+
+        override fun Modifier.longPressDraggableHandle(
+            enabled: Boolean,
+            interactionSource: MutableInteractionSource?,
+            onDragStarted: (Offset) -> Unit,
+            onDragStopped: () -> Unit,
+        ): Modifier = this
+    }
+
+    private fun item(): WorkspaceManagerViewModel.WorkspaceItem {
+        val id = Workspace.Id()
+        return WorkspaceManagerViewModel.WorkspaceItem(
+            id = id,
+            topId = id,
+            type = Workspace.Type.EXPLORER,
+            title = "/sdcard/Download".toCaString(),
+            autoTitle = "/sdcard/Download".toCaString(),
+            subtitle = null,
+        )
+    }
+
+    private fun renderCard(isTourAnchor: Boolean): TourTargetRegistry {
+        val registry = TourTargetRegistry()
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalTourTargetRegistry provides registry) {
+                PreviewWrapper {
+                    WorkspaceGridItem(
+                        reorderableScope = noopReorderableScope,
+                        workspace = item(),
+                        onClose = {},
+                        onSelect = {},
+                        livePreview = false,
+                        isTourAnchor = isTourAnchor,
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        return registry
+    }
+
+    @Test
+    fun `the anchor card registers the header above the preview`() {
+        val registry = renderCard(isTourAnchor = true)
+
+        val header = registry.get(WorkspaceManagerTour.REORDER_TARGET)
+        val preview = registry.get(WorkspaceManagerTour.SELECT_TARGET)
+        header shouldNotBe null
+        preview shouldNotBe null
+        header shouldNotBe preview
+        // Robolectric measures text badly, so only the ordering is asserted, never a pixel value.
+        (header!!.top < preview!!.top) shouldBe true
+    }
+
+    @Test
+    fun `a card that is not the anchor registers nothing`() {
+        val registry = renderCard(isTourAnchor = false)
+
+        registry.get(WorkspaceManagerTour.REORDER_TARGET) shouldBe null
+        registry.get(WorkspaceManagerTour.SELECT_TARGET) shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTourTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTourTest.kt
@@ -1,40 +1,70 @@
 package eu.darken.butler.workspace.ui.manager.tour
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 /**
- * The tour id is persisted as "completed", and the target id has to match the one the manager's FAB
- * registers — a drift in either silently turns the tour into a no-op or replays it.
+ * The tour id is persisted as "completed", and the three target ids have to match the ones the
+ * manager's FAB and first card register — a drift in either silently turns a step into a grace-skip
+ * or replays the whole tour.
  */
 class WorkspaceManagerTourTest : BaseTest() {
 
-    private val definition = WorkspaceManagerTour.definition
+    private fun definition(
+        prepareAddTab: suspend () -> Unit = {},
+        prepareFirstCard: suspend () -> Unit = {},
+    ) = WorkspaceManagerTour.definition(
+        prepareAddTab = prepareAddTab,
+        prepareFirstCard = prepareFirstCard,
+    )
 
     @Test
     fun `the tour id is stable`() {
         WorkspaceManagerTour.id.raw shouldBe "tour.workspace.manager"
-        definition.id shouldBe WorkspaceManagerTour.id
+        definition().id shouldBe WorkspaceManagerTour.id
     }
 
     @Test
-    fun `a single step anchors on the add-tab target`() {
-        definition.steps.size shouldBe 1
-        definition.steps.single().let {
-            it.stepId shouldBe "addTab"
-            it.targetId shouldBe WorkspaceManagerTour.ADD_TAB_TARGET
-        }
+    fun `the steps anchor on the add-tab button and both card halves in order`() {
+        definition().steps.map { it.stepId to it.targetId } shouldBe listOf(
+            "addTab" to WorkspaceManagerTour.ADD_TAB_TARGET,
+            "reorder" to WorkspaceManagerTour.REORDER_TARGET,
+            "select" to WorkspaceManagerTour.SELECT_TARGET,
+        )
         WorkspaceManagerTour.ADD_TAB_TARGET shouldBe "workspaceManager.addTab"
+        WorkspaceManagerTour.REORDER_TARGET shouldBe "workspaceManager.cardHeader"
+        WorkspaceManagerTour.SELECT_TARGET shouldBe "workspaceManager.cardPreview"
     }
 
     @Test
-    fun `the step needs no prepareTarget because the overlay opens unscrolled`() {
-        definition.steps.single().prepareTarget shouldBe null
+    fun `every step prepares its own target`() {
+        definition().steps.forEach { it.prepareTarget shouldNotBe null }
+    }
+
+    @Test
+    fun `the add-tab step scrolls back to the top and both card steps to the first card`() = runTest {
+        val calls = mutableListOf<String>()
+        val steps = definition(
+            prepareAddTab = { calls += "addTab" },
+            prepareFirstCard = { calls += "firstCard" },
+        ).steps
+        steps.forEach { it.prepareTarget?.invoke() }
+        calls shouldBe listOf("addTab", "firstCard", "firstCard")
+    }
+
+    @Test
+    fun `every step carries a title and a body`() {
+        definition().steps.forEach {
+            it.title shouldNotBe null
+            it.body shouldNotBe null
+        }
     }
 
     @Test
     fun `click protection is on so the highlighted button cannot be tapped through the scrim`() {
-        definition.clickProtection shouldBe true
+        definition().clickProtection shouldBe true
     }
 }


### PR DESCRIPTION
## What changed

The tab manager's guided tour now explains the two things you can do to a tab card that were
previously undiscoverable: press and hold a tab's title bar to drag it into a new position, and
press and hold a tab's preview to start picking several tabs at once.

Each gets its own step, spotlighting the exact part of the card the gesture works on, since both
are the same press-and-hold on different halves of the same card. The tour also waits until you
actually have a tab open before it runs, so it can't play through while the cards it describes
aren't there.

## Technical Context

- **Anchoring**: the two card targets are registered by exactly one card, the first in the grid
  (`itemsIndexed` + `index == 0`). The target registry is keyed by id, so tagging every card would
  file one rect per tab under a single id and let the last one positioned win. Same uniqueness
  argument `FirstTabTour` already documents.
- **Non-empty-grid gate**: `GuidedTourController.completeLocked()` persists a tour as completed as
  soon as *one* step renders, and the manager is reachable with zero tabs. Without the gate, opening
  it empty would render the add-tab step, grace-skip both card steps for want of an anchor, and burn
  the tour permanently. Worth close review — it is the reason the tour's start condition changed.
- **Completion guard** (`GuidedTourController`, `GuidedTourHost`): a tour is now only persisted as
  completed once every one of its steps has rendered; a partial walk is treated as skip-for-now and
  returns on the next launch. This is shared by all three tours. `FirstTabTour` has one step so its
  behaviour is unchanged, and `TemplatesTour`'s two targets are both unconditionally reachable, so
  neither can enter a replay loop.
- **Scroll hooks**: every step carries a `prepareTarget`. The status card above the grid is a
  wrapping `FlowRow` and each preview is a fixed 160dp, so in a short window the first card's
  preview falls below the fold and its anchor never registers. The add-tab step prepares in the
  opposite direction, because that button hides on scroll and stepping backward has to restore the
  top of the grid.
- **Two known defects are deliberately not fixed here**, both in constrained or changing window
  configurations, both deferred to a follow-up: in a very short viewport (~221dp) the third step's
  bubble renders its controls but no title or body; and if the activity is recreated mid-tour (a
  rotation, say), the scroll hooks stay bound to a grid state that no longer backs the on-screen
  grid, so the affected step is skipped. The first was observed on a device; the second is verified
  from the code but its runtime impact was not reproduced. Neither affects the ordinary path.
