### PR TITLE
Workspace: Let the closed-tab undo bar be swiped away

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/undo/ClosedWorkspaceStash.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/undo/ClosedWorkspaceStash.kt
@@ -264,6 +264,12 @@ class ClosedWorkspaceStash @Inject constructor(
         dropPendingLocked("dismissed")
     }
 
+    /** The user dismissed the bar for a specific entry; a superseded token is a no-op. */
+    fun dismiss(closeToken: Long) = synchronized(lock) {
+        if (pending?.closeToken != closeToken) return@synchronized
+        dropPendingLocked("dismissed")
+    }
+
     /** Publications made while restoring are the restore itself and must not invalidate anything. */
     fun beginRestore() = synchronized(lock) {
         restoring = true

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/undo/ClosedWorkspaceStashTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/undo/ClosedWorkspaceStashTest.kt
@@ -295,6 +295,7 @@ class ClosedWorkspaceStashTest : BaseTest() {
         stash.feedback.value shouldNotBe null
 
         stash.dismiss(token)
+        stash.peekEntry() shouldBe null
         stash.feedback.value shouldBe null
 
         scope.testScheduler.advanceTimeBy(ClosedWorkspaceStash.FEEDBACK_TIMEOUT + 1.seconds)

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/undo/ClosedWorkspaceStashTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/undo/ClosedWorkspaceStashTest.kt
@@ -286,6 +286,48 @@ class ClosedWorkspaceStashTest : BaseTest() {
     }
 
     @Test
+    fun `dismiss(token) drops the matching offered entry and its timeout does not act afterwards`() = runTest {
+        val id = Workspace.Id()
+        val token = armed(id)
+        contributeUiHalf(token, id)
+        stash.commitIdentity(snapshotOf(token, id))
+        stash.markDestructionComplete(token)
+        stash.feedback.value shouldNotBe null
+
+        stash.dismiss(token)
+        stash.feedback.value shouldBe null
+
+        scope.testScheduler.advanceTimeBy(ClosedWorkspaceStash.FEEDBACK_TIMEOUT + 1.seconds)
+        scope.testScheduler.runCurrent()
+
+        stash.feedback.value shouldBe null
+    }
+
+    @Test
+    fun `dismiss(token) for a superseded entry leaves the current one intact`() = runTest {
+        val first = Workspace.Id()
+        val firstToken = armed(first)
+        contributeUiHalf(firstToken, first)
+        stash.commitIdentity(snapshotOf(firstToken, first))
+        stash.disarm(firstToken)
+        stash.markDestructionComplete(firstToken)
+
+        val second = Workspace.Id()
+        val secondToken = armed(second)
+        contributeUiHalf(secondToken, second)
+        stash.commitIdentity(snapshotOf(secondToken, second))
+        stash.disarm(secondToken)
+        stash.markDestructionComplete(secondToken)
+        stash.feedback.value?.closeToken shouldBe secondToken
+
+        // A swipe that settles on the bar the superseding entry already replaced
+        stash.dismiss(firstToken)
+
+        stash.feedback.value?.closeToken shouldBe secondToken
+        stash.peekEntry() shouldNotBe null
+    }
+
+    @Test
     fun `a stashed entry names what it holds`() = runTest {
         val id = Workspace.Id()
         val token = armed(id)

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBar.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBar.kt
@@ -5,9 +5,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -23,13 +27,14 @@ import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.ui.SwipeToDismissItem
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceFeedback
 import eu.darken.butler.common.R as CommonR
 import eu.darken.butler.workspace.R as WorkspaceR
 
 /**
- * Names the tab that was just closed and offers to bring it back. Butler has no
- * [androidx.compose.material3.SnackbarHost] infrastructure, so this follows the existing
+ * Names the tab that was just closed and offers to bring it back, or to swipe it away. Butler has
+ * no [androidx.compose.material3.SnackbarHost] infrastructure, so this follows the existing
  * `FavoritesFeedbackBar` chrome convention: a card in a floating bar stack.
  *
  * The name is resolved here rather than by the stash: a user-set name overrides the automatic one,
@@ -40,43 +45,61 @@ fun WorkspaceClosedFeedbackBar(
     modifier: Modifier = Modifier,
     feedback: ClosedWorkspaceFeedback,
     onUndo: () -> Unit,
+    onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
     val label = feedback.customTitle ?: feedback.automaticTitle.get(context)
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .border(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-                shape = RoundedCornerShape(16.dp),
-            ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-        ),
+    SwipeToDismissItem(
+        modifier = modifier.fillMaxWidth(),
+        onDismiss = onDismiss,
+        dismissThreshold = 0.5f,
+        backgroundShape = RoundedCornerShape(16.dp),
+        backgroundColor = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        dismissContent = {
+            Icon(
+                imageVector = Icons.TwoTone.Close,
+                contentDescription = stringResource(CommonR.string.general_dismiss_action),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        },
     ) {
-        Row(
+        Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                    shape = RoundedCornerShape(16.dp),
+                ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            ),
         ) {
-            Text(
-                modifier = Modifier.weight(1f),
-                text = stringResource(WorkspaceR.string.workspace_closed_undo_message, label),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            TextButton(onClick = onUndo) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 Text(
-                    text = stringResource(CommonR.string.general_undo_action),
-                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.weight(1f),
+                    text = stringResource(WorkspaceR.string.workspace_closed_undo_message, label),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
+                TextButton(onClick = onUndo) {
+                    Text(
+                        text = stringResource(CommonR.string.general_undo_action),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                }
             }
         }
     }
@@ -94,6 +117,7 @@ private fun WorkspaceClosedFeedbackBarPreview() {
                 automaticTitle = "Downloads".toCaString(),
             ),
             onUndo = {},
+            onDismiss = {},
         )
     }
 }
@@ -110,6 +134,7 @@ private fun WorkspaceClosedFeedbackBarNamedPreview() {
                 automaticTitle = "Downloads".toCaString(),
             ),
             onUndo = {},
+            onDismiss = {},
         )
     }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBar.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBar.kt
@@ -5,21 +5,20 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.dismiss
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
@@ -53,21 +52,14 @@ fun WorkspaceClosedFeedbackBar(
         modifier = modifier.fillMaxWidth(),
         onDismiss = onDismiss,
         dismissThreshold = 0.5f,
-        backgroundShape = RoundedCornerShape(16.dp),
-        backgroundColor = MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        dismissContent = {
-            Icon(
-                imageVector = Icons.TwoTone.Close,
-                contentDescription = stringResource(CommonR.string.general_dismiss_action),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
-            )
-        },
+        // Snackbar convention: the bar travels with the finger and nothing is revealed behind it.
+        backgroundColor = Color.Transparent,
+        dismissContent = {},
     ) {
         Card(
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics { dismiss { onDismiss(); true } }
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -484,10 +484,16 @@ fun WorkspacesScreenHost(
                     position = BarPosition.BOTTOM,
                 ) {
                     FloatingBar(key = "workspace-closed-undo") {
-                        WorkspaceClosedFeedbackBar(
-                            feedback = feedback,
-                            onUndo = { vm.undoClose() },
-                        )
+                        // A superseding entry can reach composition without an intervening null,
+                        // which would leave the swipe state parked at the previous entry's
+                        // dismissed anchor - rendering the new bar as a bare swipe background.
+                        key(feedback.closeToken) {
+                            WorkspaceClosedFeedbackBar(
+                                feedback = feedback,
+                                onUndo = { vm.undoClose() },
+                                onDismiss = { vm.dismissClosedFeedback(feedback.closeToken) },
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -42,6 +42,7 @@ import eu.darken.butler.workspace.ui.LocalWorkspacePagerVisibility
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.core.undo.ClosedWorkspaceFeedback
 import eu.darken.butler.workspace.ui.dialogs.ClearSessionConfirmationDialog
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialogAction
@@ -57,6 +58,7 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceManagerScreen
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
 import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.manager.rememberWindowSizeInfo
@@ -483,18 +485,11 @@ fun WorkspacesScreenHost(
                     modifier = Modifier.align(Alignment.BottomCenter),
                     position = BarPosition.BOTTOM,
                 ) {
-                    FloatingBar(key = "workspace-closed-undo") {
-                        // A superseding entry can reach composition without an intervening null,
-                        // which would leave the swipe state parked at the previous entry's
-                        // dismissed anchor - rendering the new bar as a bare swipe background.
-                        key(feedback.closeToken) {
-                            WorkspaceClosedFeedbackBar(
-                                feedback = feedback,
-                                onUndo = { vm.undoClose() },
-                                onDismiss = { vm.dismissClosedFeedback(feedback.closeToken) },
-                            )
-                        }
-                    }
+                    WorkspaceClosedUndoBar(
+                        feedback = feedback,
+                        onUndo = { vm.undoClose() },
+                        onDismiss = { vm.dismissClosedFeedback(feedback.closeToken) },
+                    )
                 }
             }
         }
@@ -575,6 +570,30 @@ fun WorkspacesScreenHost(
                     onCloseSelected = { vm.onCloseSelectedFromLimitDialog(it) },
                 )
             }
+        }
+    }
+}
+
+/**
+ * The undo offer's bar declaration. Separate from its caller so a test drives the composition the
+ * app runs, key and all, rather than a re-declaration of it.
+ */
+@Composable
+internal fun FloatingBarScope.WorkspaceClosedUndoBar(
+    feedback: ClosedWorkspaceFeedback,
+    onUndo: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    FloatingBar(key = "workspace-closed-undo") {
+        // A superseding entry can reach composition without an intervening null, which would leave
+        // the swipe state parked at the previous entry's dismissed anchor - the new bar arrives
+        // already swiped away and takes no further gesture.
+        key(feedback.closeToken) {
+            WorkspaceClosedFeedbackBar(
+                feedback = feedback,
+                onUndo = onUndo,
+                onDismiss = onDismiss,
+            )
         }
     }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -582,6 +582,13 @@ class WorkspacesViewModel @Inject constructor(
         }
     }
 
+    // Not launched: dismiss is a plain synchronized call, and dispatching it asynchronously would
+    // let a superseding entry land between the swipe settling and the coroutine running.
+    fun dismissClosedFeedback(closeToken: Long) {
+        log(tag) { "dismissClosedFeedback($closeToken)" }
+        closedStash.dismiss(closeToken)
+    }
+
     fun dismissBanner(workspaceId: Workspace.Id) = launch {
         log(tag) { "dismissBanner($workspaceId)" }
         _bannerStates.update { it - workspaceId }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBarTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBarTest.kt
@@ -1,0 +1,131 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.undo.ClosedWorkspaceFeedback
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class WorkspaceClosedFeedbackBarTest : ComposeTest() {
+
+    private fun feedbackOf(closeToken: Long) = ClosedWorkspaceFeedback(
+        closeToken = closeToken,
+        customTitle = null,
+        automaticTitle = "Downloads".toCaString(),
+    )
+
+    @Test
+    fun `swipe left dismisses and does not undo`() {
+        var dismissCount = 0
+        var undoCount = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceClosedFeedbackBar(
+                    modifier = Modifier.testTag("bar"),
+                    feedback = feedbackOf(1L),
+                    onUndo = { undoCount++ },
+                    onDismiss = { dismissCount++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("bar").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+
+        dismissCount shouldBe 1
+        undoCount shouldBe 0
+    }
+
+    @Test
+    fun `swipe right dismisses and does not undo`() {
+        var dismissCount = 0
+        var undoCount = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceClosedFeedbackBar(
+                    modifier = Modifier.testTag("bar"),
+                    feedback = feedbackOf(1L),
+                    onUndo = { undoCount++ },
+                    onDismiss = { dismissCount++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("bar").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        dismissCount shouldBe 1
+        undoCount shouldBe 0
+    }
+
+    @Test
+    fun `tapping undo calls onUndo and does not dismiss`() {
+        var dismissCount = 0
+        var undoCount = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceClosedFeedbackBar(
+                    modifier = Modifier.testTag("bar"),
+                    feedback = feedbackOf(1L),
+                    onUndo = { undoCount++ },
+                    onDismiss = { dismissCount++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Undo").performClick()
+        composeTestRule.waitForIdle()
+
+        undoCount shouldBe 1
+        dismissCount shouldBe 0
+    }
+
+    @Test
+    fun `a superseding entry is swipeable`() {
+        val dismissedTokens = mutableListOf<Long>()
+        var feedback by mutableStateOf(feedbackOf(1L))
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                val entry = feedback
+                key(entry.closeToken) {
+                    WorkspaceClosedFeedbackBar(
+                        modifier = Modifier.testTag("bar"),
+                        feedback = entry,
+                        onUndo = {},
+                        onDismiss = { dismissedTokens += entry.closeToken },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("bar").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+        dismissedTokens shouldBe listOf(1L)
+
+        // The stash's flow conflates, so a newer entry can arrive without an intervening null
+        composeTestRule.runOnIdle { feedback = feedbackOf(2L) }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("bar").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+
+        dismissedTokens shouldBe listOf(1L, 2L)
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBarTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBarTest.kt
@@ -1,7 +1,6 @@
 package eu.darken.butler.workspace.ui.workspaces
 
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -15,6 +14,8 @@ import androidx.compose.ui.test.swipeRight
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceFeedback
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
@@ -96,6 +97,11 @@ class WorkspaceClosedFeedbackBarTest : ComposeTest() {
         dismissCount shouldBe 0
     }
 
+    /**
+     * Drives [WorkspaceClosedUndoBar] rather than the bar itself: the keying that makes a
+     * superseding entry swipeable lives there, so a test that declared its own key would pass
+     * against a production composable that had lost it.
+     */
     @Test
     fun `a superseding entry is swipeable`() {
         val dismissedTokens = mutableListOf<Long>()
@@ -104,9 +110,8 @@ class WorkspaceClosedFeedbackBarTest : ComposeTest() {
         composeTestRule.setContent {
             PreviewWrapper {
                 val entry = feedback
-                key(entry.closeToken) {
-                    WorkspaceClosedFeedbackBar(
-                        modifier = Modifier.testTag("bar"),
+                FloatingBarStack(position = BarPosition.BOTTOM) {
+                    WorkspaceClosedUndoBar(
                         feedback = entry,
                         onUndo = {},
                         onDismiss = { dismissedTokens += entry.closeToken },
@@ -115,7 +120,7 @@ class WorkspaceClosedFeedbackBarTest : ComposeTest() {
             }
         }
 
-        composeTestRule.onNodeWithTag("bar").performTouchInput { swipeLeft() }
+        composeTestRule.onNodeWithText(MESSAGE).performTouchInput { swipeLeft() }
         composeTestRule.waitForIdle()
         dismissedTokens shouldBe listOf(1L)
 
@@ -123,9 +128,13 @@ class WorkspaceClosedFeedbackBarTest : ComposeTest() {
         composeTestRule.runOnIdle { feedback = feedbackOf(2L) }
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithTag("bar").performTouchInput { swipeLeft() }
+        composeTestRule.onNodeWithText(MESSAGE).performTouchInput { swipeLeft() }
         composeTestRule.waitForIdle()
 
         dismissedTokens shouldBe listOf(1L, 2L)
+    }
+
+    companion object {
+        private const val MESSAGE = "Closed \"Downloads\""
     }
 }


### PR DESCRIPTION
## What changed

Closing a tab shows a bar offering to bring it back. Until now that bar only went away on its own after 8 seconds, and while it was up it covered the tab manager's "Add tab" button.

You can now swipe the bar away in either direction to dismiss it immediately. It moves with your finger the way a normal snackbar does: nothing is revealed behind it, no coloured panel and no close icon. Tapping "Undo" still restores the tab exactly as before, and the bar still disappears on its own if you ignore it.

Swiping the bar away is a dismissal, not an undo, so the tab stays closed.

## Technical Context

- The undo bar is not a Material `SnackbarHost` (this surface has none) but a card in the floating bar stack, so the swipe reuses the existing `SwipeToDismissItem` wrapper rather than introducing a new mechanism. That wrapper already fires its callback only after the gesture settles, which is what keeps a partially-completed swipe from leaking into the workspace pager.
- `ClosedWorkspaceStash.dismiss()` existed but was unusable from the UI: it drops whatever entry is pending, so a swipe settling just as a second tab close published its own entry would have destroyed the new tab's undo offer before the user ever saw it. A token-checked `dismiss(closeToken)` overload was added, mirroring the existing `consume(closeToken)`. The parameterless version stays for the clear-session path, which wants the unconditional drop.
- The ViewModel calls that overload directly rather than from a coroutine. It is a plain synchronized, non-suspending call, and dispatching it asynchronously would reopen the very window the token check closes.
- The bar is wrapped in `key(closeToken)`. The feedback flow conflates, so one entry can replace another with no intervening null; without the key the swipe state would persist across the swap and the replacement bar would arrive already swiped away and refuse further gestures. `WorkspaceClosedUndoBar` was extracted so the regression test drives the production composition including that key, rather than re-declaring it.
- Worth a close read: the `dismiss` overload's token guard in `ClosedWorkspaceStash`, and the `key(closeToken)` wrapper at the call site. Both exist for races that are easy to reintroduce and hard to notice.
- Manual on-device checking covered what unit tests cannot: that a swipe genuinely dismisses the bar rather than the 8s timer doing it (distinguished via the stash's own log output), and that a timeout firing mid-gesture leaves the tab set untouched.
