### PR TITLE
Bugreport: Resume an interrupted debug recording after a restart

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRecorder.kt
@@ -46,8 +46,10 @@ import kotlin.uuid.Uuid
  * report's directory in the unified store ([BugReportStorage]).
  *
  * `meta.json` is written at START, so even a crash mid-recording leaves a complete report directory;
- * a `.recording` sentinel marks the report as ongoing while the logger is attached. On the next
- * launch, [sweepOrphanedSentinels] finalizes any interrupted recording (no resume).
+ * a `.recording` sentinel marks the report as ongoing while the logger is attached. The sentinel
+ * doubles as the resume marker: on the next main-process launch, [recoverInterruptedRecording]
+ * reattaches to a recording interrupted by process death (force stop, crash, system kill) and keeps
+ * appending to its `report.log`, so the reproduction the user was capturing is not silently cut off.
  *
  * Lives in app-common so the bug-report workspace module (which cannot depend on `:app`) can drive
  * recording. Does NOT depend on [BugReportRepo] (the repo observes this recorder, not vice versa).
@@ -75,16 +77,26 @@ class BugReportRecorder @Inject constructor(
     internal var wallClock: () -> kotlin.time.Instant = { Clock.System.now() }
     internal var monotonicClock: () -> Long = android.os.SystemClock::elapsedRealtime
 
+    // Test seam for the recovery process gate: the JVM test process name is not the package name.
+    internal var processName: () -> String? = { currentProcessName() }
+
     private val mutex = Mutex()
     private var fileLogger: FileLogger? = null
 
     /**
      * Monotonic base for the duration heuristic, guarded by [mutex] like [fileLogger]. Deliberately
      * NOT part of the public [State]: no consumer measures duration itself (they all render the wall
-     * stamp), and there is no resume — an interrupted recording is finalized by
-     * [sweepOrphanedSentinels], never continued, so no monotonic base ever has to survive a process.
+     * stamp). A resumed recording gets a fresh base in the new process and waives the minimum
+     * instead ([minDurationWaived]) — the pre-death portion cannot be measured monotonically.
      */
     private var startedAtMonotonicMs: Long = 0L
+
+    /**
+     * Set for resumed recordings: the session spans a process death, so it either already met the
+     * minimum before dying or the death itself is the evidence — warning "too short" right after
+     * reopening would be a false positive.
+     */
+    private var minDurationWaived: Boolean = false
 
     private val internalState = MutableStateFlow(State())
     val state: StateFlow<State> = internalState.asStateFlow()
@@ -124,6 +136,7 @@ class BugReportRecorder @Inject constructor(
             // Committed before the session infos are logged: those reads take seconds, and until the
             // id is published the finished report directory on disk has nothing marking it as live.
             startedAtMonotonicMs = startedAtMonotonic
+            minDurationWaived = false
             internalState.value = State(
                 isRecording = true,
                 recordingId = id,
@@ -149,7 +162,7 @@ class BugReportRecorder @Inject constructor(
         // time). State.startedAtMs stays wall — that is the stamp the banner, the contact form and
         // the bug-report workspace render, and it is not what this heuristic measures.
         val elapsed = monotonicClock() - startedAtMonotonicMs
-        if (elapsed < MIN_RECORDING_MS) return@withLock StopResult.TooShort
+        if (!minDurationWaived && elapsed < MIN_RECORDING_MS) return@withLock StopResult.TooShort
         val id = current.recordingId
         stopInternal()
         if (id != null) StopResult.Stopped(id) else StopResult.NotRecording
@@ -180,9 +193,22 @@ class BugReportRecorder @Inject constructor(
         fileLogger = null
         recorderPathPublisher.publish(null)
         startedAtMonotonicMs = 0L
+        minDurationWaived = false
         val id = internalState.value.recordingId
         if (id != null) {
-            runCatching { File(File(storageLayout.writeRoot, id), BugReportStorage.RECORDING_SENTINEL).delete() }
+            // Every root: a resumed recording can live in the legacy private root. A sentinel that
+            // survives a clean stop would resurrect the recording on the next launch (recovery still
+            // guards on the log's clean END line, but that is the fallback, not the plan).
+            storageLayout.allReportDirs(id).forEach { dir ->
+                val sentinel = File(dir, BugReportStorage.RECORDING_SENTINEL)
+                try {
+                    if (sentinel.exists() && !sentinel.delete()) {
+                        log(TAG, ERROR) { "Could not remove recording sentinel: $sentinel" }
+                    }
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Could not remove recording sentinel $sentinel: ${e.asLog()}" }
+                }
+            }
         }
         internalState.value = State()
     }
@@ -201,37 +227,132 @@ class BugReportRecorder @Inject constructor(
     }
 
     /**
-     * Finalize any recording interrupted by process death: drop `.recording` sentinels (the dir is
-     * already a complete report) and delete incomplete recording dirs that never got a `report.log`.
+     * Resume the recording interrupted by process death, if there is one: the newest sentinel-bearing
+     * recording whose log does NOT end with [FileLogger.END_MARKER] gets its [FileLogger] reattached
+     * (append mode, so its `=== BEGIN ===` header marks the process boundary in the log). Any other
+     * leftover sentinel is finalized (the dir is already a complete report): a clean-END log means a
+     * stop whose sentinel delete failed, and only one recording can ever be live. Recording dirs that
+     * never got a `report.log` are deleted.
      *
-     * MAIN PROCESS ONLY — an isolated process must never finalize the main process's live recording.
-     * Runs under [mutex] and skips the currently-active recording id so it can never race [start] and
-     * tear down a live recording (e.g. if init cleanup is delayed past a user-initiated start).
+     * MAIN PROCESS ONLY, fail-closed — the `:isolated` process constructs this class too and must
+     * neither resume nor finalize the main process's recording. Runs under [mutex] and skips the
+     * currently-active recording id so it can never race [start] and tear down a live recording
+     * (e.g. if init cleanup is delayed past a user-initiated start).
      */
-    suspend fun sweepOrphanedSentinels() = mutex.withLock {
-        if (!isMainProcess()) return@withLock
+    suspend fun recoverInterruptedRecording() = mutex.withLock {
+        if (processName() != context.packageName) return@withLock
         val activeId = internalState.value.recordingId
-        // Every root: a sentinel left behind by a version that still wrote to the private root would
-        // otherwise stay forever, and a sentinel-bearing directory is skipped by deleteAll().
+
+        val candidates = mutableListOf<Pair<File, BugReport>>()
+        val seenIds = mutableSetOf<String>()
         storageLayout.roots.forEach { root ->
             root.listFiles()?.forEach { dir ->
                 if (!dir.isDirectory) return@forEach
                 if (dir.name.startsWith(BugReportStorage.TMP_PREFIX)) return@forEach
                 if (!dir.name.startsWith(BugReportStorage.RECORDING_ID_PREFIX)) return@forEach
                 if (dir.name == activeId) return@forEach
+                // First root wins, matching scan(): a sentinel on a shadowed copy must never resume
+                // it — logging would append to a copy the report list is not showing.
+                val shadowed = !seenIds.add(dir.name)
                 val logFile = File(dir, BugReportStorage.LOG_FILE)
-                if (logFile.exists()) {
-                    val sentinel = File(dir, BugReportStorage.RECORDING_SENTINEL)
-                    if (sentinel.exists()) {
-                        runCatching { sentinel.delete() }
-                        log(TAG, WARN) { "Finalized interrupted recording: ${dir.name}" }
-                    }
-                } else {
+                if (!logFile.exists()) {
                     // Died between meta.json and report.log creation — incomplete, never surfaceable.
                     runCatching { dir.deleteRecursively() }
                     log(TAG, WARN) { "Dropped incomplete recording dir: ${dir.name}" }
+                    return@forEach
+                }
+                if (!File(dir, BugReportStorage.RECORDING_SENTINEL).exists()) return@forEach
+                val meta = readResumableMeta(dir)
+                if (shadowed || meta == null || endsCleanly(logFile)) {
+                    finalize(dir)
+                } else {
+                    candidates += dir to meta
                 }
             }
+        }
+
+        // A user-initiated start that won the race owns the session — leftovers only get finalized.
+        if (activeId != null) {
+            candidates.forEach { (dir, _) -> finalize(dir) }
+            return@withLock
+        }
+
+        // Newest wins; the sort is stable, so between equal stamps the earlier root wins — the same
+        // precedence scan() applies when an id exists in both roots.
+        val byAge = candidates.sortedByDescending { (_, meta) -> meta.createdAt }
+        byAge.drop(1).forEach { (dir, _) -> finalize(dir) }
+        byAge.firstOrNull()?.let { (dir, meta) -> resume(dir, meta) }
+    }
+
+    /** The recording's metadata, or null if it cannot be safely appended to under [dir]'s name. */
+    private fun readResumableMeta(dir: File): BugReport? {
+        val meta = try {
+            json.decodeFromString(BugReport.serializer(), File(dir, BugReportStorage.META_FILE).readText())
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Unreadable meta in ${dir.name}: ${e.message}" }
+            return null
+        }
+        if (meta.type != BugReport.Type.RECORDING) return null
+        if (meta.id != dir.name) return null
+        return meta
+    }
+
+    /** Whether the log's last non-blank line is [FileLogger.END_MARKER]; bounded tail read. */
+    private fun endsCleanly(logFile: File): Boolean = try {
+        java.io.RandomAccessFile(logFile, "r").use { raf ->
+            val readSize = minOf(raf.length(), END_PROBE_BYTES)
+            raf.seek(raf.length() - readSize)
+            val tail = ByteArray(readSize.toInt())
+            raf.readFully(tail)
+            tail.decodeToString().lineSequence().lastOrNull { it.isNotBlank() } == FileLogger.END_MARKER
+        }
+    } catch (e: Exception) {
+        log(TAG, WARN) { "Could not read log tail of $logFile: ${e.asLog()}" }
+        false
+    }
+
+    private fun finalize(dir: File) {
+        val sentinel = File(dir, BugReportStorage.RECORDING_SENTINEL)
+        try {
+            if (!sentinel.exists() || sentinel.delete()) {
+                log(TAG, WARN) { "Finalized interrupted recording: ${dir.name}" }
+            } else {
+                log(TAG, ERROR) { "Could not finalize recording, sentinel not deletable: $sentinel" }
+            }
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Could not finalize recording $sentinel: ${e.asLog()}" }
+        }
+    }
+
+    /** Reattach to an interrupted recording. Caller holds [mutex]. */
+    private suspend fun resume(reportDir: File, meta: BugReport) {
+        try {
+            val logFile = File(reportDir, BugReportStorage.LOG_FILE)
+            val logger = FileLogger(logFile, worldReadable = false)
+            if (!logger.start()) {
+                log(TAG, ERROR) { "FileLogger could not reattach for ${meta.id}, finalizing instead" }
+                finalize(reportDir)
+                return
+            }
+            Logging.install(logger)
+            fileLogger = logger
+            recorderPathPublisher.publish(reportDir.path)
+
+            startedAtMonotonicMs = monotonicClock()
+            minDurationWaived = true
+            internalState.value = State(
+                isRecording = true,
+                recordingId = meta.id,
+                startedAtMs = meta.createdAt.toEpochMilliseconds(),
+                currentLogSize = logFile.length(),
+            )
+            startLogSizeUpdates(reportDir)
+
+            log(TAG, INFO) { "Recording resumed after process death: ${meta.id}" }
+            logSessionInfos()
+        } catch (e: Throwable) {
+            log(TAG, ERROR) { "resume() failed for ${meta.id}: ${e.asLog()}" }
+            runCatching { stopInternal() }
         }
     }
 
@@ -301,11 +422,6 @@ class BugReportRecorder @Inject constructor(
      */
     private class HeaderRead<T>(val value: T)
 
-    private fun isMainProcess(): Boolean {
-        val name = currentProcessName() ?: return true // best-effort: assume main if undetermined
-        return name == context.packageName
-    }
-
     private fun currentProcessName(): String? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) return Application.getProcessName()
         val pid = android.os.Process.myPid()
@@ -350,5 +466,8 @@ class BugReportRecorder @Inject constructor(
 
         // Diagnostics read local storage only; a longer wait would just delay the recording start.
         private val DIAGNOSTICS_TIMEOUT = 5.seconds
+
+        // Comfortably covers the END marker plus a torn trailing line.
+        private const val END_PROBE_BYTES = 4096L
     }
 }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -76,10 +76,12 @@ class BugReportRepo @Inject constructor(
         appScope.launch(dispatcherProvider.IO) {
             try {
                 reapStaleTempDirs()
-                bugReportRecorder.sweepOrphanedSentinels()
+                // Before prune(): a resumed recording must be claimed (or its leftovers finalized)
+                // before retention decisions are made.
+                bugReportRecorder.recoverInterruptedRecording()
                 prune()
-                // Cleanup may have dropped sentinels/dirs after an early scan already ran; make sure
-                // collectors re-scan so an interrupted recording stops showing as ongoing.
+                // Cleanup may have changed dirs after an early scan already ran; make sure collectors
+                // re-scan so the list reflects the recovered/finalized state.
                 refresh()
             } catch (e: Exception) {
                 log(TAG, WARN) { "Initial cleanup failed: ${e.asLog()}" }
@@ -209,7 +211,10 @@ class BugReportRepo @Inject constructor(
      * when compression throws — a half-written `<id>.zip` would then be shared as if it were whole.
      */
     suspend fun buildShareZip(id: String): File = withContext(dispatcherProvider.IO) {
-        require(id != bugReportRecorder.state.value.recordingId) { "Cannot share an active recording" }
+        // Via the recorder mutex, not a bare state read: during the startup window an interrupted
+        // recording is listed as shareable while recovery may be about to reattach to it — this
+        // blocks until recovery has claimed or finalized it and then reflects the outcome.
+        require(!bugReportRecorder.isActiveOrStarting(id)) { "Cannot share an active recording" }
         val files = resolveReportDir(id)?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
         require(files.isNotEmpty()) { "No report files for $id" }
 
@@ -341,9 +346,9 @@ class BugReportRepo @Inject constructor(
                 }
                 val logFile = File(dir, BugReportStorage.LOG_FILE)
                 // "Ongoing" is tied to the live recorder, not just the sentinel: a recording interrupted
-                // by process death keeps a stale sentinel until the init sweep clears it, but it is a
-                // complete, surfaceable report — so it shows as a normal report immediately instead of
-                // vanishing from the list during the brief startup-cleanup window.
+                // by process death keeps its sentinel until startup recovery resumes or finalizes it, but
+                // it is a complete, surfaceable report — so it shows as a normal report immediately
+                // instead of vanishing from the list during the brief startup-recovery window.
                 val isOngoing = File(dir, BugReportStorage.RECORDING_SENTINEL).exists() &&
                     dir.name == bugReportRecorder.state.value.recordingId
                 byId[report.id] = BugReportInfo(
@@ -375,8 +380,13 @@ class BugReportRepo @Inject constructor(
     }
 
     private fun prune() {
-        // Never prune the active recording, even if it would otherwise be the oldest.
-        val valid = scan().filter { !it.isOngoingRecording }
+        // Never prune the active recording, even if it would otherwise be the oldest. Guarded by the
+        // on-disk sentinel, not just recorder state: this also runs in the :isolated process, where
+        // recorder state is empty for a recording the main process owns.
+        val valid = scan().filter { info ->
+            !info.isOngoingRecording && storageLayout.allReportDirs(info.id)
+                .none { File(it, BugReportStorage.RECORDING_SENTINEL).exists() }
+        }
         if (valid.size <= MAX_REPORTS) return
         valid.drop(MAX_REPORTS).forEach { stale ->
             storageLayout.allReportDirs(stale.id).forEach { it.deleteRecursively() }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
@@ -34,7 +34,11 @@ object BugReportStorage {
 
     const val SEEN_MARKER = ".seen"
 
-    /** Present only while a [BugReport.Type.RECORDING] report is actively being written. */
+    /**
+     * Present only while a [BugReport.Type.RECORDING] report is actively being written. Doubles as
+     * the resume marker: if it survives a process death, the next main-process launch reattaches to
+     * the recording ([BugReportRecorder.recoverInterruptedRecording]).
+     */
     const val RECORDING_SENTINEL = ".recording"
 
     const val RECORDING_ID_PREFIX = "recording_"

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/RecorderPathPublisher.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/RecorderPathPublisher.kt
@@ -12,9 +12,10 @@ import javax.inject.Singleton
  * `report.log`.
  *
  * An output channel, never a resume marker: [BugReportRecorder] alone decides whether a recording is
- * live, via the `.recording` sentinel. Deliberately process-local and never persisted, so a fresh
- * process starts at `null` even if a recording was interrupted by process death, and so publishing
- * can neither suspend nor fail (a write that throws would abort an otherwise working recording).
+ * live, via the `.recording` sentinel, and republishes the path here once it has claimed a session
+ * (fresh start or startup resume). Deliberately process-local and never persisted, so a fresh
+ * process starts at `null` until the recorder has claimed one, and so publishing can neither suspend
+ * nor fail (a write that throws would abort an otherwise working recording).
  */
 @Singleton
 class RecorderPathPublisher @Inject constructor() {

--- a/app-common/src/main/java/eu/darken/butler/common/debug/logging/FileLogger.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/logging/FileLogger.kt
@@ -26,9 +26,11 @@ class FileLogger(
     fun start(): Boolean {
         if (logWriter != null) return true
         Log.i(TAG, "Starting logger for " + logFile.path)
+        var createdByUs = false
         try {
             logFile.parentFile!!.mkdirs()
-            if (logFile.createNewFile()) Log.i(TAG, "File logger writing to ${logFile.path}")
+            createdByUs = logFile.createNewFile()
+            if (createdByUs) Log.i(TAG, "File logger writing to ${logFile.path}")
             if (worldReadable) {
                 if (logFile.setReadable(true, false)) Log.i(TAG, "Debug run log read permission set")
                 if (logFile.setWritable(true, false)) Log.i(TAG, "Debug run log write permission set")
@@ -54,7 +56,9 @@ class FileLogger(
             } catch (ignore: IOException) {
             }
             logWriter = null
-            logFile.delete()
+            // A pre-existing file may hold a recording accumulated before a resume attempt — a
+            // failed (re)start must not destroy it. Only remove what this start created.
+            if (createdByUs) logFile.delete()
             false
         }
     }
@@ -64,7 +68,7 @@ class FileLogger(
         logWriter?.let {
             logWriter = null
             try {
-                it.write("=== END ===\n")
+                it.write("$END_MARKER\n")
                 it.close()
             } catch (ignore: IOException) {
             }
@@ -92,6 +96,9 @@ class FileLogger(
 
     companion object {
         private val TAG = logTag("Debug", "FileLogger")
+
+        /** Last line of a cleanly stopped log; its absence marks a log cut off by process death. */
+        const val END_MARKER = "=== END ==="
     }
 }
 

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRecorderTest.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.upgrade.UpgradeDiagnostics
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -53,6 +54,8 @@ class BugReportRecorderTest : BaseTest() {
         @Volatile var monotonic: Long = MONOTONIC_BASE,
     )
 
+    private val json = Json { ignoreUnknownKeys = true }
+
     private fun createRecorder(
         appScope: CoroutineScope,
         clocks: TestClocks,
@@ -62,13 +65,41 @@ class BugReportRecorderTest : BaseTest() {
         appScope = appScope,
         dispatcherProvider = TestDispatcherProvider(),
         butlerId = ButlerId(context),
-        json = Json { ignoreUnknownKeys = true },
+        json = json,
         storageLayout = storageLayout,
         recorderPathPublisher = recorderPathPublisher,
         upgradeDiagnostics = upgradeDiagnostics,
     ).apply {
         wallClock = { clocks.wall }
         monotonicClock = { clocks.monotonic }
+        // The JVM test process is not the app's main process; recovery fails closed without this.
+        processName = { context.packageName }
+    }
+
+    /** An on-disk recording as process death leaves it: meta + log + sentinel. */
+    private fun writeInterruptedRecording(
+        id: String,
+        root: File = reportsDir,
+        createdAt: Instant = WALL_BASE,
+        logText: String = "pre-death line\n",
+    ): File {
+        val dir = File(root, id).apply { mkdirs() }
+        val report = BugReport(
+            id = id,
+            createdAt = createdAt,
+            type = BugReport.Type.RECORDING,
+            appVersion = "1.0",
+            deviceFingerprint = "fp",
+            apiLevel = "29",
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            installId = "iid",
+            locale = "en",
+        )
+        File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
+        File(dir, "report.log").writeText(logText)
+        File(dir, ".recording").createNewFile()
+        return dir
     }
 
     /**
@@ -380,38 +411,149 @@ class BugReportRecorderTest : BaseTest() {
     }
 
     @Test
-    fun `sweep finalizes an interrupted recording and drops an incomplete one`() = runTest {
-        // Interrupted-but-complete: meta + log + dangling sentinel.
-        val interrupted = File(reportsDir, "recording_1_aaaa").apply { mkdirs() }
-        File(interrupted, "meta.json").writeText("{}")
-        File(interrupted, "report.log").writeText("x")
-        File(interrupted, ".recording").createNewFile()
+    fun `recovery finalizes an unresumable recording and drops an incomplete one`() = runTest {
+        // Sentinel present but the meta is unreadable: never append to it, finalize instead.
+        val unresumable = File(reportsDir, "recording_1_aaaa").apply { mkdirs() }
+        File(unresumable, "meta.json").writeText("{}")
+        File(unresumable, "report.log").writeText("x")
+        File(unresumable, ".recording").createNewFile()
 
         // Incomplete: meta written but log never created.
         val incomplete = File(reportsDir, "recording_2_bbbb").apply { mkdirs() }
         File(incomplete, "meta.json").writeText("{}")
 
         // No recorder is started here, so this needs neither the clock fakes nor the leak harness.
-        createRecorder(CoroutineScope(Dispatchers.Unconfined), TestClocks()).sweepOrphanedSentinels()
+        createRecorder(CoroutineScope(Dispatchers.Unconfined), TestClocks()).recoverInterruptedRecording()
 
-        interrupted.exists() shouldBe true
-        File(interrupted, ".recording").exists() shouldBe false
+        unresumable.exists() shouldBe true
+        File(unresumable, ".recording").exists() shouldBe false
         incomplete.exists() shouldBe false
     }
 
     @Test
-    fun `sweep finalizes an interrupted recording in the legacy root`() = runTest {
+    fun `recovery finalizes an unresumable recording in the legacy root`() = runTest {
         // Written by a version that still recorded into filesDir: deleteAll() skips a directory with a
-        // sentinel, so a sweep that only looks at the write root would leave this one undeletable.
-        val interrupted = File(privateReportsDir, "recording_5_eeee").apply { mkdirs() }
-        File(interrupted, "meta.json").writeText("{}")
-        File(interrupted, "report.log").writeText("x")
-        File(interrupted, ".recording").createNewFile()
+        // sentinel, so recovery that only looks at the write root would leave this one undeletable.
+        val unresumable = File(privateReportsDir, "recording_5_eeee").apply { mkdirs() }
+        File(unresumable, "meta.json").writeText("{}")
+        File(unresumable, "report.log").writeText("x")
+        File(unresumable, ".recording").createNewFile()
 
-        createRecorder(CoroutineScope(Dispatchers.Unconfined), TestClocks()).sweepOrphanedSentinels()
+        createRecorder(CoroutineScope(Dispatchers.Unconfined), TestClocks()).recoverInterruptedRecording()
 
-        interrupted.exists() shouldBe true
-        File(interrupted, ".recording").exists() shouldBe false
+        unresumable.exists() shouldBe true
+        File(unresumable, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `recovery resumes an interrupted recording`() = withRecorder { recorder ->
+        val id = "recording_10_rrrr"
+        val dir = writeInterruptedRecording(id, createdAt = WALL_BASE)
+
+        recorder.recoverInterruptedRecording()
+
+        val state = recorder.state.value
+        state.isRecording shouldBe true
+        state.recordingId shouldBe id
+        // The wall stamp is the logical recording's start, not the resume moment.
+        state.startedAtMs shouldBe WALL_BASE.toEpochMilliseconds()
+        recorderPathPublisher.path.value shouldBe dir.path
+        File(dir, ".recording").exists() shouldBe true
+        // Appended, not truncated: the pre-death log survives and the reattach header marks the seam.
+        val logText = File(dir, "report.log").readText()
+        logText shouldContain "pre-death line"
+        logText shouldContain "=== BEGIN"
+    }
+
+    @Test
+    fun `a resumed recording can be stopped immediately`() = withRecorder { recorder ->
+        // The session spans a process death — it was either already long enough or the death is the
+        // evidence. The short-recording prompt right after reopening would be a false positive.
+        val dir = writeInterruptedRecording("recording_11_ssss")
+
+        recorder.recoverInterruptedRecording()
+        recorder.requestStop().shouldBeInstanceOf<BugReportRecorder.StopResult.Stopped>()
+
+        recorder.state.value.isRecording shouldBe false
+        File(dir, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `recovery ignores a cleanly stopped recording with a leftover sentinel`() = withRecorder { recorder ->
+        // A clean stop writes the END marker before removing the sentinel; if the removal failed, the
+        // marker tells recovery this is not an interrupted recording.
+        val dir = writeInterruptedRecording("recording_12_tttt", logText = "line\n=== END ===\n")
+
+        recorder.recoverInterruptedRecording()
+
+        recorder.state.value.isRecording shouldBe false
+        dir.exists() shouldBe true
+        File(dir, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `recovery resumes the newest recording and finalizes older leftovers`() = withRecorder { recorder ->
+        val older = writeInterruptedRecording("recording_13_uuuu", createdAt = WALL_BASE - 1.hours)
+        val newer = writeInterruptedRecording("recording_14_vvvv", createdAt = WALL_BASE)
+
+        recorder.recoverInterruptedRecording()
+
+        recorder.state.value.recordingId shouldBe "recording_14_vvvv"
+        File(newer, ".recording").exists() shouldBe true
+        older.exists() shouldBe true
+        File(older, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `recovery does not disturb an active recording`() = withRecorder { recorder ->
+        recorder.start()
+        val activeId = recorder.state.value.recordingId!!
+        val leftover = writeInterruptedRecording("recording_15_wwww")
+
+        recorder.recoverInterruptedRecording()
+
+        recorder.state.value.recordingId shouldBe activeId
+        File(leftover, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `stop clears the sentinel of a recording resumed from the legacy root`() = withRecorder { recorder ->
+        val dir = writeInterruptedRecording("recording_16_xxxx", root = privateReportsDir)
+
+        recorder.recoverInterruptedRecording()
+        recorder.state.value.recordingId shouldBe "recording_16_xxxx"
+
+        recorder.forceStop()
+
+        File(dir, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `recovery never resumes a shadowed copy`() = withRecorder { recorder ->
+        // The same id in both roots, but only the legacy copy carries the sentinel. scan() surfaces
+        // the external copy, so resuming the legacy one would append to a report nobody is shown.
+        val external = writeInterruptedRecording("recording_18_zzzz")
+        File(external, ".recording").delete()
+        val legacy = writeInterruptedRecording("recording_18_zzzz", root = privateReportsDir)
+
+        recorder.recoverInterruptedRecording()
+
+        recorder.state.value.isRecording shouldBe false
+        File(legacy, ".recording").exists() shouldBe false
+    }
+
+    @Test
+    fun `recovery fails closed outside the main process`() = withRecorder(
+        configure = { processName = { "eu.darken.butler:isolated" } },
+    ) { recorder ->
+        // The :isolated process constructs the recorder too; it must neither resume nor finalize the
+        // main process's recording.
+        val dir = writeInterruptedRecording("recording_17_yyyy")
+
+        recorder.recoverInterruptedRecording()
+
+        recorder.state.value.isRecording shouldBe false
+        File(dir, ".recording").exists() shouldBe true
     }
 
     private class RecordingLogger : Logging.Logger {

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -157,6 +157,26 @@ class BugReportRepoTest : BaseTest() {
     }
 
     @Test
+    fun `retention never prunes a sentinel-bearing recording even when the recorder looks idle`() = runTest {
+        val repo = createRepo()
+        val base = kotlin.time.Clock.System.now()
+        // Oldest report of all, sentinel on disk, recorder state empty — the :isolated process view
+        // of a recording the main process owns. Without the sentinel guard it is first to be pruned.
+        writeReportDir(
+            "recording_8_hhhh",
+            BugReport.Type.RECORDING,
+            ongoing = true,
+            createdAt = base - 100.seconds,
+        )
+        repeat(30) { writeReportDir("filler_$it", createdAt = base - (30 - it).seconds) }
+
+        repo.captureReport(IllegalStateException("boom"))
+
+        repo.reports.first() shouldHaveSize 26
+        File(reportsDir, "recording_8_hhhh").exists() shouldBe true
+    }
+
+    @Test
     fun `ongoing recording is surfaced with isOngoingRecording flag`() = runTest {
         val repo = createRepo()
         writeReportDir("recording_1_aaaa", BugReport.Type.RECORDING, ongoing = true)
@@ -225,6 +245,17 @@ class BugReportRepoTest : BaseTest() {
 
         File(reportsDir, "recording_7_gggg").exists() shouldBe false
         repo.reports.first() shouldHaveSize 0
+    }
+
+    @Test
+    fun `buildShareZip refuses a recording the recorder is about to claim`() = runTest {
+        val repo = createRepo()
+        // The startup-recovery window: the report is listed as complete while the recorder has not
+        // published the id yet. The share guard goes through the recorder mutex, so it must reject.
+        writeReportDir("recording_9_iiii", BugReport.Type.RECORDING, ongoing = true)
+        startingRecordingIds += "recording_9_iiii"
+
+        shouldThrow<IllegalArgumentException> { repo.buildShareZip("recording_9_iiii") }
     }
 
     @Test

--- a/app-common/src/test/java/eu/darken/butler/common/debug/logging/FileLoggerTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/logging/FileLoggerTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.butler.common.debug.logging
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.io.File
+import java.nio.file.Files
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class FileLoggerTest : BaseTest() {
+
+    @Test
+    fun `a failed start preserves a pre-existing log file`() {
+        // The resume path reattaches to a log that already holds the pre-death recording; a failed
+        // reattach must not destroy it.
+        val dir = Files.createTempDirectory("filelogger-test").toFile()
+        val logFile = File(dir, "report.log").apply { writeText("precious pre-death log") }
+        logFile.setWritable(false)
+        try {
+            val logger = FileLogger(logFile, worldReadable = false)
+
+            logger.start() shouldBe false
+
+            logFile.exists() shouldBe true
+            logFile.readText() shouldBe "precious pre-death log"
+        } finally {
+            logFile.setWritable(true)
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `start appends to an existing log file`() {
+        val dir = Files.createTempDirectory("filelogger-test").toFile()
+        val logFile = File(dir, "report.log").apply { writeText("existing line\n") }
+        try {
+            val logger = FileLogger(logFile, worldReadable = false)
+
+            logger.start() shouldBe true
+            logger.stop()
+
+            val content = logFile.readText()
+            content.startsWith("existing line\n") shouldBe true
+            content.contains("=== BEGIN") shouldBe true
+            content.trimEnd().endsWith(FileLogger.END_MARKER) shouldBe true
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Force stopping the app (or a crash or system kill) while a debug recording is running no longer silently ends the recording. On the next launch Butler reattaches to it: the recording banner and the Bug reports workspace show it as ongoing again, new log lines append to the same report, and the recording keeps its original start time. Stopping right after such a restart skips the "recording too short" warning, since the session already spans a process death.

## Technical Context

- Root cause: the unified bug-report system finalized interrupted recordings on the next launch instead of resuming them, dropping the old recorder's resume behavior. The `.recording` sentinel now doubles as the resume marker; startup recovery reattaches the file logger in append mode (main-process only, fail-closed on an undetermined process name).
- A log whose last line is the clean end marker is treated as a stop whose sentinel deletion failed and is finalized, never resumed. With several leftover sentinels only the newest valid recording resumes; shadowed same-id copies in the legacy storage root are finalized, matching the report list's root precedence.
- Fixes latent issues resume exposes: a failed logger (re)start no longer deletes a pre-existing log file, stop clears the sentinel in every storage root, retention pruning skips sentinel-bearing reports (the `:isolated` process could otherwise prune the main process's live recording), and sharing guards through the recorder mutex to close a startup race window.
- Deserves close review: candidate selection in the recovery pass (root precedence, active-recording guard) and the waived minimum-duration path.
