### PR TITLE
Editor: Say a file is gone instead of showing an error

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathGoneError.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathGoneError.kt
@@ -1,0 +1,19 @@
+package eu.darken.butler.common.files.errors
+
+import eu.darken.butler.common.error.HasLocalizedError
+
+/**
+ * Marks a failure as "the target is gone", i.e. the operation failed because the thing itself no
+ * longer exists rather than because something went wrong reaching it.
+ *
+ * A marker rather than a base class: the implementors deliberately disagree on details a shared
+ * supertype would have to settle. [PathNotFoundException] is cause-less so the classifier cannot
+ * re-find the failure it replaced, while a workspace-local variant may want to keep the original
+ * error, and not every one of them has an [eu.darken.butler.common.files.APath] to point at.
+ *
+ * Renderers use this to pick the "it's gone" presentation without knowing any concrete type. The
+ * [HasLocalizedError] requirement is what makes that safe: the shared screen shows nothing but the
+ * implementor's own wording, and the generic fallback it would otherwise land on puts the exception
+ * class name in the title - the exact thing this presentation exists to avoid.
+ */
+interface PathGoneError : HasLocalizedError

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathNotFoundException.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathNotFoundException.kt
@@ -1,6 +1,11 @@
 package eu.darken.butler.common.files.errors
 
+import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.error.LocalizedError
+import eu.darken.butler.common.error.LocalizedErrorContext
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.io.R
 
 /**
  * The path is positively known not to exist, as opposed to being unreadable.
@@ -11,4 +16,18 @@ import eu.darken.butler.common.files.APath
  */
 class PathNotFoundException(
     path: APath<*>,
-) : ReadException(message = "Path does not exist", path = path)
+) : ReadException(message = "Path does not exist", path = path), PathGoneError {
+
+    // Without this the inherited label renders as the literal class name "ReadException".
+    override fun getLocalizedError(context: LocalizedErrorContext) = LocalizedError(
+        throwable = this,
+        label = R.string.path_action_not_found_title.toCaString(),
+        description = caString {
+            val resolved = path!!
+            it.getString(
+                R.string.path_action_not_found_description,
+                resolved.name.ifBlank { resolved.path },
+            )
+        },
+    )
+}

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
@@ -4,7 +4,7 @@ import eu.darken.butler.common.ElevatedAccessUnavailableException
 import eu.darken.butler.common.error.causeChain
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
 import eu.darken.butler.common.files.errors.PathException
-import eu.darken.butler.common.files.errors.PathNotFoundException
+import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
 import java.io.IOException
@@ -48,8 +48,13 @@ object PermissionErrorClassifier {
         // Pass 4: Generic permission-style exception types without a more specific message.
         for (t in error.causeChain) {
             when (t) {
-                // A path that isn't there is not a path we were kept out of.
-                is PathNotFoundException -> return null
+                // A path that isn't there is not a path we were kept out of. Keyed on the marker
+                // rather than one concrete type, so a gone-error that is also a PathException does
+                // not fall through to the denial below. Like every branch in this loop it answers
+                // for the first chain link that matches, so a marker nested UNDER a generic
+                // PathException wrapper does not veto - the wrapper is reached first. No producer
+                // wraps one today; both are thrown at the top level.
+                is PathGoneError -> return null
                 is PathException -> return Reason.ACCESS_DENIED
                 is SecurityException -> return Reason.ACCESS_DENIED
                 is java.nio.file.AccessDeniedException -> return Reason.ACCESS_DENIED

--- a/app-common-io/src/main/res/values/strings.xml
+++ b/app-common-io/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="path_action_file_exists_description">A file named \"%1$s\" already exists at \"%2$s\".</string>
     <string name="path_action_folder_exists_description">A folder named \"%1$s\" already exists at \"%2$s\".</string>
 
+    <string name="path_action_not_found_title">File is gone</string>
+    <string name="path_action_not_found_description">\"%1$s\" was deleted, renamed or moved somewhere else.</string>
+
     <string name="path_action_permission_denied_title">Permission denied</string>
     <string name="path_action_permission_denied_description">Cannot access \"%1$s\" at \"%2$s\" due to insufficient permissions.</string>
     <string name="path_action_permission_denied_no_mechanism_description">Cannot access \"%1$s\" at \"%2$s\". No method available to perform this operation.</string>

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
@@ -1,8 +1,12 @@
 package eu.darken.butler.common.files.permissions
 
 import eu.darken.butler.common.ElevatedAccessUnavailableException
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.error.LocalizedError
+import eu.darken.butler.common.error.LocalizedErrorContext
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
@@ -159,6 +163,38 @@ class PermissionErrorClassifierTest : BaseTest() {
 
         PermissionErrorClassifier.classify(e) shouldBe null
         PermissionErrorClassifier.isPermissionError(e) shouldBe false
+    }
+
+    @Test
+    fun `a top-level gone marker is not a permission failure even when it is a PathException`() {
+        // The marker, not the one type, is what pass 4 answers to: a gone-error that also happens
+        // to be a PathException would otherwise fall through to ACCESS_DENIED and offer the user a
+        // permission fix for a file that is simply not there. Only the top level is covered - see
+        // the sibling test for what a nested marker does.
+        val e = object : ReadException(message = "Path does not exist", path = LocalPath.build("/sdcard/gone.txt")),
+            PathGoneError {
+            override fun getLocalizedError(context: LocalizedErrorContext) = LocalizedError(
+                throwable = this,
+                label = "gone".toCaString(),
+                description = "gone".toCaString(),
+            )
+        }
+
+        PermissionErrorClassifier.classify(e) shouldBe null
+        PermissionErrorClassifier.isPermissionError(e) shouldBe false
+    }
+
+    @Test
+    fun `a gone marker nested under a generic wrapper does not veto`() {
+        // Documents the limit rather than endorsing it: pass 4 answers for the first matching chain
+        // link, and the ReadException wrapper is reached before the marker underneath it. Nothing
+        // wraps a gone-error today; if something starts to, this is the test that will say so.
+        val wrapped = ReadException(
+            path = LocalPath.build("/sdcard/gone.txt"),
+            cause = PathNotFoundException(LocalPath.build("/sdcard/gone.txt")),
+        )
+
+        PermissionErrorClassifier.classify(wrapped) shouldBe Reason.ACCESS_DENIED
     }
 
     @Test

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/DocumentBuffer.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/DocumentBuffer.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.ServiceConnectionLostException
@@ -1603,6 +1604,7 @@ class DocumentBuffer @AssistedInject constructor(
         if (chain.any {
                 it is PathPermissionDeniedException ||
                     it is MissingUriPermissionException ||
+                    it is PathNotFoundException ||
                     it is FileNotFoundException ||
                     it is NoSuchFileException
             }

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/EditorDataSource.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/EditorDataSource.kt
@@ -1,10 +1,10 @@
 package eu.darken.butler.editor.core.sources
 
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.write.FileCommitContext
 import eu.darken.butler.editor.core.engine.ContentSource
 import kotlinx.coroutines.flow.StateFlow
 import okio.Source
-import java.io.FileNotFoundException
 import kotlin.time.Instant
 
 /**
@@ -21,7 +21,8 @@ interface EditorDataSource {
     /**
      * Opens the data source and prepares it for reading/writing.
      * @throws IOException if the resource cannot be opened
-     * @throws FileNotFoundException if the resource doesn't exist
+     * @throws PathNotFoundException if the resource doesn't exist
+     * @throws SaveArtifactsRemainException if it is gone but an interrupted save left artifacts
      */
     suspend fun open()
 

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/FileDataSource.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/FileDataSource.kt
@@ -8,10 +8,11 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
-import eu.darken.butler.common.files.extensions.exists
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.extensions.lookup
 import eu.darken.butler.common.files.write.FileCommitContext
 import eu.darken.butler.common.files.write.AtomicFileWriter
@@ -22,6 +23,8 @@ import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,7 +35,6 @@ import okio.BufferedSink
 import okio.Source
 import okio.buffer
 import okio.use
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.charset.Charset
 import kotlin.uuid.Uuid
@@ -119,19 +121,6 @@ class FileDataSource @AssistedInject constructor(
     override suspend fun open() {
         log(tag) { "Opening file data source: $filePath" }
         try {
-            if (!filePath.exists(gatewaySwitch)) {
-                // A save crash between backup-move and restore leaves the backup as the only
-                // copy; point the user at it instead of a bare not-found
-                val backups = scanSaveArtifacts()
-                if (backups.isNotEmpty()) {
-                    throw FileNotFoundException(
-                        "File does not exist: ${filePath.path} - a backup from an interrupted save " +
-                            "exists: ${backups.joinToString { it.name }}",
-                    )
-                }
-                throw FileNotFoundException("File does not exist: ${filePath.path}")
-            }
-
             val lookup = filePath.lookup(gatewaySwitch, LookupOptions.BASE)
 
             val sampleBytes = readDetectionSample()
@@ -176,9 +165,47 @@ class FileDataSource @AssistedInject constructor(
                 "Opened FileDataSource: size=${lookup.size} bytes, charset=$detectedCharset, " +
                     "hasBOM=$hasBOM, canWrite=$canWrite"
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(tag, ERROR) { "Failed to open - ${e.asLog()}" }
-            throw e
+            throw e.asGoneIfAbsent()
+        }
+    }
+
+    /**
+     * Re-reads a failed open as "the file is gone" only when a probe positively says so.
+     *
+     * The probe has to be [GatewaySwitch.existsStrict], not `exists()`: the latter answers `false`
+     * for a path that is merely unreadable, and mistaking that for a deletion would both tell the
+     * user the wrong story and - because the gone types are [PathGoneError] - suppress the
+     * permission handling that would have offered them a fix. An unreachable SMB host, a wedged
+     * document provider and a failing probe all answer [Existence.UNKNOWN], where the original
+     * error is the one carrying the signal.
+     *
+     * Deliberately after the attempt rather than before it: a pre-flight check cannot see a file
+     * deleted between the check and the read, which is exactly the race a restored tab hits.
+     */
+    private suspend fun Throwable.asGoneIfAbsent(): Throwable {
+        val existence = try {
+            gatewaySwitch.existsStrict(filePath)
+        } catch (probeError: CancellationException) {
+            throw probeError
+        } catch (probeError: Exception) {
+            log(tag, WARN) { "asGoneIfAbsent(): Probe failed for $filePath: ${probeError.asLog()}" }
+            Existence.UNKNOWN
+        }
+        currentCoroutineContext().ensureActive()
+        if (existence != Existence.ABSENT) return this
+
+        // A save crash between backup-move and restore leaves the backup as the only copy;
+        // point the user at it instead of a bare not-found.
+        val backups = scanSaveArtifacts()
+        log(tag, INFO) { "asGoneIfAbsent(): $filePath is gone (${backups.size} artifacts), was ${asLog()}" }
+        return if (backups.isNotEmpty()) {
+            SaveArtifactsRemainException(filePath, backups)
+        } else {
+            PathNotFoundException(filePath)
         }
     }
 

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/SaveArtifactsRemainException.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/sources/SaveArtifactsRemainException.kt
@@ -1,0 +1,38 @@
+package eu.darken.butler.editor.core.sources
+
+import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.error.LocalizedError
+import eu.darken.butler.common.error.LocalizedErrorContext
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.errors.PathGoneError
+import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.editor.R
+
+/**
+ * The file is gone, but artifacts of an interrupted save are still next to it - so the user's
+ * content most likely survives inside one of them.
+ *
+ * Distinct from [eu.darken.butler.common.files.errors.PathNotFoundException] because the recovery
+ * story is the opposite: nothing is lost yet. [artifacts] is a field rather than text in the
+ * message so a recovery action can consume it without re-scanning or parsing.
+ */
+class SaveArtifactsRemainException(
+    path: APath<*>,
+    val artifacts: List<APath<*>>,
+) : ReadException(message = "Path does not exist, ${artifacts.size} save artifact(s) remain", path = path),
+    PathGoneError {
+
+    override fun getLocalizedError(context: LocalizedErrorContext) = LocalizedError(
+        throwable = this,
+        label = R.string.editor_error_save_artifacts_label.toCaString(),
+        description = caString {
+            val resolved = path!!
+            it.getString(
+                R.string.editor_error_save_artifacts_description,
+                resolved.name.ifBlank { resolved.path },
+                artifacts.joinToString { artifact -> artifact.name },
+            )
+        },
+    )
+}

--- a/app-workspace-editor/src/main/res/values/strings.xml
+++ b/app-workspace-editor/src/main/res/values/strings.xml
@@ -58,6 +58,10 @@
     <string name="editor_backing_lost_banner_title">File no longer available</string>
     <string name="editor_backing_lost_banner_message">It may have been moved or deleted. This view is read-only — reopen or close it.</string>
 
+    <!-- Interrupted-save recovery notice -->
+    <string name="editor_error_save_artifacts_label">File is gone, but a backup remains</string>
+    <string name="editor_error_save_artifacts_description">\"%1$s\" is missing, but a save that was interrupted left this behind: %2$s. Your content is most likely still in it.</string>
+
     <!-- External change notice -->
     <string name="editor_external_change_banner_title">File changed on disk</string>
     <string name="editor_external_change_banner_message">Another app modified this file.</string>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceContentPathTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceContentPathTest.kt
@@ -244,9 +244,10 @@ class EditorWorkspaceContentPathTest : BaseTest() {
         val file = File(tempDir, "doc.txt").apply { writeText("content") }
         val path = LocalPath.build(file)
         val gateway = createMockGateway()
-        // The load hangs on the first existence check, so cancellation deterministically lands
-        // mid-initialization
-        coEvery { gateway.exists(any()) } coAnswers { awaitCancellation() }
+        // The load hangs on the first gateway access, so cancellation deterministically lands
+        // mid-initialization. That access is the lookup: open() attempts the real read and only
+        // probes existence afterwards, to tell a deleted file apart from an unreadable one.
+        coEvery { gateway.lookup(any(), any()) } coAnswers { awaitCancellation() }
         val workspace = createWorkspace(path, gateway)
         try {
             // Seeded identity is visible while the load is stuck

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceLifecycleTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceLifecycleTest.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.local.LocalFileSystemOps
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import eu.darken.butler.editor.core.engine.ContentSource
@@ -20,6 +21,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -56,6 +58,7 @@ class EditorWorkspaceLifecycleTest : BaseTest() {
         }
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>
@@ -320,7 +323,14 @@ class EditorWorkspaceLifecycleTest : BaseTest() {
             createMockGateway(),
         )
         try {
-            withTimeout(10_000) { workspace.state.first { it is EditorWorkspace.State.Error } }
+            val errorState = withTimeout(10_000) {
+                workspace.state.first { it is EditorWorkspace.State.Error }
+            } as EditorWorkspace.State.Error
+
+            // The type is what routes the tab to the "file is gone" screen rather than the
+            // generic report-this-error one, so it is part of the contract, not an implementation
+            // detail of FileDataSource
+            errorState.error.shouldBeInstanceOf<PathNotFoundException>()
 
             // Poke an engine state flow: the resulting internal emission must not flip the
             // tab back to a Ready scratch view

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferBackingLostTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferBackingLostTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.editor.core.engine
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.ServiceConnectionLostException
@@ -164,6 +165,8 @@ class DocumentBufferBackingLostTest : BaseTest() {
         latchesFor { ReadException("Does not exist", path) } shouldBe true
         latchesFor { FileNotFoundException("ENOENT") } shouldBe true
         latchesFor { NoSuchFileException("/tmp/mergetest.txt") } shouldBe true
+        // Matched by type, not by its message happening to contain "does not exist"
+        latchesFor { PathNotFoundException(path) } shouldBe true
         latchesFor {
             PathPermissionDeniedException(path, "lookup", PathPermissionDeniedException.Reason.ACCESS_DENIED)
         } shouldBe true

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineCancelInitTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineCancelInitTest.kt
@@ -26,9 +26,10 @@ class EditorEngineCancelInitTest : EditorEngineTestBase() {
     @Test
     fun `cancelInitialization aborts a hanging load and leaves the engine empty`() = runTest {
         // The load hangs on the very first gateway access, so the cancel deterministically
-        // lands mid-initialization
+        // lands mid-initialization. That access is the lookup: open() attempts the real read and
+        // only probes existence afterwards, to tell a deleted file apart from an unreadable one.
         val gateway = mockk<GatewaySwitch>().apply {
-            coEvery { exists(any()) } coAnswers { awaitCancellation() }
+            coEvery { lookup(any(), any()) } coAnswers { awaitCancellation() }
         }
         val fileFactory = object : FileDataSource.Factory {
             override fun create(

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceArtifactTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceArtifactTest.kt
@@ -5,11 +5,13 @@ import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.local.LocalFileSystemOps
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import eu.darken.butler.editor.core.engine.ContentSource
 import eu.darken.butler.workspace.core.Workspace
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -34,6 +36,7 @@ class FileDataSourceArtifactTest : BaseTest() {
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>
@@ -106,5 +109,31 @@ class FileDataSourceArtifactTest : BaseTest() {
         val source = openSource(tempDir, gateway)
 
         (source.contentSource.value as ContentSource.File).staleBackups shouldBe emptyList()
+    }
+
+    @Test
+    fun `a gone file whose backup survives reports the artifacts as a field`(@TempDir tempDir: File) = runTest {
+        // The document itself is never created - a crash between backup-move and restore
+        File(tempDir, "doc.txt.butler-save-bak-1a2b3c4d").writeText("the only good copy")
+        val filePath = LocalPath.build(File(tempDir, "doc.txt"))
+        val source = FileDataSource(workspaceId, filePath, createMockGateway())
+
+        val error = runCatching { source.open() }.exceptionOrNull()
+
+        error.shouldBeInstanceOf<SaveArtifactsRemainException>()
+        // Structural, so a recovery action can consume it without re-scanning or parsing a message
+        error.artifacts.map { it.name } shouldBe listOf("doc.txt.butler-save-bak-1a2b3c4d")
+        error.path!!.name shouldBe "doc.txt"
+    }
+
+    @Test
+    fun `a gone file with no surviving backup is a plain not-found`(@TempDir tempDir: File) = runTest {
+        val filePath = LocalPath.build(File(tempDir, "doc.txt"))
+        val source = FileDataSource(workspaceId, filePath, createMockGateway())
+
+        val error = runCatching { source.open() }.exceptionOrNull()
+
+        error.shouldBeInstanceOf<PathNotFoundException>()
+        error.path!!.name shouldBe "doc.txt"
     }
 }

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceTest.kt
@@ -6,6 +6,10 @@ import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.errors.PathNotFoundException
+import eu.darken.butler.common.files.errors.PathPermissionDeniedException
+import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.local.LocalFileSystemOps
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import eu.darken.butler.workspace.core.Workspace
@@ -21,7 +25,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import testhelpers.BaseTest
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.uuid.Uuid
 
@@ -114,8 +117,10 @@ class FileDataSourceTest : BaseTest() {
     fun `open throws on non-existent file`(@TempDir tempDir: File) = runTest {
         // Given: Non-existent file
         val mockGateway = mockk<GatewaySwitch>().apply {
-        coEvery { canWrite(any()) } returns true
+            coEvery { canWrite(any()) } returns true
             coEvery { exists(any()) } returns false
+            coEvery { existsStrict(any()) } returns Existence.ABSENT
+            coEvery { lookup(any(), any()) } throws ReadException("no such file", null)
         }
         val dataSource = FileDataSource(
             workspaceId,
@@ -125,7 +130,47 @@ class FileDataSourceTest : BaseTest() {
 
         // When & Then: Open throws
         val exception = runCatching { dataSource.open() }.exceptionOrNull()
-        exception shouldBe instanceOf<FileNotFoundException>()
+        exception shouldBe instanceOf<PathNotFoundException>()
+        // The path travels as a field, which is what lets the UI render it without parsing
+        (exception as PathNotFoundException).path!!.name shouldBe "nonexistent.txt"
+    }
+
+    @Test
+    fun `an unreadable file is not reported as gone`(@TempDir tempDir: File) = runTest {
+        // A path the probe cannot answer for - an unreachable host, a wedged provider, or a denial.
+        // Calling that "deleted" would tell the user the wrong story AND, because the gone types
+        // are PathGoneError, suppress the permission handling that would have offered them a fix.
+        val denied = PathPermissionDeniedException(
+            path = LocalPath.build(File(tempDir, "locked.txt")),
+            operation = "lookup",
+            reason = PathPermissionDeniedException.Reason.ACCESS_DENIED,
+        )
+        val mockGateway = mockk<GatewaySwitch>().apply {
+            coEvery { canWrite(any()) } returns true
+            coEvery { existsStrict(any()) } returns Existence.UNKNOWN
+            coEvery { lookup(any(), any()) } throws denied
+        }
+        val dataSource = FileDataSource(workspaceId, LocalPath.build(File(tempDir, "locked.txt")), mockGateway)
+
+        val exception = runCatching { dataSource.open() }.exceptionOrNull()
+
+        // The original error survives untouched - it is the one carrying the signal
+        exception shouldBe denied
+    }
+
+    @Test
+    fun `a file that still exists keeps its original failure`(@TempDir tempDir: File) = runTest {
+        val boom = IOException("provider blew up")
+        val mockGateway = mockk<GatewaySwitch>().apply {
+            coEvery { canWrite(any()) } returns true
+            coEvery { existsStrict(any()) } returns Existence.PRESENT
+            coEvery { lookup(any(), any()) } throws boom
+        }
+        val dataSource = FileDataSource(workspaceId, LocalPath.build(File(tempDir, "there.txt")), mockGateway)
+
+        val exception = runCatching { dataSource.open() }.exceptionOrNull()
+
+        exception shouldBe boom
     }
 
     // ==================== Byte Source Tests ====================

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/SaveArtifactsRemainExceptionTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/SaveArtifactsRemainExceptionTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.butler.editor.core.sources
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.error.localized
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathGoneError
+import eu.darken.butler.workspace.ui.states.PathGoneBody
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The interrupted-save case is the one where the user's content still exists, so the screen has to
+ * say that and name what to look for - the opposite message from a plain deletion.
+ */
+class SaveArtifactsRemainExceptionTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val path = LocalPath.build("/storage/emulated/0/Documents/doc.txt")
+    private val backup = LocalPath.build("/storage/emulated/0/Documents/doc.txt.butler-save-bak-1a2b3c4d")
+
+    private val error = SaveArtifactsRemainException(path, listOf(backup))
+
+    @Test
+    fun `routes to the gone presentation`() {
+        error.shouldBeInstanceOf<PathGoneError>()
+    }
+
+    @Test
+    fun `the rendered wording names the surviving backup, not the exception class`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PathGoneBody(error = error)
+            }
+        }
+
+        composeTestRule.onNodeWithText("doc.txt.butler-save-bak-1a2b3c4d", substring = true).assertIsDisplayed()
+
+        // The generic localized fallback puts the class name in the title; landing on it here would
+        // mean the override is missing and the screen is lying about how bad the situation is.
+        val rendered = error.localized(context).label.get(context)
+        rendered shouldNotContain "SaveArtifactsRemainException"
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerErrors.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerErrors.kt
@@ -6,6 +6,7 @@ import eu.darken.butler.common.error.HasLocalizedError
 import eu.darken.butler.common.error.LocalizedError
 import eu.darken.butler.common.error.LocalizedErrorContext
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.viewer.R
 
 class ViewerNotAFileException(
@@ -54,7 +55,7 @@ class ViewerUndecodableImageException(
 class ViewerFileGoneException(
     val displayName: String,
     cause: Throwable? = null,
-) : IllegalArgumentException("File no longer exists: $displayName", cause), HasLocalizedError {
+) : IllegalArgumentException("File no longer exists: $displayName", cause), PathGoneError {
 
     constructor(path: APath<*>, cause: Throwable? = null) : this(path.name, cause)
 

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
@@ -37,6 +37,7 @@ import eu.darken.butler.viewer.R
 import eu.darken.butler.viewer.core.ApkInstallState
 import eu.darken.butler.viewer.core.VersionComparison
 import androidx.core.net.toUri
+import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.viewer.core.ViewerContent
 import eu.darken.butler.viewer.core.ViewerExternalChange
 import eu.darken.butler.viewer.core.ViewerSource
@@ -44,6 +45,7 @@ import eu.darken.butler.viewer.core.ViewerFileInfo
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
 import eu.darken.butler.workspace.ui.error.ErrorCard
+import eu.darken.butler.workspace.ui.states.PathGoneBody
 import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
@@ -509,15 +511,26 @@ private fun ViewerContentArea(
                 onToggleChrome = onToggleChrome,
             )
 
-            is ViewerContent.Failed -> ErrorCard(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(24.dp),
-                title = stringResource(R.string.viewer_error_title),
-                error = content.error,
-                onShareError = { onShareError(content.error) },
-                onRetry = onRetry,
-            )
+            // A file that is simply gone is not a fault to report or retry, so it gets the shared
+            // "path is gone" treatment rather than an error card with a dead retry button.
+            is ViewerContent.Failed -> if (content.error is PathGoneError) {
+                PathGoneBody(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    error = content.error,
+                )
+            } else {
+                ErrorCard(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    title = stringResource(R.string.viewer_error_title),
+                    error = content.error,
+                    onShareError = { onShareError(content.error) },
+                    onRetry = onRetry,
+                )
+            }
         }
     }
 }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileGoneStateTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileGoneStateTest.kt
@@ -1,0 +1,52 @@
+package eu.darken.butler.viewer.ui.viewer
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathGoneError
+import eu.darken.butler.viewer.R
+import eu.darken.butler.viewer.core.ViewerFileGoneException
+import eu.darken.butler.workspace.ui.states.PathGoneBody
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import testhelpers.ComposeTest
+import eu.darken.butler.common.R as CommonR
+
+/**
+ * A deleted image is a fact about the file, not a viewer fault: it must not arrive as a reportable
+ * error with a retry that cannot work.
+ */
+class ViewerFileGoneStateTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val error = ViewerFileGoneException(LocalPath.build("/sdcard/DCIM/holiday.jpg"))
+
+    @Test
+    fun `the viewer's gone error carries the shared marker`() {
+        // This is what routes it away from the error card in ViewerWorkspacePage
+        error.shouldBeInstanceOf<PathGoneError>()
+    }
+
+    @Test
+    fun `it renders the viewer's own wording, without a report or retry action`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PathGoneBody(error = error)
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.viewer_error_file_gone_label))
+            .assertIsDisplayed()
+
+        // The card's actions would both be dead ends here: nothing to report, nothing to retry
+        composeTestRule
+            .onAllNodesWithText(context.getString(CommonR.string.general_share_error_action))
+            .assertCountEquals(0)
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/PathGoneContent.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/PathGoneContent.kt
@@ -1,0 +1,194 @@
+package eu.darken.butler.workspace.ui.states
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Close
+import androidx.compose.material.icons.twotone.Share
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerMascot
+import eu.darken.butler.common.compose.ButlerMascotMode.*
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.error.localized
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathNotFoundException
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.insets.paneInsets
+import eu.darken.butler.workspace.ui.manager.FakeWorkspaceButtonProvider
+import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
+import eu.darken.butler.workspace.ui.manager.WorkspaceButton
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.common.R as CommonR
+
+/**
+ * "The thing you opened is gone" - for a workspace that cannot open its target because the path no
+ * longer exists, as opposed to failing in a way worth reporting.
+ *
+ * Wording comes from the throwable's own [localized] error, so each workspace keeps its own
+ * phrasing (a missing file, a missing file with a recoverable save backup, a deleted image) while
+ * sharing one presentation. Nothing here is workspace-specific, and nothing here type-matches:
+ * deciding that a failure *is* a vanished path belongs to the caller, which is the only layer that
+ * can see its own exception types.
+ */
+@Composable
+fun PathGoneBody(
+    modifier: Modifier = Modifier,
+    error: Throwable,
+) {
+    val context = LocalContext.current
+    val localized = remember(error) { error.localized(c = context) }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        ButlerMascot(
+            modifier = Modifier.size(96.dp),
+            variant = Static.Sad(),
+        )
+
+        Text(
+            text = localized.label.get(context),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text = localized.description.get(context),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+/**
+ * Full-pane variant of [PathGoneBody], shaped like [WorkspaceErrorContent] so a workspace whose
+ * lifecycle failed on a vanished path can swap one overlay for the other.
+ *
+ * No retry: the overwhelmingly common cause is a deletion, which retrying cannot cure.
+ */
+@Composable
+fun PathGoneContent(
+    modifier: Modifier = Modifier,
+    design: WorkspaceDesign = WorkspaceDesign(),
+    error: Throwable,
+    onShareError: () -> Unit,
+    onCloseWorkspace: (() -> Unit)? = null,
+    currentWorkspaceId: Workspace.Id? = null,
+) {
+    val paneInsets = design.paneInsets()
+    val statusBarInset = paneInsets.top
+    val navBarInset = paneInsets.bottom
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(top = statusBarInset + 32.dp, bottom = navBarInset + 32.dp, start = 32.dp, end = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically),
+        ) {
+            PathGoneBody(
+                modifier = Modifier.fillMaxWidth(),
+                error = error,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+            ) {
+                if (onCloseWorkspace != null) {
+                    TextButton(onClick = onCloseWorkspace) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Close,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(stringResource(R.string.workspace_close_tab_action))
+                        }
+                    }
+                }
+
+                OutlinedButton(onClick = onShareError) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Share,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(stringResource(CommonR.string.general_share_error_action))
+                    }
+                }
+            }
+        }
+
+        if (design.isSingle && LocalWorkspaceButtonProvider.current != null) {
+            WorkspaceButton(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = statusBarInset + 24.dp, end = 24.dp),
+                currentWorkspaceId = currentWorkspaceId,
+            )
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PathGoneContentPreview() {
+    CompositionLocalProvider(
+        LocalWorkspaceButtonProvider provides FakeWorkspaceButtonProvider()
+    ) {
+        PathGoneContent(
+            error = PathNotFoundException(LocalPath.build("/storage/emulated/0/Documents/notes.txt")),
+            onShareError = {},
+            onCloseWorkspace = {},
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PathGoneBodyPreview() {
+    PathGoneBody(
+        error = PathNotFoundException(LocalPath.build("/storage/emulated/0/Pictures/holiday.jpg")),
+    )
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/states/PathGoneContentTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/states/PathGoneContentTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.butler.workspace.ui.states
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathNotFoundException
+import eu.darken.butler.workspace.R
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The point of this screen is that a vanished file reads as a fact about the file rather than as a
+ * fault in the app, so the assertions are about the words the user actually gets.
+ */
+class PathGoneContentTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val path = LocalPath.build("/storage/emulated/0/Documents/notes.txt")
+
+    @Test
+    fun `names the missing file rather than the exception class`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PathGoneBody(error = PathNotFoundException(path))
+            }
+        }
+
+        // The filename is what the user recognises; the raw path and the class name are not.
+        composeTestRule.onNodeWithText("notes.txt", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the full-pane variant offers closing the tab`() {
+        var closed = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PathGoneContent(
+                    error = PathNotFoundException(path),
+                    onShareError = {},
+                    onCloseWorkspace = { closed = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.workspace_close_tab_action)).performClick()
+        closed shouldBe true
+    }
+
+    @Test
+    fun `close is absent when the caller offers no way to close`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PathGoneContent(
+                    error = PathNotFoundException(path),
+                    onShareError = {},
+                    onCloseWorkspace = null,
+                )
+            }
+        }
+
+        composeTestRule
+            .onAllNodesWithText(context.getString(R.string.workspace_close_tab_action))
+            .assertCountEquals(0)
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceMapper.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceMapper.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.visible
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.states.PathGoneContent
 import eu.darken.butler.workspace.ui.states.WorkspacePausedContent
 import eu.darken.butler.workspace.ui.states.WorkspaceErrorContent
 import eu.darken.butler.workspace.ui.states.WorkspaceInitializingContent
@@ -58,14 +60,28 @@ fun WorkspaceMapper(
                 )
             }
             is Workspace.LifecycleState.Error -> {
-                WorkspaceErrorContent(
-                    modifier = Modifier.fillMaxSize(),
-                    design = design,
-                    error = lifecycleState.error,
-                    onShareError = { onShareError(lifecycleState.error) },
-                    onCloseWorkspace = onCloseWorkspace,
-                    currentWorkspaceId = info.id,
-                )
+                // A target that simply no longer exists is not a fault worth reporting, so it gets
+                // its own wording instead of the mascot-and-stack-trace treatment.
+                val error = lifecycleState.error
+                if (error is PathGoneError) {
+                    PathGoneContent(
+                        modifier = Modifier.fillMaxSize(),
+                        design = design,
+                        error = error,
+                        onShareError = { onShareError(error) },
+                        onCloseWorkspace = onCloseWorkspace,
+                        currentWorkspaceId = info.id,
+                    )
+                } else {
+                    WorkspaceErrorContent(
+                        modifier = Modifier.fillMaxSize(),
+                        design = design,
+                        error = error,
+                        onShareError = { onShareError(error) },
+                        onCloseWorkspace = onCloseWorkspace,
+                        currentWorkspaceId = info.id,
+                    )
+                }
             }
             is Workspace.LifecycleState.Ready -> {
                 // Page is visible - no overlay needed


### PR DESCRIPTION
## What changed

Open a file in the editor, delete it outside Butler, then reopen the app. The restored tab used to greet you with a generic error screen: a title carrying an exception class name, and the actual reason hidden behind a technical-details expander. It looked like Butler had broken, and invited bug reports for something that is not a bug.

The tab now says the file is gone and names it, and offers to close itself. The wording separates two situations: a file that is simply missing, and a file that is missing but where an interrupted save left a backup behind, which usually means the content still survives in that backup.

The viewer already had good wording for a deleted file, but rendered it as a reportable error card with a retry button that could not help. It now uses the same presentation.

## Technical Context

- Root cause: `FileDataSource` was the only file-access path in the tree throwing a raw `java.io.FileNotFoundException` rather than a `PathException` subtype. It carried the path as message text and implemented no `HasLocalizedError`, so `Throwable.localized()` fell through to its generic branch, which appends the exception class name to the user-visible title.
- A `PathGoneError` marker joins the two new editor types and the viewer's existing `ViewerFileGoneException`. It shares only the marker and the screen, deliberately not the exception type: `PathNotFoundException` is documented as cause-less so the permission classifier cannot re-find the failure it replaced, while the viewer's variant keeps the original cause on purpose and has one call site with no path at all. The marker extends `HasLocalizedError` because the shared screen renders nothing but the implementor's own wording, and the generic fallback would put the class name back in the title.
- Worth close review: absence is established by probing `existsStrict` *after* the read attempt fails, never by a pre-flight `exists()`. `exists()` answers false for a path that is merely unreadable (its own docs say so, and the SMB backend maps every failure to it), so a pre-flight would report an inaccessible file as deleted and, because gone errors now veto permission classification, suppress the fix that would have helped. Probing afterwards also closes the window where a file is deleted between the check and the read. This mirrors `DirectoryLocationLoader.asNotFoundIfGone()`.
- `PermissionErrorClassifier` keys its non-denial branch on the marker rather than on `PathNotFoundException` alone, so a gone error that is also a `PathException` no longer falls through to `ACCESS_DENIED`. That branch answers for the first matching link in the cause chain, so a marker nested under a generic wrapper does not veto. Nothing wraps one today, and a test pins the limit rather than hiding it.
- Two editor tests froze initialization by making `exists()` hang forever. That is no longer the first gateway access, so their stubs moved to `lookup()`.
