### PR TITLE
General: Fix guided tours losing their text and skipping steps

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourController.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourController.kt
@@ -61,8 +61,49 @@ class GuidedTourController @Inject constructor(
         startLocked(definition)
     }
 
+    /**
+     * Adopt [definition] into a live session for the same tour at the same steps.
+     *
+     * A screen that recomposes from scratch - activity recreation - hands us a definition whose
+     * `prepareTarget` hooks capture that composition's state holders, while the ones the session
+     * holds capture the disposed ones. Scrolling a detached `LazyGridState` is a silent no-op, so
+     * the step's anchor never comes into view and the host grace-skips it. Step ids have to match
+     * as well as the tour id, or [TourSession.stepIndex] would carry over onto different steps.
+     */
+    private suspend fun adoptRefreshedDefinition(definition: TourDefinition): Boolean {
+        val live = _session.value ?: return false
+        if (!live.definition.describesSameSessionAs(definition)) return false
+        // Same instance: an effect re-ran inside one composition, nothing was rebuilt. Bail before
+        // the prepare below, or reopening the tab manager would re-scroll the grid under the user.
+        if (live.definition === definition) return true
+        log(TAG, VERBOSE) { "adoptRefreshedDefinition(${definition.id.raw}) at ${live.stepIndex}" }
+        // Publish only after the hook, like next() does: the host keys its missing-target grace
+        // window on the session object, so a timer running through the prepare below still names the
+        // old definition and next() drops it. Publishing first would restart that timer with the
+        // identity the guard accepts.
+        // The step already on screen needs the fresh hook too: its anchor may have gone with the old
+        // composition, and a single-step tour has no later navigation that would ever run it.
+        definition.steps[live.stepIndex].prepareTarget?.invoke()
+        // prepareTarget can suspend long enough for a grace-skip to advance or end the session.
+        val still = _session.value ?: return true
+        if (!still.definition.describesSameSessionAs(definition)) return true
+        _session.value = still.copy(definition = definition)
+        return true
+    }
+
+    /**
+     * Whether [other] is the same tour, from the same screen, at the same steps - i.e. a rebuild of
+     * what this session is already running rather than a different tour or a second live instance.
+     */
+    private fun TourDefinition.describesSameSessionAs(other: TourDefinition): Boolean =
+        id == other.id &&
+            ownerKey == other.ownerKey &&
+            steps.map { it.stepId } == other.steps.map { it.stepId }
+
     /** Publishes the session if the tour is eligible. Returns whether this call started it. */
     private suspend fun startLocked(definition: TourDefinition): Boolean {
+        // Same tour still live: the caller recomposed rather than asking for a new tour.
+        if (adoptRefreshedDefinition(definition)) return false
         if (!shouldStart(definition)) {
             log(TAG, VERBOSE) { "start(${definition.id.raw}): blocked by prefs or active session" }
             return false
@@ -88,12 +129,22 @@ class GuidedTourController @Inject constructor(
      * two would advance twice — on a two-step tour that shows the last step and immediately
      * completes it, persisting a tour the user never saw. Both parts of the identity are checked
      * because step ids are only unique within a definition.
+     *
+     * [fromDefinition] extends that identity to the build of the tour the request was made against.
+     * A request raised against a definition that has since been replaced by [adoptRefreshedDefinition]
+     * names a step that still matches by id, so the pair above would accept it and advance past the
+     * step the adoption just restored. It has no default: a caller that cannot name the build it
+     * raised its request against is exactly the unguarded case this exists to catch.
      */
-    suspend fun next(fromTour: TourId, fromStepId: String) {
+    suspend fun next(fromTour: TourId, fromStepId: String, fromDefinition: TourDefinition) {
         val onComplete: (suspend () -> Unit)? = mutationMutex.withLock {
             val s = _session.value ?: return@withLock null
             if (s.definition.id != fromTour || s.currentStep.stepId != fromStepId) {
                 log(TAG, VERBOSE) { "next(${fromTour.raw}/$fromStepId): no longer the current step" }
+                return@withLock null
+            }
+            if (fromDefinition !== s.definition) {
+                log(TAG, VERBOSE) { "next(${fromTour.raw}/$fromStepId): no longer the current definition" }
                 return@withLock null
             }
             if (s.isLast) return@withLock completeLocked()

--- a/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourHost.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/tour/GuidedTourHost.kt
@@ -84,8 +84,11 @@ private fun resolveStepLayout(step: TourStep, registry: TourTargetRegistry): Ste
 @Composable
 fun GuidedTourHost(
     session: StateFlow<TourSession?>,
-    /** Advance past the given step of the given tour; identity travels along so a stale request can be dropped. */
-    onNext: (TourId, String) -> Unit,
+    /**
+     * Advance past the given step of the given tour, built from the given definition; the full
+     * identity travels along so a stale request can be dropped.
+     */
+    onNext: (TourId, String, TourDefinition) -> Unit,
     onPrevious: () -> Unit,
     onDontShowAgain: () -> Unit,
     onDisableAllTours: () -> Unit,
@@ -117,7 +120,9 @@ fun GuidedTourHost(
         if (layout !is StepLayout.Pending) return@LaunchedEffect
         delay(MISSING_TARGET_GRACE_MS)
         val tid = step.targetId ?: return@LaunchedEffect
-        if (registry.get(tid) == null) onNext(activeSession.definition.id, step.stepId)
+        if (registry.get(tid) == null) {
+            onNext(activeSession.definition.id, step.stepId, activeSession.definition)
+        }
     }
 
     // Confirm-exit UI state, hoisted here so the BackHandler below can drive it. Keyed per tour
@@ -137,13 +142,13 @@ fun GuidedTourHost(
     val doubleTapTimeoutMs = remember { ViewConfiguration.getDoubleTapTimeout().toLong() }
     var lastBubbleAdvanceUptime by remember(activeTourId?.raw) { mutableStateOf<Long?>(null) }
     val onBubbleNext: () -> Unit = advance@{
-        val tourId = activeTourId ?: return@advance
+        val definition = current?.definition ?: return@advance
         val stepId = step?.stepId ?: return@advance
         val now = SystemClock.uptimeMillis()
         val last = lastBubbleAdvanceUptime
         if (last != null && now - last < doubleTapTimeoutMs) return@advance
         lastBubbleAdvanceUptime = now
-        onNext(tourId, stepId)
+        onNext(definition.id, stepId, definition)
     }
 
     CompositionLocalProvider(LocalTourTargetRegistry provides registry) {
@@ -356,7 +361,7 @@ private fun GuidedTourHostPreviewActive() {
     Box(modifier = Modifier.fillMaxSize()) {
         GuidedTourHost(
             session = sessionFlow,
-            onNext = { _, _ -> },
+            onNext = { _, _, _ -> },
             onPrevious = {},
             onDontShowAgain = {},
             onDisableAllTours = {},
@@ -404,7 +409,7 @@ private fun GuidedTourHostPreviewCenterless() {
     Box(modifier = Modifier.fillMaxSize()) {
         GuidedTourHost(
             session = sessionFlow,
-            onNext = { _, _ -> },
+            onNext = { _, _, _ -> },
             onPrevious = {},
             onDontShowAgain = {},
             onDisableAllTours = {},
@@ -434,7 +439,7 @@ private fun GuidedTourHostPreviewIdle() {
     Box(modifier = Modifier.fillMaxSize()) {
         GuidedTourHost(
             session = sessionFlow,
-            onNext = { _, _ -> },
+            onNext = { _, _, _ -> },
             onPrevious = {},
             onDontShowAgain = {},
             onDisableAllTours = {},

--- a/app-common/src/main/java/eu/darken/butler/common/compose/tour/Tour.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/tour/Tour.kt
@@ -26,6 +26,13 @@ data class TourDefinition(
     val steps: List<TourStep>,
     val clickProtection: Boolean = true,
     /**
+     * Identifies the screen instance that built this definition, for tours that can be on screen
+     * more than once. `null` means the tour is single-instance app-wide. Two live instances of the
+     * same tour carry different keys, which is what stops one adopting the other's session and
+     * pointing its prepare hooks at the wrong pane.
+     */
+    val ownerKey: String? = null,
+    /**
      * Runs after a successful completion has been persisted and the active session has been
      * cleared. It is not invoked for skip, dismiss, disable-all, or a no-render grace-skip.
      */

--- a/app-common/src/main/java/eu/darken/butler/common/compose/tour/TourBubble.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/tour/TourBubble.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapp
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.takeOrElse
 import eu.darken.butler.common.R
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.ButlerMascot
@@ -87,6 +88,14 @@ private val MaxBubbleWidth = 480.dp
 private val SideMargin = 16.dp
 private val TargetGap = 16.dp
 private val NarrowThreshold = 360.dp
+
+// Fixed vertical chrome inside the bubble: 16dp top + 16dp bottom content padding, the 40dp control
+// row, and the 16dp gap under the copy. The tail, where there is one, sits on top of this.
+private val BubbleChrome = 88.dp
+
+// Gap between a step's title and its body. Shared by StepContent and the height floors below so the
+// space reserved for the copy and the space it actually occupies cannot drift apart.
+private val TitleBodyGap = 4.dp
 
 @Composable
 internal fun TourBubble(
@@ -208,22 +217,34 @@ private fun BoxScope.AnchoredBubble(
             (maxHPx - rect.top + gapPx).toDp()
         }
     }
-    val clampedY = if (placeBelow) {
-        rawY.coerceAtLeast(insets.calculateTopPadding())
-    } else {
-        rawY.coerceAtLeast(insets.calculateBottomPadding())
-    }
     // Far-side inset: keeps the bubble's *other* edge inside the safe area too.
     val farTopPad = insets.calculateTopPadding() + SideMargin
     val farBottomPad = insets.calculateBottomPadding() + SideMargin
+    val nearInset = if (placeBelow) insets.calculateTopPadding() else insets.calculateBottomPadding()
+    val farPad = if (placeBelow) farBottomPad else farTopPad
 
-    // The bubble's max height is whatever is left between the cutout-side gap and the
-    // far-side safe inset, so bottom edges never run under the nav bar.
-    val bubbleMaxHeight = if (placeBelow) {
-        (maxHeight - clampedY - farBottomPad).coerceAtLeast(160.dp)
-    } else {
-        (maxHeight - clampedY - farTopPad).coerceAtLeast(160.dp)
+    // Buy the minimum height out of the offset, not out of heightIn: padding runs ahead of heightIn
+    // in the same chain, so heightIn can only shrink what padding left over. Where the viewport
+    // cannot hold both the gap and a readable bubble, the bubble slides over part of the cutout -
+    // copy the user cannot read defeats the step, a partly covered spotlight does not.
+    // The copy allowance is one line of each style the bubble renders, taken from the theme and
+    // converted through the density the text itself uses, so it grows exactly as the text does. A
+    // standalone sp value cannot: from API 34 font scaling is non-linear, and a large sp constant
+    // lands deep in the damped region while the text it stands in for is still growing.
+    // lineHeight may be unspecified in a restyled theme and toDp() only accepts Sp, hence the
+    // fallback to the style's own font size.
+    val typography = MaterialTheme.typography
+    val wanted = with(density) {
+        BubbleChrome + TailHeight +
+            typography.titleMedium.lineHeight.takeOrElse { typography.titleMedium.fontSize }.toDp() +
+            typography.bodyLarge.lineHeight.takeOrElse { typography.bodyLarge.fontSize }.toDp() +
+            TitleBodyGap
     }
+    val floor = wanted.coerceAtMost((maxHeight - farPad - nearInset).coerceAtLeast(0.dp))
+    val clampedY = rawY
+        .coerceAtLeast(nearInset)
+        .coerceAtMost((maxHeight - farPad - floor).coerceAtLeast(nearInset))
+    val bubbleMaxHeight = (maxHeight - clampedY - farPad).coerceAtLeast(0.dp)
 
     Box(
         modifier = Modifier
@@ -275,13 +296,25 @@ private fun BoxScope.CenterlessBubble(
     onFocusWithinChanged: (Boolean) -> Unit,
 ) {
     // Cap height at the safe area; the body has its own vertical scroll for content that doesn't
-    // fit. Match the anchored 160.dp floor — multi-window / split-screen can leave available
-    // height below SideMargin * 2 and the bubble would otherwise collapse to an unusable sliver.
-    val bubbleMaxHeight = (maxHeight - topPad - bottomPad).coerceAtLeast(160.dp)
+    // fit. Same chain-order trap as AnchoredBubble: padding runs before heightIn, so the floor has
+    // to be bought out of the two SideMargins. Never out of the raw insets - the bubble would slide
+    // under the system bars. No tail here, so no tail height in the budget.
+    val typography = MaterialTheme.typography
+    val wanted = with(LocalDensity.current) {
+        BubbleChrome +
+            typography.titleMedium.lineHeight.takeOrElse { typography.titleMedium.fontSize }.toDp() +
+            typography.bodyLarge.lineHeight.takeOrElse { typography.bodyLarge.fontSize }.toDp() +
+            TitleBodyGap
+    }
+    val shortfall = (wanted - (maxHeight - topPad - bottomPad)).coerceAtLeast(0.dp)
+    val giveBack = (shortfall / 2f).coerceAtMost(SideMargin)
+    val effectiveTopPad = topPad - giveBack
+    val effectiveBottomPad = bottomPad - giveBack
+    val bubbleMaxHeight = (maxHeight - effectiveTopPad - effectiveBottomPad).coerceAtLeast(0.dp)
     Box(
         modifier = Modifier
             .align(Alignment.Center)
-            .padding(start = startPad, end = endPad, top = topPad, bottom = bottomPad)
+            .padding(start = startPad, end = endPad, top = effectiveTopPad, bottom = effectiveBottomPad)
             .widthIn(max = MaxBubbleWidth)
             .heightIn(max = bubbleMaxHeight),
     ) {
@@ -470,7 +503,7 @@ private fun StepContent(
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )
-                    Spacer(Modifier.height(4.dp))
+                    Spacer(Modifier.height(TitleBodyGap))
                 }
                 Text(
                     text = step.body.get(context),

--- a/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourControllerTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourControllerTest.kt
@@ -5,7 +5,9 @@ import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.datastore.DataStoreValue
 import eu.darken.butler.common.tour.TourPreferences
 import eu.darken.butler.common.tour.TourSettings
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -224,8 +226,8 @@ class GuidedTourControllerTest : BaseTest() {
         // tapped for. Without the identity guard both would advance.
         val ctrl = controller()
         ctrl.start(basicDefinition)
-        ctrl.next(basicDefinition.id, "a")
-        ctrl.next(basicDefinition.id, "a")
+        ctrl.next(basicDefinition.id, "a", basicDefinition)
+        ctrl.next(basicDefinition.id, "a", basicDefinition)
         ctrl.session.value!!.stepIndex shouldBe 1
     }
 
@@ -235,7 +237,7 @@ class GuidedTourControllerTest : BaseTest() {
         ctrl.start(basicDefinition)
         ctrl.nextFromCurrent()
         ctrl.session.value!!.stepIndex shouldBe 1
-        ctrl.next(basicDefinition.id, "a") // the step the session has already left
+        ctrl.next(basicDefinition.id, "a", basicDefinition) // the step the session has already left
         ctrl.session.value!!.stepIndex shouldBe 1
     }
 
@@ -244,7 +246,8 @@ class GuidedTourControllerTest : BaseTest() {
         // Step ids are not unique across definitions, so the tour has to be checked as well.
         val ctrl = controller()
         ctrl.start(basicDefinition)
-        ctrl.next(TourId("test.other"), "a")
+        // The live definition is passed, so the tour id is the only part of the identity that differs.
+        ctrl.next(TourId("test.other"), "a", basicDefinition)
         ctrl.session.value!!.stepIndex shouldBe 0
     }
 
@@ -255,7 +258,7 @@ class GuidedTourControllerTest : BaseTest() {
         ctrl.markAllStepsRendered(basicDefinition)
         ctrl.nextFromCurrent()
         ctrl.nextFromCurrent() // now on the last step "c"
-        ctrl.next(basicDefinition.id, "b")
+        ctrl.next(basicDefinition.id, "b", basicDefinition)
         ctrl.session.value!!.stepIndex shouldBe 2
         prefsFlow.value.completed shouldBe emptySet()
     }
@@ -609,6 +612,151 @@ class GuidedTourControllerTest : BaseTest() {
         ctrl.session.value shouldBe null
         prefsFlow.value.dismissed shouldBe setOf(def.id.raw)
     }
+
+    /** Stands in for one composition's build of the same tour: its hooks write to [sink]. */
+    private fun refreshableDefinition(
+        sink: MutableList<String>,
+        ownerKey: String? = "pane.1",
+        stepIds: List<String> = listOf("one", "two"),
+    ) = TourDefinition(
+        id = TourId("test.refresh"),
+        ownerKey = ownerKey,
+        steps = stepIds.map { stepId ->
+            TourStep(
+                stepId = stepId,
+                body = stepId.toCaString(),
+                prepareTarget = { sink += stepId },
+            )
+        },
+    )
+
+    @Test
+    fun `a refreshed definition swaps the prepare hooks in place`() = runTest {
+        val staleSink = mutableListOf<String>()
+        val freshSink = mutableListOf<String>()
+        val stale = refreshableDefinition(staleSink)
+        val fresh = refreshableDefinition(freshSink)
+        val ctrl = controller()
+        ctrl.start(stale)
+        // What an activity recreation looks like from here: same tour, rebuilt hooks.
+        ctrl.tryStart(fresh) shouldBe false
+        ctrl.next(fresh.id, "one", fresh)
+        // The step on screen is re-prepared, and the advance runs the fresh hook, not the stale one.
+        freshSink shouldBe listOf("one", "two")
+        staleSink shouldBe listOf("one")
+        ctrl.session.value!!.stepIndex shouldBe 1
+    }
+
+    @Test
+    fun `re-submitting the same definition instance does not re-run its prepare hook`() = runTest {
+        val sink = mutableListOf<String>()
+        val def = refreshableDefinition(sink)
+        val ctrl = controller()
+        ctrl.start(def)
+        ctrl.tryStart(def) shouldBe false
+        sink shouldBe listOf("one")
+    }
+
+    @Test
+    fun `a definition with different steps is not adopted`() = runTest {
+        val staleSink = mutableListOf<String>()
+        val otherSink = mutableListOf<String>()
+        val stale = refreshableDefinition(staleSink)
+        val other = refreshableDefinition(otherSink, stepIds = listOf("one", "different"))
+        val ctrl = controller()
+        ctrl.start(stale)
+        ctrl.tryStart(other) shouldBe false
+        ctrl.session.value!!.definition shouldBeSameInstanceAs stale
+        otherSink shouldBe emptyList()
+    }
+
+    @Test
+    fun `a second instance of the same tour does not adopt the first`() = runTest {
+        val firstSink = mutableListOf<String>()
+        val secondSink = mutableListOf<String>()
+        val first = refreshableDefinition(firstSink, ownerKey = "pane.1")
+        val second = refreshableDefinition(secondSink, ownerKey = "pane.2")
+        val ctrl = controller()
+        ctrl.start(first)
+        ctrl.tryStart(second) shouldBe false
+        ctrl.session.value!!.definition shouldBeSameInstanceAs first
+        secondSink shouldBe emptyList()
+    }
+
+    @Test
+    fun `a request naming the definition adoption replaced is dropped`() = runTest {
+        val prepareEntered = CompletableDeferred<Unit>()
+        val releasePrepare = CompletableDeferred<Unit>()
+        fun definition(prepare: (suspend () -> Unit)?) = TourDefinition(
+            id = TourId("test.adopt.race.identity"),
+            ownerKey = "pane.1",
+            steps = listOf(TourStep(stepId = "one", body = "one".toCaString(), prepareTarget = prepare)),
+        )
+        val stale = definition(null)
+        val fresh = definition {
+            prepareEntered.complete(Unit)
+            releasePrepare.await()
+        }
+        val ctrl = controller()
+        ctrl.start(stale)
+
+        val adoptJob = launch { ctrl.tryStart(fresh) }
+        runCurrentUntilIdle()
+        prepareEntered.isCompleted shouldBe true
+
+        // The grace window opened before the rebuild, so the request names the definition the
+        // adoption has since replaced.
+        val skipJob = launch { ctrl.next(fresh.id, "one", fromDefinition = stale) }
+        runCurrentUntilIdle()
+
+        releasePrepare.complete(Unit)
+        adoptJob.join()
+        skipJob.join()
+
+        val session = ctrl.session.value.shouldNotBeNull()
+        session.stepIndex shouldBe 0
+        session.definition shouldBeSameInstanceAs fresh
+    }
+
+    @Test
+    fun `a grace request captured while adoption is parked does not skip the restored step`() = runTest {
+        val prepareEntered = CompletableDeferred<Unit>()
+        val releasePrepare = CompletableDeferred<Unit>()
+        // One step only: a grace-skip on the last step runs the completion path, so a request that
+        // gets through here ends the session outright instead of merely advancing it.
+        fun definition(prepare: (suspend () -> Unit)?) = TourDefinition(
+            id = TourId("test.adopt.race.host"),
+            ownerKey = "pane.1",
+            steps = listOf(TourStep(stepId = "one", body = "one".toCaString(), prepareTarget = prepare)),
+        )
+        val stale = definition(null)
+        val fresh = definition {
+            prepareEntered.complete(Unit)
+            releasePrepare.await()
+        }
+        val ctrl = controller()
+        ctrl.start(stale)
+
+        val adoptJob = launch { ctrl.tryStart(fresh) }
+        runCurrentUntilIdle()
+        prepareEntered.isCompleted shouldBe true
+        releasePrepare.isCompleted shouldBe false
+
+        // GuidedTourHost keys its missing-target grace window on the session object, so a session
+        // republished mid-adoption restarts that timer, and the request it fires names whatever
+        // definition the session held at the moment the timer started.
+        val capturedByTimer = ctrl.session.value.shouldNotBeNull().definition
+        val skipJob = launch { ctrl.next(fresh.id, "one", fromDefinition = capturedByTimer) }
+        runCurrentUntilIdle()
+
+        releasePrepare.complete(Unit)
+        adoptJob.join()
+        skipJob.join()
+
+        val session = ctrl.session.value.shouldNotBeNull()
+        session.stepIndex shouldBe 0
+        session.definition shouldBeSameInstanceAs fresh
+    }
 }
 
 @Serializable
@@ -622,7 +770,7 @@ private fun GuidedTourController.markAllStepsRendered(definition: TourDefinition
 /** Advance from whatever step is current — the identity the real bubble would send. */
 private suspend fun GuidedTourController.nextFromCurrent() {
     val s = session.value ?: return
-    next(s.definition.id, s.currentStep.stepId)
+    next(s.definition.id, s.currentStep.stepId, s.definition)
 }
 
 private fun TestScope.runCurrentUntilIdle() {

--- a/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourHostTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/tour/GuidedTourHostTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.common.compose.tour
 
 import android.view.KeyEvent as NativeKeyEvent
+import android.view.View
 import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
@@ -23,9 +25,13 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -36,7 +42,11 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyPress
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
 import io.kotest.matchers.shouldBe
@@ -128,7 +138,7 @@ class GuidedTourHostTest : ComposeTest() {
         composeTestRule.setHostContent(
             sessionFlow,
             preregister = mapOf("first" to targetRect),
-            onNext = { _, _ -> nextCount++ },
+            onNext = { _, _, _ -> nextCount++ },
         ) {
             Text("CONTENT_MARKER")
         }
@@ -221,7 +231,7 @@ class GuidedTourHostTest : ComposeTest() {
         composeTestRule.setHostContent(
             sessionFlow,
             preregister = mapOf("first" to targetRect),
-            onNext = { _, _ -> nextCount++ },
+            onNext = { _, _, _ -> nextCount++ },
         ) {
             // Small clickable at top-start. The bubble (placeBelow = true given the target rect)
             // is anchored top-center, padded down 16dp from targetRect.bottom (~216dp) — its
@@ -315,7 +325,7 @@ class GuidedTourHostTest : ComposeTest() {
         composeTestRule.mainClock.autoAdvance = false
         composeTestRule.setHostContent(
             sessionFlow,
-            onNext = { tourId, stepId -> advances += tourId to stepId },
+            onNext = { tourId, stepId, _ -> advances += tourId to stepId },
         ) {
             Text("CONTENT_MARKER")
         }
@@ -337,7 +347,7 @@ class GuidedTourHostTest : ComposeTest() {
         composeTestRule.setHostContent(
             sessionFlow,
             preregister = mapOf("first" to targetRect),
-            onNext = { tourId, stepId -> advances += tourId to stepId },
+            onNext = { tourId, stepId, _ -> advances += tourId to stepId },
         ) {
             Text("CONTENT_MARKER")
         }
@@ -361,7 +371,7 @@ class GuidedTourHostTest : ComposeTest() {
         val sessionFlow = MutableStateFlow<TourSession?>(TourSession(centerlessDef, 0))
         var nextCount = 0
         composeTestRule.mainClock.autoAdvance = false
-        composeTestRule.setHostContent(sessionFlow, onNext = { _, _ -> nextCount++ }) {
+        composeTestRule.setHostContent(sessionFlow, onNext = { _, _, _ -> nextCount++ }) {
             Text("CONTENT_MARKER")
         }
         // Advance well past MISSING_TARGET_GRACE_MS — if grace-skip leaked, onNext would fire.
@@ -378,7 +388,7 @@ class GuidedTourHostTest : ComposeTest() {
         var nextCount = 0
         composeTestRule.setHostContent(
             sessionFlow,
-            onNext = { _, _ -> nextCount++ },
+            onNext = { _, _, _ -> nextCount++ },
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
                 Box(
@@ -421,7 +431,7 @@ class GuidedTourHostTest : ComposeTest() {
         composeTestRule.setHostContent(
             sessionFlow,
             preregister = mapOf("first" to targetRect),
-            onNext = { _, _ -> nextCount++ },
+            onNext = { _, _, _ -> nextCount++ },
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
                 Box(
@@ -647,7 +657,155 @@ class GuidedTourHostTest : ComposeTest() {
         composeTestRule.onAllNodesWithText("Skip the tour?").assertCountEquals(0)
         composeTestRule.onNodeWithText("Body of step 2").assertExists()
     }
+
+    @Test
+    fun `anchored bubble keeps its copy when the anchor leaves almost no room`() {
+        val def = TourDefinition(
+            id = TourId("test.cramped"),
+            steps = listOf(
+                TourStep(
+                    stepId = "only",
+                    title = "Cramped title".toCaString(),
+                    body = "Cramped body".toCaString(),
+                ),
+            ),
+        )
+        val anchor = with(composeTestRule.density) {
+            Rect(left = 0f, top = 20.dp.toPx(), right = 400.dp.toPx(), bottom = 180.dp.toPx())
+        }
+        composeTestRule.setHostContent(
+            session = MutableStateFlow(TourSession(def, stepIndex = 0)),
+            hostModifier = Modifier.size(width = 400.dp, height = 240.dp),
+            preregister = mapOf("only" to anchor),
+        ) { Box(Modifier.fillMaxSize()) }
+
+        composeTestRule.onNodeWithText("Cramped title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cramped body").assertIsDisplayed()
+    }
+
+    @Test
+    fun `bubble placed above the anchor also keeps its copy`() {
+        // Anchor near the bottom edge, so the bubble takes the above-the-target branch.
+        val def = TourDefinition(
+            id = TourId("test.cramped.above"),
+            steps = listOf(
+                TourStep(
+                    stepId = "only",
+                    title = "Cramped title".toCaString(),
+                    body = "Cramped body".toCaString(),
+                ),
+            ),
+        )
+        val anchor = with(composeTestRule.density) {
+            Rect(left = 0f, top = 200.dp.toPx(), right = 400.dp.toPx(), bottom = 230.dp.toPx())
+        }
+        composeTestRule.setHostContent(
+            session = MutableStateFlow(TourSession(def, stepIndex = 0)),
+            hostModifier = Modifier.size(width = 400.dp, height = 240.dp),
+            preregister = mapOf("only" to anchor),
+        ) { Box(Modifier.fillMaxSize()) }
+
+        composeTestRule.onNodeWithText("Cramped title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cramped body").assertIsDisplayed()
+    }
+
+    @Test
+    fun `non-zero insets do not push the bubble under the safe area`() {
+        val def = TourDefinition(
+            id = TourId("test.cramped.insets"),
+            steps = listOf(
+                TourStep(
+                    stepId = "only",
+                    title = "Cramped title".toCaString(),
+                    body = "Cramped body".toCaString(),
+                ),
+            ),
+        )
+        val anchor = with(composeTestRule.density) {
+            Rect(left = 0f, top = 20.dp.toPx(), right = 400.dp.toPx(), bottom = 180.dp.toPx())
+        }
+        var view: View? = null
+        composeTestRule.setHostContent(
+            session = MutableStateFlow(TourSession(def, stepIndex = 0)),
+            hostModifier = Modifier.size(width = 400.dp, height = 240.dp),
+            preregister = mapOf("only" to anchor),
+            onView = { view = it },
+        ) { Box(Modifier.fillMaxSize()) }
+        composeTestRule.runOnUiThread {
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 0, 0, BOTTOM_INSET_PX))
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(view!!, insets)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Cramped title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cramped body").assertIsDisplayed()
+        // Room for the copy comes out of the target-side gap, never out of the safe area: the
+        // controls stay above the bottom inset.
+        // Single-step tour, so the advance button is the finishing one.
+        val controlsBottom = composeTestRule.onNodeWithContentDescription("Done")
+            .getUnclippedBoundsInRoot()
+            .bottom
+        (controlsBottom <= 240.dp - BOTTOM_INSET_PX.dp) shouldBe true
+    }
+
+    @Test
+    fun `the floor grows with font scale`() {
+        val def = TourDefinition(
+            id = TourId("test.cramped.fontscale"),
+            steps = listOf(
+                TourStep(
+                    stepId = "only",
+                    title = "Cramped title".toCaString(),
+                    body = "Cramped body".toCaString(),
+                ),
+            ),
+        )
+        val anchor = with(composeTestRule.density) {
+            Rect(left = 0f, top = 20.dp.toPx(), right = 400.dp.toPx(), bottom = 180.dp.toPx())
+        }
+        composeTestRule.setHostContent(
+            session = MutableStateFlow(TourSession(def, stepIndex = 0)),
+            hostModifier = Modifier.size(width = 400.dp, height = 240.dp),
+            preregister = mapOf("only" to anchor),
+            // A plain Density converts sp to dp linearly, so the reserved copy height doubles
+            // here — unlike text measurement, which Robolectric fakes at a fixed line height.
+            // That linearity is also this test's limit: from API 34 the platform damps large sp
+            // values instead, and a floor that fails to grow under that curve still passes here.
+            // This covers the arithmetic; only an on-device check covers the curve.
+            densityOverride = Density(density = 1f, fontScale = 2f),
+        ) { Box(Modifier.fillMaxSize()) }
+
+        composeTestRule.onNodeWithText("Cramped title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cramped body").assertIsDisplayed()
+    }
+
+    @Test
+    fun `centerless bubble keeps its copy on a short screen`() {
+        val def = TourDefinition(
+            id = TourId("test.centerless.cramped"),
+            steps = listOf(
+                TourStep(
+                    stepId = "only",
+                    targetId = null,
+                    title = "Cramped title".toCaString(),
+                    body = "Cramped body".toCaString(),
+                ),
+            ),
+        )
+        composeTestRule.setHostContent(
+            session = MutableStateFlow(TourSession(def, stepIndex = 0)),
+            hostModifier = Modifier.size(width = 400.dp, height = 140.dp),
+        ) { Box(Modifier.fillMaxSize()) }
+
+        composeTestRule.onNodeWithText("Cramped title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cramped body").assertIsDisplayed()
+    }
 }
+
+/** 40dp at the tests' density (1f), applied as a bottom system-bar inset. */
+private const val BOTTOM_INSET_PX = 40
 
 /**
  * Focused content that records every key event reaching it. Key events travel the focused node's
@@ -672,12 +830,15 @@ private fun KeyProbe(received: MutableList<Key>) {
 private fun ComposeContentTestRule.setHostContent(
     session: StateFlow<TourSession?>,
     preregister: Map<String, Rect> = emptyMap(),
-    onNext: (TourId, String) -> Unit = { _, _ -> },
+    onNext: (TourId, String, TourDefinition) -> Unit = { _, _, _ -> },
     onPrevious: () -> Unit = {},
     onDontShowAgain: () -> Unit = {},
     onDisableAllTours: () -> Unit = {},
     onStepRendered: (TourId, String) -> Unit = { _, _ -> },
     onBackOwner: (OnBackPressedDispatcherOwner) -> Unit = {},
+    onView: (View) -> Unit = {},
+    hostModifier: Modifier = Modifier.fillMaxSize(),
+    densityOverride: Density? = null,
     content: @Composable () -> Unit,
 ) {
     // Pre-seed a registry the host will use directly (skips real layout).
@@ -687,18 +848,22 @@ private fun ComposeContentTestRule.setHostContent(
         LocalOnBackPressedDispatcherOwner.current?.let { owner ->
             SideEffect { onBackOwner(owner) }
         }
+        val view = LocalView.current
+        SideEffect { onView(view) }
         PreviewWrapper {
-            GuidedTourHost(
-                session = session,
-                onNext = onNext,
-                onPrevious = onPrevious,
-                onDontShowAgain = onDontShowAgain,
-                onDisableAllTours = onDisableAllTours,
-                modifier = Modifier.fillMaxSize(),
-                registry = registry,
-                onStepRendered = onStepRendered,
-                content = content,
-            )
+            CompositionLocalProvider(LocalDensity provides (densityOverride ?: LocalDensity.current)) {
+                GuidedTourHost(
+                    session = session,
+                    onNext = onNext,
+                    onPrevious = onPrevious,
+                    onDontShowAgain = onDontShowAgain,
+                    onDisableAllTours = onDisableAllTours,
+                    modifier = hostModifier,
+                    registry = registry,
+                    onStepRendered = onStepRendered,
+                    content = content,
+                )
+            }
         }
     }
 }

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
@@ -102,11 +102,12 @@ fun TemplatesWorkspacePageHost(
     val listState = rememberWorkspaceLazyListState(id, slot = TemplatesScrollSlots.LIST)
 
     val tourController = LocalGuidedTourController.current
-    val tourDefinition = remember(listState) {
+    val tourDefinition = remember(listState, id) {
         TemplatesTour.definition(
             prepareFirstTemplate = {
                 listState.scrollToItem(TemplatesWorkspacePageDefaults.FIRST_TEMPLATE_ITEM_INDEX)
             },
+            ownerKey = id.longTag,
         )
     }
     // LocalLayerActive, not LocalWorkspaceFocused: a dialog open over this page leaves the pane

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/tour/TemplatesTour.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/tour/TemplatesTour.kt
@@ -31,9 +31,16 @@ object TemplatesTour : GuidedTour {
      *
      * Both steps always run: every layout renders exactly one Butler button (Templates page in
      * single-pane, navigation rail otherwise), so a conditional step list would be dead code.
+     *
+     * [ownerKey] names the pane that built this definition: the picker can be open in two panes at
+     * once, and the keys are what keep one pane's session from adopting the other's prepare hooks.
      */
-    fun definition(prepareFirstTemplate: suspend () -> Unit): TourDefinition = TourDefinition(
+    fun definition(
+        prepareFirstTemplate: suspend () -> Unit,
+        ownerKey: String,
+    ): TourDefinition = TourDefinition(
         id = id,
+        ownerKey = ownerKey,
         clickProtection = true,
         steps = listOf(
             TourStep(

--- a/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
+++ b/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
@@ -172,6 +172,7 @@ class TemplatesWorkspacePageTest : ComposeTest() {
                 prepareFirstTemplate = {
                     listState.scrollToItem(TemplatesWorkspacePageDefaults.FIRST_TEMPLATE_ITEM_INDEX)
                 },
+                ownerKey = "pane",
             )
             .steps.first().prepareTarget!!
         runBlocking { prepare() }

--- a/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/tour/TemplatesTourTest.kt
+++ b/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/tour/TemplatesTourTest.kt
@@ -7,7 +7,7 @@ import testhelpers.BaseTest
 
 class TemplatesTourTest : BaseTest() {
 
-    private val definition = TemplatesTour.definition(prepareFirstTemplate = {})
+    private val definition = TemplatesTour.definition(prepareFirstTemplate = {}, ownerKey = "pane")
 
     @Test
     fun `the tour id is stable`() {

--- a/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/MainActivity.kt
@@ -253,8 +253,8 @@ class MainActivity : Activity2() {
             CompositionLocalProvider(LocalGuidedTourController provides guidedTourController) {
                 GuidedTourHost(
                     session = guidedTourController.session,
-                    onNext = { tourId, stepId ->
-                        coroutineScope.launch { guidedTourController.next(tourId, stepId) }
+                    onNext = { tourId, stepId, definition ->
+                        coroutineScope.launch { guidedTourController.next(tourId, stepId, definition) }
                     },
                     onPrevious = { coroutineScope.launch { guidedTourController.previous() } },
                     onDontShowAgain = { coroutineScope.launch { guidedTourController.dismissForever() } },


### PR DESCRIPTION
## What changed

Guided tours — the speech bubbles that point at things the first time you use a screen — had two problems.

On short screens, in split-screen, or with a large system font, a bubble could lose its title and body entirely: the mascot and the buttons still drew, so you got a highlighted element with nothing explaining it. At large font sizes it could instead show the title with the body squeezed down to an unreadable sliver. Bubbles now reserve enough room for their text at whatever font size the device is set to.

Tours also broke when the screen was rebuilt underneath them — rotating the device, switching to dark mode, or anything else that recreates the screen. The tour would silently skip the step it was on, and the single-step first-run tour could end for good without ever being shown again. Tours now survive a rebuild and carry on from the step they were on.

## Technical Context

- The height floor was inert. `Modifier.padding` reduces the max-height constraint before `heightIn` sees it, and `heightIn` can only lower a max, so `coerceAtLeast(160.dp)` could never grant back space the padding had already consumed. The floor is now bought out of the anchor offset instead. Same bug and same repair in the centred variant, which reclaims its two side margins but never the raw insets, so the bubble cannot slide under the system bars.
- The copy allowance is derived from `MaterialTheme.typography` line heights, converted through the same `LocalDensity` as the text, rather than a fixed `sp` constant. From API 34 font scaling is non-linear and damps large `sp` values: measured on an emulator, a `56.sp` allowance grew the bubble by 9px when the font scale doubled, where linear arithmetic predicted 98px — so the reservation stopped tracking the text it was reserving for.
- `GuidedTourController` is a `@Singleton`, but screens build their `TourDefinition` with `remember(<state holder>)`. After an activity rebuild the live session still held `prepareTarget` hooks capturing a disposed `LazyGridState`/`LazyListState`/`BringIntoViewRequester`; scrolling a detached state is a silent no-op, so the step's anchor never registered and the host grace-skipped it. `startLocked` now adopts a rebuilt definition when tour id, `ownerKey` and the step-id list all match, and runs the current step's fresh hook.
- `ownerKey` is new on `TourDefinition` and exists for the templates tour: its picker can be open in two panes at once, and without a per-pane key the second pane's start would repoint the running tour's hooks at the pane the user is not touring. The other two tours can only exist once and leave it null.
- Worth close review: `GuidedTourHost.onNext` and `GuidedTourController.next` now carry the `TourDefinition` a request was raised against, and adoption publishes the refreshed session only *after* running the prepare hook. Both halves are load-bearing and the order is not incidental — publishing first restarts the host's 600ms missing-anchor timer with the very identity the guard accepts, which reopens the skip the guard closes.
