### PR TITLE
General: Treat yaml, json and 60 more file types as text

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/MimeInfo.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/MimeInfo.kt
@@ -124,6 +124,7 @@ data class MimeInfo(
                 "sh", "bash", "zsh", "fish", "ksh", "bat", "cmd", "ps1",
                 "gradle", "cmake", "make", "mk", "lua", "dart", "pro",
                 "gitignore", "gitattributes", "editorconfig", "bashrc", "zshrc", "profile",
+                "dockerfile",
                 -> "text/plain"
 
                 // Android

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/MimeInfo.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/MimeInfo.kt
@@ -34,9 +34,27 @@ data class MimeInfo(
             "application/javascript",
             "application/x-sh",
             "application/x-shellscript",
+            "application/x-httpd-php",
+            "application/sql",
+            "application/x-yaml",
+            "application/yaml",
+            "application/toml",
+            "application/x-perl",
+            "application/x-ruby",
+        )
+
+        /** Text files that carry no extension at all, so they can only be matched on the whole name. */
+        private val TEXT_FILE_NAMES = setOf(
+            "makefile",
+            "dockerfile",
+            "license",
+            "readme",
+            "changelog",
         )
 
         fun fromFileName(fileName: String): MimeInfo {
+            if (fileName.lowercase(Locale.ROOT) in TEXT_FILE_NAMES) return MimeInfo("text/plain")
+
             val extension = fileName.substringAfterLast('.', "").lowercase(Locale.ROOT)
 
             val rawType = when (extension) {
@@ -49,6 +67,8 @@ data class MimeInfo(
                 "heic" -> "image/heic"
                 "heif" -> "image/heif"
                 "avif" -> "image/avif"
+                // Text on the wire, but the Viewer renders it as a vector image - calling it text
+                // would route it to the Editor instead.
                 "svg" -> "image/svg+xml"
 
                 // Videos
@@ -79,7 +99,32 @@ data class MimeInfo(
                 "doc" -> "application/msword"
                 "docx" -> "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 "txt" -> "text/plain"
-                "md" -> "text/markdown"
+                "md", "markdown" -> "text/markdown"
+
+                // Text
+                "json" -> "application/json"
+                "xml" -> "application/xml"
+                "html", "htm" -> "text/html"
+                "css" -> "text/css"
+                "csv" -> "text/csv"
+                // "mjs"/"cjs" and "ksh" below are not in any of the tables this one replaced, they
+                // come from Language.EXTENSION_MAP - the Editor already highlights them, so leaving
+                // them out would be a fresh inconsistency.
+                "js", "mjs", "cjs" -> "text/javascript"
+                // ".ts" is read as TypeScript, not as an MPEG transport stream: an MPEG-TS video
+                // therefore gets a text thumbnail of its leading bytes and an "Open in editor" row
+                // that lands on the Editor's read-only binary banner. A content sniff is not an
+                // option, this function does no I/O and runs per row while a list renders.
+                "ts",
+                "yml", "yaml", "toml", "ini", "cfg", "conf", "config", "properties", "env",
+                "log", "rst", "adoc", "tex", "tsv",
+                "jsx", "tsx", "scss", "sass", "less",
+                "kt", "kts", "java", "py", "c", "cpp", "cc", "cxx", "h", "hpp",
+                "cs", "php", "rb", "go", "rs", "swift", "m", "mm", "sql",
+                "sh", "bash", "zsh", "fish", "ksh", "bat", "cmd", "ps1",
+                "gradle", "cmake", "make", "mk", "lua", "dart", "pro",
+                "gitignore", "gitattributes", "editorconfig", "bashrc", "zshrc", "profile",
+                -> "text/plain"
 
                 // Android
                 "apk" -> MIME_APK

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/TextFileDetector.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/TextFileDetector.kt
@@ -1,32 +1,10 @@
 package eu.darken.butler.common.files
 
+/**
+ * Call-shape convenience over [MimeInfo], which owns the table. Every overload answers from it, so
+ * a name, a type and a path never disagree about the same file.
+ */
 object TextFileDetector {
-    private val TEXT_FILE_EXTENSIONS = setOf(
-        // Plain text
-        "txt", "md", "markdown",
-
-        // Configuration
-        "json", "xml", "yml", "yaml", "toml", "ini", "cfg", "conf", "config",
-
-        // Web
-        "html", "htm", "css", "js", "jsx", "ts", "tsx", "scss", "sass", "less",
-
-        // Programming languages
-        "kt", "kts", "java", "py", "c", "cpp", "cc", "cxx", "h", "hpp",
-        "cs", "php", "rb", "go", "rs", "swift", "m", "mm", "sql",
-
-        // Shell scripts
-        "sh", "bash", "zsh", "fish", "bat", "cmd", "ps1",
-
-        // Build files
-        "gradle", "cmake", "make", "mk", "properties", "env",
-
-        // Documentation
-        "log", "rst", "adoc", "tex",
-
-        // Data
-        "csv", "tsv",
-    )
 
     /**
      * Checks if a file is a text file based on its MIME type
@@ -36,11 +14,10 @@ object TextFileDetector {
     }
 
     /**
-     * Checks if a file is a text file based on its file extension
+     * Checks if a file is a text file based on its file name
      */
     fun isTextFile(fileName: String): Boolean {
-        val extension = fileName.substringAfterLast('.', "").lowercase()
-        return extension in TEXT_FILE_EXTENSIONS
+        return MimeInfo.fromFileName(fileName).isText
     }
 
     /**

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/MimeInfoTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/MimeInfoTest.kt
@@ -39,10 +39,80 @@ class MimeInfoTest : BaseTest() {
         "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "txt" to "text/plain",
         "md" to "text/markdown",
+        "markdown" to "text/markdown",
         "apk" to "application/vnd.android.package-archive",
         "apks" to "application/zip",
         "xapk" to "application/zip",
         "apkm" to "application/zip",
+        "json" to "application/json",
+        "xml" to "application/xml",
+        "html" to "text/html",
+        "htm" to "text/html",
+        "css" to "text/css",
+        "csv" to "text/csv",
+        "js" to "text/javascript",
+        "mjs" to "text/javascript",
+        "cjs" to "text/javascript",
+        "yml" to "text/plain",
+        "yaml" to "text/plain",
+        "toml" to "text/plain",
+        "ini" to "text/plain",
+        "cfg" to "text/plain",
+        "conf" to "text/plain",
+        "config" to "text/plain",
+        "properties" to "text/plain",
+        "env" to "text/plain",
+        "log" to "text/plain",
+        "rst" to "text/plain",
+        "adoc" to "text/plain",
+        "tex" to "text/plain",
+        "tsv" to "text/plain",
+        "jsx" to "text/plain",
+        "ts" to "text/plain",
+        "tsx" to "text/plain",
+        "scss" to "text/plain",
+        "sass" to "text/plain",
+        "less" to "text/plain",
+        "kt" to "text/plain",
+        "kts" to "text/plain",
+        "java" to "text/plain",
+        "py" to "text/plain",
+        "c" to "text/plain",
+        "cpp" to "text/plain",
+        "cc" to "text/plain",
+        "cxx" to "text/plain",
+        "h" to "text/plain",
+        "hpp" to "text/plain",
+        "cs" to "text/plain",
+        "php" to "text/plain",
+        "rb" to "text/plain",
+        "go" to "text/plain",
+        "rs" to "text/plain",
+        "swift" to "text/plain",
+        "m" to "text/plain",
+        "mm" to "text/plain",
+        "sql" to "text/plain",
+        "sh" to "text/plain",
+        "bash" to "text/plain",
+        "zsh" to "text/plain",
+        "fish" to "text/plain",
+        "ksh" to "text/plain",
+        "bat" to "text/plain",
+        "cmd" to "text/plain",
+        "ps1" to "text/plain",
+        "gradle" to "text/plain",
+        "cmake" to "text/plain",
+        "make" to "text/plain",
+        "mk" to "text/plain",
+        "lua" to "text/plain",
+        "dart" to "text/plain",
+        "pro" to "text/plain",
+        "gitignore" to "text/plain",
+        "gitattributes" to "text/plain",
+        "editorconfig" to "text/plain",
+        "bashrc" to "text/plain",
+        "zshrc" to "text/plain",
+        "profile" to "text/plain",
     )
 
     @Test
@@ -96,5 +166,68 @@ class MimeInfoTest : BaseTest() {
         MimeInfo.fromFileName("a.doc").isPdf shouldBe false
         MimeInfo.fromFileName("a.xyz").isPdf shouldBe false
         MimeInfo.fromFileName("a.pdf").isImage shouldBe false
+    }
+
+    @Test
+    fun `text files are recognized by their extension`() {
+        MimeInfo.fromFileName("x.yaml").isText shouldBe true
+        MimeInfo.fromFileName("x.kt").isText shouldBe true
+        MimeInfo.fromFileName("x.sh").isText shouldBe true
+        MimeInfo.fromFileName("x.log").isText shouldBe true
+        MimeInfo.fromFileName("x.lua").isText shouldBe true
+        MimeInfo.fromFileName(".gitignore").isText shouldBe true
+
+        MimeInfo.fromFileName("x.png").isText shouldBe false
+        MimeInfo.fromFileName("x.zip").isText shouldBe false
+        MimeInfo.fromFileName("x.apk").isText shouldBe false
+        MimeInfo.fromFileName("x.pdf").isText shouldBe false
+        MimeInfo.fromFileName("x.mp3").isText shouldBe false
+        MimeInfo.fromFileName("x.xyz").isText shouldBe false
+    }
+
+    @Test
+    fun `ts is read as TypeScript source, not as an MPEG transport stream`() {
+        MimeInfo.fromFileName("app.ts").rawType shouldBe "text/plain"
+        MimeInfo.fromFileName("app.ts").isVideo shouldBe false
+    }
+
+    @Test
+    fun `extensionless text files are recognized by their name`() {
+        listOf("Makefile", "Dockerfile", "LICENSE", "README", "CHANGELOG").forEach { name ->
+            listOf(name.lowercase(), name.uppercase(), name).forEach { variant ->
+                MimeInfo.fromFileName(variant).rawType shouldBe "text/plain"
+            }
+        }
+    }
+
+    @Test
+    fun `a known text name with an extension takes the extension path`() {
+        MimeInfo.fromFileName("README.backup").rawType shouldBe "application/octet-stream"
+        MimeInfo.fromFileName("Dockerfile.bak").rawType shouldBe "application/octet-stream"
+    }
+
+    @Test
+    fun `svg stays a vector image so the viewer keeps rendering it`() {
+        MimeInfo.fromFileName("a.svg").rawType shouldBe "image/svg+xml"
+        MimeInfo.fromFileName("a.svg").isImage shouldBe true
+        MimeInfo.fromFileName("a.svg").isText shouldBe false
+    }
+
+    @Test
+    fun `externally declared text types count as text`() {
+        listOf(
+            "application/yaml",
+            "application/x-yaml",
+            "application/toml",
+            "application/sql",
+            "application/x-httpd-php",
+            "application/x-perl",
+            "application/x-ruby",
+        ).forEach { declared ->
+            MimeInfo(declared).isText shouldBe true
+        }
+
+        MimeInfo("application/zip").isText shouldBe false
+        MimeInfo("application/octet-stream").isText shouldBe false
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/MimeInfoTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/MimeInfoTest.kt
@@ -113,6 +113,7 @@ class MimeInfoTest : BaseTest() {
         "bashrc" to "text/plain",
         "zshrc" to "text/plain",
         "profile" to "text/plain",
+        "dockerfile" to "text/plain",
     )
 
     @Test
@@ -198,6 +199,7 @@ class MimeInfoTest : BaseTest() {
                 MimeInfo.fromFileName(variant).rawType shouldBe "text/plain"
             }
         }
+        MimeInfo.fromFileName("web.dockerfile").rawType shouldBe "text/plain"
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/TextFileDetectorTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/TextFileDetectorTest.kt
@@ -1,0 +1,19 @@
+package eu.darken.butler.common.files
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class TextFileDetectorTest : BaseTest() {
+
+    @Test
+    fun `all three overloads agree on the same file`() {
+        TextFileDetector.isTextFile("a.yaml") shouldBe true
+        TextFileDetector.isTextFile(MimeInfo.fromFileName("a.yaml")) shouldBe true
+        TextFileDetector.isTextFile(LocalPath.build("/x/a.yaml")) shouldBe true
+
+        TextFileDetector.isTextFile("a.png") shouldBe false
+        TextFileDetector.isTextFile(MimeInfo.fromFileName("a.png")) shouldBe false
+        TextFileDetector.isTextFile(LocalPath.build("/x/a.png")) shouldBe false
+    }
+}

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorClipboardController.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/EditorClipboardController.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.TextFileDetector
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.editor.core.EditorWorkspace
 import eu.darken.butler.editor.core.engine.ClipboardCapacityException
@@ -216,16 +217,14 @@ class EditorClipboardController(
 
     /**
      * Cheap, no-I/O suggestion heuristic for the paste sheet. Requires regular-file metadata (so
-     * directories/symlinks never surface) and then accepts a known text extension, a known text
-     * filename/dotfile, or any extensionless regular file. It only decides what is *suggested* -
-     * an explicitly picked file is always attempted and [PasteFileReader] rejects real binaries.
+     * directories/symlinks never surface) and then defers to the shared text table.
      */
     private fun isLikelyTextFile(lookup: APathLookup<*>): Boolean {
         if (lookup.fileType != FileType.FILE) return false
         val name = lookup.name
-        if (name in KNOWN_TEXT_FILENAMES) return true
-        val ext = name.substringAfterLast('.', "").lowercase()
-        return ext.isEmpty() || ext in TEXT_EXTENSIONS
+        // An extensionless file is still offered: the sheet only SUGGESTS, and PasteFileReader
+        // rejects real binaries when one is actually picked.
+        return name.substringAfterLast('.', "").isEmpty() || TextFileDetector.isTextFile(name)
     }
 
     companion object {
@@ -241,17 +240,5 @@ class EditorClipboardController(
          * Selections passing this may still fail the exact byte check in [addToButlerClipboard].
          */
         val BUTLER_CLIPBOARD_PREFILTER_CHARS = ClipboardClip.Text.MAX_SIZE_BYTES.toLong()
-
-        internal val TEXT_EXTENSIONS = setOf(
-            "txt", "md", "json", "xml", "html", "css", "js", "kt", "java", "py", "sh",
-            "yml", "yaml", "csv", "log", "conf", "ini", "properties", "gradle", "toml",
-            "c", "cpp", "h", "hpp", "rs", "go", "rb", "php", "sql", "ts", "tsx", "jsx",
-        )
-
-        /** Common extensionless / dotfile text files the extension heuristic would otherwise miss. */
-        internal val KNOWN_TEXT_FILENAMES = setOf(
-            ".env", ".gitignore", ".gitattributes", ".editorconfig", ".bashrc", ".zshrc",
-            ".profile", "Makefile", "Dockerfile", "LICENSE", "README", "CHANGELOG",
-        )
     }
 }

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorClipboardControllerTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/EditorClipboardControllerTest.kt
@@ -507,6 +507,23 @@ class EditorClipboardControllerTest : BaseTest() {
     }
 
     @Test
+    fun `pasteable clipboard suggests every extension the shared text table knows`() = runTest {
+        val clips = listOf("script.lua", "main.dart", "readme.rst", "rules.pro").map { name ->
+            ClipboardClip.Paths(
+                origin = workspaceId,
+                mode = ClipboardClip.Paths.Mode.COPY,
+                paths = listOf(fileLookup(name)),
+            )
+        }
+        val controller = controller(repo = mockRepo(clips))
+
+        val pasteable = controller.pasteableClipboard.first()
+
+        pasteable.flatMap { it.paths }.map { it.name } shouldBe
+            listOf("script.lua", "main.dart", "readme.rst", "rules.pro")
+    }
+
+    @Test
     fun `pasting a paths clip skips directories`() = runTest {
         val workspace = mockWorkspace()
         val controller = controller(workspace)

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheetTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheetTest.kt
@@ -182,4 +182,29 @@ class FileOptionsBottomSheetTest : ComposeTest() {
 
         countOf("Install") shouldBe 0
     }
+
+    @Test
+    fun `a yaml file can be opened in the editor`() {
+        setSheetContent(fileNamed("notes.yaml"))
+
+        composeTestRule.onNodeWithText("Open in editor").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Open in editor").performClick()
+
+        lastAction.shouldBeInstanceOf<ExplorerActionBarItem.File.OpenInEditor>()
+    }
+
+    @Test
+    fun `a yaml file is described as plain text`() {
+        setSheetContent(fileNamed("notes.yaml"))
+
+        countOf("Plain text") shouldBe 1
+        countOf("Unknown type") shouldBe 0
+    }
+
+    @Test
+    fun `a binary file is not offered to the editor`() {
+        setSheetContent(fileNamed("blob.bin"))
+
+        countOf("Open in editor") shouldBe 0
+    }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/OpenInNewTabsUseCaseTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/OpenInNewTabsUseCaseTest.kt
@@ -2,6 +2,8 @@ package eu.darken.butler.workspace.core
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.TextFileDetector
 import eu.darken.butler.workspace.contracts.editor.EditorArguments
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
@@ -127,6 +129,25 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
 
         items.forEach { item ->
             request(item).type shouldBe requests(analyze(item)).single().type
+        }
+    }
+
+    /**
+     * The plain "Open" row routes by the same predicate, so a yaml file must not land in the viewer.
+     * The Explorer feeds the [MimeInfo] overload, the Searcher the name one - both have to answer
+     * the same here.
+     */
+    @Test
+    fun `a yaml file routes to the editor`() {
+        val yamlFile = LocalPath.build("/storage/emulated/0/Documents/notes.yaml")
+
+        listOf(
+            TextFileDetector.isTextFile(MimeInfo.fromFileName("notes.yaml")),
+            TextFileDetector.isTextFile("notes.yaml"),
+        ).forEach { isText ->
+            useCase.classify(
+                OpenInNewTabsUseCase.Item.File(yamlFile, isText = isText),
+            ) shouldBe Workspace.Type.EDITOR
         }
     }
 

--- a/app/src/main/java/eu/darken/butler/common/MimeTypeTool.kt
+++ b/app/src/main/java/eu/darken/butler/common/MimeTypeTool.kt
@@ -3,13 +3,23 @@ package eu.darken.butler.common
 import android.webkit.MimeTypeMap
 import dagger.Reusable
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.MimeInfo
+import java.util.Locale
 import javax.inject.Inject
 
 @Reusable
 class MimeTypeTool @Inject constructor() {
 
+    /**
+     * Butler's own table answers first, so a thumbnail agrees with what every workspace shows for
+     * the same file. MimeTypeMap covers what the table does not know, e.g. tiff or jfif, which
+     * would otherwise lose their thumbnails.
+     */
     suspend fun determineMimeType(lookup: APathLookup<*>): String {
-        val ext = lookup.name.substringAfterLast('.', "").lowercase()
+        val own = MimeInfo.fromFileName(lookup.name).rawType
+        if (own != MimeTypes.Unknown.value) return own
+
+        val ext = lookup.name.substringAfterLast('.', "").lowercase(Locale.ROOT)
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext) ?: MimeTypes.Unknown.value
     }
 }

--- a/app/src/main/java/eu/darken/butler/common/coil/fetchers/PathPreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/butler/common/coil/fetchers/PathPreviewFetcher.kt
@@ -159,7 +159,7 @@ class PathPreviewFetcher @Inject constructor(
                 } ?: fallbackIcon
             }
 
-            textPreviewGenerator.isTextPreviewable(mimeType, data.lookedUp.extension) -> {
+            textPreviewGenerator.isTextPreviewable(mimeType) -> {
                 // Generate cache key
                 val cacheKey = keyer.key(data, options)
 

--- a/app/src/main/java/eu/darken/butler/common/coil/fetchers/TextPreviewGenerator.kt
+++ b/app/src/main/java/eu/darken/butler/common/coil/fetchers/TextPreviewGenerator.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.withTranslation
 import coil3.request.Options
-import eu.darken.butler.common.MimeTypes
 import coil3.size.Dimension
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
@@ -22,6 +21,7 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.MimeInfo
 import eu.darken.butler.common.files.preview.PreviewBudget
 import eu.darken.butler.common.theming.ThemeColor
 import eu.darken.butler.common.theming.ThemeColorProvider
@@ -78,43 +78,11 @@ class TextPreviewGenerator @Inject constructor(
             }
         )
 
-    fun isTextPreviewable(mimeType: String, extension: String? = null): Boolean =
-        mimeType.startsWith("text/")
-            || mimeType in TEXT_MIME_TYPES
-            || (mimeType == MimeTypes.Unknown.value && extension in TEXT_EXTENSIONS)
+    /** [MimeInfo] owns the table, so a thumbnail never disagrees with the rest of the app. */
+    fun isTextPreviewable(mimeType: String): Boolean = MimeInfo(mimeType).isText
 
     companion object {
         private val TAG = logTag("Coil", "Fetcher", "Path", "Text")
-
-        private val TEXT_MIME_TYPES = setOf(
-            "application/json",
-            "application/xml",
-            "application/x-sh",
-            "application/x-shellscript",
-            "application/javascript",
-            "application/x-httpd-php",
-            "application/sql",
-            "application/x-yaml",
-            "application/toml",
-            "application/x-perl",
-            "application/x-ruby",
-        )
-
-        /**
-         * Extensions for text files that Android's MimeTypeMap doesn't recognize,
-         * returning `application/octet-stream` instead.
-         */
-        val TEXT_EXTENSIONS = setOf(
-            "kt", "kts",
-            "gradle",
-            "rs", "go", "rb", "lua", "swift", "dart",
-            "toml", "ini", "cfg", "conf",
-            "properties",
-            "bat", "cmd", "ps1",
-            "dockerfile",
-            "gitignore", "gitattributes", "editorconfig",
-            "pro", "svg",
-        )
     }
 
     /**

--- a/app/src/test/java/eu/darken/butler/common/MimeTypeToolTest.kt
+++ b/app/src/test/java/eu/darken/butler/common/MimeTypeToolTest.kt
@@ -1,0 +1,80 @@
+package eu.darken.butler.common
+
+import android.webkit.MimeTypeMap
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MimeTypeToolTest : BaseTest() {
+
+    private val tool = MimeTypeTool()
+    private val defaultLocale = Locale.getDefault()
+
+    /** Above API 30 the shadow proxies the real map unless the mappings were cleared first. */
+    @Before
+    fun isolatePlatformMap() {
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).clearMappings()
+    }
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    private fun lookup(name: String): APathLookup<*> = LocalPathLookup(
+        lookedUp = LocalPath.build("/storage/emulated/0/Download/$name"),
+        fileType = FileType.FILE,
+        size = 128L,
+        modifiedAt = null,
+    )
+
+    private fun registerPlatformMapping(extension: String, mimeType: String) {
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypeMapping(extension, mimeType)
+    }
+
+    @Test
+    fun `butler's own table answers for a text extension`() = runTest {
+        tool.determineMimeType(lookup("notes.yaml")) shouldBe "text/plain"
+    }
+
+    @Test
+    fun `an extension only the platform knows resolves through the fallback`() = runTest {
+        registerPlatformMapping("tiff", "image/tiff")
+
+        tool.determineMimeType(lookup("scan.tiff")) shouldBe "image/tiff"
+    }
+
+    @Test
+    fun `an extension nobody knows stays unknown`() = runTest {
+        tool.determineMimeType(lookup("blob.xyz")) shouldBe MimeTypes.Unknown.value
+    }
+
+    @Test
+    fun `butler's table wins over a conflicting platform mapping`() = runTest {
+        registerPlatformMapping("yaml", "application/x-yaml")
+
+        tool.determineMimeType(lookup("notes.yaml")) shouldBe "text/plain"
+    }
+
+    @Test
+    fun `an uppercase platform-only extension resolves under a turkish locale`() = runTest {
+        registerPlatformMapping("tiff", "image/tiff")
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+
+        tool.determineMimeType(lookup("SCAN.TIFF")) shouldBe "image/tiff"
+    }
+}

--- a/app/src/test/java/eu/darken/butler/common/coil/TextPreviewGeneratorTest.kt
+++ b/app/src/test/java/eu/darken/butler/common/coil/TextPreviewGeneratorTest.kt
@@ -301,30 +301,15 @@ class TextPreviewGeneratorTest : BaseTest() {
         textPreviewGenerator.isTextPreviewable("application/octet-stream") shouldBe false
     }
 
+    /**
+     * Extensions no longer reach this predicate: the file name is resolved against the shared table
+     * before the fetcher asks, so what is left to decide is the type boundary.
+     */
     @Test
-    fun `isTextPreviewable falls back to extension for unknown MIME type`() {
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "kt") shouldBe true
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "kts") shouldBe true
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "gradle") shouldBe true
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "rs") shouldBe true
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "go") shouldBe true
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "properties") shouldBe true
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "gitignore") shouldBe true
-    }
-
-    @Test
-    fun `isTextPreviewable extension fallback only applies to unknown MIME type`() {
-        // Extension fallback should NOT activate for known non-text MIME types
-        textPreviewGenerator.isTextPreviewable("application/zip", "kt") shouldBe false
-        textPreviewGenerator.isTextPreviewable("image/png", "rs") shouldBe false
-    }
-
-    @Test
-    fun `isTextPreviewable rejects unknown extensions`() {
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "apk") shouldBe false
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "so") shouldBe false
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", "dex") shouldBe false
-        textPreviewGenerator.isTextPreviewable("application/octet-stream", null) shouldBe false
+    fun `isTextPreviewable decides on the resolved type alone`() {
+        textPreviewGenerator.isTextPreviewable("text/plain") shouldBe true
+        textPreviewGenerator.isTextPreviewable("application/x-yaml") shouldBe true
+        textPreviewGenerator.isTextPreviewable("application/octet-stream") shouldBe false
     }
 
     // Helper functions

--- a/app/src/test/java/eu/darken/butler/main/core/external/ExternalOpenOptionsTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/core/external/ExternalOpenOptionsTest.kt
@@ -115,6 +115,24 @@ class ExternalOpenOptionsTest : BaseTest() {
     }
 
     @Test
+    fun `yaml arriving without a declared type counts as text`() {
+        computeExternalOpenOptions(MimeInfo.fromFileName("notes.yaml"), 1024L) shouldBe listOf(
+            ExternalOpenOption.VIEW,
+            ExternalOpenOption.EDIT_AS_TEXT,
+            ExternalOpenOption.SAVE_AS,
+        )
+    }
+
+    @Test
+    fun `yaml declared by the sending app counts as text`() {
+        computeExternalOpenOptions(MimeInfo("application/yaml"), 1024L) shouldBe listOf(
+            ExternalOpenOption.VIEW,
+            ExternalOpenOption.EDIT_AS_TEXT,
+            ExternalOpenOption.SAVE_AS,
+        )
+    }
+
+    @Test
     fun `unknown content can be viewed or saved`() {
         computeExternalOpenOptions(MimeInfo("application/octet-stream"), 512L) shouldBe listOf(
             ExternalOpenOption.VIEW,


### PR DESCRIPTION
## What changed

Butler only recognized `.txt` and `.md` files as text. Every other text file — `.yaml`, `.json`, `.kt`, `.log`, `.conf`, shell scripts and around 60 more — was treated as unknown binary in the Explorer: the file details sheet said "Unknown type", there was no "Open in editor" action, tapping Open landed on a screen saying the content type is unsupported, dragging the file into another pane did the same, and the file list showed a generic icon instead of a preview of the text.

All of that now works for every text file type Butler knows. Files with no extension at all — `Dockerfile`, `Makefile`, `LICENSE`, `README`, `CHANGELOG` — are recognized too, as are dotfiles like `.gitignore` and `.bashrc`. A text file shared into Butler from another app now offers "Edit as text" as well.

Two consequences worth knowing:

- `.ts` is read as TypeScript, not as an MPEG transport stream. An MPEG-TS video therefore shows a text preview and offers the editor, where it opens read-only behind the existing binary banner. The extension is genuinely ambiguous and Butler already treated it as text elsewhere.
- "Open with" and Share now hand out the real type (`text/plain` and friends) instead of `application/octet-stream`, so text editors appear in the chooser where they previously did not.

Closes #80

## Technical Context

- Root cause: `MimeInfo.fromFileName` had exactly two text arms and fell back to `application/octet-stream`. Every Explorer affordance reads that one value — the editor row, the Open routing through `OpenInNewTabsUseCase.classify`, the drag kind, and the Type label — so all four failed together. Widening only the action sheet would have left Open still landing on the Viewer's unsupported placeholder.
- There were five independent extension/MIME tables answering "is this text?", and they disagreed: the Searcher's already contained `yaml`, which is why the same file behaved differently there. Four are now consolidated into `MimeInfo` — both its extension table and its MIME-type set. `Language.EXTENSION_MAP` stays separate on purpose: syntax highlighting needs per-language granularity that text-ness collapses.
- No Explorer, Searcher or Viewer call site was touched. They already read `MimeInfo`/`TextFileDetector` and simply get the corrected answer, which is the check that this sits at the right layer. `TextFileDetector`'s three overloads previously disagreed with each other — the `MimeInfo` one read the narrow predicate while looking like the wide one — and now all delegate to the same table.
- `MimeTypeTool` asks `MimeInfo` before the platform `MimeTypeMap` so thumbnails agree with the rest of the app, with the platform map kept as fallback so image and video types Butler's table does not know (`tiff`, `jfif`) keep their thumbnails. That ordering is the part most worth close review; `MimeTypeToolTest` pins it with a deliberately conflicting platform mapping.
- Side effect outside the Explorer: a binary file *named* `readme` or `license` now skips the Searcher's binary sniff during content search and gets decoded and scanned instead. Bounded by the existing content-size cap.
