### PR TITLE
Fix: Root setup card no longer claims the root manager is missing

### DIFF
--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootCardStatus.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootCardStatus.kt
@@ -8,22 +8,20 @@ enum class RootCardStatus {
     DISABLED,
     CONNECTING,
     CONNECTED,
-    NOT_INSTALLED,
     NOT_CONNECTED,
     CONNECTION_FAILED,
 }
 
 /**
- * The installed-manager lookup only knows a handful of package ids, so it says nothing about a
- * device whose root manager is not one of them. It is consulted after the probe concluded it failed,
- * never as a reason to contradict a service that is answering.
+ * The installed-manager lookup only knows a handful of package ids, so it cannot tell an absent
+ * root manager from one it does not recognise. The card never keys its wording on it.
  */
 fun RootSetupModule.Result?.toCardStatus(): RootCardStatus = when {
     this == null || useRoot != true -> RootCardStatus.DISABLED
     else -> when (serviceState) {
         is RootServiceState.Available -> RootCardStatus.CONNECTED
         is RootServiceState.NotChecked, is RootServiceState.Connecting -> RootCardStatus.CONNECTING
-        is RootServiceState.Failed -> if (isInstalled) RootCardStatus.NOT_CONNECTED else RootCardStatus.NOT_INSTALLED
+        is RootServiceState.Failed -> RootCardStatus.NOT_CONNECTED
         is RootServiceState.TimedOut -> RootCardStatus.CONNECTION_FAILED
     }
 }

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -48,7 +48,6 @@ fun RootShizukuActions(
                     RootCardStatus.DISABLED -> null
                     RootCardStatus.CONNECTED -> stringResource(R.string.setup_status_connected)
                     RootCardStatus.CONNECTING -> stringResource(R.string.setup_status_connecting)
-                    RootCardStatus.NOT_INSTALLED -> stringResource(R.string.setup_status_not_installed)
                     RootCardStatus.NOT_CONNECTED -> stringResource(R.string.setup_status_not_connected)
                     RootCardStatus.CONNECTION_FAILED -> stringResource(R.string.setup_status_connection_failed)
                 }

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/SetupStateIndicator.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/SetupStateIndicator.kt
@@ -44,9 +44,6 @@ fun SetupStateIndicator(
                         RootCardStatus.CONNECTING -> {
                             Icons.TwoTone.RadioButtonUnchecked to MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         }
-                        RootCardStatus.NOT_INSTALLED -> {
-                            Icons.TwoTone.Error to MaterialTheme.colorScheme.error
-                        }
                         RootCardStatus.NOT_CONNECTED -> {
                             Icons.TwoTone.Error to MaterialTheme.colorScheme.tertiary
                         }

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootCardStatusTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 /**
- * The card's headline, its sub-line and its icon each render the same decision, so the decision is
- * made once, here, rather than re-derived per surface.
+ * The card's connection sub-line and its icon render the same decision, so the decision is made
+ * once, here, rather than re-derived per surface.
  */
 class RootCardStatusTest : BaseTest() {
 
@@ -59,12 +59,13 @@ class RootCardStatusTest : BaseTest() {
         result(true, isInstalled = true, RootServiceState.NotChecked).toCardStatus() shouldBe RootCardStatus.CONNECTING
     }
 
-    @Test fun `a failed probe without a known manager is not installed`() {
-        result(true, isInstalled = false, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.NOT_INSTALLED
-    }
-
-    @Test fun `a failed probe with a known manager is not connected`() {
+    /**
+     * The lookup cannot tell an absent root manager from one it does not recognise, so a failed
+     * probe reads as not connected either way.
+     */
+    @Test fun `a failed probe is not connected`() {
         result(true, isInstalled = true, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.NOT_CONNECTED
+        result(true, isInstalled = false, RootServiceState.Failed).toCardStatus() shouldBe RootCardStatus.NOT_CONNECTED
     }
 
     /**

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/RootSetupCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/RootSetupCardStatusTest.kt
@@ -18,7 +18,8 @@ import testhelpers.ComposeTest
 /**
  * The card is where the headline and the connection sub-line meet, so this is what catches them
  * disagreeing about one state. The icon is not asserted: it carries no content description and
- * Robolectric cannot draw, [RootCardStatusTest] covers the decision both of them render.
+ * Robolectric cannot draw, [RootCardStatusTest] covers the decision the sub-line and the icon
+ * render.
  */
 class RootSetupCardStatusTest : ComposeTest() {
 
@@ -61,6 +62,14 @@ class RootSetupCardStatusTest : ComposeTest() {
         renderCard(RootServiceState.Connecting)
 
         composeTestRule.onNodeWithText(context.getString(R.string.setup_status_connecting)).assertIsDisplayed()
+        assertNotShown(context.getString(R.string.setup_status_not_installed))
+    }
+
+    @Test
+    fun `a failed probe without a known manager is reported as not connected`() {
+        renderCard(RootServiceState.Failed)
+
+        composeTestRule.onNodeWithText(context.getString(R.string.setup_status_not_connected)).assertIsDisplayed()
         assertNotShown(context.getString(R.string.setup_status_not_installed))
     }
 }


### PR DESCRIPTION
## What changed

When Butler's root connection fails on a device whose root manager app it doesn't recognize (for example a hidden, repackaged Magisk), the setup card claimed "Not installed" with a red error icon. That claim is false on such devices: a root manager is installed, Butler just can't identify it. The card now says "Not connected", the same wording already used when a recognized manager fails to connect. The affected code was unreleased, so no published build ever showed the wrong text.

## Technical Context

- Root cause: the failed-connection branch treated the package-id lookup (which only knows three manager package ids) as proof of absence, so an unrecognized manager rendered as missing.
- The now-unreachable "not installed" card state was removed outright rather than kept as dead code; both render surfaces switch exhaustively over the status enum, so reintroducing it later is a compile error, not a silent fall-through.
- The "Not installed" string resource stays: the Shizuku card still renders it through its own separate path.
- A render-level Robolectric test pins the fix (it fails on the unfixed code); the unit-level mapping tests now assert "not connected" for a failed probe regardless of the lookup result.

Reported in a support email (beta tester with hidden Magisk); found while verifying the related fix in 6b6ea87ff.
