### PR TITLE
Explorer: Offer root setup for Android/data when the root manager is not recognised

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/permissions/core/PathPermissionCheck.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/permissions/core/PathPermissionCheck.kt
@@ -112,9 +112,6 @@ class PathPermissionCheck @Inject constructor(
             }
 
             val setupModules = setupStateProvider.state.first()
-            val isRootAvailable = setupModules.modules[SetupModule.Type.ROOT]
-                ?.let { it as? SetupModule.State.Current }?.isAvailable == true
-            log(TAG) { "ROOT maybe available? $isRootAvailable" }
             val isShizukuAvailable = setupModules.modules[SetupModule.Type.SHIZUKU]
                 ?.let { it as? SetupModule.State.Current }?.isAvailable == true
             log(TAG) { "SHIZUKU maybe available? $isShizukuAvailable" }
@@ -126,7 +123,10 @@ class PathPermissionCheck @Inject constructor(
                     log(TAG) { "Android 13+ detected, SAF not available for $localPath" }
                     PathRequirements(
                         combos = setOfNotNull(
-                            if (isRootAvailable) setOf(SetupModule.Type.ROOT) else null,
+                            // Offered no matter whether a known root manager package resolves: that lookup
+                            // can't tell an absent manager from an unrecognised one. Shizuku stays gated,
+                            // without its app there is no route at all.
+                            setOf(SetupModule.Type.ROOT),
                             if (isShizukuAvailable) setOf(SetupModule.Type.SHIZUKU) else null,
                         )
                     )
@@ -145,7 +145,7 @@ class PathPermissionCheck @Inject constructor(
                                 SAFPickerGrant(it, localPath)
                             },
                         combos = setOfNotNull(
-                            if (isRootAvailable) setOf(SetupModule.Type.ROOT) else null,
+                            setOf(SetupModule.Type.ROOT),
                             if (isShizukuAvailable) setOf(SetupModule.Type.SHIZUKU) else null,
                         )
                     )

--- a/app-common-io/src/main/java/eu/darken/butler/permissions/core/PathPermissionCheck.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/permissions/core/PathPermissionCheck.kt
@@ -239,8 +239,10 @@ class PathPermissionCheck @Inject constructor(
         trackSetupState(
             relevantTypes = combos.flatten().toSet(),
             build = { moduleStates, installState ->
+                // Re-determined per emission: a mechanism that was still resolving during the first
+                // read has to enter the combos once it reports in.
                 PathRequirements(
-                    combos = combos,
+                    combos = determineModuleRequirements(path).combos,
                     complete = moduleStates.filterValues { it }.keys,
                     shizukuInstalled = installState.shizuku,
                     rootInstalled = installState.root,
@@ -296,11 +298,11 @@ class PathPermissionCheck @Inject constructor(
         build: suspend (Map<SetupModule.Type, Boolean>, InstallState) -> PathRequirements,
     ): Flow<PathRequirements> = setupStateProvider.state
         .map { providerState ->
-            val relevantModules = providerState.modules.values
+            // Every resolved module, not just the relevant ones: a combo set rebuilt per emission
+            // can name a type that was not relevant when tracking started.
+            val moduleStates = providerState.modules.values
                 .filterIsInstance<SetupModule.State.Current>()
-                .filter { module -> module.type in relevantTypes }
-
-            val moduleStates = relevantModules.associate { it.type to it.isComplete }
+                .associate { it.type to it.isComplete }
 
             val hasAllModules = relevantTypes.all { type ->
                 moduleStates.containsKey(type)

--- a/app-common-io/src/test/java/eu/darken/butler/permissions/core/PathPermissionCheckTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/permissions/core/PathPermissionCheckTest.kt
@@ -12,6 +12,8 @@ import eu.darken.butler.common.storage.saf.AndroidDataAccessChecker
 import eu.darken.butler.common.storage.saf.SAFPickerIntentBuilder
 import eu.darken.butler.setup.core.SetupModule
 import eu.darken.butler.setup.core.SetupStateProvider
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -41,6 +43,10 @@ class PathPermissionCheckTest : BaseTest() {
         documentUIAllowed: Boolean = true,
         safPickerIntent: Intent? = null,
         completedTypes: Set<SetupModule.Type> = emptySet(),
+        rootAvailable: Boolean = true,
+        rootInstalled: Boolean = false,
+        shizukuAvailable: Boolean = true,
+        shizukuInstalled: Boolean = false,
     ): PathPermissionCheck {
         // Create setup modules for all possible types
         val modules = mapOf(
@@ -52,12 +58,14 @@ class PathPermissionCheckTest : BaseTest() {
             SetupModule.Type.ROOT to mockk<SetupModule.State.Current>(relaxed = true) {
                 every { type } returns SetupModule.Type.ROOT
                 every { isComplete } returns (SetupModule.Type.ROOT in completedTypes)
-                every { isAvailable } returns true
+                every { isAvailable } returns rootAvailable
+                every { isInstalled } returns rootInstalled
             },
             SetupModule.Type.SHIZUKU to mockk<SetupModule.State.Current>(relaxed = true) {
                 every { type } returns SetupModule.Type.SHIZUKU
                 every { isComplete } returns (SetupModule.Type.SHIZUKU in completedTypes)
-                every { isAvailable } returns true
+                every { isAvailable } returns shizukuAvailable
+                every { isInstalled } returns shizukuInstalled
             }
         )
 
@@ -249,6 +257,84 @@ class PathPermissionCheckTest : BaseTest() {
             setOf(SetupModule.Type.ROOT),
             setOf(SetupModule.Type.SHIZUKU)
         )
+    }
+
+    @Test
+    fun `test Android 33+ - offers root when no root manager is installed`() = runTest {
+        val androidDataPath = LocalPath.build("/storage/emulated/0/Android/data")
+        val testPath = LocalPath.build("/storage/emulated/0/Android/data/com.example")
+
+        val checker = createChecker(
+            apiLevel = 33,
+            androidDataPath = androidDataPath,
+            rootAvailable = false,
+            rootInstalled = false,
+            shizukuAvailable = false,
+        )
+
+        val requirements = checker.monitor(testPath).first()
+
+        requirements.combos shouldBe setOf(setOf(SetupModule.Type.ROOT))
+        requirements.needsSetup shouldBe true
+    }
+
+    @Test
+    fun `test Android 33+ - offers root when the manager is unrecognised but root works`() = runTest {
+        val androidDataPath = LocalPath.build("/storage/emulated/0/Android/data")
+        val testPath = LocalPath.build("/storage/emulated/0/Android/data/com.example")
+
+        val checker = createChecker(
+            apiLevel = 33,
+            androidDataPath = androidDataPath,
+            rootAvailable = true,
+            rootInstalled = false,
+            shizukuAvailable = false,
+        )
+
+        val requirements = checker.monitor(testPath).first()
+
+        requirements.combos shouldBe setOf(setOf(SetupModule.Type.ROOT))
+        requirements.rootInstalled shouldBe false
+    }
+
+    @Test
+    fun `test Android 33+ - Shizuku stays gated on install`() = runTest {
+        val androidDataPath = LocalPath.build("/storage/emulated/0/Android/data")
+        val testPath = LocalPath.build("/storage/emulated/0/Android/data/com.example")
+
+        val withoutShizuku = createChecker(
+            apiLevel = 33,
+            androidDataPath = androidDataPath,
+            shizukuAvailable = false,
+        ).monitor(testPath).first()
+        withoutShizuku.combos.flatten() shouldNotContain SetupModule.Type.SHIZUKU
+
+        val withShizuku = createChecker(
+            apiLevel = 33,
+            androidDataPath = androidDataPath,
+            shizukuAvailable = true,
+        ).monitor(testPath).first()
+        withShizuku.combos shouldBe setOf(
+            setOf(SetupModule.Type.ROOT),
+            setOf(SetupModule.Type.SHIZUKU)
+        )
+    }
+
+    @Test
+    fun `test Android 30-32 with DocumentsUI restricted - offers root when no root manager is installed`() = runTest {
+        val androidDataPath = LocalPath.build("/storage/emulated/0/Android/data")
+        val testPath = LocalPath.build("/storage/emulated/0/Android/data/com.example")
+
+        val checker = createChecker(
+            apiLevel = 30,
+            androidDataPath = androidDataPath,
+            documentUIAllowed = false,
+            rootAvailable = false,
+        )
+
+        val requirements = checker.monitor(testPath).first()
+
+        requirements.combos shouldContain setOf(SetupModule.Type.ROOT)
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/permissions/core/PathPermissionCheckTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/permissions/core/PathPermissionCheckTest.kt
@@ -22,8 +22,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,6 +51,7 @@ class PathPermissionCheckTest : BaseTest() {
         rootInstalled: Boolean = false,
         shizukuAvailable: Boolean = true,
         shizukuInstalled: Boolean = false,
+        setupStates: Flow<SetupStateProvider.State>? = null,
     ): PathPermissionCheck {
         // Create setup modules for all possible types
         val modules = mapOf(
@@ -72,7 +77,7 @@ class PathPermissionCheckTest : BaseTest() {
         val providerState = SetupStateProvider.State(modules = modules)
 
         val setupStateProvider = mockk<SetupStateProvider>(relaxed = true) {
-            every { state } returns flowOf(providerState)
+            every { state } returns (setupStates ?: flowOf(providerState))
         }
 
         val accessChecker = mockk<LocalPathAccessChecker>(relaxed = true) {
@@ -514,5 +519,62 @@ class PathPermissionCheckTest : BaseTest() {
 
         requirements shouldBe PathRequirements()
         requirements.needsSetup shouldBe false
+    }
+
+    @Test
+    fun `batch monitor picks up a mechanism that resolves after the first emission`() = runTest {
+        val androidDataPath = LocalPath.build("/storage/emulated/0/Android/data")
+        val testPath = LocalPath.build("/storage/emulated/0/Android/data/com.example")
+
+        val rootModule = mockk<SetupModule.State.Current>(relaxed = true) {
+            every { type } returns SetupModule.Type.ROOT
+            every { isComplete } returns false
+            every { isAvailable } returns true
+            every { isInstalled } returns false
+        }
+        val shizukuLoading = mockk<SetupModule.State.Loading>(relaxed = true) {
+            every { type } returns SetupModule.Type.SHIZUKU
+        }
+        val shizukuResolved = mockk<SetupModule.State.Current>(relaxed = true) {
+            every { type } returns SetupModule.Type.SHIZUKU
+            every { isComplete } returns false
+            every { isAvailable } returns true
+            every { isInstalled } returns true
+        }
+
+        val setupStates = MutableStateFlow(
+            SetupStateProvider.State(
+                modules = mapOf(
+                    SetupModule.Type.ROOT to rootModule,
+                    SetupModule.Type.SHIZUKU to shizukuLoading,
+                )
+            )
+        )
+
+        val checker = createChecker(
+            apiLevel = 33,
+            androidDataPath = androidDataPath,
+            setupStates = setupStates,
+        )
+
+        val emissions = mutableListOf<PathRequirements>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            checker.monitor(listOf(testPath)).collect { emissions.add(it) }
+        }
+
+        emissions.last().combos shouldBe setOf(setOf(SetupModule.Type.ROOT))
+
+        setupStates.value = SetupStateProvider.State(
+            modules = mapOf(
+                SetupModule.Type.ROOT to rootModule,
+                SetupModule.Type.SHIZUKU to shizukuResolved,
+            )
+        )
+
+        emissions.last().combos shouldBe setOf(
+            setOf(SetupModule.Type.ROOT),
+            setOf(SetupModule.Type.SHIZUKU)
+        )
+        job.cancel()
     }
 }

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/engine/SearchEngine.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/engine/SearchEngine.kt
@@ -72,9 +72,10 @@ class SearchEngine @AssistedInject constructor(
      * Setup requirements that would unlock the items the current scan could not read
      * (e.g. Android/data without root/Shizuku enabled). Complements [setupRequirements], which
      * gates on the target roots before a search starts: a target can pass that pre-flight check
-     * yet still hit protected subtrees mid-walk. Only viable mechanisms are ever suggested —
-     * [PathPermissionCheck] filters on availability (root manager / Shizuku installed). Derived
-     * from [targetProgressState], so it resets with it on every new search.
+     * yet still hit protected subtrees mid-walk. For a protected local path that needs setup
+     * escalation, [PathPermissionCheck] offers root without checking for a known root manager
+     * package, while Shizuku is only offered when its app is installed. Derived from
+     * [targetProgressState], so it resets with it on every new search.
      */
     val accessErrorRequirements: StateFlow<PathRequirements> = _targetProgressState
         .map { progress -> progress.flatMap { it.accessErrorPaths }.filterDistinctRoots() }

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/AccessErrorsSheetContent.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/AccessErrorsSheetContent.kt
@@ -41,9 +41,10 @@ import eu.darken.butler.workspace.contracts.searcher.SearchTarget
 /**
  * Detail sheet behind the progress card's "N items couldn't be accessed" line: lists the
  * inaccessible paths in full (absolute — a file explorer must be exact about locations) and, when
- * a viable mechanism exists (root/Shizuku available — already availability-filtered by
- * PathPermissionCheck), offers the setup action. When nothing can unlock the items, the body text
- * is the terminal explanation and no action is shown.
+ * a mechanism exists that could unlock them, offers the setup action. For protected local paths
+ * that means root (offered without checking for a known root manager package) or Shizuku (only
+ * when its app is installed). When nothing can unlock the items, the body text is the terminal
+ * explanation and no action is shown.
  */
 @Composable
 fun AccessErrorsSheetContent(

--- a/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/root/RootSetupModule.kt
@@ -152,9 +152,6 @@ class RootSetupModule @Inject constructor(
 
         override val type: SetupModule.Type = SetupModule.Type.ROOT
 
-        override val isAvailable: Boolean
-            get() = isInstalled
-
         override val isComplete: Boolean = when {
             useRoot == true -> ourService // Only complete if enabled AND connected
             useRoot == false -> true // Complete if explicitly disabled


### PR DESCRIPTION
## What changed

On Android 11 and newer, opening `Android/data` or `Android/obb` on a device whose root manager's application id is not one Butler recognises (and with no Shizuku installed) showed the generic "Navigation failed" error. The same navigation on a device with a recognised root manager showed the "Permission needed" card with a route to root setup. Butler now offers root setup for those folders regardless of whether it recognises the root manager package. Shizuku is still only offered when its app is installed.

Two smaller changes ride along. The Searcher's "items couldn't be accessed" sheet now picks up an access mechanism that finishes loading while a search is already running instead of freezing the set it saw first. Two doc comments that described the old filtering were corrected.

## Technical Context

- Root cause: the permission check gated the root option on `SetupModule.State.Current.isAvailable`, which the root setup module aliased to a package lookup over three hardcoded root-manager ids. An unrecognised manager emptied the combo set, and the check then short-circuited to "nothing required", so the Explorer attempted the load and surfaced its failure.
- The Shizuku gate is kept on purpose: without the Shizuku app there is genuinely no route, whereas the root package lookup cannot tell an absent manager from an unrecognised one.
- The live-mechanism change in the batch monitor is deliberately non-blocking. It never waits for a module still in `Loading`, because the DocumentsProvider consumes the first emission and the Shizuku module's state can block on a cold root probe.
- Accepted consequence: the Searcher and app-details access-error sheets now offer root setup on devices with no recognised root manager, which matches the existing unconditional root requirement for `/data`.
- Checked on an API 37 emulator without a root manager or Shizuku: `Android/data` shows the "Permission needed" card, and its action opens a setup screen showing only the root card.
