### PR TITLE
Release: Wait up to 30 minutes for main's checks before releasing

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Pre-flight main health check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          POLL_ATTEMPTS: "20"
+          POLL_ATTEMPTS: "60"
           POLL_INTERVAL_SECONDS: "30"
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What changed

No user-facing behavior change. A release dispatched right after a push to main no longer fails its pre-flight check with "Required checks never settled" while CI is still running. The pre-flight now waits up to 30 minutes instead of 10.

## Technical Context

- The unit-test jobs on main take about 15 minutes end to end (every run over the last two days finished 15 to 17 minutes after start), so the previous 20 × 30 s budget expired a few minutes before CI went green. Seen on run 33560809489.
- `POLL_ATTEMPTS` raised from 20 to 60; the interval stays at 30 s. The job sets no `timeout-minutes`, so the outer bound remains GitHub's 6-hour default.