### PR TITLE
IO: Stop leaking file handles when previews are cancelled

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
@@ -287,6 +287,7 @@ class GatewaySwitch @Inject constructor(
         openForHandover(dispatcherProvider.IO) {
             try {
                 // create() owns the handle from here on and closes it itself if it throws.
+                // Closing the descriptor runs the proxy's release callback, which closes the handle and frees the lease.
                 val handle = file(path, readWrite = false)
                 proxyPfdFactory.create(handle, "r").seekableOrNull()
             } catch (e: Exception) {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/GatewaySwitch.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.files
 
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.coroutine.openForHandover
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
@@ -33,11 +34,9 @@ import eu.darken.butler.common.sharedresource.adoptChildResource
 import android.os.ParcelFileDescriptor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.plus
-import kotlinx.coroutines.withContext
 import okio.FileHandle
 import okio.IOException
 import java.io.InputStream
@@ -261,7 +260,7 @@ class GatewaySwitch @Inject constructor(
     suspend fun openReadPFD(path: APath<*>): ParcelFileDescriptor? = when (path) {
         is LocalPath -> directReadPfdOrNull(path) ?: proxyReadPfdOrNull(path)
 
-        is SAFPath -> safGateway.openReadPFD(path)?.seekableOrNull()
+        is SAFPath -> openForHandover(dispatcherProvider.IO) { safGateway.openReadPFD(path)?.seekableOrNull() }
 
         // No preview descriptors for archive entries: producing one would require decompressing
         // the entry to scratch storage, which previews must not trigger implicitly.
@@ -271,10 +270,10 @@ class GatewaySwitch @Inject constructor(
     }
 
     private suspend fun directReadPfdOrNull(path: LocalPath): ParcelFileDescriptor? =
-        withContext(dispatcherProvider.IO) {
+        openForHandover(dispatcherProvider.IO) {
             try {
                 val file = path.file
-                if (!file.isFile || !file.canRead()) return@withContext null
+                if (!file.isFile || !file.canRead()) return@openForHandover null
                 ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).seekableOrNull()
             } catch (e: CancellationException) {
                 throw e
@@ -284,33 +283,17 @@ class GatewaySwitch @Inject constructor(
             }
         }
 
-    /**
-     * NonCancellable because both halves carry something a cancellation must not drop: the handle
-     * holds a gateway lease until the descriptor is released, and statSize below may block on a
-     * Binder call.
-     */
-    private suspend fun proxyReadPfdOrNull(path: APath<*>): ParcelFileDescriptor? {
-        var openedPfd: ParcelFileDescriptor? = null
-        return try {
-            withContext(NonCancellable + dispatcherProvider.IO) {
-                try {
-                    // create() owns the handle from here on and closes it itself if it throws.
-                    val handle = file(path, readWrite = false)
-                    openedPfd = proxyPfdFactory.create(handle, "r").seekableOrNull()
-                    openedPfd
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "openReadPFD($path): Proxy lane failed: ${e.asLog()}" }
-                    null
-                }
+    private suspend fun proxyReadPfdOrNull(path: APath<*>): ParcelFileDescriptor? =
+        openForHandover(dispatcherProvider.IO) {
+            try {
+                // create() owns the handle from here on and closes it itself if it throws.
+                val handle = file(path, readWrite = false)
+                proxyPfdFactory.create(handle, "r").seekableOrNull()
+            } catch (e: Exception) {
+                log(TAG, WARN) { "openReadPFD($path): Proxy lane failed: ${e.asLog()}" }
+                null
             }
-        } catch (e: CancellationException) {
-            // Resuming into a cancelled caller discards the return value, so nobody downstream ever
-            // sees this descriptor - it has to be closed here. That also runs the proxy's release
-            // callback, which closes the handle and frees the gateway lease.
-            runCatching { openedPfd?.close() }
-            throw e
         }
-    }
 
     private fun ParcelFileDescriptor.seekableOrNull(): ParcelFileDescriptor? {
         val size = try {

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/GatewaySwitchPfdTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/GatewaySwitchPfdTest.kt
@@ -20,7 +20,9 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okio.FileHandle
 import org.junit.Before
@@ -222,6 +224,83 @@ class GatewaySwitchPfdTest : BaseTest() {
         job.join()
 
         verify { proxyPfd.close() }
+    }
+
+    @Test
+    fun `a proxy descriptor is closed when the caller is cancelled during an undispatched handoff`() = runTest {
+        val path = LocalPath.build("storage", "emulated", "0", "not-there")
+        val handle = mockk<FileHandle>(relaxed = true)
+        val proxyPfd = seekablePfd()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { localGateway.file(path, false) } coAnswers {
+            gate.await()
+            handle
+        }
+        every { proxyPfdFactory.create(handle, "r") } returns proxyPfd
+        // Caller and lane on one dispatcher: the hand-back is then an undispatched resume, which
+        // reports no cancellation of its own.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val switch = GatewaySwitch(
+            appScope = TestScope(),
+            dispatcherProvider = TestDispatcherProvider(dispatcher),
+            safGateway = safGateway,
+            localGateway = localGateway,
+            archiveGateway = archiveGateway,
+            smbGateway = smbGateway,
+            safLocationManager = safLocationManager,
+            proxyPfdFactory = proxyPfdFactory,
+        )
+        var handedBack = false
+
+        val job = launch(dispatcher) {
+            switch.openReadPFD(path)
+            handedBack = true
+        }
+        runCurrent()
+
+        job.cancel()
+        gate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 1) { proxyPfd.close() }
+        handedBack shouldBe false
+        job.isCancelled shouldBe true
+    }
+
+    @Test
+    fun `a SAF descriptor is closed when the caller is cancelled during an undispatched handoff`() = runTest {
+        val safPfd = seekablePfd()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { safGateway.openReadPFD(safPath) } coAnswers {
+            gate.await()
+            safPfd
+        }
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val switch = GatewaySwitch(
+            appScope = TestScope(),
+            dispatcherProvider = TestDispatcherProvider(dispatcher),
+            safGateway = safGateway,
+            localGateway = localGateway,
+            archiveGateway = archiveGateway,
+            smbGateway = smbGateway,
+            safLocationManager = safLocationManager,
+            proxyPfdFactory = proxyPfdFactory,
+        )
+        var handedBack = false
+
+        val job = launch(dispatcher) {
+            switch.openReadPFD(safPath)
+            handedBack = true
+        }
+        runCurrent()
+
+        job.cancel()
+        gate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 1) { safPfd.close() }
+        handedBack shouldBe false
+        job.isCancelled shouldBe true
     }
 
     @Test

--- a/app-common/src/main/java/eu/darken/butler/common/coroutine/CoroutineExtensions.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/coroutine/CoroutineExtensions.kt
@@ -1,9 +1,14 @@
 package eu.darken.butler.common.coroutine
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.Closeable
 
@@ -37,6 +42,32 @@ suspend fun <T : Any> CoroutineScope.runDetachedWithTimeout(
         // detached coroutine running unobserved on the long-lived scope. Cancelling can't interrupt a
         // thread already blocked in a binder transaction, but it does drop queued/cooperative work.
         deferred.cancel()
+    }
+}
+
+/**
+ * Opens a resource whose ownership transfers to the caller, and closes it instead of leaking it when
+ * the caller is no longer there to receive it.
+ *
+ * Two separate things can go wrong. A cancellation arriving while [open] runs would make
+ * `withContext` discard whatever the block returned, so the open runs under [NonCancellable].
+ * A cancellation arriving as the block hands its result back is reported on only one of
+ * `withContext`'s two resume paths, so the reference is kept out here and the caller's cancellation
+ * is checked explicitly. Either way nobody downstream ever receives the resource, which makes this
+ * the only place it can still be closed.
+ */
+suspend fun <T : Closeable> openForHandover(
+    dispatcher: CoroutineDispatcher,
+    open: suspend () -> T?,
+): T? {
+    var opened: T? = null
+    try {
+        withContext(NonCancellable + dispatcher) { opened = open() }
+        currentCoroutineContext().ensureActive()
+        return opened
+    } catch (e: CancellationException) {
+        runCatching { opened?.close() }
+        throw e
     }
 }
 

--- a/app-common/src/test/java/eu/darken/butler/common/coroutine/CoroutineExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/coroutine/CoroutineExtensionsTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.coroutine
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,16 +10,21 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import okio.IOException
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.io.Closeable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Real time, not [kotlinx.coroutines.test.runTest]: the point of the helper is that it survives a
- * thread blocked in a synchronous call, which virtual time would skip right past.
+ * The [runDetachedWithTimeout] tests run in real time, not [kotlinx.coroutines.test.runTest]: the
+ * point of that helper is that it survives a thread blocked in a synchronous call, which virtual
+ * time would skip right past.
  */
 class CoroutineExtensionsTest : BaseTest() {
 
@@ -82,5 +88,63 @@ class CoroutineExtensionsTest : BaseTest() {
         blockRan.get() shouldBe false
 
         scope.cancel()
+    }
+
+    private class TestCloseable : Closeable {
+        var closeCount = 0
+            private set
+
+        override fun close() {
+            closeCount++
+        }
+    }
+
+    @Test fun `a resource opened while the caller is being cancelled is closed`() = runTest {
+        // Distinct dispatchers, so the hand-back is a real dispatched resume.
+        val callerDispatcher = StandardTestDispatcher(testScheduler)
+        val openDispatcher = StandardTestDispatcher(testScheduler)
+        val gate = CompletableDeferred<Unit>()
+        val resource = TestCloseable()
+        var received: TestCloseable? = null
+
+        val job = launch(callerDispatcher) {
+            received = openForHandover(openDispatcher) {
+                gate.await()
+                resource
+            }
+        }
+        runCurrent()
+
+        job.cancel()
+        gate.complete(Unit)
+        runCurrent()
+
+        resource.closeCount shouldBe 1
+        received shouldBe null
+        job.isCancelled shouldBe true
+    }
+
+    @Test fun `a resource handed back to a cancelled caller is closed`() = runTest {
+        // One dispatcher for both, so withContext resumes undispatched and reports no cancellation.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val gate = CompletableDeferred<Unit>()
+        val resource = TestCloseable()
+        var received: TestCloseable? = null
+
+        val job = launch(dispatcher) {
+            received = openForHandover(dispatcher) {
+                gate.await()
+                resource
+            }
+        }
+        runCurrent()
+
+        job.cancel()
+        gate.complete(Unit)
+        runCurrent()
+
+        resource.closeCount shouldBe 1
+        received shouldBe null
+        job.isCancelled shouldBe true
     }
 }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerContentReader.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerContentReader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.ParcelFileDescriptor
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.coroutine.openForHandover
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
@@ -11,7 +12,6 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
@@ -57,13 +57,11 @@ class ViewerContentReader @Inject constructor(
     suspend fun openStreamForHandover(source: ViewerSource): InputStream = when (source) {
         is ViewerSource.Stored -> gatewaySwitch.openInputStream(source.path)
 
-        // NonCancellable around the open: the provider call suspends, and a cancellation arriving
-        // as it returns would discard the only reference to an open stream. Enough of those and the
-        // process runs out of descriptors.
-        is ViewerSource.Streamed -> withContext(NonCancellable + dispatcherProvider.IO) {
+        // A cancellation racing the open would otherwise discard the only reference to an open
+        // stream. Enough of those and the process runs out of descriptors.
+        is ViewerSource.Streamed -> openForHandover(dispatcherProvider.IO) {
             context.contentResolver.openInputStream(source.uri)
-                ?: throw ViewerContentUnreadableException(source.displayName)
-        }
+        } ?: throw ViewerContentUnreadableException(source.displayName)
     }
 
     /**
@@ -76,9 +74,9 @@ class ViewerContentReader @Inject constructor(
     suspend fun openReadPfd(source: ViewerSource): ParcelFileDescriptor? = when (source) {
         is ViewerSource.Stored -> gatewaySwitch.openReadPFD(source.path)
 
-        // Same NonCancellable reasoning as openStreamForHandover: the descriptor must not be opened
-        // and then dropped by a cancellation racing the return.
-        is ViewerSource.Streamed -> withContext(NonCancellable + dispatcherProvider.IO) {
+        // Same handover reasoning as openStreamForHandover: the descriptor must not be opened and
+        // then dropped by a cancellation racing the return.
+        is ViewerSource.Streamed -> openForHandover(dispatcherProvider.IO) {
             try {
                 context.contentResolver.openFileDescriptor(source.uri, "r")?.seekableOrNull()
             } catch (e: CancellationException) {

--- a/app/src/main/java/eu/darken/butler/common/coil/fetchers/SharedContentPreviewFetcher.kt
+++ b/app/src/main/java/eu/darken/butler/common/coil/fetchers/SharedContentPreviewFetcher.kt
@@ -12,6 +12,7 @@ import coil3.request.Options
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.coil.targetEdgePx
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.coroutine.openForHandover
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
@@ -19,7 +20,6 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.preview.PdfPreviewGenerator
 import eu.darken.butler.common.pkgs.ApkIconExtractor
 import eu.darken.butler.common.previews.SharedContentPreview
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -71,9 +71,9 @@ class SharedContentPreviewFetcher(
 
     // Opening/statting a content:// descriptor can block (cloud/document providers), so keep it off
     // Coil's fetch dispatcher.
-    private suspend fun openReadPfd(): ParcelFileDescriptor? = withContext(dispatcherProvider.IO) {
+    private suspend fun openReadPfd(): ParcelFileDescriptor? = openForHandover(dispatcherProvider.IO) {
         try {
-            val pfd = context.contentResolver.openFileDescriptor(data.uri, "r") ?: return@withContext null
+            val pfd = context.contentResolver.openFileDescriptor(data.uri, "r") ?: return@openForHandover null
             if (pfd.statSize < 0) {
                 runCatching { pfd.close() } // non-seekable (pipe-backed provider) -> can't parse
                 null


### PR DESCRIPTION
## What changed

Opening a preview hands a file descriptor to whoever asked for it. When the request was cancelled first, which happens routinely as previews scroll off screen, that descriptor could be created and then dropped without ever being closed, holding the file handle and its storage lease open until garbage collection. Enough of those and the app runs out of descriptors.

Every preview path is covered now: local files, files that need root or ADB, network storage, SAF documents, the viewer's image and PDF handover, and share-sheet previews. Previously only one of them had any protection, and only half of it.

## Technical Context

- Handing a resource out of a `withContext` block has two separate cancellation windows. A cancellation landing while the block runs makes `withContext` discard the block's return value outright. A cancellation landing as the block hands its result back is reported on only one of `withContext`'s two resume paths: `DispatchedCoroutine.afterResume` starts with `if (tryResume()) return`, so when the block finishes before the caller suspends, the value comes back through `getResult()`, which never consults the caller's Job. `NonCancellable` closes the first window and does nothing for the second.
- Covering both takes `NonCancellable` around the open, the reference kept in a variable outside the block, and an explicit `ensureActive()` on the caller's context. `openForHandover` in `app-common` states that once; six call sites use it.
- `SAFGateway` is untouched on purpose. Its `runIO` nests inside the helper's `NonCancellable` scope and inherits the protection from there.
- Two comments in `ViewerContentReader` claimed `NonCancellable` protected the hand-back. It does not, and they are corrected.
- This started as an intermittent CI failure in `GatewaySwitchPfdTest`, which turned out to be the leak actually occurring rather than a flaky assertion. The two new lane tests in that file pin the previously unchecked resume path, and both fail against the unmodified code with the exact signature the CI failures showed.
