### PR TITLE
Bugreport: Collapse the log on the report details screen

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -19,6 +19,8 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import android.net.Uri
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -181,6 +183,9 @@ class BugReportRepo @Inject constructor(
         file.bufferedReader().useLines { lines ->
             lines.forEach { line ->
                 total++
+                // The loop itself never suspends, so without this an abandoned read keeps scanning
+                // to EOF. Sampled rather than per-line to keep the check off the hot path.
+                if (total % CANCEL_CHECK_LINES == 0) currentCoroutineContext().ensureActive()
                 if (ring.size == maxLines) ring.removeFirst()
                 ring.addLast(line)
             }
@@ -405,5 +410,6 @@ class BugReportRepo @Inject constructor(
         private val TAG = logTag("Debug", "BugReport", "Repo")
         private const val MAX_REPORTS = 25
         private const val TMP_GRACE_MS = 60_000L
+        private const val CANCEL_CHECK_LINES = 1000
     }
 }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -117,6 +117,7 @@ fun BugReportWorkspacePageHost(
             state = s,
             onReportClick = { info -> vm.openReport(info.id) },
             onBack = { vm.closeReport() },
+            onToggleLog = { vm.setLogExpanded(it) },
             onShareReport = { report -> vm.requestShareConsent(report.id) },
             onDeleteReport = { id -> vm.delete(id) },
             onDeleteAll = { vm.requestDeleteAllConfirmation() },
@@ -138,6 +139,7 @@ fun BugReportWorkspacePage(
     onDeleteAll: () -> Unit = {},
     onStartRecording: () -> Unit = {},
     onStopRecording: () -> Unit = {},
+    onToggleLog: (Boolean) -> Unit = {},
 ) {
     val detail = state.detail
     if (detail != null) {
@@ -148,6 +150,7 @@ fun BugReportWorkspacePage(
             onBack = onBack,
             onShare = { onShareReport(detail.info.report) },
             onDelete = { onDeleteReport(detail.info.id) },
+            onToggleLog = onToggleLog,
         )
         return
     }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -16,8 +16,8 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.ui.ViewModel3
 import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
 @HiltViewModel(assistedFactory = BugReportWorkspaceViewModel.Factory::class)
@@ -79,7 +80,7 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     // flatMapLatest cancels an in-flight load when either changes, and catching a read failure
     // (e.g. the report deleted between scan and read) keeps it from killing the collector — it
     // surfaces as LogState.Error instead.
-    private val detailLog: Flow<DetailLog?> = logSelection
+    private val detailLog: StateFlow<DetailLog?> = logSelection
         .map { it.reportId to it.requestId }
         .distinctUntilChanged()
         .flatMapLatest { (reportId, requestId) ->
@@ -112,6 +113,9 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
             }
         }
         .onEach { lastLogState.value = it?.state }
+        // Shared eagerly: the page's state flow stops when nothing collects it for 5s, and a cold
+        // detailLog would re-run the completed read from scratch on the next subscription.
+        .stateIn(vmScope, SharingStarted.Eagerly, null)
 
     val state = combine(
         bugReportRepo.reports,

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -20,9 +20,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 
 @HiltViewModel(assistedFactory = BugReportWorkspaceViewModel.Factory::class)
@@ -33,8 +36,13 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     private val bugReportRecorder: BugReportRecorder,
 ) : ViewModel3(dispatchers, logTag("BugReport", "Workspace", id.shortTag, "Page")) {
 
-    /** The report currently shown in the full-screen detail view, or null while on the list. */
-    private val selectedReportId = MutableStateFlow<String?>(null)
+    // One object rather than one flow per field: a report switch has to be observable as a single
+    // value, otherwise a collector can see the new report paired with the previous report's
+    // expansion and start a full log scan that is immediately cancelled again.
+    private val logSelection = MutableStateFlow(LogSelection())
+
+    // What the last completed read produced, so a retry can be told apart from a cached tail.
+    private val lastLogState = MutableStateFlow<LogState?>(null)
 
     // Overlay visibility lives here rather than in the page host: the page and its overlays are
     // siblings, so a `remember` in the page would be a different instance from the one the overlays
@@ -65,52 +73,61 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         if (it.activeDialog is ActiveDialog.DeleteAllConfirmation) it.copy(activeDialog = null) else it
     }
 
-    // Loads the selected report's log tail. flatMapLatest cancels an in-flight load when the selection
-    // changes, and runCatching keeps a read failure (e.g. the report deleted between scan and read)
-    // from killing the collector — it surfaces as LogState.Error instead.
-    private val detailLog: Flow<DetailLog?> = selectedReportId.flatMapLatest { reportId ->
-        if (reportId == null) {
-            flowOf(null)
-        } else {
-            flow {
-                emit(DetailLog(reportId, LogState.Loading))
-                val logState = try {
-                    val tail = bugReportRepo.readLogTail(reportId, MAX_LOG_PREVIEW_LINES)
-                    if (tail.totalLines == 0) {
-                        LogState.Empty
-                    } else {
-                        LogState.Loaded(
-                            lines = tail.lines,
-                            totalLines = tail.totalLines,
-                            shownLines = tail.lines.size,
-                            isTruncated = tail.totalLines > tail.lines.size,
-                        )
+    // Loads the selected report's log tail once the user has asked for it — a requestId of 0 means
+    // the section was never expanded, so nothing is read from disk. Keying on report + request id
+    // (distinct) is what keeps a plain collapse/expand from restarting a completed read.
+    // flatMapLatest cancels an in-flight load when either changes, and catching a read failure
+    // (e.g. the report deleted between scan and read) keeps it from killing the collector — it
+    // surfaces as LogState.Error instead.
+    private val detailLog: Flow<DetailLog?> = logSelection
+        .map { it.reportId to it.requestId }
+        .distinctUntilChanged()
+        .flatMapLatest { (reportId, requestId) ->
+            if (reportId == null || requestId == 0) {
+                flowOf(null)
+            } else {
+                flow {
+                    emit(DetailLog(reportId, LogState.Loading))
+                    val logState = try {
+                        val tail = bugReportRepo.readLogTail(reportId, MAX_LOG_PREVIEW_LINES)
+                        if (tail.totalLines == 0) {
+                            LogState.Empty
+                        } else {
+                            LogState.Loaded(
+                                lines = tail.lines,
+                                totalLines = tail.totalLines,
+                                shownLines = tail.lines.size,
+                                isTruncated = tail.totalLines > tail.lines.size,
+                            )
+                        }
+                    } catch (e: CancellationException) {
+                        // Selection changed/closed mid-read — let cancellation propagate, don't log an error.
+                        throw e
+                    } catch (e: Exception) {
+                        log(tag, ERROR) { "readLogTail failed for $reportId: ${e.asLog()}" }
+                        LogState.Error
                     }
-                } catch (e: CancellationException) {
-                    // Selection changed/closed mid-read — let cancellation propagate, don't log an error.
-                    throw e
-                } catch (e: Exception) {
-                    log(tag, ERROR) { "readLogTail failed for $reportId: ${e.asLog()}" }
-                    LogState.Error
+                    emit(DetailLog(reportId, logState))
                 }
-                emit(DetailLog(reportId, logState))
             }
         }
-    }
+        .onEach { lastLogState.value = it?.state }
 
     val state = combine(
         bugReportRepo.reports,
         bugReportRecorder.state,
-        selectedReportId,
+        logSelection,
         detailLog,
-    ) { reports, recorder, selectedId, loadedLog ->
+    ) { reports, recorder, selection, loadedLog ->
         // Derive the detail from the live list: if the selected report is gone (deleted/pruned), the
         // detail collapses to null and the UI returns to the list automatically.
-        val detail = selectedId?.let { sid ->
+        val detail = selection.reportId?.let { sid ->
             reports.firstOrNull { it.id == sid }?.let { info ->
                 Detail(
                     info = info,
-                    logState = loadedLog?.takeIf { it.reportId == sid }?.state ?: LogState.Loading,
+                    logState = loadedLog?.takeIf { it.reportId == sid }?.state
+                        ?: if (selection.expanded) LogState.Loading else LogState.Idle,
+                    isLogExpanded = selection.expanded,
                 )
             }
         }
@@ -124,14 +141,32 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         )
     }.asStateFlow()
 
+    /** Every selection change goes through here, so a report switch always resets the log state too. */
+    private fun selectReport(reportId: String?) {
+        logSelection.value = LogSelection(reportId)
+        lastLogState.value = null
+    }
+
     fun openReport(reportId: String) {
         log(tag, INFO) { "openReport($reportId)" }
-        selectedReportId.value = reportId
+        selectReport(reportId)
         markSeen(reportId)
     }
 
     fun closeReport() {
-        selectedReportId.value = null
+        selectReport(null)
+    }
+
+    fun setLogExpanded(expanded: Boolean) {
+        logSelection.update { current ->
+            // A new request id restarts the read. Re-expanding after a failure is the retry path; a
+            // successful tail stays cached across collapse/expand cycles.
+            val needsLoad = expanded && (current.requestId == 0 || lastLogState.value == LogState.Error)
+            current.copy(
+                expanded = expanded,
+                requestId = if (needsLoad) current.requestId + 1 else current.requestId,
+            )
+        }
     }
 
     /** Acknowledge a report so a crash no longer auto-surfaces. Called on explicit user actions. */
@@ -142,7 +177,7 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     fun delete(reportId: String) = launch {
         log(tag, INFO) { "delete($reportId)" }
         bugReportRepo.delete(reportId)
-        if (selectedReportId.value == reportId) selectedReportId.value = null
+        if (logSelection.value.reportId == reportId) selectReport(null)
     }
 
     fun deleteAll() {
@@ -152,7 +187,7 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         dismissDeleteAllConfirmation()
         launch {
             bugReportRepo.deleteAll()
-            selectedReportId.value = null
+            selectReport(null)
         }
     }
 
@@ -203,9 +238,12 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     data class Detail(
         val info: BugReportInfo,
         val logState: LogState,
+        val isLogExpanded: Boolean,
     )
 
     sealed interface LogState {
+        /** The log has not been requested yet — the section is collapsed and nothing was read. */
+        data object Idle : LogState
         data object Loading : LogState
         data class Loaded(
             val lines: List<String>,
@@ -221,6 +259,13 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
     private data class DetailLog(
         val reportId: String,
         val state: LogState,
+    )
+
+    /** [requestId] 0 means the log was never requested; each increment starts a fresh read. */
+    private data class LogSelection(
+        val reportId: String? = null,
+        val expanded: Boolean = false,
+        val requestId: Int = 0,
     )
 
     @AssistedFactory

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -84,9 +84,9 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         .distinctUntilChanged()
         .flatMapLatest { (reportId, requestId) ->
             if (reportId == null || requestId == 0) {
-                flowOf(null)
+                flowOf<DetailLog?>(null)
             } else {
-                flow {
+                flow<DetailLog?> {
                     emit(DetailLog(reportId, LogState.Loading))
                     val logState = try {
                         val tail = bugReportRepo.readLogTail(reportId, MAX_LOG_PREVIEW_LINES)

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
@@ -279,7 +279,7 @@ private fun LazyListScope.logSection(
                     },
                 ),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.padding(start = 4.dp).size(20.dp),
             )
         }
     }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.bugreport.ui.detail
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,9 +20,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ExpandLess
+import androidx.compose.material.icons.twotone.ExpandMore
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -69,6 +75,7 @@ fun BugReportDetailContent(
     onBack: () -> Unit,
     onShare: () -> Unit,
     onDelete: () -> Unit,
+    onToggleLog: (Boolean) -> Unit,
 ) {
     val paneInsets = design.paneInsets()
     val navBarInset = paneInsets.bottom
@@ -109,7 +116,12 @@ fun BugReportDetailContent(
             if (hasError) {
                 item { ErrorCard(report = report) }
             }
-            logSection(logState = detail.logState, logSizeBytes = detail.info.logSizeBytes)
+            logSection(
+                logState = detail.logState,
+                logSizeBytes = detail.info.logSizeBytes,
+                isExpanded = detail.isLogExpanded,
+                onToggle = { onToggleLog(!detail.isLogExpanded) },
+            )
         }
 
         FloatingBarStack(
@@ -222,13 +234,18 @@ private fun ErrorCard(report: BugReport) {
 private fun LazyListScope.logSection(
     logState: BugReportWorkspaceViewModel.LogState,
     logSizeBytes: Long,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
 ) {
     item {
         // Compact header: title on the left; size + line count ("3.2 kB · X lines" or
         // "… · last X of Y lines") on the right — the size lives here rather than in the metadata card.
+        // The row is the toggle, so it carries the minimum interactive height itself.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .clickable(role = Role.Button) { onToggle() }
                 .padding(top = 4.dp, bottom = 2.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -252,9 +269,24 @@ private fun LazyListScope.logSection(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            Icon(
+                imageVector = if (isExpanded) Icons.TwoTone.ExpandLess else Icons.TwoTone.ExpandMore,
+                contentDescription = stringResource(
+                    if (isExpanded) {
+                        eu.darken.butler.common.R.string.general_collapse_action
+                    } else {
+                        eu.darken.butler.common.R.string.general_expand_action
+                    },
+                ),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
+    if (!isExpanded) return
     when (logState) {
+        BugReportWorkspaceViewModel.LogState.Idle -> {}
+
         BugReportWorkspaceViewModel.LogState.Loading -> item {
             Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(modifier = Modifier.size(24.dp))
@@ -372,10 +404,12 @@ private fun BugReportDetailContentCrashPreview() {
                     shownLines = 12,
                     isTruncated = true,
                 ),
+                isLogExpanded = true,
             ),
             onBack = {},
             onShare = {},
             onDelete = {},
+            onToggleLog = {},
         )
     }
 }
@@ -394,10 +428,12 @@ private fun BugReportDetailContentRecordingPreview() {
                     shownLines = 8,
                     isTruncated = false,
                 ),
+                isLogExpanded = true,
             ),
             onBack = {},
             onShare = {},
             onDelete = {},
+            onToggleLog = {},
         )
     }
 }
@@ -411,10 +447,31 @@ private fun BugReportDetailContentLoadingPreview() {
             detail = BugReportWorkspaceViewModel.Detail(
                 info = BugReportInfo(report = sampleReport(BugReport.Type.REPORTED, withError = true), isSeen = true, logSizeBytes = 12_000L),
                 logState = BugReportWorkspaceViewModel.LogState.Loading,
+                isLogExpanded = true,
             ),
             onBack = {},
             onShare = {},
             onDelete = {},
+            onToggleLog = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun BugReportDetailContentLogCollapsedPreview() {
+    PreviewWrapper {
+        BugReportDetailContent(
+            design = WorkspaceDesign(),
+            detail = BugReportWorkspaceViewModel.Detail(
+                info = BugReportInfo(report = sampleReport(BugReport.Type.CRASH, withError = true), isSeen = true, logSizeBytes = 24_000L),
+                logState = BugReportWorkspaceViewModel.LogState.Idle,
+                isLogExpanded = false,
+            ),
+            onBack = {},
+            onShare = {},
+            onDelete = {},
+            onToggleLog = {},
         )
     }
 }

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModelLogTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModelLogTest.kt
@@ -13,14 +13,17 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
@@ -169,5 +172,41 @@ class BugReportWorkspaceViewModelLogTest : BaseTest() {
 
         coVerify(exactly = 2) { repo.readLogTail("a", any()) }
         vm.detail().logState shouldBe loaded
+    }
+
+    @Test
+    fun `a fresh state collector after the sharing timeout does not reread the tail`() = runTest {
+        // The VM's own dispatcher has to be on the test scheduler, otherwise WhileSubscribed's 5s
+        // timeout runs on real time, advanceTimeBy() never fires it and the test passes vacuously.
+        val vm = BugReportWorkspaceViewModel(
+            id = Workspace.Id(),
+            dispatchers = TestDispatcherProvider(UnconfinedTestDispatcher(testScheduler)),
+            bugReportRepo = repo,
+            bugReportRecorder = recorder,
+        )
+
+        // Held separately from createVM()'s backgroundScope collector: this one has to be cancelled
+        // mid-test to simulate the page leaving composition.
+        val firstCollector = launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect { } }
+
+        vm.openReport("a")
+        vm.setLogExpanded(true)
+        advanceUntilIdle()
+        coVerify(exactly = 1) { repo.readLogTail("a", any()) }
+
+        vm.setLogExpanded(false)
+        advanceUntilIdle()
+
+        firstCollector.cancelAndJoin()
+        // Past WhileSubscribed(5000), so the shared flow really stops instead of being kept alive.
+        advanceTimeBy(10_000)
+        runCurrent()
+
+        val secondCollector = launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.readLogTail("a", any()) }
+
+        secondCollector.cancelAndJoin()
     }
 }

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModelLogTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModelLogTest.kt
@@ -1,0 +1,173 @@
+package eu.darken.butler.bugreport.ui
+
+import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel.LogState
+import eu.darken.butler.common.debug.bugreport.BugReport
+import eu.darken.butler.common.debug.bugreport.BugReportInfo
+import eu.darken.butler.common.debug.bugreport.BugReportRecorder
+import eu.darken.butler.common.debug.bugreport.BugReportRepo
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+import kotlin.time.Instant
+
+/**
+ * Opening a report must not touch the log file: the tail is read the first time the user expands the
+ * section, is kept across collapse/expand cycles, and is dropped again when another report is opened.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BugReportWorkspaceViewModelLogTest : BaseTest() {
+
+    private val tail = BugReportRepo.LogTail(lines = listOf("line"), totalLines = 1)
+    private val loaded = LogState.Loaded(lines = listOf("line"), totalLines = 1, shownLines = 1, isTruncated = false)
+
+    private fun info(id: String) = BugReportInfo(
+        report = BugReport(
+            id = id,
+            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+            type = BugReport.Type.RECORDING,
+            errorClass = null,
+            errorMessage = null,
+            stackTrace = null,
+            threadName = null,
+            appVersion = "v0.0.0-beta1",
+            deviceFingerprint = "Pixel/foo",
+            apiLevel = "36",
+            flavor = "FOSS",
+            buildType = "RELEASE",
+            installId = "abc",
+            locale = "en-US",
+        ),
+        isSeen = true,
+        logSizeBytes = 4_096L,
+    )
+
+    // The detail is derived from the report list, so an unstubbed reports flow would never produce
+    // one; a relaxed readLogTail would report 0 total lines and map to LogState.Empty.
+    private val repo = mockk<BugReportRepo>(relaxed = true).apply {
+        every { reports } returns flowOf(listOf(info("a"), info("b")))
+        coEvery { readLogTail(any(), any()) } returns tail
+    }
+    private val recorder = mockk<BugReportRecorder>(relaxed = true).apply {
+        every { state } returns MutableStateFlow(BugReportRecorder.State())
+    }
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    // The state flow is WhileSubscribed(5000): without a live collector nothing runs at all, and
+    // "the log was never read" would hold for an eager implementation too.
+    private fun TestScope.createVM(): BugReportWorkspaceViewModel {
+        val vm = BugReportWorkspaceViewModel(
+            id = Workspace.Id(),
+            dispatchers = TestDispatcherProvider(),
+            bugReportRepo = repo,
+            bugReportRecorder = recorder,
+        )
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.state.collect { } }
+        return vm
+    }
+
+    private suspend fun BugReportWorkspaceViewModel.detail() = state.first()!!.detail!!
+
+    @Test
+    fun `opening a report reads nothing from disk`() = runTest {
+        val vm = createVM()
+
+        vm.openReport("a")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.readLogTail(any(), any()) }
+        vm.detail().logState shouldBe LogState.Idle
+        vm.detail().isLogExpanded shouldBe false
+    }
+
+    @Test
+    fun `expanding the section loads the tail`() = runTest {
+        val vm = createVM()
+
+        vm.openReport("a")
+        vm.setLogExpanded(true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.readLogTail("a", any()) }
+        vm.detail().logState shouldBe loaded
+        vm.detail().isLogExpanded shouldBe true
+    }
+
+    @Test
+    fun `re-expanding a loaded section does not read again`() = runTest {
+        val vm = createVM()
+
+        vm.openReport("a")
+        vm.setLogExpanded(true)
+        vm.setLogExpanded(false)
+        vm.setLogExpanded(true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.readLogTail("a", any()) }
+        vm.detail().logState shouldBe loaded
+    }
+
+    @Test
+    fun `switching reports resets the section instead of loading the new log`() = runTest {
+        val vm = createVM()
+
+        vm.openReport("a")
+        vm.setLogExpanded(true)
+        advanceUntilIdle()
+
+        vm.openReport("b")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.readLogTail("b", any()) }
+        vm.detail().logState shouldBe LogState.Idle
+        vm.detail().isLogExpanded shouldBe false
+    }
+
+    @Test
+    fun `re-expanding after a failed read retries`() = runTest {
+        coEvery { repo.readLogTail(any(), any()) } throws IOException("nope")
+        val vm = createVM()
+
+        vm.openReport("a")
+        vm.setLogExpanded(true)
+        advanceUntilIdle()
+        vm.detail().logState shouldBe LogState.Error
+
+        vm.setLogExpanded(false)
+        coEvery { repo.readLogTail(any(), any()) } returns tail
+        vm.setLogExpanded(true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.readLogTail("a", any()) }
+        vm.detail().logState shouldBe loaded
+    }
+}

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContentTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContentTest.kt
@@ -1,0 +1,135 @@
+package eu.darken.butler.bugreport.ui.detail
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.bugreport.R
+import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.debug.bugreport.BugReport
+import eu.darken.butler.common.debug.bugreport.BugReportInfo
+import eu.darken.butler.common.formatFileSize
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import kotlin.time.Instant
+
+/** The log tail is only rendered while the section is expanded; the header is the toggle. */
+@Config(qualifiers = "w400dp-h800dp")
+class BugReportDetailContentTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val logSectionTitle = context.getString(R.string.bugreport_detail_section_log)
+    private val expandLabel = context.getString(eu.darken.butler.common.R.string.general_expand_action)
+    private val collapseLabel = context.getString(eu.darken.butler.common.R.string.general_collapse_action)
+    private val logSizeBytes = 24_000L
+
+    // No error fields: the detail then renders without the error card, which keeps the log section
+    // on screen in Robolectric's fixed-size wrapper.
+    private val info = BugReportInfo(
+        report = BugReport(
+            id = "report-1",
+            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+            type = BugReport.Type.RECORDING,
+            errorClass = null,
+            errorMessage = null,
+            stackTrace = null,
+            threadName = null,
+            appVersion = "v0.0.0-beta1",
+            deviceFingerprint = "Pixel/foo",
+            apiLevel = "36",
+            flavor = "FOSS",
+            buildType = "RELEASE",
+            installId = "abc",
+            locale = "en-US",
+        ),
+        isSeen = true,
+        logSizeBytes = logSizeBytes,
+    )
+
+    private val loaded = BugReportWorkspaceViewModel.LogState.Loaded(
+        lines = listOf(MARKER_LINE),
+        totalLines = 1,
+        shownLines = 1,
+        isTruncated = false,
+    )
+
+    private fun setContent(
+        logState: BugReportWorkspaceViewModel.LogState,
+        isLogExpanded: Boolean,
+        onToggleLog: (Boolean) -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                BugReportDetailContent(
+                    design = WorkspaceDesign(),
+                    detail = BugReportWorkspaceViewModel.Detail(
+                        info = info,
+                        logState = logState,
+                        isLogExpanded = isLogExpanded,
+                    ),
+                    onBack = {},
+                    onShare = {},
+                    onDelete = {},
+                    onToggleLog = onToggleLog,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a collapsed section renders no log body but keeps the header summary`() {
+        setContent(logState = loaded, isLogExpanded = false)
+
+        composeTestRule.onNodeWithText(MARKER_LINE).assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertExists()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.bugreport_detail_log_count, 1), substring = true)
+            .assertExists()
+    }
+
+    @Test
+    fun `the default state shows the log size without having read the log`() {
+        setContent(logState = BugReportWorkspaceViewModel.LogState.Idle, isLogExpanded = false)
+
+        composeTestRule.onNodeWithText(formatFileSize(context, logSizeBytes)).assertExists()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.bugreport_detail_log_count, 1), substring = true)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertExists()
+    }
+
+    @Test
+    fun `an expanded section renders the log body`() {
+        setContent(logState = loaded, isLogExpanded = true)
+
+        composeTestRule.onNodeWithText(MARKER_LINE).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(collapseLabel).assertExists()
+    }
+
+    @Test
+    fun `tapping the header requests the expansion`() {
+        var toggledTo: Boolean? = null
+        setContent(
+            logState = BugReportWorkspaceViewModel.LogState.Idle,
+            isLogExpanded = false,
+            onToggleLog = { toggledTo = it },
+        )
+
+        // Via the semantics action, not performClick: in this fixed-size wrapper a laid-out but
+        // off-screen node swallows a click without reporting a failure.
+        composeTestRule.onNodeWithText(logSectionTitle).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeTestRule.runOnIdle { toggledTo shouldBe true }
+    }
+
+    companion object {
+        private const val MARKER_LINE = "MARKER-LINE"
+    }
+}


### PR DESCRIPTION
## What changed

The bug report details screen no longer shows the log by default. The "Recent log" section starts
collapsed, showing just the log's size, and you tap the header to reveal it.

The log is also no longer read from disk until you ask for it. Opening a report backed by a long
recording used to scan the whole file before the screen was usable, even though most of the time
you are there to read the error and its stack trace, not the log. Once loaded, the log stays loaded:
collapsing and expanding again is instant, and it survives the tab going off screen. Opening a
different report starts collapsed again.

If reading the log fails, collapsing and expanding retries it, instead of leaving you to back out
and reopen the report.

## Technical Context

- The read is gated on a request counter rather than a plain "expanded" flag. Collapsing keeps the
  loaded tail cached, while re-expanding after a read error bumps the counter and starts a fresh
  read, which is what makes the retry work without also re-reading on every toggle.
- Report id, expansion and the request counter live in one `LogSelection` value rather than three
  flows. Separate flows let an A-to-B report switch be observed as the new report paired with the
  previous one's expansion state, which starts a full scan of B that is then immediately cancelled.
- The read pipeline is shared eagerly. It was cold, and the page's state flow stops after five
  seconds without collectors, so `distinctUntilChanged` reset on every re-collection and re-ran the
  completed read whenever the page came back on screen, with the section still collapsed. Worth a
  close look, since it is the subtlest part of the change; there is a regression test covering the
  unsubscribe/resubscribe path.
- `readLogTail` in `app-common` now checks for cancellation every 1000 lines. Its line loop never
  suspends, so an abandoned read previously scanned to the end of the file regardless. This is the
  only change outside the bug report module.
- The header row is now interactive, so it carries a 48dp minimum height. It was around 26dp before,
  which is well under the minimum touch target.
