### PR TITLE
General: Show the privacy policy and prefill shared report emails

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/PrivacyPolicy.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/PrivacyPolicy.kt
@@ -1,0 +1,5 @@
+package eu.darken.butler.common
+
+import android.content.Context
+
+fun openPrivacyPolicy(context: Context): Boolean = WebpageTool.open(context, ButlerLinks.PRIVACY_POLICY)

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -211,14 +211,16 @@ class BugReportRepo @Inject constructor(
      * Built under a temporary name and renamed on success, because [Zipper] leaves its output behind
      * when compression throws — a half-written `<id>.zip` would then be shared as if it were whole.
      */
-    suspend fun buildShareZip(id: String): File =
-        buildShareZip(withContext(dispatcherProvider.IO) { resolveReportDir(id) }, id)
+    suspend fun buildShareZip(id: String): File {
+        requireNotRecording(id)
+        val dir = withContext(dispatcherProvider.IO) { resolveReportDir(id) }
+        return buildShareZip(dir, id)
+    }
 
     private suspend fun buildShareZip(dir: File?, id: String): File = withContext(dispatcherProvider.IO) {
-        // Via the recorder mutex, not a bare state read: during the startup window an interrupted
-        // recording is listed as shareable while recovery may be about to reattach to it — this
-        // blocks until recovery has claimed or finalized it and then reflects the outcome.
-        require(!bugReportRecorder.isActiveOrStarting(id)) { "Cannot share an active recording" }
+        // Kept even though every caller here already guarded: this overload takes an
+        // already-resolved dir, so it must not be shareable past the guard on its own.
+        requireNotRecording(id)
         val files = dir?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
         require(files.isNotEmpty()) { "No report files for $id" }
 
@@ -249,6 +251,7 @@ class BugReportRepo @Inject constructor(
      * chooser. [FLAG_GRANT_READ_URI_PERMISSION] + clipData grant the receiving app read access.
      */
     suspend fun buildShareIntent(id: String): Intent {
+        requireNotRecording(id)
         // One resolve for both the zip and the body: the same id can exist under two storage roots,
         // and resolving twice could attach one copy while describing the other.
         val entry = withContext(dispatcherProvider.IO) { resolveReportEntry(id) }
@@ -305,6 +308,16 @@ class BugReportRepo @Inject constructor(
         appendLine("Report: $id")
         appendLine()
         append("Details are in the attached zip.")
+    }
+
+    /**
+     * Via the recorder mutex, not a bare state read: during the startup window an interrupted
+     * recording is listed as shareable while recovery may be about to reattach to it — this blocks
+     * until recovery has claimed or finalized it and then reflects the outcome. Run it before the
+     * store is read, so the report is resolved from the view recovery left behind.
+     */
+    private suspend fun requireNotRecording(id: String) {
+        require(!bugReportRecorder.isActiveOrStarting(id)) { "Cannot share an active recording" }
     }
 
     private fun refresh() {

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -9,6 +9,7 @@ import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.BuildConfigWrap
 import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.R
 import eu.darken.butler.common.compression.Zipper
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
@@ -210,12 +211,15 @@ class BugReportRepo @Inject constructor(
      * Built under a temporary name and renamed on success, because [Zipper] leaves its output behind
      * when compression throws — a half-written `<id>.zip` would then be shared as if it were whole.
      */
-    suspend fun buildShareZip(id: String): File = withContext(dispatcherProvider.IO) {
+    suspend fun buildShareZip(id: String): File =
+        buildShareZip(withContext(dispatcherProvider.IO) { resolveReportDir(id) }, id)
+
+    private suspend fun buildShareZip(dir: File?, id: String): File = withContext(dispatcherProvider.IO) {
         // Via the recorder mutex, not a bare state read: during the startup window an interrupted
         // recording is listed as shareable while recovery may be about to reattach to it — this
         // blocks until recovery has claimed or finalized it and then reflects the outcome.
         require(!bugReportRecorder.isActiveOrStarting(id)) { "Cannot share an active recording" }
-        val files = resolveReportDir(id)?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
+        val files = dir?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
         require(files.isNotEmpty()) { "No report files for $id" }
 
         if (!shareDir.exists()) shareDir.mkdirs()
@@ -245,13 +249,62 @@ class BugReportRepo @Inject constructor(
      * chooser. [FLAG_GRANT_READ_URI_PERMISSION] + clipData grant the receiving app read access.
      */
     suspend fun buildShareIntent(id: String): Intent {
-        val uri = buildShareUri(id)
+        // One resolve for both the zip and the body: the same id can exist under two storage roots,
+        // and resolving twice could attach one copy while describing the other.
+        val entry = withContext(dispatcherProvider.IO) { resolveReportEntry(id) }
+        val zip = buildShareZip(entry?.first, id)
+        val uri = FileProvider.getUriForFile(context, "${BuildConfigWrap.APPLICATION_ID}.provider", zip)
         return Intent(Intent.ACTION_SEND).apply {
             type = "application/zip"
+            putExtra(
+                Intent.EXTRA_SUBJECT,
+                context.getString(
+                    R.string.general_bug_report_subject,
+                    context.getString(R.string.app_name),
+                    id,
+                ),
+            )
+            putExtra(Intent.EXTRA_TEXT, buildShareBody(id, entry?.second))
             putExtra(Intent.EXTRA_STREAM, uri)
             clipData = ClipData.newRawUri("", uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
+    }
+
+    /**
+     * Mail body for [buildShareIntent]: two prompts for the user to fill in plus the metadata triage
+     * needs before opening the zip. Section headers and the metadata labels stay English — the
+     * developer reading them does; only the prompts, which address the user, are localized.
+     *
+     * [report] is null when the report directory vanished between resolve and read. The body is
+     * best-effort context, so that drops the metadata rather than failing the share.
+     */
+    internal fun buildShareBody(id: String, report: BugReport?): String = buildString {
+        appendLine("--- What happened? ---")
+        appendLine(context.getString(R.string.general_bug_report_body_what_happened_prompt))
+        appendLine()
+        appendLine("--- Expected behavior ---")
+        appendLine(context.getString(R.string.general_bug_report_body_expected_prompt))
+        appendLine()
+        appendLine("--- Report info ---")
+        report?.let {
+            appendLine("App: ${it.appVersion}")
+            appendLine("Device: ${it.deviceFingerprint}")
+            appendLine("Android: API ${it.apiLevel}")
+            appendLine("Type: ${it.type}")
+            // A RECORDING has no triggering exception, so it has no error fields to describe.
+            val error = when (it.type) {
+                BugReport.Type.CRASH, BugReport.Type.REPORTED -> listOfNotNull(
+                    it.errorClass,
+                    it.errorMessage?.lineSequence()?.firstOrNull(),
+                ).joinToString(": ")
+                BugReport.Type.RECORDING -> ""
+            }
+            if (error.isNotBlank()) appendLine("Error: $error")
+        }
+        appendLine("Report: $id")
+        appendLine()
+        append("Details are in the attached zip.")
     }
 
     private fun refresh() {
@@ -301,12 +354,15 @@ class BugReportRepo @Inject constructor(
     }
 
     /**
-     * The copy of [id] that [scan] surfaced: the first root holding a valid report directory. A
-     * corrupt external copy must not shadow the readable private one the list is showing.
+     * The copy of [id] that [scan] surfaced: the first root holding a valid report directory, paired
+     * with its metadata. A corrupt external copy must not shadow the readable private one the list is
+     * showing, and returning both together keeps a caller needing each from resolving twice.
      */
-    private fun resolveReportDir(id: String): File? = storageLayout
+    private fun resolveReportEntry(id: String): Pair<File, BugReport>? = storageLayout
         .allReportDirs(id)
-        .firstOrNull { readReport(it) != null }
+        .firstNotNullOfOrNull { dir -> readReport(dir)?.let { dir to it } }
+
+    private fun resolveReportDir(id: String): File? = resolveReportEntry(id)?.first
 
     /** Parses a report directory, or null if it is a temp dir, incomplete, unreadable or mislabelled. */
     private fun readReport(dir: File): BugReport? {

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -74,6 +74,10 @@
     <string name="general_error_report_consent_title">Share error report?</string>
     <string name="general_error_report_consent_message">The report contains the error and the stack trace it produced, the app\'s recent log trail, and details about the state it was in: file names and paths, search queries, package names, URIs, network and SMB host names, your device and build information, and an anonymous install ID. Only share it with people you trust.</string>
     <string name="general_error_report_consent_confirm">Share report</string>
+    <string name="general_privacy_policy_action">Privacy policy</string>
+    <string name="general_bug_report_subject">%1$s Bug Report (%2$s)</string>
+    <string name="general_bug_report_body_what_happened_prompt">(Describe what happened here.)</string>
+    <string name="general_bug_report_body_expected_prompt">(Describe what you expected instead.)</string>
     <string name="general_duration_input_label">Duration</string>
     <string name="general_size_input_label">Size</string>
     <string name="general_upgrade_action">Upgrade</string>

--- a/app-common/src/test/java/eu/darken/butler/common/PrivacyPolicyTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/PrivacyPolicyTest.kt
@@ -1,0 +1,28 @@
+package eu.darken.butler.common
+
+import android.app.Application
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+
+/** The consent dialogs route their privacy policy action here, so this is where the URL is pinned. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PrivacyPolicyTest : BaseTest() {
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `the policy page opens`() {
+        openPrivacyPolicy(application) shouldBe true
+
+        shadowOf(application).nextStartedActivity!!.data shouldBe Uri.parse(ButlerLinks.PRIVACY_POLICY)
+    }
+}

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoShareOrderTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoShareOrderTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.butler.common.debug.bugreport
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.debug.logging.RingLogBuffer
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * The share guard ([BugReportRecorder.isActiveOrStarting]) takes the recorder mutex and therefore
+ * waits out startup recovery of an interrupted recording. Storage resolution must not run before it,
+ * or the share path picks the directory to package from a view of the store recovery is still
+ * allowed to change.
+ *
+ * The order is observed through the two collaborators the repo takes as constructor dependencies, so
+ * the assertion is deterministic rather than timing-dependent.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class BugReportRepoShareOrderTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val realLayout by lazy { BugReportStorageLayout(context) }
+    private val reportsDir get() = realLayout.writeRoot
+    private val json = Json { ignoreUnknownKeys = true }
+    private val recorderState = MutableStateFlow(BugReportRecorder.State())
+
+    /** Call trail across the two collaborators, in the order the repo invoked them. */
+    private val calls = mutableListOf<String>()
+
+    private fun createRepo(): BugReportRepo {
+        val recorder = mockk<BugReportRecorder>(relaxed = true) {
+            every { state } returns recorderState
+            coEvery { isActiveOrStarting(any()) } answers {
+                calls += "guard"
+                firstArg<String>() == recorderState.value.recordingId
+            }
+        }
+        // Delegates to the real layout so the repo still sees the report written below; the stubs
+        // exist only to timestamp the storage reads.
+        val layout = mockk<BugReportStorageLayout> {
+            every { roots } returns realLayout.roots
+            every { writeRoot } returns realLayout.writeRoot
+            every { findReportDir(any()) } answers { realLayout.findReportDir(firstArg()) }
+            every { allReportDirs(any()) } answers {
+                calls += "resolve"
+                realLayout.allReportDirs(firstArg())
+            }
+        }
+        return BugReportRepo(
+            context = context,
+            appScope = CoroutineScope(Dispatchers.Unconfined),
+            dispatcherProvider = TestDispatcherProvider(),
+            ringLogBuffer = RingLogBuffer(),
+            bugReportRecorder = recorder,
+            butlerId = ButlerId(context),
+            json = json,
+            storageLayout = layout,
+        )
+    }
+
+    private fun writeReportDir(
+        id: String,
+        type: BugReport.Type = BugReport.Type.REPORTED,
+        createdAt: Instant = Clock.System.now(),
+    ) {
+        val dir = File(reportsDir, id).apply { mkdirs() }
+        val report = BugReport(
+            id = id,
+            createdAt = createdAt,
+            type = type,
+            appVersion = "1.0",
+            deviceFingerprint = "fp",
+            apiLevel = "29",
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            installId = "iid",
+            locale = "en",
+        )
+        File(dir, BugReportStorage.META_FILE).writeText(json.encodeToString(BugReport.serializer(), report))
+        File(dir, BugReportStorage.LOG_FILE).writeText("rec log")
+    }
+
+    @Test
+    fun `buildShareZip consults the recorder guard before resolving the report from storage`() = runTest {
+        val repo = createRepo()
+        writeReportDir("order_1")
+        // The repo's init cleanup already scanned the store; only the share call is under test.
+        calls.clear()
+
+        repo.buildShareZip("order_1")
+
+        withClue("call order was $calls") {
+            // Both collaborators were reached, so the ordering assertion below is not vacuous.
+            calls shouldContain "resolve"
+            calls.first() shouldBe "guard"
+        }
+    }
+}

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.common.debug.bugreport
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.R
 import eu.darken.butler.common.debug.logging.RingLogBuffer
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
@@ -10,6 +11,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -76,12 +78,16 @@ class BugReportRepoTest : BaseTest() {
         root: File = reportsDir,
         logText: String = "rec log",
         createdAt: Instant = kotlin.time.Clock.System.now(),
-    ) {
+        errorClass: String? = null,
+        errorMessage: String? = null,
+    ): BugReport {
         val dir = File(root, id).apply { mkdirs() }
         val report = BugReport(
             id = id,
             createdAt = createdAt,
             type = type,
+            errorClass = errorClass,
+            errorMessage = errorMessage,
             appVersion = "1.0",
             deviceFingerprint = "fp",
             apiLevel = "29",
@@ -93,6 +99,7 @@ class BugReportRepoTest : BaseTest() {
         File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
         File(dir, "report.log").writeText(logText)
         if (ongoing) File(dir, ".recording").createNewFile()
+        return report
     }
 
     @Test
@@ -418,5 +425,83 @@ class BugReportRepoTest : BaseTest() {
         createRepo()
 
         stale.exists() shouldBe false
+    }
+
+    private val whatPrompt: String
+        get() = context.getString(R.string.general_bug_report_body_what_happened_prompt)
+
+    private val expectedPrompt: String
+        get() = context.getString(R.string.general_bug_report_body_expected_prompt)
+
+    @Test
+    fun `the share body carries both prompts and the report metadata`() {
+        val repo = createRepo()
+        val report = writeReportDir("body_1")
+
+        repo.buildShareBody("body_1", report) shouldBe listOf(
+            "--- What happened? ---",
+            whatPrompt,
+            "",
+            "--- Expected behavior ---",
+            expectedPrompt,
+            "",
+            "--- Report info ---",
+            "App: 1.0",
+            "Device: fp",
+            "Android: API 29",
+            "Type: REPORTED",
+            "Report: body_1",
+            "",
+            "Details are in the attached zip.",
+        ).joinToString("\n")
+    }
+
+    @Test
+    fun `a crash body names the error and its first message line`() {
+        val repo = createRepo()
+        val report = writeReportDir(
+            id = "body_2",
+            type = BugReport.Type.CRASH,
+            errorClass = "java.lang.IllegalStateException",
+            errorMessage = "boom\nsecond line",
+        )
+
+        val body = repo.buildShareBody("body_2", report)
+
+        body shouldContain "Error: java.lang.IllegalStateException: boom"
+        body shouldNotContain "second line"
+    }
+
+    // The fixture carries error fields a real recording never has, so the assertion pins the type
+    // gate rather than the metadata just happening to be null.
+    @Test
+    fun `a recording body has no error line`() {
+        val repo = createRepo()
+        val report = writeReportDir(
+            id = "body_3",
+            type = BugReport.Type.RECORDING,
+            errorClass = "java.lang.IllegalStateException",
+            errorMessage = "boom",
+        )
+
+        repo.buildShareBody("body_3", report) shouldNotContain "Error:"
+    }
+
+    @Test
+    fun `a body without metadata still identifies the report`() {
+        val repo = createRepo()
+
+        repo.buildShareBody("body_4", null) shouldBe listOf(
+            "--- What happened? ---",
+            whatPrompt,
+            "",
+            "--- Expected behavior ---",
+            expectedPrompt,
+            "",
+            "--- Report info ---",
+            "Report: body_4",
+            "",
+            "Details are in the attached zip.",
+        ).joinToString("\n")
     }
 }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
@@ -18,6 +18,7 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.error.ErrorEventHandler
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.launch
 
@@ -64,6 +65,7 @@ fun BugReportWorkspaceOverlaysHost(
         },
         onConfirmDeleteAll = { vm.deleteAll() },
         onDismissDeleteAll = { vm.dismissDeleteAllConfirmation() },
+        onPrivacyPolicy = { openPrivacyPolicy(context) },
     )
 
     // Last on purpose: layers stack in composition order, so an error raised while one of
@@ -80,11 +82,13 @@ fun BugReportWorkspaceOverlays(
     onStopRecordingAnyway: () -> Unit = {},
     onConfirmDeleteAll: () -> Unit = {},
     onDismissDeleteAll: () -> Unit = {},
+    onPrivacyPolicy: () -> Unit = {},
 ) {
     when (val dialog = overlayState.activeDialog) {
         is ActiveDialog.ShareConsent -> ShareConsentDialog(
             onConfirm = { onShareConsent(dialog.reportId) },
             onDismiss = onDismissShareConsent,
+            onPrivacyPolicy = onPrivacyPolicy,
         )
 
         ActiveDialog.ShortRecordingWarning -> ShortRecordingWarningDialog(

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -94,6 +94,7 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import kotlinx.coroutines.delay
 import kotlin.time.Instant
+import eu.darken.butler.common.R as CommonR
 
 @Composable
 fun BugReportWorkspacePageHost(
@@ -596,6 +597,7 @@ private fun EmptyState(modifier: Modifier = Modifier) {
 internal fun ShareConsentDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
+    onPrivacyPolicy: () -> Unit,
 ) {
     PaneBoundAlertDialog(
         onDismissRequest = onDismiss,
@@ -607,6 +609,11 @@ internal fun ShareConsentDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.bugreport_cancel_action)) }
+        },
+        neutralButton = {
+            TextButton(onClick = onPrivacyPolicy) {
+                Text(stringResource(CommonR.string.general_privacy_policy_action))
+            }
         },
     )
 }

--- a/app-workspace-bugreport/src/main/res/values/strings.xml
+++ b/app-workspace-bugreport/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
 
     <string name="bugreport_share_chooser_title">Share bug report</string>
     <string name="bugreport_share_consent_title">Share report?</string>
-    <string name="bugreport_share_consent_message">This report includes app logs that may contain file names and paths. Only share it with people you trust.</string>
+    <string name="bugreport_share_consent_message">This report includes app logs that can contain file names, paths, and app and device information. Only share it with people you trust.</string>
 
     <string name="bugreport_detail_back_action">Back</string>
     <string name="bugreport_detail_section_error">Error</string>

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 import testhelpers.ComposeTest
 import testhelpers.coroutine.TestDispatcherProvider
+import eu.darken.butler.common.R as CommonR
 
 /** The bug report page's dialogs render from the overlay slot, not from the page host. */
 class BugReportWorkspaceOverlaysTest : ComposeTest() {
@@ -86,6 +87,31 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
         composeTestRule.onNodeWithText(context.getString(R.string.bugreport_share_action)).performClick()
 
         composeTestRule.runOnIdle { consentedFor shouldBe "report-1" }
+    }
+
+    @Test
+    fun `the share consent offers the privacy policy`() {
+        var opened = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    BugReportWorkspaceOverlays(
+                        overlayState = BugReportWorkspaceViewModel.OverlayState(
+                            activeDialog = ActiveDialog.ShareConsent("report-1"),
+                        ),
+                        onPrivacyPolicy = { opened++ },
+                    )
+                }
+            }
+        }
+
+        val label = context.getString(CommonR.string.general_privacy_policy_action)
+        composeTestRule.onNodeWithText(label).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(label).performClick()
+
+        composeTestRule.runOnIdle { opened shouldBe 1 }
     }
 
     @Test

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspaceOverlays.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspaceOverlays.kt
@@ -3,8 +3,10 @@ package eu.darken.butler.developer.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.error.ErrorEventHandler
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.developer.ui.DeveloperWorkspaceViewModel.Factory
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
@@ -58,9 +60,11 @@ fun DeveloperWorkspaceOverlays(
     onDismissErrorShare: () -> Unit = {},
 ) {
     if (showErrorShareConsent) {
+        val context = LocalContext.current
         ErrorShareConsentDialog(
             onConfirm = onConfirmErrorShare,
             onDismiss = onDismissErrorShare,
+            onPrivacyPolicy = { openPrivacyPolicy(context) },
         )
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceOverlays.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceOverlays.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.explorer.ui.explorer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
@@ -11,6 +12,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.issue.Issue
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.core.engine.BrowsingAbortedException
@@ -154,9 +156,11 @@ fun ExplorerWorkspaceOverlays(
     }
 
     if (showErrorShareConsent) {
+        val context = LocalContext.current
         ErrorShareConsentDialog(
             onConfirm = { vm?.confirmErrorShare() },
             onDismiss = { vm?.dismissErrorShare() },
+            onPrivacyPolicy = { openPrivacyPolicy(context) },
         )
     }
 

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspaceOverlays.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspaceOverlays.kt
@@ -3,8 +3,10 @@ package eu.darken.butler.saver.ui.saver
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.error.ErrorEventHandler
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.error.ErrorShareConsentDialog
 import eu.darken.butler.workspace.ui.insets.paneInsets
@@ -47,9 +49,11 @@ fun SaverWorkspaceOverlaysHost(
     }
 
     if (pendingErrorShare != null) {
+        val context = LocalContext.current
         ErrorShareConsentDialog(
             onConfirm = { vm.confirmErrorShare() },
             onDismiss = { vm.dismissErrorShare() },
+            onPrivacyPolicy = { openPrivacyPolicy(context) },
         )
     }
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceOverlays.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceOverlays.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -13,6 +14,7 @@ import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.issue.Issue
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.searcher.ui.search.dialogs.SearchErrorDialog
 import eu.darken.butler.searcher.ui.search.dialogs.SearcherDialogHost
 import eu.darken.butler.searcher.ui.search.elements.AccessErrorsSheetContent
@@ -225,9 +227,11 @@ fun SearcherWorkspaceOverlays(
     )
 
     if (showErrorShareConsent) {
+        val context = LocalContext.current
         ErrorShareConsentDialog(
             onConfirm = { onPageAction(SearcherPageAction.Error.ConfirmShare) },
             onDismiss = { onPageAction(SearcherPageAction.Error.DismissShare) },
+            onPrivacyPolicy = { openPrivacyPolicy(context) },
         )
     }
 

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceOverlays.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceOverlays.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.error.ErrorEventHandler
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.viewer.core.ViewerContent
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.dialogs.DeleteConfirmationDialog
@@ -85,9 +87,11 @@ fun ViewerWorkspaceOverlaysHost(
     }
 
     if (pendingErrorShare != null) {
+        val context = LocalContext.current
         ErrorShareConsentDialog(
             onConfirm = { vm.confirmErrorShare() },
             onDismiss = { vm.dismissErrorShare() },
+            onPrivacyPolicy = { openPrivacyPolicy(context) },
         )
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/error/ErrorShareConsentDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/error/ErrorShareConsentDialog.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.common.R as CommonR
 fun ErrorShareConsentDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
+    onPrivacyPolicy: () -> Unit,
 ) {
     AdaptiveAlertDialog(
         onDismissRequest = onDismiss,
@@ -38,6 +39,11 @@ fun ErrorShareConsentDialog(
                 Text(stringResource(CommonR.string.general_cancel_action))
             }
         },
+        neutralButton = {
+            TextButton(onClick = onPrivacyPolicy) {
+                Text(stringResource(CommonR.string.general_privacy_policy_action))
+            }
+        },
     )
 }
 
@@ -48,5 +54,6 @@ private fun ErrorShareConsentDialogPreview() {
     ErrorShareConsentDialog(
         onConfirm = {},
         onDismiss = {},
+        onPrivacyPolicy = {},
     )
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/error/ErrorShareConsentDialogTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/error/ErrorShareConsentDialogTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.butler.workspace.ui.error
+
+import android.content.Context
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+import eu.darken.butler.common.R as CommonR
+
+class ErrorShareConsentDialogTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    // Pane host: all but one call site render this dialog as a workspace pane overlay, so the
+    // pane-bound renderer is what the dialog actually runs under.
+    @Test
+    fun `the privacy policy action is offered`() {
+        var opened = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    ErrorShareConsentDialog(
+                        onConfirm = {},
+                        onDismiss = {},
+                        onPrivacyPolicy = { opened++ },
+                    )
+                }
+            }
+        }
+
+        val label = context.getString(CommonR.string.general_privacy_policy_action)
+        composeTestRule.onNodeWithText(label).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(label).performClick()
+
+        composeTestRule.runOnIdle { opened shouldBe 1 }
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -33,6 +33,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.tour.LocalGuidedTourController
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.navigation.NavigationEventHandler
+import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.main.ui.motd.MotdCard
 import eu.darken.butler.main.ui.review.ReviewCard
 import eu.darken.butler.workspace.core.Workspace
@@ -570,6 +571,7 @@ fun WorkspacesScreenHost(
             ErrorShareConsentDialog(
                 onConfirm = { vm.confirmErrorShare() },
                 onDismiss = { vm.dismissErrorShare() },
+                onPrivacyPolicy = { openPrivacyPolicy(context) },
             )
         }
 

--- a/app/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareIntentTest.kt
+++ b/app/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareIntentTest.kt
@@ -1,0 +1,104 @@
+package eu.darken.butler.common.debug.bugreport
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.R
+import eu.darken.butler.common.debug.logging.RingLogBuffer
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import kotlin.time.Instant
+
+/**
+ * Lives in :app because [androidx.core.content.FileProvider] resolves against the application's
+ * provider authority and its path XML, which only the app manifest declares.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BugReportShareIntentTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val storageLayout by lazy { BugReportStorageLayout(context) }
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun createRepo(): BugReportRepo {
+        val recorder = mockk<BugReportRecorder>(relaxed = true) {
+            every { state } returns MutableStateFlow(BugReportRecorder.State())
+        }
+        return BugReportRepo(
+            context = context,
+            appScope = CoroutineScope(Dispatchers.Unconfined),
+            dispatcherProvider = TestDispatcherProvider(),
+            ringLogBuffer = RingLogBuffer(),
+            bugReportRecorder = recorder,
+            butlerId = ButlerId(context),
+            json = json,
+            storageLayout = storageLayout,
+        )
+    }
+
+    private fun writeReportDir(id: String): BugReport {
+        val dir = File(storageLayout.writeRoot, id).apply { mkdirs() }
+        val report = BugReport(
+            id = id,
+            createdAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+            type = BugReport.Type.CRASH,
+            errorClass = "java.lang.IllegalStateException",
+            errorMessage = "boom",
+            appVersion = "1.0",
+            deviceFingerprint = "fp",
+            apiLevel = "29",
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            installId = "iid",
+            locale = "en",
+        )
+        File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
+        File(dir, "report.log").writeText("log line")
+        return report
+    }
+
+    @Test
+    fun `the share intent carries the subject, the body and a readable zip`() = runTest {
+        val repo = createRepo()
+        writeReportDir("crash_1")
+
+        val intent = repo.buildShareIntent("crash_1")
+
+        intent.action shouldBe Intent.ACTION_SEND
+        intent.type shouldBe "application/zip"
+
+        intent.getStringExtra(Intent.EXTRA_SUBJECT) shouldBe context.getString(
+            R.string.general_bug_report_subject,
+            context.getString(R.string.app_name),
+            "crash_1",
+        )
+
+        val body = intent.getStringExtra(Intent.EXTRA_TEXT)!!
+        body shouldContain context.getString(R.string.general_bug_report_body_what_happened_prompt)
+        body shouldContain context.getString(R.string.general_bug_report_body_expected_prompt)
+        body shouldContain "Error: java.lang.IllegalStateException: boom"
+        body shouldContain "Report: crash_1"
+
+        val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)!!
+        uri.toString() shouldContain "crash_1.zip"
+        intent.clipData!!.getItemAt(0).uri shouldBe uri
+        (intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION) shouldBe Intent.FLAG_GRANT_READ_URI_PERMISSION
+    }
+}


### PR DESCRIPTION
## What changed

Sharing a report now points at the privacy policy. Both consent dialogs — the one behind the Share button in the Bug reports workspace, and the error report consent that can appear from any workspace — carry a **Privacy policy** button that opens the policy in a browser. The bug report consent text also says plainly that a report can contain app and device information, not just file names and paths.

Sharing a bug report to an email app now fills the message in for you: a subject naming the app and the report, two prompts to describe what happened and what you expected, and the report's app version, device, Android level and error details underneath. Previously the email arrived with an attachment and nothing else, so every report had to be written from scratch — and reports that arrived with no description at all could not be acted on.

## Technical Context

- `buildShareIntent` resolves the report directory and its metadata **once** and derives the zip, the `FileProvider` uri and the mail body from that same pair. A report id can legitimately exist under two storage roots, so resolving separately for the attachment and for the description could attach one copy while describing another.
- The mail body's section headers and metadata labels are deliberately English while the two user-facing prompts are localized. This matches the existing convention in `SupportContactFormViewModel.buildBody` and `ErrorReportTool.buildRoutingBody`: those lines are read by the maintainer, the prompts are read by the reporter.
- The intent-level test lives in `:app` rather than `:app-common` because `FileProvider` resolves against the application's provider authority and path XML, which only the app manifest declares — the same constraint `ErrorReportPackagerTest` already documents for its own placement. In `:app-common` such a test cannot run at all, since `BuildConfigWrap.APPLICATION_ID` is unresolvable there.
- `onPrivacyPolicy` is a required parameter on both dialogs rather than a defaulted one, so the compiler enforces the wiring at all six `ErrorShareConsentDialog` call sites instead of leaving a silently dead button in whichever one was missed.
- Worth close review: the `BugReportRepo` resolve-once refactor, since it restructures a path the support contact form also uses via `buildShareUri`. That entry point keeps its previous signature and behaviour, with the new zip builder taking an already-resolved directory underneath it.
