### PR TITLE
Viewer: Add previous/next file arrows when opened from an Explorer

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerWorkspace.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerWorkspace.kt
@@ -93,7 +93,7 @@ class ExplorerWorkspace @AssistedInject constructor(
     private val restoreOperationFactory: RestoreOperation.Factory,
     private val explorerSettings: ExplorerSettings,
     private val errorIncidentStore: ErrorIncidentStore,
-) : Workspace<ExplorerArguments> {
+) : Workspace<ExplorerArguments>, Workspace.FileListingSource {
 
     private val tag = logTag("Explorer", "Workspace", id.shortTag)
 
@@ -186,6 +186,19 @@ class ExplorerWorkspace @AssistedInject constructor(
     fun updateSaveAsFilename(filename: String) {
         log(tag) { "updateSaveAsFilename($filename)" }
         _saveAsFilename.value = filename
+    }
+
+    private val _fileListing = MutableStateFlow<List<APath<*>>>(emptyList())
+
+    /**
+     * Published by the page's ViewModel: the sorted and filtered listing only exists there, while a
+     * viewer stepping through it can only reach this instance.
+     */
+    override val fileListing: StateFlow<List<APath<*>>> = _fileListing.asStateFlow()
+
+    fun publishFileListing(files: List<APath<*>>) {
+        log(tag) { "publishFileListing(${files.size} files)" }
+        _fileListing.value = files
     }
 
     // Same derivation the factory hands the paused stand-in, so both name this tab identically

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerWorkspace.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerWorkspace.kt
@@ -60,12 +60,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -188,17 +190,26 @@ class ExplorerWorkspace @AssistedInject constructor(
         _saveAsFilename.value = filename
     }
 
-    private val _fileListing = MutableStateFlow<List<APath<*>>>(emptyList())
+    private val _published = MutableStateFlow<FileListingPublication?>(null)
 
     /**
      * Published by the page's ViewModel: the sorted and filtered listing only exists there, while a
      * viewer stepping through it can only reach this instance.
+     *
+     * Reads empty while the tab is on a different location than the listing was computed for, e.g.
+     * a load in flight or a navigation. A paused instance's state no longer changes, so its last
+     * listing stays readable until the viewer's origin lookup reports the tab gone.
      */
-    override val fileListing: StateFlow<List<APath<*>>> = _fileListing.asStateFlow()
+    override val fileListing: StateFlow<List<APath<*>>> = combine(
+        _state,
+        _published,
+    ) { state, published ->
+        resolveFileListing(state, published)
+    }.stateIn(scope, SharingStarted.Eagerly, emptyList())
 
-    fun publishFileListing(files: List<APath<*>>) {
-        log(tag) { "publishFileListing(${files.size} files)" }
-        _fileListing.value = files
+    fun publishFileListing(locationId: String, files: List<APath<*>>) {
+        log(tag) { "publishFileListing($locationId, ${files.size} files)" }
+        _published.value = FileListingPublication(locationId = locationId, files = files)
     }
 
     // Same derivation the factory hands the paused stand-in, so both name this tab identically
@@ -653,3 +664,18 @@ class ExplorerWorkspace @AssistedInject constructor(
         fun factory(factory: Factory): WorkspaceFactory<*> = factory
     }
 }
+
+/** The listing the page's ViewModel computed, tagged with the location it was computed for. */
+internal data class FileListingPublication(
+    val locationId: String,
+    val files: List<APath<*>>,
+)
+
+/** A publication only counts while the tab is still on the location it was computed for. */
+internal fun resolveFileListing(
+    state: ExplorerWorkspace.State,
+    published: FileListingPublication?,
+): List<APath<*>> = published
+    ?.takeIf { it.locationId == (state as? ExplorerWorkspace.State.Ready)?.currentLocation?.locationId }
+    ?.files
+    .orEmpty()

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/ExplorerItem.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/ExplorerItem.kt
@@ -308,3 +308,7 @@ sealed interface ExplorerItem {
  */
 fun ExplorerItem.needsSignIn(): Boolean = this is ExplorerItem.Storage.Network &&
     status == ExplorerItem.Storage.Network.Status.SIGN_IN_REQUIRED
+
+/** The entries "next file" may step to: every file (regular or symlink), never a directory, in list order. */
+internal fun List<ExplorerItem>.toFileListing(): List<APath<*>> =
+    filterIsInstance<ExplorerItem.File>().map { it.path }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -556,8 +556,14 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
+    /** A processed listing together with the location it was computed for. */
+    private data class ProcessedListing(
+        val locationId: String,
+        val items: List<ExplorerItem>,
+    )
+
     // Sorted/filtered items, shared to prevent duplicate processing
-    private val processedItemsFlow: Flow<List<ExplorerItem>?> = combineMany(
+    private val processedListingFlow: Flow<ProcessedListing?> = combineMany(
         workspaceReadyState
             .map { it?.currentLocation?.items }
             .distinctUntilChanged { old, new -> old.hasSameItemsAs(new) },
@@ -571,12 +577,17 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         // flatMapLatest does not clear this combine's last sort value, so items are only paired with
         // a resolution that was computed for the location they came from - otherwise the next
         // folder's listing would briefly render under the previous folder's sort.
-        if (resolvedSort == null || resolvedSort.locationKey != location?.locationId) return@combineMany null
+        if (resolvedSort == null || location == null || resolvedSort.locationKey != location.locationId) {
+            return@combineMany null
+        }
         items
             ?.let { viewSettings.applyFilters(it, filterState, useRegexPatterns) }
             ?.let { itemSorter.sortItems(it, resolvedSort.resolution.settings) }
             ?.let { applyFavoritePriority(it, location, pickerConfig, favoritePaths) }
+            ?.let { ProcessedListing(locationId = location.locationId, items = it) }
     }.shareIn(vmScope, SharingStarted.Lazily, replay = 1)
+
+    private val processedItemsFlow: Flow<List<ExplorerItem>?> = processedListingFlow.map { it?.items }
 
     init {
         // Keep the focus controller's item count in sync so wrap-around math and
@@ -585,12 +596,12 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
             .onEach { focus.updateItemCount(it?.size ?: 0) }
             .launchInViewModel()
 
-        // Paired with the incarnation that produced the items, so a listing never lands in a
-        // resumed instance it was not computed for. A load in flight (null, the skeleton rows)
-        // publishes empty: a viewer must not keep stepping through a folder this tab left.
+        // Carries the location the listing was computed for, and never publishes a null: a tab being
+        // paused turns this ViewModel's workspace lookup null before the collector switches off, and
+        // an empty publication would reach the instance the viewer still reads its last listing from.
         workspaceSource
-            .flatMapLatest { ws -> if (ws == null) emptyFlow() else processedItemsFlow.map { ws to it } }
-            .onEach { (ws, items) -> ws.publishFileListing(items?.toFileListing().orEmpty()) }
+            .flatMapLatest { ws -> if (ws == null) emptyFlow() else processedListingFlow.filterNotNull().map { ws to it } }
+            .onEach { (ws, listing) -> ws.publishFileListing(listing.locationId, listing.items.toFileListing()) }
             .launchInViewModel()
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -66,6 +66,7 @@ import eu.darken.butler.explorer.core.SortSettings
 import eu.darken.butler.explorer.core.smbSignInLocationId
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.core.engine.ExplorerLocation
+import eu.darken.butler.explorer.core.engine.toFileListing
 import eu.darken.butler.explorer.core.favorites.ExplorerFavoritesRepo
 import eu.darken.butler.explorer.core.favorites.FavoriteItem
 import eu.darken.butler.explorer.core.favorites.FavoriteFeedback
@@ -582,6 +583,14 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         // shrink-clamping always see the same list the page renders.
         processedItemsFlow
             .onEach { focus.updateItemCount(it?.size ?: 0) }
+            .launchInViewModel()
+
+        // Paired with the incarnation that produced the items, so a listing never lands in a
+        // resumed instance it was not computed for. A load in flight (null, the skeleton rows)
+        // publishes empty: a viewer must not keep stepping through a folder this tab left.
+        workspaceSource
+            .flatMapLatest { ws -> if (ws == null) emptyFlow() else processedItemsFlow.map { ws to it } }
+            .onEach { (ws, items) -> ws.publishFileListing(items?.toFileListing().orEmpty()) }
             .launchInViewModel()
     }
 
@@ -1450,6 +1459,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 ViewerArguments.Default(
                     filePath = it,
                     callerWorkspaceId = if (asDrillDown) id else null,
+                    listingSourceId = id,
                 )
             },
         )
@@ -1468,7 +1478,9 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
             analysis = analysis,
             createExplorerArguments = { path -> ExplorerArguments.Default(startPath = path) },
             createEditorArguments = { path -> EditorArguments.Default(filePath = path) },
-            createViewerArguments = { path -> ViewerArguments.Default(filePath = path) },
+            createViewerArguments = { path ->
+                ViewerArguments.Default(filePath = path, listingSourceId = id)
+            },
         )
 
         // Execute batch creation directly - WorkspaceRepo handles confirmation and banner

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerFileListingTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerFileListingTest.kt
@@ -4,7 +4,9 @@ import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.MimeInfo
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.explorer.core.engine.BrowsingEngine
 import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.core.engine.ExplorerLocation
 import eu.darken.butler.explorer.core.engine.toFileListing
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.core.Workspace
@@ -13,6 +15,10 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -26,6 +32,12 @@ import org.robolectric.annotation.Config
 class ExplorerFileListingTest {
 
     private val directory = LocalPath.build("/storage/emulated/0/DCIM")
+
+    private val directoryLocation = ExplorerLocation.Directory(
+        path = directory,
+        items = emptyList(),
+        progress = null,
+    )
 
     private fun lookup(name: String, type: FileType) = LocalPathLookup(
         lookedUp = directory.child(name),
@@ -47,6 +59,10 @@ class ExplorerFileListingTest {
     private fun folder(name: String) = ExplorerItem.RegularDirectory(
         lookup = lookup(name, FileType.DIRECTORY),
     )
+
+    private fun ready(location: ExplorerLocation?) = ExplorerWorkspace.State.Ready(currentLocation = location)
+
+    private val files = listOf(directory.child("a.jpg"), directory.child("b.jpg"))
 
     @Test
     fun `only files make the listing, in display order`() {
@@ -77,15 +93,72 @@ class ExplorerFileListingTest {
     }
 
     @Test
-    fun `the published listing is what a stepping viewer reads`() {
+    fun `a publication is read while the tab is on the location it was computed for`() {
+        val publication = FileListingPublication(directoryLocation.locationId, files)
+
+        resolveFileListing(ready(directoryLocation), publication) shouldBe files
+    }
+
+    @Test
+    fun `a publication for another location is not read`() {
+        val publication = FileListingPublication(ExplorerLocation.Home().locationId, files)
+
+        resolveFileListing(ready(directoryLocation), publication) shouldBe emptyList()
+    }
+
+    @Test
+    fun `a tab that shows no location has nothing to step through`() {
+        val publication = FileListingPublication(directoryLocation.locationId, files)
+
+        resolveFileListing(ready(null), publication) shouldBe emptyList()
+        resolveFileListing(ExplorerWorkspace.State.Initializing, publication) shouldBe emptyList()
+        resolveFileListing(ExplorerWorkspace.State.Error(RuntimeException("Nope")), publication) shouldBe emptyList()
+    }
+
+    @Test
+    fun `a tab that never settled on a location publishes nothing`() {
         val workspace = testExplorerWorkspace(ExplorerArguments.Default(startPath = directory))
 
         workspace.fileListing.value shouldBe emptyList()
 
-        val files = listOf(directory.child("a.jpg"), directory.child("b.jpg"))
-        workspace.publishFileListing(files)
+        workspace.publishFileListing(directoryLocation.locationId, files)
 
         // Read through the interface: that is the only thing the viewer knows about this tab.
-        (workspace as Workspace.FileListingSource).fileListing.value shouldBe files
+        (workspace as Workspace.FileListingSource).fileListing.value shouldBe emptyList()
+    }
+
+    @Test
+    fun `the published listing is what a stepping viewer reads`() = runTest {
+        val engineLocation = MutableStateFlow(BrowsingEngine.State())
+        val engine = mockk<BrowsingEngine>(relaxed = true).apply {
+            every { location } returns engineLocation
+        }
+        val workspace = testExplorerWorkspace(
+            ExplorerArguments.Default(startPath = directory),
+            UnconfinedTestDispatcher(testScheduler),
+            browsingEngine = engine,
+        )
+
+        try {
+            advanceUntilIdle()
+            engineLocation.value = BrowsingEngine.State(
+                location = directoryLocation,
+                breadcrumbs = emptyList(),
+                target = ExplorerNavigation.Target.Directory(directory),
+            )
+            advanceUntilIdle()
+
+            workspace.publishFileListing(directoryLocation.locationId, files)
+            advanceUntilIdle()
+
+            // Read through the interface: that is the only thing the viewer knows about this tab.
+            (workspace as Workspace.FileListingSource).fileListing.value shouldBe files
+
+            workspace.publishFileListing(ExplorerLocation.Home().locationId, files)
+            advanceUntilIdle()
+            (workspace as Workspace.FileListingSource).fileListing.value shouldBe emptyList()
+        } finally {
+            workspace.release()
+        }
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerFileListingTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerFileListingTest.kt
@@ -1,0 +1,91 @@
+package eu.darken.butler.explorer.core
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.core.engine.toFileListing
+import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * What a viewer opened from this tab may step through: the listing the Explorer shows, files only.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ExplorerFileListingTest {
+
+    private val directory = LocalPath.build("/storage/emulated/0/DCIM")
+
+    private fun lookup(name: String, type: FileType) = LocalPathLookup(
+        lookedUp = directory.child(name),
+        fileType = type,
+        size = 1L,
+        modifiedAt = null,
+    )
+
+    private fun file(name: String) = ExplorerItem.RegularFile(
+        lookup = lookup(name, FileType.FILE),
+        mimeType = MimeInfo("image/jpeg"),
+    )
+
+    private fun symlink(name: String) = ExplorerItem.SymbolicLink(
+        lookup = lookup(name, FileType.SYMBOLIC_LINK),
+        mimeType = MimeInfo("image/jpeg"),
+    )
+
+    private fun folder(name: String) = ExplorerItem.RegularDirectory(
+        lookup = lookup(name, FileType.DIRECTORY),
+    )
+
+    @Test
+    fun `only files make the listing, in display order`() {
+        val items = listOf(
+            folder("albums"),
+            file("b.jpg"),
+            symlink("link.jpg"),
+            ExplorerItem.Peek(directory.child("peek.jpg")),
+            file("a.jpg"),
+            ExplorerItem.Trash.Root(
+                itemId = Uuid.random(),
+                deletedAt = Instant.fromEpochMilliseconds(0),
+                originalLookup = mockk { every { lookedUp } returns directory.child("deleted.jpg") },
+                trashLookup = null,
+            ),
+        )
+
+        items.toFileListing() shouldBe listOf(
+            directory.child("b.jpg"),
+            directory.child("link.jpg"),
+            directory.child("a.jpg"),
+        )
+    }
+
+    @Test
+    fun `an empty listing has nothing to step through`() {
+        emptyList<ExplorerItem>().toFileListing() shouldBe emptyList()
+    }
+
+    @Test
+    fun `the published listing is what a stepping viewer reads`() {
+        val workspace = testExplorerWorkspace(ExplorerArguments.Default(startPath = directory))
+
+        workspace.fileListing.value shouldBe emptyList()
+
+        val files = listOf(directory.child("a.jpg"), directory.child("b.jpg"))
+        workspace.publishFileListing(files)
+
+        // Read through the interface: that is the only thing the viewer knows about this tab.
+        (workspace as Workspace.FileListingSource).fileListing.value shouldBe files
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerWorkspace.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerWorkspace.kt
@@ -103,6 +103,20 @@ class ViewerWorkspace @AssistedInject constructor(
     val storedPath: APath<*>? = (source as? ViewerSource.Stored)?.path
 
     /**
+     * The workspace whose listing this viewer steps through with "previous" and "next", or null when
+     * it was not opened from one.
+     */
+    val listingSourceId: Workspace.Id? = (creationArguments as? ViewerArguments.Default)?.listingSourceId
+
+    /**
+     * Arguments for a viewer on [path], the neighbour of this one in that listing. The caller and
+     * the listing survive the step; the caption does not - it belonged to the shared file, not to
+     * whatever sits next to it. Null for streamed content, which has no listing to step through.
+     */
+    fun siblingArguments(path: APath<*>): ViewerArguments.Default? =
+        (creationArguments as? ViewerArguments.Default)?.copy(filePath = path, caption = null)
+
+    /**
      * Text the sender attached when this file was shared. Not part of [source] - it says nothing
      * about how the content is read - but it travels with the tab, including across the rebind a
      * saved copy performs.

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerActionBarItem.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerActionBarItem.kt
@@ -1,6 +1,8 @@
 package eu.darken.butler.viewer.ui.viewer
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.NavigateBefore
+import androidx.compose.material.icons.automirrored.twotone.NavigateNext
 import androidx.compose.material.icons.automirrored.twotone.OpenInNew
 import androidx.compose.material.icons.twotone.ContentCopy
 import androidx.compose.material.icons.twotone.ContentCut
@@ -33,6 +35,22 @@ sealed interface ViewerActionBarItem : WorkspaceActionBarItem {
     override val isDestructive: Boolean get() = false
     override val group: WorkspaceActionBarItem.Group get() = WorkspaceActionBarItem.Group.PRIMARY
     override val badge: Boolean get() = false
+
+    /** Step to the previous file of the listing this viewer was opened from. */
+    data class PreviousFile(
+        override val isEnabled: Boolean,
+    ) : ViewerActionBarItem {
+        override val icon = Icons.AutoMirrored.TwoTone.NavigateBefore
+        override val label = R.string.viewer_previous_file_action.toCaString()
+    }
+
+    /** Step to the next file of that same listing. */
+    data class NextFile(
+        override val isEnabled: Boolean,
+    ) : ViewerActionBarItem {
+        override val icon = Icons.AutoMirrored.TwoTone.NavigateNext
+        override val label = R.string.viewer_next_file_action.toCaString()
+    }
 
     /**
      * Write streamed content to a place the user picks. The only action a streamed source offers,

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerNeighbours.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerNeighbours.kt
@@ -1,0 +1,25 @@
+package eu.darken.butler.viewer.ui.viewer
+
+import eu.darken.butler.common.files.APath
+
+/**
+ * Where one step lands from [current]. Both neighbours null means the file is alone in its listing.
+ * [current] is what the snapshot was resolved for: the page state only accepts it while it matches
+ * the file on display, so a step never acts on the previous file's neighbours.
+ */
+data class ViewerNeighbours(
+    val current: APath<*>,
+    val previous: APath<*>?,
+    val next: APath<*>?,
+)
+
+/** Null when [current] is not in [files]: the listing moved on, so there is nothing to step through. */
+internal fun resolveNeighbours(current: APath<*>, files: List<APath<*>>): ViewerNeighbours? {
+    val index = files.indexOf(current)
+    if (index < 0) return null
+    return ViewerNeighbours(
+        current = current,
+        previous = files.getOrNull(index - 1),
+        next = files.getOrNull(index + 1),
+    )
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
@@ -111,6 +111,8 @@ fun ViewerWorkspacePageHost(
             callerWorkspaceId = callerWorkspaceId,
             onAction = { action ->
                 when (action) {
+                    is ViewerActionBarItem.PreviousFile -> vm.showPreviousFile()
+                    is ViewerActionBarItem.NextFile -> vm.showNextFile()
                     ViewerActionBarItem.OpenWith -> vm.openWith()
                     ViewerActionBarItem.Share -> vm.share()
                     ViewerActionBarItem.Copy -> vm.copyToClipboard()
@@ -555,6 +557,28 @@ private fun ViewerWorkspacePageImagePreview() {
             fileInfo = previewFileInfo,
             source = previewSource,
             imageSource = null,
+        ),
+    )
+}
+
+/** Opened from an Explorer listing: the bar leads with the two steps through that listing. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ViewerWorkspacePageSteppablePreview() {
+    ViewerWorkspacePage(
+        workspaceId = Workspace.Id(),
+        state = ViewerWorkspaceViewModel.State.Ready(
+            content = ViewerContent.Image(MimeInfo("image/jpeg")),
+            fileInfo = previewFileInfo,
+            source = previewSource,
+            imageSource = null,
+            // Last file of its folder, so stepping forward is offered but not available.
+            neighbours = ViewerNeighbours(
+                current = previewPath,
+                previous = LocalPath.build("/storage/emulated/0/DCIM/Camera/IMG_20240817_183041.jpg"),
+                next = null,
+            ),
         ),
     )
 }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
@@ -23,6 +23,7 @@ import eu.darken.butler.common.files.SmbPath
 import eu.darken.butler.common.files.actions.PathActionIssue
 import eu.darken.butler.common.files.validation.FilenameValidator
 import eu.darken.butler.common.flow.SingleEventFlow
+import eu.darken.butler.common.flow.combine as combineMany
 import eu.darken.butler.common.issue.Issue
 import eu.darken.butler.common.pkgs.installer.AppInstallEvent
 import eu.darken.butler.common.pkgs.installer.AppInstallInspector
@@ -72,6 +73,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -167,8 +169,16 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
             )
         }
 
-    /** Which page the user navigated to. Not persisted: a restored session starts at page one again. */
-    private val pdfPageIndexFlow = MutableStateFlow(0)
+    /**
+     * Which page the user navigated to, with the source it was chosen in. Not persisted: a restored
+     * session starts at page one again.
+     *
+     * Keyed by source because this tab can be replaced under its own id - stepping to the next file,
+     * or saving a stream - while the ViewModel lives on. A bare index would carry the old document's
+     * page into the new one, and clearing it on the swap would request page 0 of the document that
+     * is on its way out.
+     */
+    private val pdfPageIndexFlow = MutableStateFlow<PdfPageSelection?>(null)
 
     /**
      * The selected page is rendered here, not in the workspace: a full-screen page bitmap must not
@@ -191,6 +201,7 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
                         flowOf<PdfPage?>(null)
                     } else {
                         pdfPageIndexFlow
+                            .map { selection -> selection?.takeIf { it.source == workspace.source }?.index ?: 0 }
                             // A document that shrank underneath the viewer must not render a page
                             // index that no longer exists.
                             .map { it.coerceIn(0, pdf.pageCount - 1) }
@@ -234,13 +245,42 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         .distinctUntilChanged()
         .asStateFlow()
 
-    val state = combine(
+    /**
+     * The last listing the current origin published, so a paused origin - whose stand-in holds none -
+     * does not take the arrows away. Outside the per-workspace flow because a step replaces this tab
+     * under its own id and the ViewModel outlives each [ViewerWorkspace] incarnation.
+     */
+    private var lastListing: Pair<Workspace.Id, List<APath<*>>>? = null
+
+    /** Where a step from the file on display would land, or null when there is nothing to step to. */
+    private val neighboursFlow: Flow<ViewerNeighbours?> = workspaceSource.flatMapLatest { workspace ->
+        val originId = workspace.listingSourceId
+        val path = workspace.storedPath
+        if (originId == null || path == null) return@flatMapLatest flowOf(null)
+        val live = workspaceProvider.retrieve(originId).flatMapLatest { origin ->
+            (origin as? Workspace.FileListingSource)?.fileListing ?: flowOf<List<APath<*>>?>(null)
+        }
+        // A paused stand-in stays in the info list with a Paused lifecycle; a closed id leaves it.
+        val originExists = workspaceRemote.state
+            .map { state -> state.infos.any { it.id == originId } }
+            .distinctUntilChanged()
+        combine(live, originExists) { listing, exists ->
+            when {
+                !exists -> null
+                listing != null -> listing.also { lastListing = originId to it }
+                else -> lastListing?.takeIf { it.first == originId }?.second
+            }
+        }.map { files -> files?.let { resolveNeighbours(path, it) } }
+    }.distinctUntilChanged()
+
+    val state = combineMany(
         snapshots,
         renderErrorFlow,
         imageSourceFlow,
         pdfPageFlow,
         trashSettings.enabled.flow,
-    ) { snapshot, renderFailure, imageSource, pdfPage, trashEnabled ->
+        neighboursFlow,
+    ) { snapshot, renderFailure, imageSource, pdfPage, trashEnabled, rawNeighbours ->
         val (source, workspaceState) = snapshot
         // Only the failure of what is on display now: one recorded for a source this tab has since
         // been rebound away from would hide the new content behind the old one's error.
@@ -269,6 +309,9 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         val isGone = workspaceState.externalChange == ViewerExternalChange.Gone ||
             failure is ViewerFileGoneException ||
             failure is ViewerBrokenSymlinkException
+        // Only the snapshot resolved for the file on display: this tab is replaced under its own id
+        // when a step lands, and the neighbours of the file it left would step the wrong way.
+        val neighbours = rawNeighbours?.takeIf { it.current == (source as? ViewerSource.Stored)?.path }
         State.Ready(
             content = content,
             fileInfo = workspaceState.fileInfo,
@@ -280,8 +323,10 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
                 trashEnabled = trashEnabled,
                 content = content,
                 isGone = isGone,
+                neighbours = neighbours,
             ),
             externalChange = workspaceState.externalChange,
+            neighbours = neighbours,
         ) as State
     }
         .catch { error ->
@@ -475,7 +520,51 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
             delta = delta,
         ) ?: return
         log(tag) { "movePdfPage($delta) -> page $target" }
-        pdfPageIndexFlow.value = target
+        pdfPageIndexFlow.value = PdfPageSelection(source = ready.source, index = target)
+    }
+
+    fun showPreviousFile() = stepFile(delta = -1)
+
+    fun showNextFile() = stepFile(delta = 1)
+
+    /** Held for the whole swap, not just the create; see [stepFile]. */
+    private var fileStep: Job? = null
+
+    /**
+     * Moves this tab to a neighbour by REPLACING it with a viewer on that file - the same mechanism
+     * and for the same reasons as [rebindToSavedFile]; a viewer's file comes from its creation
+     * arguments and cannot be swapped in place.
+     */
+    private fun stepFile(delta: Int) {
+        val ready = state.value as? State.Ready ?: return
+        val neighbours = ready.neighbours ?: return
+        val target = (if (delta < 0) neighbours.previous else neighbours.next) ?: run {
+            log(tag) { "stepFile($delta) ignored, no neighbour" }
+            return
+        }
+        if (fileStep?.isActive == true) {
+            log(tag) { "stepFile($delta) ignored, a step is in flight" }
+            return
+        }
+        fileStep = vmScope.launch {
+            val workspace = workspaceSource.first()
+            val arguments = workspace.siblingArguments(target) ?: return@launch
+            log(tag, INFO) { "stepFile($delta) -> $target" }
+            val result = workspaceRemote.createAndFocus(
+                type = Workspace.Type.VIEWER,
+                arguments = arguments,
+                replace = id,
+                id = id,
+                // The neighbour may already be open in another tab; sending the user there would
+                // leave this one on the file they just stepped away from.
+                skipContentDedup = true,
+            )
+            // The guard has to outlive the create: the page state observes the swap asynchronously,
+            // and a tap in between would read the old file's neighbours.
+            if (result is WorkspaceAction.Create.Result.Success) {
+                workspaceSource.first { it.storedPath == target }
+            }
+        }
     }
 
     fun close() = launch {
@@ -1002,6 +1091,12 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         val error: Throwable,
     )
 
+    /** The page the user chose, and the document they chose it in. */
+    private data class PdfPageSelection(
+        val source: ViewerSource,
+        val index: Int,
+    )
+
     /** One rendered PDF page. A null [bitmap] with [failed] false means the render is still running. */
     data class PdfPage(
         val index: Int,
@@ -1020,7 +1115,13 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
             val source: ViewerSource,
             val imageSource: ZoomableImageSource?,
             val pdfPage: PdfPage? = null,
-            val actions: List<ViewerActionBarItem> = viewerActions(source, trashEnabled = false, content = content),
+            val neighbours: ViewerNeighbours? = null,
+            val actions: List<ViewerActionBarItem> = viewerActions(
+                source,
+                trashEnabled = false,
+                content = content,
+                neighbours = neighbours,
+            ),
             val externalChange: ViewerExternalChange? = null,
         ) : State
     }
@@ -1054,16 +1155,25 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
  * [isGone] drops everything that needs the file itself, the same way streamed content never gets
  * those entries. Opening its location survives: the folder is still there, and it is where the user
  * would go looking for what happened to the file.
+ *
+ * [neighbours] leads the bar when the viewer was opened from a listing it can step through, [isGone]
+ * or not: a file deleted behind the viewer's back stays in that listing until it is refreshed, and
+ * moving on is the useful thing to do then.
  */
 internal fun viewerActions(
     source: ViewerSource,
     trashEnabled: Boolean,
     content: ViewerContent = ViewerContent.Loading,
     isGone: Boolean = false,
+    neighbours: ViewerNeighbours? = null,
 ): List<ViewerActionBarItem> = when (source) {
     is ViewerSource.Streamed -> listOf(ViewerActionBarItem.SaveCopy)
 
     is ViewerSource.Stored -> buildList {
+        if (neighbours != null) {
+            add(ViewerActionBarItem.PreviousFile(isEnabled = neighbours.previous != null))
+            add(ViewerActionBarItem.NextFile(isEnabled = neighbours.next != null))
+        }
         if (!isGone) {
             // Leads for a package file: it is what the user came for, and everything below applies
             // to the file rather than to the app it would install.

--- a/app-workspace-viewer/src/main/res/values/strings.xml
+++ b/app-workspace-viewer/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="viewer_back_action">Back</string>
 
     <!-- Action bar -->
+    <string name="viewer_previous_file_action">Previous file</string>
+    <string name="viewer_next_file_action">Next file</string>
     <string name="viewer_open_location_action">Open location</string>
     <string name="viewer_clipboard_copied">%1$s copied. Paste it in an Explorer tab.</string>
     <string name="viewer_clipboard_cut">%1$s cut. Paste it in an Explorer tab to move it.</string>

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerArgumentsSerializationTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerArgumentsSerializationTest.kt
@@ -55,6 +55,19 @@ class ViewerArgumentsSerializationTest : BaseTest() {
     }
 
     @Test
+    fun `the listing this viewer steps through is not persisted`() {
+        val stepping = ViewerArguments.Default(filePath = path, listingSourceId = Workspace.Id())
+
+        val serialized = json.encodeToJsonElement<ViewerArguments>(stepping)
+
+        // Byte-identical to a plain tab: the workspace it stepped through is gone by the time a
+        // saved session is restored, so there would be nothing to step with.
+        serialized shouldBe json.encodeToJsonElement<ViewerArguments>(ViewerArguments.Default(filePath = path))
+        json.decodeFromString<ViewerArguments>(serialized.toString()) shouldBe
+            ViewerArguments.Default(filePath = path)
+    }
+
+    @Test
     fun `a persisted drill-down deserializes as a tab`() {
         val modal = ViewerArguments.Default(filePath = path, callerWorkspaceId = Workspace.Id())
 

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerActionsTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerActionsTest.kt
@@ -89,4 +89,58 @@ class ViewerActionsTest : BaseTest() {
         viewerActions(streamed, trashEnabled = false, content = apk) shouldBe
             listOf(ViewerActionBarItem.SaveCopy)
     }
+
+    private val photo = LocalPath.build("/storage/emulated/0/DCIM/photo.jpg")
+    private val previous = LocalPath.build("/storage/emulated/0/DCIM/earlier.jpg")
+    private val next = LocalPath.build("/storage/emulated/0/DCIM/later.jpg")
+
+    @Test
+    fun `a viewer without a listing offers no steps`() {
+        val actions = viewerActions(stored, trashEnabled = false, content = apk)
+
+        actions.filterIsInstance<ViewerActionBarItem.PreviousFile>() shouldBe emptyList()
+        actions.filterIsInstance<ViewerActionBarItem.NextFile>() shouldBe emptyList()
+    }
+
+    @Test
+    fun `stepping leads the bar and follows what the listing holds`() {
+        val actions = viewerActions(
+            stored,
+            trashEnabled = false,
+            content = apk,
+            neighbours = ViewerNeighbours(current = photo, previous = previous, next = null),
+        )
+
+        actions.take(2) shouldBe listOf(
+            ViewerActionBarItem.PreviousFile(isEnabled = true),
+            ViewerActionBarItem.NextFile(isEnabled = false),
+        )
+    }
+
+    @Test
+    fun `a file that is gone can still be stepped away from`() {
+        // It stays in the Explorer's listing until that tab refreshes, and moving on is the way out.
+        val actions = viewerActions(
+            stored,
+            trashEnabled = false,
+            content = apk,
+            isGone = true,
+            neighbours = ViewerNeighbours(current = photo, previous = previous, next = next),
+        )
+
+        actions.take(2) shouldBe listOf(
+            ViewerActionBarItem.PreviousFile(isEnabled = true),
+            ViewerActionBarItem.NextFile(isEnabled = true),
+        )
+    }
+
+    @Test
+    fun `streamed content is never stepped through`() {
+        viewerActions(
+            streamed,
+            trashEnabled = false,
+            content = apk,
+            neighbours = ViewerNeighbours(current = photo, previous = previous, next = next),
+        ) shouldBe listOf(ViewerActionBarItem.SaveCopy)
+    }
 }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileStepTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileStepTest.kt
@@ -1,0 +1,331 @@
+package eu.darken.butler.viewer.ui.viewer
+
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.validation.FilenameValidator
+import eu.darken.butler.common.flow.SingleEventFlow
+import eu.darken.butler.common.trash.TrashSettings
+import eu.darken.butler.viewer.core.ViewerContent
+import eu.darken.butler.viewer.core.ViewerSource
+import eu.darken.butler.viewer.core.ViewerWorkspace
+import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import testhelpers.error.recordingIncidentStore
+
+/**
+ * Stepping to the neighbouring file of the listing this viewer was opened from: which arrows the bar
+ * offers, and what one tap does.
+ *
+ * A step replaces this tab under its own id, so the ViewModel outlives every workspace it drives -
+ * which is why the guard against a second tap has to hold until the replacement has arrived.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ViewerFileStepTest : BaseTest() {
+
+    private val workspaceId = Workspace.Id()
+    private val originId = Workspace.Id()
+    private val callerId = Workspace.Id()
+
+    private val a = LocalPath.build("/storage/emulated/0/DCIM/a.jpg")
+    private val b = LocalPath.build("/storage/emulated/0/DCIM/b.jpg")
+    private val c = LocalPath.build("/storage/emulated/0/DCIM/c.jpg")
+
+    private val creates = mutableListOf<WorkspaceAction.Create>()
+
+    /** Set to hold a create inside the ViewModel, so a second tap arrives while one is in flight. */
+    private var createGate: CompletableDeferred<Unit>? = null
+
+    private lateinit var listing: MutableStateFlow<List<APath<*>>>
+    private lateinit var origin: MutableStateFlow<Workspace<*>?>
+    private lateinit var remoteState: MutableStateFlow<WorkspaceRemote.State>
+    private lateinit var workspaces: MutableStateFlow<ViewerWorkspace>
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        creates.clear()
+        createGate = null
+        listing = MutableStateFlow(listOf(a, b, c))
+        origin = MutableStateFlow(makeOrigin())
+        remoteState = MutableStateFlow(
+            WorkspaceRemote.State(
+                infos = listOf(
+                    Workspace.Info(id = originId, type = Workspace.Type.EXPLORER, title = "DCIM".toCaString()),
+                    Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = "b.jpg".toCaString()),
+                ),
+            ),
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun makeOrigin(): Workspace<*> {
+        val explorer = mockk<Workspace<Workspace.Arguments>>(
+            moreInterfaces = arrayOf(Workspace.FileListingSource::class),
+        )
+        every { (explorer as Workspace.FileListingSource).fileListing } returns listing
+        return explorer
+    }
+
+    /** The arguments a viewer opened from that Explorer carries, and steps with. */
+    private fun arguments(path: APath<*>) = ViewerArguments.Default(
+        filePath = path,
+        caption = "look at this",
+        callerWorkspaceId = callerId,
+        listingSourceId = originId,
+    )
+
+    private fun makeWorkspace(
+        path: APath<*>,
+        listingSourceId: Workspace.Id? = originId,
+    ) = mockk<ViewerWorkspace>().apply {
+        every { state } returns MutableStateFlow(
+            ViewerWorkspace.State(content = ViewerContent.Image(MimeInfo("image/jpeg"))),
+        )
+        every { source } returns ViewerSource.Stored(path)
+        every { storedPath } returns path
+        every { this@apply.listingSourceId } returns listingSourceId
+        every { sharedCaption } returns "look at this"
+        every { info } returns MutableStateFlow(
+            Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = path.name.toCaString()),
+        )
+        every { reload() } just Runs
+        every { siblingArguments(any()) } answers {
+            arguments(path).copy(filePath = firstArg(), caption = null)
+        }
+    }
+
+    private val incidentStore = recordingIncidentStore()
+
+    private fun makeViewModel(path: APath<*> = b): ViewerWorkspaceViewModel {
+        workspaces = MutableStateFlow(makeWorkspace(path))
+        val remote = mockk<WorkspaceRemote>(relaxed = true).apply {
+            every { events } returns emptyFlow()
+            every { this@apply.state } returns remoteState
+            coEvery { execute(any()) } coAnswers {
+                val action = firstArg<WorkspaceAction>()
+                if (action is WorkspaceAction.Create) {
+                    creates.add(action)
+                    createGate?.await()
+                }
+                WorkspaceAction.Create.Result.Success(workspaceId)
+            }
+        }
+        return ViewerWorkspaceViewModel(
+            id = workspaceId,
+            dispatchers = TestDispatcherProvider(),
+            context = mockk(relaxed = true),
+            workspaceProvider = mockk<WorkspaceProvider>().apply {
+                every { retrieve(workspaceId) } returns workspaces
+                every { retrieve(originId) } returns origin
+            },
+            workspaceRemote = remote,
+            imageSourceFactory = mockk(relaxed = true),
+            pdfPreviewLoader = mockk(relaxed = true),
+            openWithIntentUseCase = mockk(relaxed = true),
+            shareIntentUseCase = mockk(relaxed = true),
+            clipboardRepo = mockk(relaxed = true),
+            trashSettings = mockk<TrashSettings>(relaxed = true).apply {
+                every { enabled.flow } returns flowOf(false)
+            },
+            operationsManager = mockk(relaxed = true),
+            appInstallInspector = mockk(relaxed = true),
+            appInstaller = mockk(relaxed = true),
+            appInstallOperationFactory = mockk(relaxed = true),
+            apkIconExporter = mockk(relaxed = true),
+            filenameValidator = FilenameValidator(),
+            errorIncidentStore = incidentStore,
+            chromeFactory = mockk<WorkspacePageChrome.Factory>().apply {
+                every { create(any(), any()) } returns mockk<WorkspacePageChrome>().apply {
+                    every { shareIntentEvent } returns SingleEventFlow()
+                    every { pendingErrorShare } returns MutableStateFlow(null)
+                    every { pendingConflicts } returns flowOf(emptyMap())
+                }
+            },
+        )
+    }
+
+    /** The state only renders while it is collected, and stepping reads it. */
+    private fun TestScope.startCollecting(vm: ViewerWorkspaceViewModel) {
+        backgroundScope.launch(Dispatchers.Unconfined) { vm.state.collect { } }
+    }
+
+    private val ViewerWorkspaceViewModel.readyState: ViewerWorkspaceViewModel.State.Ready
+        get() = state.value as ViewerWorkspaceViewModel.State.Ready
+
+    private val ViewerWorkspaceViewModel.steps: List<ViewerActionBarItem>
+        get() = readyState.actions.filter {
+            it is ViewerActionBarItem.PreviousFile || it is ViewerActionBarItem.NextFile
+        }
+
+    @Test
+    fun `a file in the middle of the listing steps both ways`() = runTest2 {
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        vm.steps shouldBe listOf(
+            ViewerActionBarItem.PreviousFile(isEnabled = true),
+            ViewerActionBarItem.NextFile(isEnabled = true),
+        )
+    }
+
+    @Test
+    fun `stepping forward replaces this tab with the next file`() = runTest2 {
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        vm.showNextFile()
+
+        val step = creates.single()
+        step.type shouldBe Workspace.Type.VIEWER
+        step.replace shouldBe workspaceId
+        // Same id, so the tab keeps its pane slot and its sub-workspaces.
+        step.id shouldBe workspaceId
+        // The neighbour may already be open elsewhere; that must not strand this tab.
+        step.skipContentDedup shouldBe true
+        val arguments = step.arguments.shouldBeInstanceOf<ViewerArguments.Default>()
+        arguments.filePath shouldBe c
+        arguments.listingSourceId shouldBe originId
+        // A drill-down stays one: the step does not turn the overlay into a tab of its own.
+        arguments.callerWorkspaceId shouldBe callerId
+        // The caption belonged to the file that was shared, not to its neighbour.
+        arguments.caption shouldBe null
+    }
+
+    @Test
+    fun `a paused origin keeps the last listing it published`() = runTest2 {
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        // Pausing releases the live instance; the stand-in that takes its place holds no listing.
+        origin.value = null
+
+        vm.steps shouldBe listOf(
+            ViewerActionBarItem.PreviousFile(isEnabled = true),
+            ViewerActionBarItem.NextFile(isEnabled = true),
+        )
+
+        vm.showNextFile()
+        creates.single().arguments.shouldBeInstanceOf<ViewerArguments.Default>().filePath shouldBe c
+    }
+
+    @Test
+    fun `a closed origin takes the steps away`() = runTest2 {
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        remoteState.value = WorkspaceRemote.State(infos = remoteState.value.infos.filter { it.id != originId })
+
+        vm.steps shouldBe emptyList()
+    }
+
+    @Test
+    fun `a listing without the file on display offers no steps`() = runTest2 {
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        // The Explorer navigated away, or a filter dropped this file.
+        listing.value = listOf(a, c)
+
+        vm.steps shouldBe emptyList()
+    }
+
+    @Test
+    fun `the last file of a listing cannot step forward`() = runTest2 {
+        val vm = makeViewModel(path = c)
+        startCollecting(vm)
+
+        vm.steps shouldBe listOf(
+            ViewerActionBarItem.PreviousFile(isEnabled = true),
+            ViewerActionBarItem.NextFile(isEnabled = false),
+        )
+
+        vm.showNextFile()
+
+        creates shouldBe emptyList()
+    }
+
+    @Test
+    fun `a second tap while the create is still running does nothing`() = runTest2 {
+        val gate = CompletableDeferred<Unit>()
+        createGate = gate
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        vm.showNextFile()
+        vm.showNextFile()
+
+        creates.size shouldBe 1
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun `a tap before the replacement arrives does nothing`() = runTest2 {
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        // The create returned, but the provider still hands out the tab's previous incarnation:
+        // a step taken now would read the file the user already left.
+        vm.showNextFile()
+        creates.size shouldBe 1
+
+        vm.showNextFile()
+        creates.size shouldBe 1
+
+        // Once the replacement is published, the next step is allowed again.
+        workspaces.value = makeWorkspace(c)
+        vm.showPreviousFile()
+        creates.size shouldBe 2
+        creates.last().arguments.shouldBeInstanceOf<ViewerArguments.Default>().filePath shouldBe b
+    }
+
+    @Test
+    fun `neighbours resolved for the previous file never reach the new one`() = runTest2 {
+        val vm = makeViewModel()
+        val seen = mutableListOf<ViewerWorkspaceViewModel.State.Ready>()
+        backgroundScope.launch(Dispatchers.Unconfined) {
+            vm.state.collect { if (it is ViewerWorkspaceViewModel.State.Ready) seen.add(it) }
+        }
+
+        workspaces.value = makeWorkspace(c)
+
+        seen.isNotEmpty() shouldBe true
+        seen.forEach { state ->
+            val current = state.neighbours?.current ?: return@forEach
+            current shouldBe (state.source as ViewerSource.Stored).path
+        }
+    }
+}

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerNeighboursTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerNeighboursTest.kt
@@ -1,0 +1,50 @@
+package eu.darken.butler.viewer.ui.viewer
+
+import eu.darken.butler.common.files.LocalPath
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Where a file step lands, as pure list arithmetic: null means the listing no longer holds the file
+ * on display, which the ViewModel turns into "no arrows" rather than a step into the wrong folder.
+ */
+class ViewerNeighboursTest : BaseTest() {
+
+    private val a = LocalPath.build("/storage/emulated/0/DCIM/a.jpg")
+    private val b = LocalPath.build("/storage/emulated/0/DCIM/b.jpg")
+    private val c = LocalPath.build("/storage/emulated/0/DCIM/c.jpg")
+    private val files = listOf(a, b, c)
+
+    @Test
+    fun `a file in the middle can step both ways`() {
+        resolveNeighbours(b, files) shouldBe ViewerNeighbours(current = b, previous = a, next = c)
+    }
+
+    @Test
+    fun `the first file has nothing before it`() {
+        resolveNeighbours(a, files) shouldBe ViewerNeighbours(current = a, previous = null, next = b)
+    }
+
+    @Test
+    fun `the last file has nothing after it`() {
+        resolveNeighbours(c, files) shouldBe ViewerNeighbours(current = c, previous = b, next = null)
+    }
+
+    @Test
+    fun `a file alone in its listing still resolves`() {
+        // Not the same as "no listing": the arrows are offered, both of them disabled.
+        resolveNeighbours(a, listOf(a)) shouldBe ViewerNeighbours(current = a, previous = null, next = null)
+    }
+
+    @Test
+    fun `a file the listing does not hold has no neighbours at all`() {
+        resolveNeighbours(LocalPath.build("/storage/emulated/0/DCIM/gone.jpg"), files) shouldBe null
+        resolveNeighbours(a, emptyList()) shouldBe null
+    }
+
+    @Test
+    fun `the result names the file it was resolved for`() {
+        resolveNeighbours(b, files)!!.current shouldBe b
+    }
+}

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerRenderFailureTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerRenderFailureTest.kt
@@ -109,6 +109,7 @@ class ViewerRenderFailureTest : BaseTest() {
         every { state } returns states
         every { this@apply.source } returns source
         every { storedPath } returns (source as? ViewerSource.Stored)?.path
+        every { listingSourceId } returns null
         every { sharedCaption } returns null
         every { info } returns MutableStateFlow(
             Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = source.displayName.toCaString()),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerSaveCopyTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerSaveCopyTest.kt
@@ -95,6 +95,7 @@ class ViewerSaveCopyTest : BaseTest() {
             )
             every { source } returns streamed
             every { storedPath } returns null
+            every { listingSourceId } returns null
             every { sharedCaption } returns "look at this"
             every { info } returns MutableStateFlow(
                 Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = "backup.zip".toCaString()),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePageTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePageTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -62,6 +64,43 @@ class ViewerWorkspacePageTest : ComposeTest() {
             .performClick()
 
         clicked shouldBe listOf(ViewerActionBarItem.OpenWith)
+    }
+
+    @Test
+    fun `the action bar steps through the listing the viewer was opened from`() {
+        val clicked = mutableListOf<ViewerActionBarItem>()
+        val previous = LocalPath.build("/storage/emulated/0/DCIM/earlier.jpg")
+        val current = LocalPath.build("/storage/emulated/0/DCIM/photo.jpg")
+        composeTestRule.setContent {
+            PreviewWrapper {
+                ViewerWorkspacePage(
+                    workspaceId = Workspace.Id(),
+                    design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                    state = ViewerWorkspaceViewModel.State.Ready(
+                        content = ViewerContent.Image(MimeInfo("image/jpeg")),
+                        fileInfo = ViewerFileInfo(size = 1024L),
+                        source = ViewerSource.Stored(current),
+                        imageSource = null,
+                        // The last file of its listing: back is available, forward is not.
+                        neighbours = ViewerNeighbours(current = current, previous = previous, next = null),
+                    ),
+                    onAction = { clicked.add(it) },
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(R.string.viewer_next_file_action))
+            .assertIsNotEnabled()
+
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(R.string.viewer_previous_file_action))
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(R.string.viewer_previous_file_action))
+            .performClick()
+
+        clicked shouldBe listOf(ViewerActionBarItem.PreviousFile(isEnabled = true))
     }
 
     @Test

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelExternalChangeTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelExternalChangeTest.kt
@@ -71,6 +71,7 @@ class ViewerWorkspaceViewModelExternalChangeTest : BaseTest() {
             every { state } returns workspaceState
             every { source } returns this@ViewerWorkspaceViewModelExternalChangeTest.source
             every { storedPath } returns filePath
+            every { listingSourceId } returns null
             every { info } returns MutableStateFlow(
                 Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = "photo.jpg".toCaString()),
             )

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
@@ -53,7 +53,11 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
     private val mime = MimeInfo("application/pdf")
 
     private val requestedPages = mutableListOf<Int>()
+
+    /** The same requests with the document they were made for, for the tab-swap case. */
+    private val requestedDocuments = mutableListOf<Pair<ViewerSource, Int>>()
     private lateinit var workspaceState: MutableStateFlow<ViewerWorkspace.State>
+    private lateinit var workspaces: MutableStateFlow<ViewerWorkspace>
     private lateinit var loader: PdfPreviewLoader
 
     /** Set to gate a specific page's render, so the test can hold it in flight. */
@@ -66,6 +70,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
     fun setup() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         requestedPages.clear()
+        requestedDocuments.clear()
         failingPages.clear()
         renderGate = null
         workspaceState = MutableStateFlow(
@@ -75,6 +80,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
             coEvery { page(any(), any()) } coAnswers {
                 val index = secondArg<Int>()
                 requestedPages.add(index)
+                requestedDocuments.add(firstArg<ViewerSource>() to index)
                 renderGate?.takeIf { it.first == index }?.second?.await()
                 if (index in failingPages) null else mockk<Bitmap>()
             }
@@ -106,6 +112,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
             )
             every { reload() } just Runs
         }
+        workspaces = MutableStateFlow(workspace)
         val chrome = mockk<WorkspacePageChrome>().apply {
             every { shareIntentEvent } returns SingleEventFlow()
             every { pendingErrorShare } returns MutableStateFlow(null)
@@ -117,7 +124,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
             dispatchers = TestDispatcherProvider(),
             context = mockk(relaxed = true),
             workspaceProvider = mockk<WorkspaceProvider>().apply {
-                every { retrieve(workspaceId) } returns flowOf(workspace)
+                every { retrieve(workspaceId) } returns workspaces
             },
             workspaceRemote = mockk<WorkspaceRemote>(relaxed = true).apply {
                 every { events } returns emptyFlow()
@@ -235,6 +242,42 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
         vm.previousPdfPage()
         vm.readyState.pdfPage!!.index shouldBe 1
         requestedPages.takeLast(2) shouldBe listOf(2, 1)
+    }
+
+    @Test
+    fun `a tab swapped to another document starts that one at its first page`() = runTest2 {
+        // Stepping to the next file replaces this tab under its own id, so the ViewModel - and with
+        // it the page the user picked - outlives the document it was picked in.
+        val vm = makeViewModel()
+        startCollecting(vm)
+
+        vm.nextPdfPage()
+        vm.nextPdfPage()
+        requestedPages shouldBe listOf(0, 1, 2)
+
+        val otherPath = LocalPath.build("/storage/emulated/0/Download/other.pdf")
+        val otherSource = ViewerSource.Stored(otherPath)
+        workspaces.value = mockk<ViewerWorkspace>().apply {
+            every { state } returns MutableStateFlow(
+                ViewerWorkspace.State(content = ViewerContent.PdfPreview(mime, pageCount = 5)),
+            )
+            every { source } returns otherSource
+            every { storedPath } returns otherPath
+            every { listingSourceId } returns null
+            every { info } returns MutableStateFlow(
+                Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = "other.pdf".toCaString()),
+            )
+            every { reload() } just Runs
+        }
+
+        vm.readyState.pdfPage!!.index shouldBe 0
+        // Page 0 of the new document, and nothing more asked of the old one.
+        requestedDocuments shouldBe listOf(
+            source to 0,
+            source to 1,
+            source to 2,
+            otherSource to 0,
+        )
     }
 
     @Test

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
@@ -100,6 +100,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
             every { state } returnsMany listOf(workspaceState, pdfPageState)
             every { source } returns this@ViewerWorkspaceViewModelPagingTest.source
             every { storedPath } returns this@ViewerWorkspaceViewModelPagingTest.filePath
+            every { listingSourceId } returns null
             every { info } returns MutableStateFlow(
                 Workspace.Info(id = workspaceId, type = Workspace.Type.VIEWER, title = "manual.pdf".toCaString()),
             )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/contracts/viewer/ViewerArguments.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/contracts/viewer/ViewerArguments.kt
@@ -33,6 +33,12 @@ sealed interface ViewerArguments : Workspace.Arguments {
         /** Text a share attached to this file, see [Streamed.caption]. */
         val caption: String? = null,
         @Transient override val callerWorkspaceId: Workspace.Id? = null,
+        /**
+         * Workspace whose [Workspace.FileListingSource] listing this viewer steps through with "next"
+         * and "previous", or null when it was not opened from one. Session-transient like
+         * [callerWorkspaceId]: a restored tab has no listing to step through.
+         */
+        @Transient val listingSourceId: Workspace.Id? = null,
     ) : ViewerArguments, Workspace.ArgumentsWithCaller, Workspace.ArgumentsWithContentPath {
         // Get-only (no backing field): invisible to kotlinx-serialization and Parcelize, so
         // persisted session arguments are unaffected.
@@ -51,7 +57,7 @@ sealed interface ViewerArguments : Workspace.Arguments {
         // so only its presence is reported.
         override fun toString(): String =
             "ViewerArguments.Default(filePath=$filePath, caption=${caption.redacted}, " +
-                "callerWorkspaceId=$callerWorkspaceId)"
+                "callerWorkspaceId=$callerWorkspaceId, listingSourceId=$listingSourceId)"
     }
 
     /**

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/Workspace.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/Workspace.kt
@@ -160,6 +160,15 @@ interface Workspace<ArgT : Workspace.Arguments> {
     }
 
     /**
+     * A workspace showing an ordered file listing that another workspace may step through, e.g. a
+     * viewer opened from an Explorer offering "next file".
+     */
+    interface FileListingSource {
+        /** Paths of the non-directory entries on display, in display order. Empty when nothing is shown. */
+        val fileListing: StateFlow<List<APath<*>>>
+    }
+
+    /**
      * Defines how a modal workspace should be presented to the user.
      */
     enum class ModalPresentationMode {


### PR DESCRIPTION
## What changed

The viewer gets "Previous file" and "Next file" arrows in its action bar when it was opened from an Explorer. They step through the files of that Explorer listing in the order shown there, every non-folder entry included: images and PDFs render as usual, other types land on the existing "not supported" or archive card. The arrows disable at either end of the listing, disappear when the Explorer no longer shows that folder or is closed, and keep working while the Explorer tab is merely paused. Viewers opened by other means (shares, the Searcher, favourites on the Home screen) are unchanged.

## Technical Context

- Stepping replaces the viewer workspace under its own id (the mechanism "Save a copy" already uses), so a drill-down overlay stays an overlay and the tab keeps its pane slot; the file a viewer shows is immutable by design.
- The listing crosses the module boundary through a new optional `FileListingSource` workspace interface: the Explorer page publishes its sorted and filtered listing into its workspace, tagged with the location it was computed for, and the workspace only exposes it while it still shows that location. The viewer carries the source workspace id as a transient argument, like the caller id.
- Paused Explorers are hidden from the workspace lookup, so the viewer remembers the last listing it received and keeps it while the source id is still listed. The last commit closes a race where the pause published an empty listing into the instance being paused (seen on device); publications now never fire on a null listing.
- PDF page selection is keyed by the document it was chosen in, so stepping from one PDF to another opens the new one on page one without triggering a render of the old document.
- Review focus: `ViewerWorkspaceViewModel.neighboursFlow` / `stepFile` (snapshot validation and the in-flight guard), and the `processedListingFlow` change in `ExplorerWorkspaceViewModel`, whose early-null guard now also covers a null location.
