### PR TITLE
Workspace: Remove a tab from a pane without closing it

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
@@ -472,6 +472,44 @@ class WorkspacePageManager @Inject constructor(
         }
     }
 
+    /**
+     * Detaches [workspaceId] from the pane it occupies, leaving the tab open and in the list.
+     *
+     * Focus is repaired here rather than left to [setSelectedWorkspaces]: that one falls back to the
+     * assignment map's first entry, and the map is ordered by when panes were filled, so the fallback
+     * can land on an index no pane renders. It also cannot see a focused modal child, which never
+     * appears in the map, and would move focus off it whenever any pane is detached.
+     */
+    suspend fun unassignWorkspace(workspaceId: Workspace.Id) {
+        log(TAG) { "unassignWorkspace($workspaceId)" }
+        // Before the update block, which cannot suspend - same as handleWorkspaceSelection.
+        val infos = workspaceRemote.state.first().infos
+
+        _state.update { currentState ->
+            val remaining = currentState.selectedWorkspaces.filterValues { it != workspaceId }
+            if (remaining.size == currentState.selectedWorkspaces.size) {
+                log(TAG) { "unassignWorkspace: $workspaceId occupies no pane, nothing to do" }
+                return@update currentState
+            }
+
+            val rendered = remaining.filterKeys { it in 0 until currentState.currentPaneCount }
+            val focusedRoot = currentState.focusedWorkspaceId
+                ?.let { WorkspaceStacks(infos).rootOf(it)?.id }
+
+            val newFocus = when {
+                // The focused workspace - or the tab owning a focused modal - still has a pane on
+                // screen, so detaching a different one must not disturb it.
+                focusedRoot != null && rendered.containsValue(focusedRoot) -> currentState.focusedWorkspaceId
+                // Lowest rendered pane, so focus never lands on a retained index the layout does not
+                // draw. Retained indices are always at or above the pane count, so the minimum key is
+                // a rendered pane whenever one survives.
+                else -> rendered.minByOrNull { it.key }?.value ?: currentState.focusedWorkspaceId
+            }
+
+            currentState.copy(selectedWorkspaces = remaining, focusedWorkspaceId = newFocus)
+        }
+    }
+
     fun setSelectedWorkspaces(selections: Map<Int, Workspace.Id>) {
         _state.update { currentState ->
             // Auto-focus first selected if current focus not in selection

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
@@ -1510,4 +1510,144 @@ class WorkspacePageManagerTest : BaseTest() {
         collections shouldBe 0
         pageManager.state.value.selectedWorkspaces shouldBe mapOf(0 to paneOne, 1 to paneTwo)
     }
+
+    @Test
+    fun `detaching a tab frees its pane and leaves the other assignments alone`() = runTest {
+        val paneZero = Workspace.Id()
+        val paneOne = Workspace.Id()
+        val paneTwo = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(
+                createWorkspaceInfo(id = paneZero),
+                createWorkspaceInfo(id = paneOne),
+                createWorkspaceInfo(id = paneTwo),
+            )
+        )
+        pageManager.setPaneCount(3)
+        pageManager.applyRestoredUIState(paneZero, mapOf(0 to paneZero, 1 to paneOne, 2 to paneTwo))
+
+        pageManager.unassignWorkspace(paneOne)
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to paneZero, 2 to paneTwo)
+        after.focusedWorkspaceId shouldBe paneZero
+    }
+
+    @Test
+    fun `detaching a tab that occupies no pane changes nothing`() = runTest {
+        val paneZero = Workspace.Id()
+        val unassigned = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(createWorkspaceInfo(id = paneZero), createWorkspaceInfo(id = unassigned))
+        )
+        pageManager.setPaneCount(2)
+        pageManager.applyRestoredUIState(paneZero, mapOf(0 to paneZero))
+
+        val before = pageManager.state.value
+
+        pageManager.unassignWorkspace(unassigned)
+        pageManager.state.value shouldBe before
+
+        pageManager.unassignWorkspace(Workspace.Id())
+        pageManager.state.value shouldBe before
+    }
+
+    /**
+     * The assignment map is ordered by when panes filled, not by pane index, so its first entry can
+     * name a pane the current layout does not render.
+     */
+    @Test
+    fun `detaching the focused tab refocuses the lowest rendered pane`() = runTest {
+        val paneZero = Workspace.Id()
+        val retained = Workspace.Id()
+        val paneOne = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(
+                createWorkspaceInfo(id = paneZero),
+                createWorkspaceInfo(id = retained),
+                createWorkspaceInfo(id = paneOne),
+            )
+        )
+        pageManager.setPaneCount(4)
+        pageManager.applyRestoredUIState(paneZero, mapOf(0 to paneZero, 2 to retained, 1 to paneOne))
+        pageManager.setPaneCount(2)
+
+        pageManager.unassignWorkspace(paneZero)
+
+        val after = pageManager.state.value
+        after.focusedWorkspaceId shouldBe paneOne
+        after.selectedWorkspaces shouldBe mapOf(1 to paneOne, 2 to retained)
+    }
+
+    /** A modal child never appears in the assignment map, so only its owning tab can vouch for it. */
+    @Test
+    fun `a focused modal keeps focus when an unrelated pane is detached`() = runTest {
+        val owner = Workspace.Id()
+        val other = Workspace.Id()
+        val child = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(
+                createWorkspaceInfo(id = owner),
+                createWorkspaceInfo(id = other),
+                createWorkspaceInfo(id = child, callerWorkspaceId = owner),
+            )
+        )
+        pageManager.setPaneCount(2)
+        pageManager.applyRestoredUIState(child, mapOf(0 to owner, 1 to other))
+
+        pageManager.unassignWorkspace(other)
+
+        val after = pageManager.state.value
+        after.focusedWorkspaceId shouldBe child
+        after.selectedWorkspaces shouldBe mapOf(0 to owner)
+    }
+
+    /** Nothing is left on screen to focus, and a null focus is what auto-creates a tab. */
+    @Test
+    fun `detaching the last rendered tab leaves focus where it is`() = runTest {
+        val rendered = Workspace.Id()
+        val retained = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(createWorkspaceInfo(id = rendered), createWorkspaceInfo(id = retained))
+        )
+        pageManager.setPaneCount(4)
+        pageManager.applyRestoredUIState(rendered, mapOf(0 to rendered, 3 to retained))
+        pageManager.setPaneCount(1)
+
+        pageManager.unassignWorkspace(rendered)
+
+        val after = pageManager.state.value
+        after.focusedWorkspaceId shouldBe rendered
+        after.selectedWorkspaces shouldBe mapOf(3 to retained)
+    }
+
+    /** Retained assignments are what makes collapsing and expanding a layout non-destructive. */
+    @Test
+    fun `another workspace's retained assignment survives a detach`() = runTest {
+        val paneZero = Workspace.Id()
+        val paneOne = Workspace.Id()
+        val hidden = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(
+                createWorkspaceInfo(id = paneZero),
+                createWorkspaceInfo(id = paneOne),
+                createWorkspaceInfo(id = hidden),
+            )
+        )
+        pageManager.setPaneCount(4)
+        pageManager.applyRestoredUIState(paneZero, mapOf(0 to paneZero, 1 to paneOne, 3 to hidden))
+        pageManager.setPaneCount(2)
+
+        pageManager.unassignWorkspace(paneOne)
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to paneZero, 3 to hidden)
+        after.focusedWorkspaceId shouldBe paneZero
+    }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
@@ -117,6 +117,9 @@ fun AdaptiveWorkspaceLayout(
 
                     onPaneMenuToggle(false)
                 },
+                onPaneUnassign = { workspaceId ->
+                    onScreenAction(WorkspaceScreenAction.UnassignPane(workspaceId))
+                },
                 onRename = onRenameWorkspace,
                 onPaneMenuToggle = onPaneMenuToggle,
             )

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceScreenAction.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceScreenAction.kt
@@ -32,6 +32,9 @@ sealed interface WorkspaceScreenAction {
         val customTitle: String?,
     ) : WorkspaceScreenAction
 
+    /** Detaches [id] from its pane, leaving the tab open. */
+    data class UnassignPane(val id: Workspace.Id) : WorkspaceScreenAction
+
     /** Resumes a paused workspace, bringing back its live instance. Does not change focus. */
     data class ResumeWorkspace(
         val id: Workspace.Id,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -421,6 +421,9 @@ class WorkspacesViewModel @Inject constructor(
             is WorkspaceScreenAction.ToggleSelection -> {
                 workspacePageManager.toggleWorkspaceSelection(action.id, action.position)
             }
+            is WorkspaceScreenAction.UnassignPane -> {
+                workspacePageManager.unassignWorkspace(action.id)
+            }
             is WorkspaceScreenAction.SetPaneCount -> {
                 log(tag) { "Setting pane count to ${action.count}" }
                 workspacePageManager.setPaneCount(action.count)

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.twotone.Looks3
 import androidx.compose.material.icons.twotone.Looks4
 import androidx.compose.material.icons.twotone.LooksOne
 import androidx.compose.material.icons.twotone.LooksTwo
+import androidx.compose.material.icons.twotone.RemoveCircleOutline
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FloatingActionButton
@@ -103,6 +104,8 @@ object WorkspaceNavigationRailDefaults {
      * than the one under test.
      */
     const val ITEM_TEST_TAG = "workspace.rail.item"
+
+    const val UNASSIGN_TEST_TAG = "workspace.rail.unassign"
 }
 
 private val RailSectionPadding = 8.dp
@@ -213,6 +216,7 @@ fun WorkspaceNavigationRail(
     design: WorkspaceDesign = WorkspaceDesign(),
     onTabAction: (WorkspaceAction) -> Unit,
     onPaneAssignment: (workspaceId: Workspace.Id, paneIndex: Int) -> Unit,
+    onPaneUnassign: (workspaceId: Workspace.Id) -> Unit,
     onRename: (Workspace.Id) -> Unit = {},
     onPaneMenuToggle: (Boolean) -> Unit = {},
 ) {
@@ -305,6 +309,7 @@ fun WorkspaceNavigationRail(
                         ),
                         onTabAction = onTabAction,
                         onPaneAssignment = onPaneAssignment,
+                        onPaneUnassign = onPaneUnassign,
                         onRename = onRename,
                         design = design,
                         onPaneMenuToggle = onPaneMenuToggle,
@@ -616,6 +621,7 @@ private fun DraggableWorkspaceRailItem(
     closeHostId: Workspace.Id? = null,
     onTabAction: (WorkspaceAction) -> Unit,
     onPaneAssignment: (workspaceId: Workspace.Id, paneIndex: Int) -> Unit,
+    onPaneUnassign: (workspaceId: Workspace.Id) -> Unit,
     onRename: (Workspace.Id) -> Unit,
     design: WorkspaceDesign,
     onPaneMenuToggle: (Boolean) -> Unit,
@@ -655,63 +661,160 @@ private fun DraggableWorkspaceRailItem(
             onClick = { showPaneMenu = true },
         )
 
-        DropdownMenu(
+        WorkspaceRailItemMenu(
             expanded = showPaneMenu,
-            onDismissRequest = { showPaneMenu = false },
-        ) {
-            repeat(design.maxPanes) { paneIndex ->
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.workspace_pane_assign_action, paneIndex + 1)) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = when (paneIndex) {
-                                0 -> Icons.TwoTone.LooksOne
-                                1 -> Icons.TwoTone.LooksTwo
-                                2 -> Icons.TwoTone.Looks3
-                                else -> Icons.TwoTone.Looks4
-                            },
-                            contentDescription = null,
-                        )
-                    },
-                    onClick = {
-                        showPaneMenu = false
-                        onPaneMenuToggle(false)  // Explicitly hide overlays
-                        onPaneAssignment(workspace.id, paneIndex)
-                    },
+            maxPanes = design.maxPanes,
+            currentPaneIndex = currentPaneIndex,
+            onDismiss = {
+                showPaneMenu = false
+                onPaneMenuToggle(false)  // Explicitly hide overlays
+            },
+            onAssign = { paneIndex -> onPaneAssignment(workspace.id, paneIndex) },
+            onUnassign = { onPaneUnassign(workspace.id) },
+            onRename = { onRename(workspace.id) },
+            onClose = {
+                onTabAction(
+                    WorkspaceAction.Close(workspace.id, sourceWorkspaceId = closeHostId, undoable = true)
                 )
-            }
+            },
+        )
+    }
+}
+
+/**
+ * The entry's action menu. [expanded] is hoisted, so the menu cannot close itself: every item calls
+ * [onDismiss] before its own action, and [onDismiss] is what a press outside runs too.
+ *
+ * [currentPaneIndex] is what decides whether the entry can be detached, so it has to come from the
+ * assignments the layout renders - an entry parked on a pane this layout does not have shows no pane
+ * number either, and offering to remove it from one would name a pane the user cannot see.
+ */
+@Composable
+internal fun WorkspaceRailItemMenu(
+    modifier: Modifier = Modifier,
+    expanded: Boolean,
+    maxPanes: Int,
+    currentPaneIndex: Int?,
+    onDismiss: () -> Unit,
+    onAssign: (paneIndex: Int) -> Unit,
+    onUnassign: () -> Unit,
+    onRename: () -> Unit,
+    onClose: () -> Unit,
+) {
+    DropdownMenu(
+        modifier = modifier,
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+    ) {
+        repeat(maxPanes) { paneIndex ->
             DropdownMenuItem(
-                text = { Text(stringResource(CommonR.string.general_rename_action)) },
+                text = { Text(stringResource(R.string.workspace_pane_assign_action, paneIndex + 1)) },
                 leadingIcon = {
                     Icon(
-                        imageVector = Icons.TwoTone.Edit,
+                        imageVector = when (paneIndex) {
+                            0 -> Icons.TwoTone.LooksOne
+                            1 -> Icons.TwoTone.LooksTwo
+                            2 -> Icons.TwoTone.Looks3
+                            else -> Icons.TwoTone.Looks4
+                        },
                         contentDescription = null,
                     )
                 },
                 onClick = {
-                    showPaneMenu = false
-                    onPaneMenuToggle(false)
-                    onRename(workspace.id)
-                },
-            )
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_close_action)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.TwoTone.Close,
-                        contentDescription = null,
-                    )
-                },
-                onClick = {
-                    showPaneMenu = false
-                    onPaneMenuToggle(false)  // Explicitly hide overlays before closing
-                    onTabAction(
-                        WorkspaceAction.Close(workspace.id, sourceWorkspaceId = closeHostId, undoable = true)
-                    )
+                    onDismiss()
+                    onAssign(paneIndex)
                 },
             )
         }
+        if (currentPaneIndex != null) {
+            DropdownMenuItem(
+                modifier = Modifier.testTag(WorkspaceNavigationRailDefaults.UNASSIGN_TEST_TAG),
+                text = { Text(stringResource(R.string.workspace_pane_unassign_action)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.TwoTone.RemoveCircleOutline,
+                        contentDescription = null,
+                    )
+                },
+                onClick = {
+                    onDismiss()
+                    onUnassign()
+                },
+            )
+        }
+        DropdownMenuItem(
+            text = { Text(stringResource(CommonR.string.general_rename_action)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.TwoTone.Edit,
+                    contentDescription = null,
+                )
+            },
+            onClick = {
+                onDismiss()
+                onRename()
+            },
+        )
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.workspace_pane_close_action)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.TwoTone.Close,
+                    contentDescription = null,
+                )
+            },
+            onClick = {
+                onDismiss()
+                onClose()
+            },
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceRailItemMenuPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        WorkspaceRailItemMenu(
+            expanded = true,
+            // maxPanes = 4 so the icon mapping's else branch is exercised.
+            maxPanes = 4,
+            currentPaneIndex = 1,
+            onDismiss = {},
+            onAssign = {},
+            onUnassign = {},
+            onRename = {},
+            onClose = {},
+        )
+    }
+}
+
+/** An entry in no pane the layout renders has nothing to be removed from. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceRailItemMenuUnassignedPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        WorkspaceRailItemMenu(
+            expanded = true,
+            maxPanes = 4,
+            currentPaneIndex = null,
+            onDismiss = {},
+            onAssign = {},
+            onUnassign = {},
+            onRename = {},
+            onClose = {},
+        )
     }
 }
 
@@ -745,75 +848,7 @@ private fun WorkspaceNavigationRailPreview() {
         design = WorkspaceDesign(layout = WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT),
         onTabAction = {},
         onPaneAssignment = { _, _ -> },
+        onPaneUnassign = {},
         onPaneMenuToggle = {},
     )
-}
-
-@Preview2
-@ComposePreviewWrapper(ButlerPreviewWrapper::class)
-@Composable
-private fun PaneMenuPreview() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-    ) {
-        DropdownMenu(
-            expanded = true,
-            onDismissRequest = {},
-        ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_assign_action, 1)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.TwoTone.LooksOne,
-                        contentDescription = null,
-                    )
-                },
-                onClick = {},
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_assign_action, 2)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.TwoTone.LooksTwo,
-                        contentDescription = null,
-                    )
-                },
-                onClick = {},
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_assign_action, 3)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.TwoTone.Looks3,
-                        contentDescription = null,
-                    )
-                },
-                onClick = {},
-            )
-            // Four entries, because pane 4 used to fall back to the "1" icon.
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_assign_action, 4)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.TwoTone.Looks4,
-                        contentDescription = null,
-                    )
-                },
-                onClick = {},
-            )
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_close_action)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.TwoTone.Close,
-                        contentDescription = null,
-                    )
-                },
-                onClick = {},
-            )
-        }
-    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -362,6 +362,7 @@
     <!-- Workspace Navigation Rail -->
     <string name="workspace_pane_assign_action">Assign to pane %1$d</string>
     <string name="workspace_pane_close_action">Close</string>
+    <string name="workspace_pane_unassign_action">Remove from pane</string>
     <string name="workspace_dragging_description">Dragging</string>
     <string name="workspace_pane_current_description">In pane %1$d</string>
     <string name="workspace_add_tab_description">Add tab</string>

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailItemMenuTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailItemMenuTest.kt
@@ -1,0 +1,95 @@
+package eu.darken.butler.workspace.ui.workspaces.adaptive
+
+import android.content.Context
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * Detaching a tab is only offered for a pane the layout renders, so the item follows the entry's
+ * pane assignment rather than being always present.
+ *
+ * The menu cannot close itself - `expanded` is hoisted - so every item's dismissal is asserted
+ * alongside its action.
+ */
+class WorkspaceRailItemMenuTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val calls = mutableListOf<String>()
+
+    private fun renderMenu(currentPaneIndex: Int?) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceRailItemMenu(
+                    expanded = true,
+                    maxPanes = 2,
+                    currentPaneIndex = currentPaneIndex,
+                    onDismiss = { calls.add("dismiss") },
+                    onAssign = { calls.add("assign") },
+                    onUnassign = { calls.add("unassign") },
+                    onRename = { calls.add("rename") },
+                    onClose = { calls.add("close") },
+                )
+            }
+        }
+    }
+
+    private fun assignLabel(paneNumber: Int) = context.getString(
+        R.string.workspace_pane_assign_action,
+        paneNumber,
+    )
+
+    private val closeLabel get() = context.getString(R.string.workspace_pane_close_action)
+
+    @Test
+    fun `an entry in a pane can be removed from it`() {
+        renderMenu(currentPaneIndex = 1)
+
+        composeTestRule.onNodeWithTag(UNASSIGN_TAG).assertExists()
+    }
+
+    @Test
+    fun `an entry in no pane cannot be removed from one`() {
+        renderMenu(currentPaneIndex = null)
+
+        composeTestRule.onNodeWithTag(UNASSIGN_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `removing an entry from its pane dismisses the menu first`() {
+        renderMenu(currentPaneIndex = 0)
+
+        composeTestRule.onNodeWithTag(UNASSIGN_TAG).performClick()
+
+        calls shouldBe listOf("dismiss", "unassign")
+    }
+
+    @Test
+    fun `an entry in a pane keeps the assign and close items`() {
+        renderMenu(currentPaneIndex = 0)
+
+        composeTestRule.onNodeWithText(assignLabel(1)).assertExists()
+        composeTestRule.onNodeWithText(assignLabel(2)).assertExists()
+        composeTestRule.onNodeWithText(closeLabel).assertExists()
+    }
+
+    @Test
+    fun `an entry in no pane keeps the assign and close items`() {
+        renderMenu(currentPaneIndex = null)
+
+        composeTestRule.onNodeWithText(assignLabel(1)).assertExists()
+        composeTestRule.onNodeWithText(assignLabel(2)).assertExists()
+        composeTestRule.onNodeWithText(closeLabel).assertExists()
+    }
+
+    companion object {
+        private const val UNASSIGN_TAG = WorkspaceNavigationRailDefaults.UNASSIGN_TEST_TAG
+    }
+}


### PR DESCRIPTION
## What changed

On tablets and other large screens, where tabs are laid out side by side in panes with the rail down the left edge, a tab's menu gains a **Remove from pane** action. It takes the tab out of its pane and leaves the pane empty, ready for something else — the tab itself stays open and is still listed in the rail, so nothing you had open is lost.

Until now the only way to free up a pane was to close the tab in it, or to push another tab on top. The action only appears for a tab that is actually sitting in one of the panes currently on screen.

A side effect worth having: a tab parked in a pane never counts as idle, so it is never paused automatically. Taking it out of its pane hands it back to the idle-tab pausing, which is the setting that saves memory and battery.

## Technical Context

- The operation is `WorkspacePageManager.unassignWorkspace`, deliberately not map arithmetic in the composable. Three reasons, all found during plan review: a replacement map built from a Compose snapshot and applied through `SelectMultiple` → `setSelectedWorkspaces` replaces the assignments wholesale, so it would discard a concurrent create, close-cleanup, restore or auto-fill; `setSelectedWorkspaces` repairs focus with the assignment map's *first entry*, and that map is ordered by when panes filled, so it can land on a retired index no pane draws; and a focused modal child never appears in the assignment map at all, so that same fallback would pull focus off a modal standing over an unrelated pane.
- Focus repair therefore lives in the new operation: focus stays put when the focused workspace — or the tab owning a focused modal — still holds a rendered pane, otherwise it moves to the lowest rendered pane. With no rendered pane left, focus deliberately stays where it is rather than becoming null: a stranded null focus lets the pager settle on its trailing placeholder page and auto-create a tab, which is the state `handleWorkspaceClosed` already exists to repair. Closing that same tab behaves identically today.
- Detaching a *retained* assignment on a pane the current layout does not draw is deliberately not offered. That retention is what makes collapsing a layout and widening it again non-destructive, and such an entry shows no pane badge to remove in the first place.
- Left alone on purpose, both verified as pre-existing: `setSelectedWorkspaces`' own insertion-order and modal-blind focus fallback for its other callers, and the assign path's snapshot-then-replace race in `AdaptiveWorkspaceLayout.onPaneAssignment`. The new operation routes around both rather than depending on either.
- Worth close review: the branch order of the focus repair in `unassignWorkspace`, and the menu's dismissal contract — `expanded` is hoisted so the extracted `WorkspaceRailItemMenu` cannot close itself, hence every item calls `onDismiss()` before its action. On-device testing covered what CI cannot: a five-step scenario run twice on a two-pane tablet emulator, the second pass against this exact tree, checking the item's presence and absence by pane assignment, that detaching empties the pane without closing the tab, and that emptying the last occupied pane stays recoverable.
