### PR TITLE
History: Jump from an operation's details to its history entry

### DIFF
--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
@@ -127,6 +127,8 @@ fun DeveloperWorkspacePageHost(
             },
             onShareError = { vm.shareOperationError(it) },
             onHandleIssue = {},
+            onShowInHistory = { vm.showOperationInHistory(it) },
+            historyEnabled = operationsState.historyEnabled,
             topInset = statusBarInset,
             bottomInset = navBarInset,
         )

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspaceViewModel.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspaceViewModel.kt
@@ -451,6 +451,8 @@ class DeveloperWorkspaceViewModel @AssistedInject constructor(
 
     fun shareOperationError(operationId: Operation.Id) = chrome.shareOperationError(operationId)
 
+    fun showOperationInHistory(operationId: Operation.Id) = chrome.showOperationInHistory(operationId)
+
     fun confirmErrorShare() = chrome.confirmErrorShare()
 
     fun dismissErrorShare() = chrome.dismissErrorShare()

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceOverlays.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceOverlays.kt
@@ -117,6 +117,8 @@ fun ExplorerWorkspaceOverlays(
         onCancelOperation = { operationId -> vm?.requestCancelOperation(operationId) },
         onShareError = { vm?.shareError(it) },
         onHandleIssue = { operationId -> vm?.showConflictSheet(operationId) },
+        onShowInHistory = { operationId -> vm?.showOperationInHistory(operationId) },
+        historyEnabled = operationsState?.historyEnabled == true,
         topInset = statusBarInset,
         bottomInset = navBarInset,
     )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -2045,6 +2045,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
     fun shareError(id: Operation.Id) = chrome.shareOperationError(id)
 
+    fun showOperationInHistory(id: Operation.Id) = chrome.showOperationInHistory(id)
+
     fun confirmErrorShare() = chrome.confirmErrorShare()
 
     fun dismissErrorShare() = chrome.dismissErrorShare()

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryWorkspace.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryWorkspace.kt
@@ -66,6 +66,21 @@ class HistoryWorkspace @AssistedInject constructor(
     private val filterFlow = MutableStateFlow(creationArguments.filter)
     val filter: Flow<HistoryFilter> = filterFlow
 
+    private val pendingFocusEntryId = MutableStateFlow(creationArguments.focusEntryId)
+
+    /** The entry this tab was opened on, until it has actually been shown. */
+    val focusEntryId: StateFlow<String?> = pendingFocusEntryId
+
+    /**
+     * Drops the pending focus once its entry has been shown, so the details sheet doesn't reopen
+     * when the page is recomposed. Kept until then: a ViewModel replaced while the entry is still
+     * being written would otherwise leave the tab on an entry nobody ever opens. The compare makes
+     * a second ViewModel racing the first a no-op instead of clearing a newer request.
+     */
+    fun clearFocusEntryId(shown: String) {
+        pendingFocusEntryId.compareAndSet(expect = shown, update = null)
+    }
+
     fun setFilter(newFilter: HistoryFilter) {
         log(tag) { "setFilter($newFilter)" }
         filterFlow.value = newFilter

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -75,6 +75,17 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
 
     init {
         log(tag) { "Initialized for workspace $id" }
+        launch {
+            val workspace = workspaceSource.first()
+            val focusId = workspace.focusEntryId.value ?: return@launch
+            // Awaited rather than read once: history ingest runs asynchronously after the operation
+            // completes, and this tab is opened straight from that operation's own sheet. The wait
+            // ends with the ViewModel, and the tab keeps the pending focus until the sheet is up.
+            val entry = historyRepo.observeEntry(focusId).filterNotNull().first()
+            log(tag, INFO) { "Focusing entry $focusId" }
+            showEntryDetails(entry)
+            workspace.clearFocusEntryId(focusId)
+        }
     }
 
     // Not `launch`: visibility must be applied in call order, and the coroutine dispatcher is a

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryArgumentsSerializationTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryArgumentsSerializationTest.kt
@@ -74,6 +74,15 @@ class HistoryArgumentsSerializationTest : BaseTest() {
     }
 
     @Test
+    fun `focus entry survives a roundtrip`() {
+        val original = HistoryArguments.Default(focusEntryId = "op-1")
+
+        val serialized = json.encodeToJsonElement<HistoryArguments>(original)
+
+        json.decodeFromString<HistoryArguments>(serialized.toString()) shouldBe original
+    }
+
+    @Test
     fun `factory serialization matches direct serialization and roundtrips`() {
         val factory = object : HistoryWorkspace.Factory {
             override fun create(id: Workspace.Id, arguments: HistoryArguments): HistoryWorkspace = error("unused")

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryWorkspaceFocusTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryWorkspaceFocusTest.kt
@@ -1,0 +1,43 @@
+package eu.darken.butler.history.core
+
+import eu.darken.butler.workspace.contracts.history.HistoryArguments
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+
+class HistoryWorkspaceFocusTest : BaseTest() {
+
+    private fun create(arguments: HistoryArguments) = HistoryWorkspace(
+        id = Workspace.Id(),
+        creationArguments = arguments,
+        dispatcherProvider = TestDispatcherProvider(),
+    )
+
+    @Test
+    fun `the focus entry stays pending until its entry was shown`() {
+        val workspace = create(HistoryArguments.Default(focusEntryId = "op-1"))
+
+        workspace.focusEntryId.value shouldBe "op-1"
+        workspace.clearFocusEntryId("op-1")
+        workspace.focusEntryId.value shouldBe null
+    }
+
+    @Test
+    fun `showing a different entry leaves the pending focus alone`() {
+        val workspace = create(HistoryArguments.Default(focusEntryId = "op-1"))
+
+        workspace.clearFocusEntryId("op-2")
+
+        workspace.focusEntryId.value shouldBe "op-1"
+    }
+
+    @Test
+    fun `a restored tab does not reopen the entry it was created on`() = runTest {
+        val workspace = create(HistoryArguments.Default(focusEntryId = "op-1"))
+
+        workspace.createArguments().focusEntryId shouldBe null
+    }
+}

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspacePage.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspacePage.kt
@@ -174,6 +174,8 @@ internal fun SaverWorkspacePage(
             onHandleIssue = { operationId ->
                 vm?.showConflictSheet(operationId)
             },
+            onShowInHistory = { operationId -> vm?.showOperationInHistory(operationId) },
+            historyEnabled = state.historyEnabled,
             topInset = statusBarInset,
             bottomInset = navBarInset,
         )

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspaceViewModel.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspaceViewModel.kt
@@ -103,6 +103,7 @@ class SaverWorkspaceViewModel @AssistedInject constructor(
         val operationDisplay: OperationDisplay? = null,
         /** True when launched by another workspace (APK export): render as a modal, not an app-share tab. */
         val isModal: Boolean = false,
+        val historyEnabled: Boolean = false,
     ) {
         val isBatchMode: Boolean
             get() = sourceInfos.size > 1
@@ -148,7 +149,8 @@ class SaverWorkspaceViewModel @AssistedInject constructor(
             combine(
                 workspace.state,
                 workspace.currentOperation,
-            ) { wsState, managedOp ->
+                chrome.operations,
+            ) { wsState, managedOp, chromeOps ->
                 State(
                     sourceInfos = wsState.sourceInfos,
                     destination = wsState.destination,
@@ -159,6 +161,7 @@ class SaverWorkspaceViewModel @AssistedInject constructor(
                     createdAt = wsState.createdAt,
                     operationDisplay = managedOp?.toDisplayModel(),
                     isModal = wsState.callerWorkspaceId != null,
+                    historyEnabled = chromeOps.historyEnabled,
                 )
             }
         }
@@ -404,6 +407,8 @@ class SaverWorkspaceViewModel @AssistedInject constructor(
     }
 
     fun shareError(operationId: Operation.Id) = chrome.shareOperationError(operationId)
+
+    fun showOperationInHistory(operationId: Operation.Id) = chrome.showOperationInHistory(operationId)
 
     fun confirmErrorShare() = chrome.confirmErrorShare()
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceOverlays.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceOverlays.kt
@@ -220,6 +220,10 @@ fun SearcherWorkspaceOverlays(
         onHandleIssue = { operationId ->
             onPageAction(SearcherPageAction.Operations.ShowConflict(operationId))
         },
+        onShowInHistory = { operationId ->
+            onPageAction(SearcherPageAction.Operations.ShowInHistory(operationId))
+        },
+        historyEnabled = operationsState.historyEnabled,
         topInset = statusBarInset,
         bottomInset = navBarInset,
     )

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
@@ -1404,6 +1404,7 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
             is SearcherPageAction.Operations.Dismiss -> chrome.dismissOperation(action.id)
             is SearcherPageAction.Operations.ClearCompleted -> chrome.clearCompletedOperations()
             is SearcherPageAction.Operations.ShareError -> chrome.shareOperationError(action.id)
+            is SearcherPageAction.Operations.ShowInHistory -> chrome.showOperationInHistory(action.id)
             is SearcherPageAction.Operations.ShowConflict -> showConflictSheet(action.id)
 
             // Dialogs

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherPageAction.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherPageAction.kt
@@ -274,6 +274,11 @@ sealed interface SearcherPageAction {
          * (sheet display is driven by issue state; see ViewModel)
          */
         data class ShowConflict(val id: Operation.Id) : Operations
+
+        /**
+         * Open the operation's entry in a History tab
+         */
+        data class ShowInHistory(val id: Operation.Id) : Operations
     }
 
     /**

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/contracts/history/HistoryArguments.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/contracts/history/HistoryArguments.kt
@@ -18,6 +18,13 @@ import kotlinx.serialization.Serializable
 sealed interface HistoryArguments : Workspace.Arguments {
     val filter: HistoryFilter
 
+    /**
+     * Id of the entry the tab opens on, i.e. the id of the operation it records. One-shot: the tab
+     * consumes it once the entry exists and [Workspace.createArguments] never reports it back, so a
+     * restored session doesn't reopen the entry's details.
+     */
+    val focusEntryId: String?
+
     override val type: Workspace.Type get() = Workspace.Type.HISTORY
 
     @Serializable
@@ -25,5 +32,6 @@ sealed interface HistoryArguments : Workspace.Arguments {
     @Parcelize
     data class Default(
         override val filter: HistoryFilter = HistoryFilter(),
+        override val focusEntryId: String? = null,
     ) : HistoryArguments
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.uuid.Uuid
 
 @Singleton
 class OperationHistoryRepo @Inject constructor(
@@ -94,7 +93,10 @@ class OperationHistoryRepo @Inject constructor(
         val reportedChanges = collectReportedChanges(state)
         val scopePaths = collectScopePaths(metadata, state)
 
-        val rowId = Uuid.random().toString()
+        // The row is keyed by the operation it records, so UI holding an Operation.Id (the
+        // operation details sheet) can address this entry directly. Pinned by
+        // OperationHistoryPersistTest.
+        val rowId = snapshot.id.longTag
         val pathEntities = reportedChanges.take(MAX_PATHS_PER_OP).mapIndexed { index, change ->
             OperationHistoryPathEntity(
                 operationHistoryId = rowId,
@@ -293,6 +295,13 @@ class OperationHistoryRepo @Inject constructor(
     ): SimpleSQLiteQuery = buildScopedIdsQueryStatic(outcomes, kinds, pathScopes, limit)
 
     fun observeCount(): Flow<Int> = dao.observeCount()
+
+    /**
+     * Observe one entry by its id, which is the id of the operation it records. Emits null while no
+     * such row exists, so a caller that navigates to an operation right as it finishes can wait for
+     * the asynchronous ingest instead of missing it.
+     */
+    fun observeEntry(id: String): Flow<HistoryEntry?> = dao.observeById(id).map { it?.toDomain() }
 
     /**
      * Paths the operation touched or intended to touch, loaded on demand. Shown for entries that

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryDao.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryDao.kt
@@ -91,6 +91,15 @@ interface OperationHistoryDao {
     suspend fun getById(id: String): OperationHistoryWithPaths?
 
     /**
+     * Emits null until the row exists. Needed because an operation is persisted asynchronously
+     * after it completes, so a UI that navigates to an operation's entry can arrive before the
+     * write does.
+     */
+    @Transaction
+    @Query("SELECT * FROM operation_history WHERE id = :id")
+    fun observeById(id: String): Flow<OperationHistoryWithPaths?>
+
+    /**
      * On-demand load of one operation's scope index, bounded by [limit]. Deliberately not a
      * `@Relation` on [OperationHistoryWithPaths]: that projection powers the whole history list (up
      * to 2000 rows), so attaching the index would materialize hundreds of thousands of rows per list

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
@@ -19,6 +19,8 @@ data class OperationDisplay(
     val state: State = State.Queued,
     val canCancel: Boolean = false,
     val pathPlan: OperationPathPlan? = null,
+    /** Null for operations the Operation History doesn't record, e.g. Developer test data. */
+    val kind: Operation.Metadata.Kind? = null,
 ) {
     sealed interface State {
         data object Queued : State
@@ -60,6 +62,7 @@ fun ManagedOperation.toDisplayModel(): OperationDisplay {
         description = metadata.description,
         canCancel = canCancel,
         pathPlan = metadata.pathPlan,
+        kind = metadata.kind,
         state = when (state) {
             is Operation.State.Queued -> OperationDisplay.State.Queued
             is Operation.State.Active -> {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayState.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.flow.onStart
 @Stable
 data class OperationsDisplayState(
     val operations: List<OperationDisplay> = emptyList(),
+    /**
+     * Whether the Operation History is recording. False hides the paths into it, which would
+     * otherwise lead to a tab that can never show the operation.
+     */
+    val historyEnabled: Boolean = false,
 )
 
 internal val operationDisplayComparator: Comparator<OperationDisplay> =

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationActionsSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationActionsSection.kt
@@ -2,7 +2,6 @@ package eu.darken.butler.workspace.ui.operations.details
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -21,10 +20,13 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.icon
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 
 @Composable
@@ -33,6 +35,7 @@ internal fun OperationActionsSection(
     onCancel: (() -> Unit)? = null,
     onShareError: (() -> Unit)? = null,
     onHandleIssue: (() -> Unit)? = null,
+    onShowInHistory: (() -> Unit)? = null,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -58,64 +61,58 @@ internal fun OperationActionsSection(
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
             )
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                when (operation.state) {
-                    is OperationDisplay.State.Running -> {
-                        if (onCancel != null) {
-                            OutlinedButton(
-                                onClick = onCancel,
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.TwoTone.Close,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(stringResource(R.string.operations_cancel_operation))
-                            }
-                        }
-                    }
-                    is OperationDisplay.State.Failed -> {
-                        if (onShareError != null) {
-                            OutlinedButton(
-                                onClick = onShareError,
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.TwoTone.Share,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(stringResource(eu.darken.butler.common.R.string.general_share_error_action))
-                            }
-                        }
-                    }
-                    is OperationDisplay.State.Waiting -> {
-                        if (onHandleIssue != null) {
-                            OutlinedButton(
-                                onClick = onHandleIssue,
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.TwoTone.Handyman,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(stringResource(R.string.operations_details_handle_issue))
-                            }
-                        }
-                    }
-                    else -> {
-                        // No specific actions for other states
-                    }
+            when (operation.state) {
+                is OperationDisplay.State.Running -> if (onCancel != null) {
+                    ActionButton(
+                        icon = Icons.TwoTone.Close,
+                        label = stringResource(R.string.operations_cancel_operation),
+                        onClick = onCancel,
+                    )
                 }
+                is OperationDisplay.State.Failed -> if (onShareError != null) {
+                    ActionButton(
+                        icon = Icons.TwoTone.Share,
+                        label = stringResource(eu.darken.butler.common.R.string.general_share_error_action),
+                        onClick = onShareError,
+                    )
+                }
+                is OperationDisplay.State.Waiting -> if (onHandleIssue != null) {
+                    ActionButton(
+                        icon = Icons.TwoTone.Handyman,
+                        label = stringResource(R.string.operations_details_handle_issue),
+                        onClick = onHandleIssue,
+                    )
+                }
+                else -> Unit
+            }
+
+            if (onShowInHistory != null) {
+                ActionButton(
+                    icon = Workspace.Type.HISTORY.icon,
+                    label = stringResource(R.string.operations_details_show_in_history_action),
+                    onClick = onShowInHistory,
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun ActionButton(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(label)
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
@@ -45,6 +45,7 @@ fun OperationDetailsSheet(
     onCancel: (() -> Unit)? = null,
     onShareError: (() -> Unit)? = null,
     onHandleIssue: (() -> Unit)? = null,
+    onShowInHistory: (() -> Unit)? = null,
 ) {
     PaneScopedBottomSheet(
         visible = true,
@@ -58,6 +59,7 @@ fun OperationDetailsSheet(
             onCancel = onCancel,
             onShareError = onShareError,
             onHandleIssue = onHandleIssue,
+            onShowInHistory = onShowInHistory,
         )
     }
 }
@@ -68,6 +70,7 @@ private fun OperationDetailsContent(
     onCancel: (() -> Unit)? = null,
     onShareError: (() -> Unit)? = null,
     onHandleIssue: (() -> Unit)? = null,
+    onShowInHistory: (() -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier
@@ -123,7 +126,7 @@ private fun OperationDetailsContent(
         }
 
         // Actions Section - only show if there are available actions
-        val hasActions = when (operation.state) {
+        val hasActions = onShowInHistory != null || when (operation.state) {
             is OperationDisplay.State.Running -> onCancel != null
             is OperationDisplay.State.Failed -> onShareError != null
             is OperationDisplay.State.Waiting -> onHandleIssue != null
@@ -136,6 +139,7 @@ private fun OperationDetailsContent(
                 onCancel = onCancel,
                 onShareError = onShareError,
                 onHandleIssue = onHandleIssue,
+                onShowInHistory = onShowInHistory,
             )
         }
     }
@@ -322,8 +326,10 @@ private fun OperationDetailsSheetCompletedWithFilesPreview() {
                     )
                 )
             ),
+            kind = Operation.Metadata.Kind.DELETE,
             startedAt = Clock.System.now() - 3.minutes,
         ),
         onDismiss = {},
+        onShowInHistory = {},
     )
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDialogHost.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDialogHost.kt
@@ -14,6 +14,8 @@ fun OperationDialogHost(
     onCancelOperation: ((Operation.Id) -> Unit)? = null,
     onShareError: ((Operation.Id) -> Unit)? = null,
     onHandleIssue: ((Operation.Id) -> Unit)? = null,
+    onShowInHistory: ((Operation.Id) -> Unit)? = null,
+    historyEnabled: Boolean = false,
     topInset: Dp = 0.dp,
     bottomInset: Dp = 0.dp,
 ) {
@@ -49,6 +51,15 @@ fun OperationDialogHost(
                             onDismissDialog()
                         }
                     } else null,
+                    // Only what the Operation History has actually recorded: an operation without a
+                    // kind is never written there, and neither is anything at all while recording
+                    // is off, so there'd be nothing for the History tab to open on.
+                    onShowInHistory = if (onShowInHistory != null && historyEnabled && currentOperation.isInHistory) {
+                        {
+                            onShowInHistory.invoke(currentOperation.id)
+                            onDismissDialog()
+                        }
+                    } else null,
                 )
             } else {
                 // Operation not found, dismiss the dialog
@@ -57,3 +68,13 @@ fun OperationDialogHost(
         }
     }
 }
+
+private val OperationDisplay.isInHistory: Boolean
+    get() = kind != null && when (state) {
+        is OperationDisplay.State.Completed,
+        is OperationDisplay.State.Failed,
+        is OperationDisplay.State.Cancelled,
+            -> true
+
+        else -> false
+    }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/page/WorkspacePageChrome.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/page/WorkspacePageChrome.kt
@@ -17,14 +17,17 @@ import eu.darken.butler.common.error.ErrorReportTool
 import eu.darken.butler.common.flow.SingleEventFlow
 import eu.darken.butler.common.flow.replayingShare
 import eu.darken.butler.common.issue.Issue
+import eu.darken.butler.workspace.contracts.history.HistoryArguments
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.createAndFocus
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.core.clipboard.ClipboardRepo
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationErrorRecorder
 import eu.darken.butler.workspace.core.operations.OperationsManager
+import eu.darken.butler.workspace.core.operations.history.HistorySettings
 import eu.darken.butler.workspace.core.operations.get
 import eu.darken.butler.workspace.core.operations.operationsForWorkspace
 import eu.darken.butler.workspace.core.operations.withStateUpdates
@@ -36,6 +39,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.map
@@ -59,6 +63,7 @@ class WorkspacePageChrome @AssistedInject constructor(
     private val errorIncidentStore: ErrorIncidentStore,
     private val systemClipboardHelper: SystemClipboardHelper,
     private val workspaceRemote: WorkspaceRemote,
+    private val historySettings: HistorySettings,
 ) {
 
     private val tag = logTag("Workspace", "PageChrome", workspaceId.shortTag)
@@ -94,7 +99,10 @@ class WorkspacePageChrome @AssistedInject constructor(
         .withStateUpdates()
         .replayingShare(scope)
 
-    val operations: Flow<OperationsDisplayState> = managedOps.toOperationsDisplayState()
+    val operations: Flow<OperationsDisplayState> = combine(
+        managedOps.toOperationsDisplayState(),
+        historySettings.saveHistory.flow,
+    ) { state, historyEnabled -> state.copy(historyEnabled = historyEnabled) }
 
     val pendingConflicts: Flow<Map<Operation.Id, Issue>> = managedOps
         .map { ops ->
@@ -134,6 +142,21 @@ class WorkspacePageChrome @AssistedInject constructor(
     fun clearCompletedOperations() {
         log(tag) { "clearCompletedOperations()" }
         scope.launch { operationsManager.clearCompleted() }
+    }
+
+    /**
+     * Opens a History tab on the operation's own entry. The entry is keyed by the operation id, and
+     * the tab waits for it, so this also works right as the operation finishes.
+     */
+    fun showOperationInHistory(id: Operation.Id) {
+        log(tag) { "showOperationInHistory($id)" }
+        scope.launch {
+            workspaceRemote.createAndFocus(
+                type = Workspace.Type.HISTORY,
+                arguments = HistoryArguments.Default(focusEntryId = id.longTag),
+                sourceWorkspaceId = workspaceId,
+            )
+        }
     }
 
     fun shareOperationError(id: Operation.Id) {

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="operations_details_actions">Actions</string>
     <string name="operations_details_overview">Overview</string>
     <string name="operations_details_handle_issue">Handle issue</string>
+    <string name="operations_details_show_in_history_action">Show in history</string>
     <string name="operations_details_status">Status</string>
     <string name="operations_details_result">Result</string>
     <string name="operations_details_destination_folder">Destination folder</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
@@ -135,6 +135,16 @@ class OperationHistoryPersistTest : BaseTest() {
     }
 
     @Test
+    fun `the row is keyed by the operation it records`() = runTest {
+        val snapshot = testSnapshot(
+            metadata = testMetadata(Operation.Metadata.Kind.DELETE, plan = planOver(source)),
+            state = TestCompletedState(report = TestReport(affectedPaths = emptyList())),
+        )
+
+        persist(snapshot) shouldBe snapshot.id.longTag
+    }
+
+    @Test
     fun `a successful single-file copy reports only the created file`() = runTest {
         val id = persist(
             testSnapshot(

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationDisplayTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationDisplayTest.kt
@@ -34,6 +34,7 @@ class OperationDisplayTest : BaseTest() {
             every { title } returns "op".toCaString()
             every { description } returns "desc".toCaString()
             every { pathPlan } returns null
+            every { kind } returns null
         }
         return op
     }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationHistoryActionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationHistoryActionTest.kt
@@ -1,0 +1,114 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.TestApplication
+import kotlin.time.Clock
+
+/**
+ * The "Show in history" action addresses the operation's own history entry, which only exists for
+ * operations the history records: a finished operation that has a [Operation.Metadata.Kind].
+ */
+@Config(application = TestApplication::class, sdk = [34], qualifiers = "w400dp-h1600dp")
+class OperationHistoryActionTest : ComposeTest() {
+
+    private val label = "Show in history"
+
+    private fun operation(
+        id: Operation.Id = Operation.Id(),
+        kind: Operation.Metadata.Kind? = Operation.Metadata.Kind.DELETE,
+        state: OperationDisplay.State = OperationDisplay.State.Completed(
+            summary = "Deleted 3 items".toCaString(),
+            completedAt = Clock.System.now(),
+            report = null,
+        ),
+    ) = OperationDisplay(
+        id = id,
+        startedAt = Clock.System.now(),
+        icon = Icons.TwoTone.Delete,
+        title = "Deleting files".toCaString(),
+        description = "3 items".toCaString(),
+        kind = kind,
+        state = state,
+    )
+
+    private fun setHost(
+        operation: OperationDisplay,
+        onShowInHistory: ((Operation.Id) -> Unit)?,
+        historyEnabled: Boolean = true,
+        onDismiss: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    OperationDialogHost(
+                        dialogState = OperationDialogState.OperationDetails(operation.id),
+                        operations = listOf(operation),
+                        onDismissDialog = onDismiss,
+                        onShowInHistory = onShowInHistory,
+                        historyEnabled = historyEnabled,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `finished operation offers the action and dismisses the sheet`() {
+        val operation = operation()
+        val shown = mutableListOf<Operation.Id>()
+        var dismissed = 0
+        setHost(operation, onShowInHistory = { shown.add(it) }, onDismiss = { dismissed++ })
+
+        composeTestRule.onNodeWithText(label).assertIsDisplayed().performClick()
+
+        shown shouldContainExactly listOf(operation.id)
+        dismissed shouldBe 1
+    }
+
+    @Test
+    fun `an operation the history does not record has no action`() {
+        setHost(operation(kind = null), onShowInHistory = {})
+
+        composeTestRule.onNodeWithText(label).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a running operation has no action`() {
+        setHost(
+            operation(state = OperationDisplay.State.Running()),
+            onShowInHistory = {},
+        )
+
+        composeTestRule.onNodeWithText(label).assertDoesNotExist()
+    }
+
+    @Test
+    fun `no action while the history is not recording`() {
+        setHost(operation(), onShowInHistory = {}, historyEnabled = false)
+
+        composeTestRule.onNodeWithText(label).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a host that cannot show history offers no action`() {
+        setHost(operation(), onShowInHistory = null)
+
+        composeTestRule.onNodeWithText(label).assertDoesNotExist()
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/page/WorkspacePageChromeTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/page/WorkspacePageChromeTest.kt
@@ -13,6 +13,7 @@ import eu.darken.butler.workspace.core.operations.ManagedOperation
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationErrorRecorder
 import eu.darken.butler.workspace.core.operations.OperationsManager
+import eu.darken.butler.workspace.core.operations.history.HistorySettings
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -34,6 +35,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.error.recordingIncidentStore
+import testhelpers.mockDataStoreValue
 import java.io.IOException
 import kotlin.time.Clock
 
@@ -59,6 +61,7 @@ class WorkspacePageChromeTest : BaseTest() {
             every { title } returns "op".toCaString()
             every { description } returns "desc".toCaString()
             every { pathPlan } returns null
+            every { kind } returns null
         }
         return op
     }
@@ -81,6 +84,9 @@ class WorkspacePageChromeTest : BaseTest() {
         errorIncidentStore = errorIncidentStore,
         systemClipboardHelper = mockk(),
         workspaceRemote = mockk(),
+        historySettings = mockk<HistorySettings>().apply {
+            every { saveHistory } returns mockDataStoreValue(true)
+        },
     )
 
     private fun completedState(error: Throwable) = object : Operation.State.Completed {


### PR DESCRIPTION
## What changed

A finished file operation's details sheet now offers "Show in history". It opens a History tab that is already showing that operation's entry, so you can go from "the copy finished" straight to what it actually touched without scrolling the history yourself.

The action only appears when there is something to open: the operation has to be one the history records (copy, move, delete, extract and the like, not internal jobs), it has to be finished, and history saving has to be on.

## Technical Context

- History rows are now keyed by the id of the operation they record instead of a fresh random UUID. That is what makes an operation addressable in history at all. The primary key stays a string, so there is no schema change and no migration; rows written by earlier versions keep their random ids and simply cannot be reached this way. Those operations are gone from the in-memory list after a restart, so no sheet can ask for them.
- The target rides along as a one-shot `HistoryArguments.focusEntryId`. The tab holds it until the entry's sheet has actually been shown (compare-and-clear), and `createArguments()` never reports it back, so a restored session does not reopen the sheet. Consuming it up front would have stranded the request if the ViewModel were replaced mid-wait.
- History ingest runs asynchronously after an operation completes, so the tab awaits its row through a new `OperationHistoryRepo.observeEntry` flow rather than reading once. There is deliberately no timeout: a large operation's uncapped scope-index insert can take a while, and the wait ends with the ViewModel anyway.
- Each tap opens a new History tab. HISTORY is a multi-instance type where every tab is its own scoped view, so this matches the existing model; reusing a tab would need a cross-module focus channel, since `app-workspace` sits below the workspace modules and cannot reach `HistoryWorkspace`.
- Worth a close look: `WorkspacePageChrome` now folds the `saveHistory` setting into `OperationsDisplayState`, which is how all four sheet hosts (Explorer, Searcher, Saver, Developer) learn whether to offer the action.
