### PR TITLE
Workspace: Color the Butler button's new tab and close actions

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/LongClickableDropdownMenuItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/LongClickableDropdownMenuItem.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 /**
@@ -24,6 +27,7 @@ fun LongClickableDropdownMenuItem(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
+    contentColor: Color = LocalContentColor.current,
     leadingIcon: @Composable (() -> Unit)? = null,
 ) {
     Box(
@@ -37,15 +41,17 @@ fun LongClickableDropdownMenuItem(
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.CenterStart,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            leadingIcon?.invoke()
-            Text(
-                text = text,
-                style = MaterialTheme.typography.labelLarge,
-            )
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                leadingIcon?.invoke()
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
         }
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
@@ -10,9 +10,11 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
@@ -60,6 +62,10 @@ fun WorkspaceButtonMenu(
                     contentDescription = null,
                 )
             },
+            colors = MenuDefaults.itemColors(
+                textColor = NewTabColor,
+                leadingIconColor = NewTabColor,
+            ),
         )
 
         val recentItems = state?.recentItems ?: emptyList()
@@ -149,6 +155,7 @@ fun WorkspaceButtonMenu(
                     onDismissRequest()
                     onCloseAllRequested()
                 },
+                contentColor = MaterialTheme.colorScheme.error,
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.TwoTone.Close,
@@ -159,6 +166,8 @@ fun WorkspaceButtonMenu(
         }
     }
 }
+
+private val NewTabColor = Color(0xFF4CAF50)
 
 @Composable
 fun MenuCategoryHeader(

--- a/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Workspaces
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -22,6 +23,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -538,10 +540,15 @@ private fun quickCreateItem(type: Workspace.Type) = QuickCreateItem(
 )
 
 @Composable
-private fun MenuEntry(text: String, icon: ImageVector) = DropdownMenuItem(
+private fun MenuEntry(text: String, icon: ImageVector, contentColor: Color? = null) = DropdownMenuItem(
     text = { Text(text) },
     onClick = {},
     leadingIcon = { Icon(imageVector = icon, contentDescription = null) },
+    colors = if (contentColor != null) {
+        MenuDefaults.itemColors(textColor = contentColor, leadingIconColor = contentColor)
+    } else {
+        MenuDefaults.itemColors()
+    },
 )
 
 /**
@@ -571,6 +578,7 @@ private fun ExpandedWorkspaceButtonMenu(modifier: Modifier = Modifier) {
             MenuEntry(
                 text = stringResource(WorkspaceR.string.workspace_button_menu_new_tab_action),
                 icon = Icons.TwoTone.Add,
+                contentColor = Color(0xFF4CAF50),
             )
 
             MenuCategoryHeader(text = stringResource(WorkspaceR.string.workspace_button_menu_category_recent))
@@ -600,6 +608,7 @@ private fun ExpandedWorkspaceButtonMenu(modifier: Modifier = Modifier) {
                 text = stringResource(WorkspaceR.string.workspace_button_menu_close_current_action),
                 onClick = {},
                 onLongClick = {},
+                contentColor = MaterialTheme.colorScheme.error,
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.TwoTone.Close,


### PR DESCRIPTION
## What changed

The Butler button's menu now colors its two most consequential entries: "New tab" is green, and the entry that closes the current tab is red. Both the icon and the label are tinted, so the destructive action is distinguishable at a glance from the neutral entries (workspace manager, settings, recent workspaces) sitting between them.

The Play Store screenshot that shows this menu opened picks up the same two colors, so the store listing keeps matching what the app looks like.

## Technical Context

- The green reuses `Color(0xFF4CAF50)`, the same success green already hard-coded in `SearchProgressCard` and `OperationActionIndicator`. It stays a literal rather than a theme role because the theme is user-selectable (green/blue/amoled/dynamic) and none of the M3 roles carries "success" semantics. Red uses `colorScheme.error`, which every theme defines.
- `LongClickableDropdownMenuItem` had no way to tint its content, so it gained a `contentColor` parameter defaulting to `LocalContentColor.current`. It is applied through `CompositionLocalProvider` rather than passed to `Text`, so the caller's untinted `Icon` picks it up too. The default keeps the existing call site in the screenshot mock unchanged in appearance.
- `ScreenshotContent.kt` composes the menu inline instead of using a real `DropdownMenu` (layoutlib does not draw popup subtrees), so the colors have to be repeated there by hand; the two now have to be kept in sync deliberately.
