### PR TITLE
IO: Stop treating files that cannot be checked as deleted

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategy.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategy.kt
@@ -3,10 +3,12 @@ package eu.darken.butler.common.files.local.operations.strategies
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.local.LocalFileSystemOps
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
@@ -204,10 +206,19 @@ class LocalPathCopyStrategy(
         sourceOps: FileSystemOps<LocalPath, LocalPathLookup>,
         destOps: FileSystemOps<LocalPath, LocalPathLookup>
     ): TransferStrategy.TransferResult<LocalPath, LocalPath> {
-        // Check for existing file if overwrite is disabled
-        if (!options.overwrite && destOps.exists(destination)) {
-            log(TAG, DEBUG) { "Destination exists and overwrite=false: $destination" }
-            throw PathAlreadyExistsException(path = destination)
+        // Check for existing file if overwrite is disabled. The plain lookup maps a FIFO, socket or
+        // device node to FileType.UNKNOWN, i.e. to "absent", and the copy below opens the
+        // destination with TRUNCATE_EXISTING - with root that writes raw bytes into a device node.
+        if (!options.overwrite) {
+            when (destOps.existsStrict(destination)) {
+                Existence.PRESENT -> {
+                    log(TAG, DEBUG) { "Destination exists and overwrite=false: $destination" }
+                    throw PathAlreadyExistsException(path = destination)
+                }
+
+                Existence.UNKNOWN -> throw WriteException("Cannot tell whether $destination exists", destination)
+                Existence.ABSENT -> Unit
+            }
         }
 
         var totalBytesTransferred = 0L

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategy.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategy.kt
@@ -153,11 +153,7 @@ class LocalPathCopyStrategy(
         sourceOps: FileSystemOps<LocalPath, LocalPathLookup>,
         destOps: FileSystemOps<LocalPath, LocalPathLookup>
     ): TransferStrategy.TransferResult<LocalPath, LocalPath> {
-        // Check for existing file if overwrite is disabled
-        if (!options.overwrite && destOps.exists(destination)) {
-            log(TAG, DEBUG) { "Destination exists and overwrite=false: $destination" }
-            throw PathAlreadyExistsException(path = destination)
-        }
+        if (!options.overwrite) requireFreeDestination(destination, destOps)
 
         // Read the symlink target
         val linkTarget = sourceOps.readSymbolicLink(sourceLookup.lookedUp)
@@ -206,20 +202,7 @@ class LocalPathCopyStrategy(
         sourceOps: FileSystemOps<LocalPath, LocalPathLookup>,
         destOps: FileSystemOps<LocalPath, LocalPathLookup>
     ): TransferStrategy.TransferResult<LocalPath, LocalPath> {
-        // Check for existing file if overwrite is disabled. The plain lookup maps a FIFO, socket or
-        // device node to FileType.UNKNOWN, i.e. to "absent", and the copy below opens the
-        // destination with TRUNCATE_EXISTING - with root that writes raw bytes into a device node.
-        if (!options.overwrite) {
-            when (destOps.existsStrict(destination)) {
-                Existence.PRESENT -> {
-                    log(TAG, DEBUG) { "Destination exists and overwrite=false: $destination" }
-                    throw PathAlreadyExistsException(path = destination)
-                }
-
-                Existence.UNKNOWN -> throw WriteException("Cannot tell whether $destination exists", destination)
-                Existence.ABSENT -> Unit
-            }
-        }
+        if (!options.overwrite) requireFreeDestination(destination, destOps)
 
         var totalBytesTransferred = 0L
 
@@ -252,6 +235,24 @@ class LocalPathCopyStrategy(
             bytesTransferred = totalBytesTransferred,
             destinationLookup = destLookup
         )
+    }
+
+    // The plain lookup maps a FIFO, socket or device node to FileType.UNKNOWN, i.e. to "absent", and
+    // the copies below open the destination with TRUNCATE_EXISTING - with root that writes raw bytes
+    // into a device node.
+    private suspend fun requireFreeDestination(
+        destination: LocalPath,
+        destOps: FileSystemOps<LocalPath, LocalPathLookup>
+    ) {
+        when (destOps.existsStrict(destination)) {
+            Existence.PRESENT -> {
+                log(TAG, DEBUG) { "Destination exists and overwrite=false: $destination" }
+                throw PathAlreadyExistsException(path = destination)
+            }
+
+            Existence.UNKNOWN -> throw WriteException("Cannot tell whether $destination exists", destination)
+            Existence.ABSENT -> Unit
+        }
     }
 
     private suspend fun copyAttributes(

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathMoveStrategy.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathMoveStrategy.kt
@@ -3,11 +3,13 @@ package eu.darken.butler.common.files.local.operations.strategies
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.files.operations.TransferStrategy
@@ -164,9 +166,15 @@ class LocalPathMoveStrategy(
         destOps: FileSystemOps<LocalPath, LocalPathLookup>
     ): TransferStrategy.TransferResult<LocalPath, LocalPath> {
         // move() refuses an occupied destination; the fallback's truncating copy must not then
-        // silently overwrite it either — route it through conflict handling instead.
-        if (!options.overwrite && destOps.exists(destination)) {
-            throw PathAlreadyExistsException(path = destination)
+        // silently overwrite it either — route it through conflict handling instead. The plain
+        // lookup maps a FIFO, socket or device node to FileType.UNKNOWN, i.e. to "absent", which
+        // is exactly what the strict probe tells apart.
+        if (!options.overwrite) {
+            when (destOps.existsStrict(destination)) {
+                Existence.PRESENT -> throw PathAlreadyExistsException(path = destination)
+                Existence.UNKNOWN -> throw WriteException("Cannot tell whether $destination exists", destination)
+                Existence.ABSENT -> Unit
+            }
         }
 
         var totalBytesTransferred = 0L

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathDelete.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathDelete.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.error.causeChain
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
@@ -437,7 +438,15 @@ internal class GenericPathDelete<P : APath<P>, PL : APathLookup<P>>(
             return true
         }
 
-        return runCatching { !fileSystemOps.exists(path) }.getOrDefault(false)
+        // Only a definitive "not there" makes a failure a missing-path one. A denied stat reads as
+        // absent through `exists()`, which would report a permission error as a completed delete.
+        return try {
+            fileSystemOps.existsStrict(path) == Existence.ABSENT
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            false
+        }
     }
 
     private suspend fun reportScanProgress(lookup: PL, emit: suspend (DeleteAction.State<P, PL>) -> Unit) {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/write/AtomicFileWriter.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/write/AtomicFileWriter.kt
@@ -6,9 +6,11 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.extensions.exists
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
@@ -148,15 +150,37 @@ class AtomicFileWriter(
         // Producing the content above can take arbitrarily long, so the caller's pre-check is stale
         // by now. Checked here rather than inside the commit's reconciliation block: nothing has
         // been mutated yet, so this is a clean abort and not a failed commit.
-        if (requireAbsent && target.exists(gatewaySwitch)) {
-            cleanupArtifact(tempPath)
-            throw AtomicWriteTargetExistsException(target)
+        if (requireAbsent) {
+            when (gatewaySwitch.existsStrict(target)) {
+                Existence.PRESENT -> {
+                    cleanupArtifact(tempPath)
+                    throw AtomicWriteTargetExistsException(target)
+                }
+
+                // A caller that may not replace anything cannot be served on a guess.
+                Existence.UNKNOWN -> {
+                    cleanupArtifact(tempPath)
+                    throw WriteException("Cannot tell whether $target exists", target)
+                }
+
+                Existence.ABSENT -> Unit
+            }
         }
 
         withContext(NonCancellable) {
+            // Sampled before the try: an answer that cannot tell has to abort while nothing has been
+            // mutated, rather than run the reconciliation a half-finished commit needs.
+            val targetExisted = when (gatewaySwitch.existsStrict(target)) {
+                Existence.PRESENT -> true
+                Existence.ABSENT -> false
+                Existence.UNKNOWN -> {
+                    cleanupArtifact(tempPath)
+                    throw WriteException("Cannot tell whether $target exists", target)
+                }
+            }
             var backedUp = false
             try {
-                if (target.exists(gatewaySwitch)) {
+                if (targetExisted) {
                     check(gatewaySwitch.move(target, backupPath) is MoveOutcome.Moved) { "Backup move failed: $target -> $backupPath" }
                     backedUp = true
                 }
@@ -164,16 +188,20 @@ class AtomicFileWriter(
             } catch (e: Exception) {
                 // An exception may still have moved documents (e.g. a lost IPC reply), so
                 // reconcile from observable state instead of trusting the bookkeeping flag.
-                // Failed observations are "unknown" (null), never "absent" — an unknown backup
-                // state must funnel into the restore attempt, whose own failure is loud.
-                val backupPresent = if (backedUp) true else runCatching { backupPath.exists(gatewaySwitch) }.getOrNull()
-                val targetPresent = runCatching { target.exists(gatewaySwitch) }.getOrNull()
+                // Failed observations are "unknown" (null), never "absent" — a denied stat reads
+                // as absent through `exists()`, the strict probe reports it as unknown, and an
+                // unknown backup state must funnel into the restore attempt, whose own failure is
+                // loud.
+                val backupPresent = if (backedUp) true else runCatching { observePresence(backupPath) }.getOrNull()
+                val targetPresent = runCatching { observePresence(target) }.getOrNull()
                 var restored = backupPresent == false
                 when {
                     backupPresent == false -> Unit // Provably nothing to restore
 
-                    backupPresent == true && targetPresent == true -> {
-                        // The commit landed despite the exception; keep the original as backup.
+                    targetPresent == true -> {
+                        // The commit landed despite the exception; keep the original as backup. A
+                        // restore move cannot succeed onto an occupied target, so attempting one
+                        // would only turn this into an integrity failure.
                         log(tag, WARN) { "Commit errored but target exists - original kept at $backupPath: ${e.asLog()}" }
                         restored = true
                     }
@@ -209,7 +237,13 @@ class AtomicFileWriter(
         requireAbsent: Boolean = false,
         writer: suspend (FileCommitContext) -> Unit,
     ) {
-        val targetExisted = target.exists(gatewaySwitch)
+        val targetExisted = when (gatewaySwitch.existsStrict(target)) {
+            Existence.PRESENT -> true
+            Existence.ABSENT -> false
+            // Nothing has been created yet, so this aborts instead of guessing whether the target
+            // needs a backup.
+            Existence.UNKNOWN -> throw WriteException("Cannot tell whether $target exists", target)
+        }
         if (originalAccess == OriginalAccess.FromTarget) {
             check(targetExisted) { "In-place splice requires an existing target: $target" }
         }
@@ -312,6 +346,13 @@ class AtomicFileWriter(
                 }
             }
         }
+    }
+
+    /** PRESENT and ABSENT as a verdict, [Existence.UNKNOWN] as "could not tell" (null). */
+    private suspend fun observePresence(path: APath<*>): Boolean? = when (gatewaySwitch.existsStrict(path)) {
+        Existence.PRESENT -> true
+        Existence.ABSENT -> false
+        Existence.UNKNOWN -> null
     }
 
     /** Best-effort removal of a save artifact; logs (never throws) if the delete fails or returns false. */

--- a/app-common-io/src/main/java/eu/darken/butler/common/pkgs/installer/AppInstaller.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/pkgs/installer/AppInstaller.kt
@@ -18,6 +18,7 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MoveOutcome
@@ -773,9 +774,11 @@ class AppInstaller @Inject constructor(
             if (shellSwept.get()) return
             val root = LocalPath.build(SHELL_STAGING_ROOT)
             val swept = try {
-                when {
-                    !gatewaySwitch.exists(root) -> true
-                    else -> gatewaySwitch.listFiles(root)
+                when (gatewaySwitch.existsStrict(root)) {
+                    Existence.ABSENT -> true
+                    // A root that cannot be inspected leaves the sweep pending for the next run.
+                    Existence.UNKNOWN -> false
+                    Existence.PRESENT -> gatewaySwitch.listFiles(root)
                         .filter { it.name !in activeStagingNames }
                         .map { child ->
                             val removal = shellOps.execute(
@@ -846,7 +849,13 @@ class AppInstaller @Inject constructor(
     private suspend fun commitObbPartial(partial: ObbPartial) = obbLock(partial.lockKey).withLock {
         settleBackup(partial.target, partial.backup)
         try {
-            if (gatewaySwitch.exists(partial.target)) requireMoved(partial.target, partial.backup)
+            when (gatewaySwitch.existsStrict(partial.target)) {
+                Existence.PRESENT -> requireMoved(partial.target, partial.backup)
+                Existence.ABSENT -> Unit
+                // Moving the partial on top of a destination nothing could inspect would destroy
+                // whatever is there without a backup.
+                Existence.UNKNOWN -> throw IOException("Cannot tell whether ${partial.target} exists")
+            }
             requireMoved(partial.path, partial.target)
         } finally {
             // Every exit, cancellation included, and both moves inside the guard: between them the
@@ -861,10 +870,24 @@ class AppInstaller @Inject constructor(
         }
     }
 
-    /** Restores a backup whose target is gone, drops one whose target is there. */
+    /**
+     * Restores a backup whose target is gone, drops one whose target is there.
+     *
+     * A probe that cannot tell throws with the backup left in place: for a sideloaded game the
+     * backup is usually the only obtainable copy of the expansion, so neither dropping it nor
+     * moving it onto a destination nobody could inspect is an option.
+     */
     private suspend fun settleBackup(target: APath<*>, backup: APath<*>) {
-        if (!gatewaySwitch.exists(backup)) return
-        if (gatewaySwitch.exists(target)) deleteQuietly(backup) else requireMoved(backup, target)
+        when (gatewaySwitch.existsStrict(backup)) {
+            Existence.ABSENT -> return
+            Existence.UNKNOWN -> throw IOException("Cannot tell whether backup $backup exists")
+            Existence.PRESENT -> Unit
+        }
+        when (gatewaySwitch.existsStrict(target)) {
+            Existence.PRESENT -> deleteQuietly(backup)
+            Existence.ABSENT -> requireMoved(backup, target)
+            Existence.UNKNOWN -> throw IOException("Cannot tell whether $target exists, backup kept at $backup")
+        }
     }
 
     /**

--- a/app-common-io/src/main/java/eu/darken/butler/common/trash/TrashRepo.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/trash/TrashRepo.kt
@@ -1,9 +1,5 @@
 package eu.darken.butler.common.trash
 
-import android.content.Context
-import androidx.room.Room
-import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.butler.common.BuildConfigWrap
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
@@ -16,8 +12,6 @@ import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.extensions.lookup
-import eu.darken.butler.common.files.room.APathConverter
-import eu.darken.butler.common.files.room.APathLookupConverter
 import eu.darken.butler.common.trash.db.TrashDao
 import eu.darken.butler.common.trash.db.TrashDatabase
 import eu.darken.butler.common.trash.db.TrashEntity
@@ -37,29 +31,11 @@ import kotlin.uuid.Uuid
 
 @Singleton
 class TrashRepo @Inject constructor(
-    @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val gatewaySwitch: GatewaySwitch,
-    private val aPathConverter: APathConverter,
-    private val aPathLookupConverter: APathLookupConverter,
+    private val database: TrashDatabase,
 ) {
-
-    private val database by lazy {
-        Room.databaseBuilder(
-            context,
-            TrashDatabase::class.java,
-            "trash.db"
-        ).apply {
-            if (BuildConfigWrap.DEBUG) {
-                log(TAG) { "Debug mode: Enabling destructive migration for trash database" }
-                fallbackToDestructiveMigration()
-            }
-            addMigrations(*TrashDatabase.MIGRATIONS)
-            addTypeConverter(aPathConverter)
-            addTypeConverter(aPathLookupConverter)
-        }.build()
-    }
 
     private val dao: TrashDao
         get() = database.trashDao()

--- a/app-common-io/src/main/java/eu/darken/butler/common/trash/TrashRepo.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/trash/TrashRepo.kt
@@ -12,6 +12,7 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.extensions.lookup
@@ -20,6 +21,7 @@ import eu.darken.butler.common.files.room.APathLookupConverter
 import eu.darken.butler.common.trash.db.TrashDao
 import eu.darken.butler.common.trash.db.TrashDatabase
 import eu.darken.butler.common.trash.db.TrashEntity
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -66,6 +68,8 @@ class TrashRepo @Inject constructor(
         appScope.launch(dispatcherProvider.IO) {
             try {
                 syncWithFileSystem()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log(TAG, ERROR) { "Initial sync failed: ${e.asLog()}" }
             }
@@ -120,12 +124,23 @@ class TrashRepo @Inject constructor(
 
         for (entity in allItems) {
             try {
-                if (!gatewaySwitch.exists(entity.trashPath)) {
-                    // File no longer exists in recycle bin, remove from database
-                    dao.delete(entity.id)
-                    removedCount++
-                    log(TAG, DEBUG) { "Removed non-existent item from database: ${entity.id}" }
+                // A row is only dropped for a definitive "not there". An unmounted volume or a dead
+                // document provider answers UNKNOWN for every row on it, and deleting those would
+                // orphan the trashed files with no way back.
+                when (gatewaySwitch.existsStrict(entity.trashPath)) {
+                    Existence.ABSENT -> {
+                        dao.delete(entity.id)
+                        removedCount++
+                        log(TAG, DEBUG) { "Removed non-existent item from database: ${entity.id}" }
+                    }
+
+                    Existence.PRESENT -> {}
+                    Existence.UNKNOWN -> log(TAG, WARN) {
+                        "Could not verify ${entity.trashPath}, keeping ${entity.id}"
+                    }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log(TAG, WARN) { "Error checking existence of ${entity.id}: ${e.asLog()}" }
             }

--- a/app-common-io/src/main/java/eu/darken/butler/common/trash/db/TrashDatabaseModule.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/trash/db/TrashDatabaseModule.kt
@@ -1,0 +1,42 @@
+package eu.darken.butler.common.trash.db
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import eu.darken.butler.common.BuildConfigWrap
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.room.APathConverter
+import eu.darken.butler.common.files.room.APathLookupConverter
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TrashDatabaseModule {
+
+    private val TAG = logTag("Trash", "Database")
+
+    @Provides
+    @Singleton
+    fun provideTrashDatabase(
+        @ApplicationContext context: Context,
+        aPathConverter: APathConverter,
+        aPathLookupConverter: APathLookupConverter,
+    ): TrashDatabase = Room.databaseBuilder(
+        context,
+        TrashDatabase::class.java,
+        "trash.db"
+    ).apply {
+        if (BuildConfigWrap.DEBUG) {
+            log(TAG) { "Debug mode: Enabling destructive migration for trash database" }
+            fallbackToDestructiveMigration()
+        }
+        addMigrations(*TrashDatabase.MIGRATIONS)
+        addTypeConverter(aPathConverter)
+        addTypeConverter(aPathLookupConverter)
+    }.build()
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategyTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategyTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.butler.common.files.local.operations.strategies
+
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.WriteException
+import eu.darken.butler.common.files.local.LocalFileSystemOps
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.operations.MockFileSystemOps
+import eu.darken.butler.common.files.operations.TransferStrategy
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * What LocalPathCopyStrategy does with an occupied destination while overwrite is off.
+ *
+ * The copy opens the destination with TRUNCATE_EXISTING, so a destination that reads as free but
+ * is not destroys whatever is there - with root, a device node under /dev/block included.
+ */
+class LocalPathCopyStrategyTest : BaseTest() {
+
+    private lateinit var mockOps: MockFileSystemOps<LocalPath, LocalPathLookup>
+    private lateinit var strategy: LocalPathCopyStrategy
+
+    @BeforeEach
+    fun setup() {
+        mockOps = MockFileSystemOps { path, type, size, modifiedAt, permissions, ownership, createdAt ->
+            LocalPathLookup(
+                lookedUp = path,
+                fileType = type,
+                size = size,
+                modifiedAt = modifiedAt ?: kotlin.time.Instant.fromEpochMilliseconds(0),
+                target = null,
+                ownership = ownership,
+                permissions = permissions,
+                createdAt = createdAt,
+            )
+        }
+        // The baseline below is about a destination that is meant to be free; the cases that are
+        // not say so per path.
+        mockOps.defaultExistsStrict = Existence.ABSENT
+        strategy = LocalPathCopyStrategy(LocalFileSystemOps(ownershipResolver = mockk(relaxed = true)))
+        mockOps.addMockFile("/source/file.txt", "content".toByteArray())
+        mockOps.addMockDir("/dest")
+    }
+
+    @AfterEach
+    fun cleanup() {
+        mockOps.clear()
+    }
+
+    private suspend fun copy(ops: MockFileSystemOps<LocalPath, LocalPathLookup>) =
+        LocalPathCopyStrategy(LocalFileSystemOps(ownershipResolver = mockk(relaxed = true))).transferFile(
+            sourceLookup = mockOps.lookup(LocalPath.build("/source/file.txt")),
+            destination = LocalPath.build("/dest/file.txt"),
+            sourceOps = ops,
+            destOps = ops,
+            options = TransferStrategy.Options(overwrite = false, preserveAttributes = false),
+            onProgress = {},
+        )
+
+    @Test
+    fun `a free destination is copied`() = runTest {
+        val result = copy(mockOps)
+
+        result.shouldBeInstanceOf<TransferStrategy.TransferResult.Success<*, *>>()
+        mockOps.getFileContent("/dest/file.txt") shouldBe "content".toByteArray()
+    }
+
+    /**
+     * A FIFO, socket or device node is FileType.UNKNOWN to the plain lookup, i.e. indistinguishable
+     * from "nothing there".
+     */
+    @Test
+    fun `a destination the plain lookup cannot classify is a conflict`() = runTest {
+        mockOps.existsStrictAnswers["/dest/file.txt"] = Existence.PRESENT
+        val spyOps = spyk(mockOps)
+
+        shouldThrow<PathAlreadyExistsException> { copy(spyOps) }
+
+        coVerify(exactly = 0) { spyOps.openOutputStream(any(), any()) }
+        spyOps.hasFile("/dest/file.txt") shouldBe false
+        spyOps.hasFile("/source/file.txt") shouldBe true
+    }
+
+    @Test
+    fun `a destination that cannot be inspected stops the copy`() = runTest {
+        mockOps.existsStrictAnswers["/dest/file.txt"] = Existence.UNKNOWN
+        val spyOps = spyk(mockOps)
+
+        shouldThrow<WriteException> { copy(spyOps) }
+
+        coVerify(exactly = 0) { spyOps.openOutputStream(any(), any()) }
+        spyOps.hasFile("/dest/file.txt") shouldBe false
+        spyOps.hasFile("/source/file.txt") shouldBe true
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategyTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathCopyStrategyTest.kt
@@ -103,4 +103,29 @@ class LocalPathCopyStrategyTest : BaseTest() {
         spyOps.hasFile("/dest/file.txt") shouldBe false
         spyOps.hasFile("/source/file.txt") shouldBe true
     }
+
+    @Test
+    fun `a symlink is followed onto the same conflict check`() = runTest {
+        mockOps.addMockSymlink("/source/link.txt", "/source/file.txt")
+        mockOps.existsStrictAnswers["/dest/file.txt"] = Existence.PRESENT
+        val spyOps = spyk(mockOps)
+
+        shouldThrow<PathAlreadyExistsException> {
+            strategy.transferFile(
+                sourceLookup = mockOps.lookup(LocalPath.build("/source/link.txt")),
+                destination = LocalPath.build("/dest/file.txt"),
+                sourceOps = spyOps,
+                destOps = spyOps,
+                options = TransferStrategy.Options(
+                    overwrite = false,
+                    preserveAttributes = false,
+                    followSymlinks = true,
+                ),
+                onProgress = {},
+            )
+        }
+
+        coVerify(exactly = 0) { spyOps.openOutputStream(any(), any()) }
+        spyOps.hasFile("/dest/file.txt") shouldBe false
+    }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathMoveStrategyTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/strategies/LocalPathMoveStrategyTest.kt
@@ -1,11 +1,15 @@
 package eu.darken.butler.common.files.local.operations.strategies
 
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MoveOutcome
+import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.files.operations.MockFileSystemOps
 import eu.darken.butler.common.files.operations.TransferStrategy
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -36,6 +40,9 @@ class LocalPathMoveStrategyTest : BaseTest() {
     @BeforeEach
     fun setup() {
         mockOps = MockLocalFileSystemOps()
+        // Every case below is about a destination that is meant to be free; the ones that are not
+        // say so per path.
+        mockOps.defaultExistsStrict = Existence.ABSENT
         strategy = LocalPathMoveStrategy(mockOps)
     }
 
@@ -554,6 +561,60 @@ class LocalPathMoveStrategyTest : BaseTest() {
         // Destination created under the new name, source still present
         spyOps.hasFile("/data/dest/BBB") shouldBe true
         spyOps.hasFile("/data/source/AAAA") shouldBe true
+    }
+
+    // ============ OCCUPIED DESTINATION ============
+
+    /**
+     * A FIFO, socket or device node is FileType.UNKNOWN to the plain lookup, i.e. indistinguishable
+     * from "nothing there", and the fallback's truncating copy would write straight into it.
+     */
+    @Test
+    fun `a destination the plain lookup cannot classify is a conflict`() = runTest {
+        mockOps.addMockFile("/source/file.txt", "content".toByteArray())
+        mockOps.addMockDir("/dest")
+        mockOps.existsStrictAnswers["/dest/file.txt"] = Existence.PRESENT
+        val spyOps = spyk(mockOps)
+        val spyStrategy = LocalPathMoveStrategy(spyOps)
+
+        shouldThrow<PathAlreadyExistsException> {
+            spyStrategy.transferFile(
+                sourceLookup = mockOps.lookup(LocalPath.build("/source/file.txt")),
+                destination = LocalPath.build("/dest/file.txt"),
+                sourceOps = spyOps,
+                destOps = spyOps,
+                options = TransferStrategy.Options(overwrite = false),
+                onProgress = {},
+            )
+        }
+
+        coVerify(exactly = 0) { spyOps.openOutputStream(any(), any()) }
+        spyOps.hasFile("/dest/file.txt") shouldBe false
+        spyOps.hasFile("/source/file.txt") shouldBe true
+    }
+
+    @Test
+    fun `a destination that cannot be inspected stops the fallback copy`() = runTest {
+        mockOps.addMockFile("/source/file.txt", "content".toByteArray())
+        mockOps.addMockDir("/dest")
+        mockOps.existsStrictAnswers["/dest/file.txt"] = Existence.UNKNOWN
+        val spyOps = spyk(mockOps)
+        val spyStrategy = LocalPathMoveStrategy(spyOps)
+
+        shouldThrow<WriteException> {
+            spyStrategy.transferFile(
+                sourceLookup = mockOps.lookup(LocalPath.build("/source/file.txt")),
+                destination = LocalPath.build("/dest/file.txt"),
+                sourceOps = spyOps,
+                destOps = spyOps,
+                options = TransferStrategy.Options(overwrite = false),
+                onProgress = {},
+            )
+        }
+
+        coVerify(exactly = 0) { spyOps.openOutputStream(any(), any()) }
+        spyOps.hasFile("/dest/file.txt") shouldBe false
+        spyOps.hasFile("/source/file.txt") shouldBe true
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/operations/GenericPathDeleteIssueTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/operations/GenericPathDeleteIssueTest.kt
@@ -1,8 +1,11 @@
 package eu.darken.butler.common.files.operations
 
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.actions.DeleteAction
 import eu.darken.butler.common.files.actions.PathActionIssue
+import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.local.LocalPathLookup
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -374,6 +377,71 @@ class GenericPathDeleteIssueTest : BaseTest() {
         mockOps.hasFile("/file1.txt") shouldBe false
         mockOps.hasFile("/file2.txt") shouldBe false
         mockOps.hasFile("/file3.txt") shouldBe true // This one failed and still exists
+    }
+
+    /**
+     * A mock whose lookup fails with a denial rather than a "not found", so what the operation does
+     * with it is decided by the strict probe alone.
+     */
+    private fun deniedLookupOps(probe: () -> Existence) = object : MockFileSystemOps<LocalPath, LocalPathLookup>(
+        { path, type, size, modifiedAt, permissions, ownership, createdAt ->
+            LocalPathLookup(
+                lookedUp = path,
+                fileType = type,
+                size = size,
+                modifiedAt = modifiedAt ?: kotlin.time.Instant.fromEpochMilliseconds(0),
+                target = null,
+                ownership = ownership,
+                permissions = permissions,
+                createdAt = createdAt,
+            )
+        },
+    ) {
+        override suspend fun lookup(path: LocalPath, options: LookupOptions): LocalPathLookup =
+            throw SecurityException("Permission denied")
+
+        override suspend fun existsStrict(path: LocalPath): Existence {
+            existsStrictCalls.add(path.path)
+            return probe()
+        }
+    }
+
+    @Test
+    fun `a denied path that cannot be verified is not swallowed by ignoreMissing`() = runTest {
+        // ignoreMissing may only skip a definitive "not there". The probe answers UNKNOWN, so this
+        // has to surface instead of being counted as a completed delete.
+        val ops = deniedLookupOps { Existence.UNKNOWN }
+
+        shouldThrow<ReadException> {
+            LocalPath.build("/file.txt").deleteGeneric(
+                fileSystemOps = ops,
+                recursive = true,
+                ignoreMissing = true,
+                onIssue = { PathActionIssue.UnknownError.Resolution.Skip() },
+            ).last()
+        }
+
+        ops.existsStrictCalls shouldContain "/file.txt"
+    }
+
+    @Test
+    fun `a cancelled existence probe cancels the delete`() = runTest {
+        val ops = deniedLookupOps { throw CancellationException("cancel probe") }
+        var issueCount = 0
+
+        shouldThrow<CancellationException> {
+            LocalPath.build("/file.txt").deleteGeneric(
+                fileSystemOps = ops,
+                recursive = true,
+                ignoreMissing = true,
+                onIssue = {
+                    issueCount++
+                    PathActionIssue.UnknownError.Resolution.Skip()
+                },
+            ).last()
+        }
+
+        issueCount shouldBe 0
     }
 
     // ============ SCAN ERROR HANDLING ============

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/write/AtomicFileWriterTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/write/AtomicFileWriterTest.kt
@@ -2,10 +2,12 @@ package eu.darken.butler.common.files.write
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
+import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.local.LocalFileSystemOps
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import io.kotest.assertions.throwables.shouldThrow
@@ -25,8 +27,18 @@ class AtomicFileWriterTest : BaseTest() {
     private val mockOwnershipResolver = mockk<OwnershipResolver>(relaxed = true)
     private val fileSystemOps = LocalFileSystemOps(ownershipResolver = mockOwnershipResolver)
 
+    /**
+     * What the strict probe answers for a path; `null` defers to the real file. Artifact names carry
+     * a random token, so an injection has to match on the infix rather than on a full path.
+     */
+    private var strictAnswer: (LocalPath) -> Existence? = { null }
+
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers {
+            val path = firstArg<APath<*>>() as LocalPath
+            strictAnswer(path) ?: if (fileSystemOps.exists(path)) Existence.PRESENT else Existence.ABSENT
+        }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>
@@ -309,6 +321,135 @@ class AtomicFileWriterTest : BaseTest() {
             tempDir.artifacts().single().startsWith("doc.txt.butler-save-bak-") shouldBe true
             File(tempDir, tempDir.artifacts().single()).readText() shouldBe "ORIGINAL"
         }
+
+    @Test
+    fun `a backup that cannot be inspected still funnels into the restore`(@TempDir tempDir: File) = runTest {
+        val target = File(tempDir, "doc.txt").apply { writeText("ORIGINAL") }
+        val gateway = createMockGateway()
+        // The target -> backup move lands on disk but the reply is lost, so the bookkeeping flag
+        // stays unset. A denied stat on the backup is no proof that there is nothing to restore.
+        strictAnswer = { if (it.name.contains(AtomicFileWriter.BACKUP_INFIX)) Existence.UNKNOWN else null }
+        coEvery {
+            gateway.move(
+                match<APath<*>> { it.name == "doc.txt" },
+                match<APath<*>> { it.name.contains(".butler-save-bak-") },
+            )
+        } coAnswers {
+            (firstArg<APath<*>>() as LocalPath).file.renameTo((secondArg<APath<*>>() as LocalPath).file)
+            throw IOException("lost reply")
+        }
+        val writer = AtomicFileWriter(gateway, "test")
+
+        val thrown = shouldThrow<IOException> {
+            writer.replace(LocalPath.build(target), AtomicFileWriter.OriginalAccess.None) { context ->
+                context.sink.writeUtf8("NEW")
+            }
+        }
+
+        thrown.message shouldBe "lost reply"
+        coVerify(exactly = 1) {
+            gateway.existsStrict(match<APath<*>> { it.name.contains(AtomicFileWriter.BACKUP_INFIX) })
+        }
+        coVerify(exactly = 1) {
+            gateway.move(
+                match<APath<*>> { it.name.contains(".butler-save-bak-") },
+                match<APath<*>> { it.name == "doc.txt" },
+            )
+        }
+        target.readText() shouldBe "ORIGINAL"
+        tempDir.artifacts() shouldBe emptyList()
+    }
+
+    @Test
+    fun `a backup that is provably absent needs no restore`(@TempDir tempDir: File) = runTest {
+        val target = File(tempDir, "doc.txt").apply { writeText("ORIGINAL") }
+        val gateway = createMockGateway()
+        // The backup move failed before touching anything, so there is nothing to move back.
+        strictAnswer = { if (it.name.contains(AtomicFileWriter.BACKUP_INFIX)) Existence.ABSENT else null }
+        coEvery {
+            gateway.move(
+                match<APath<*>> { it.name == "doc.txt" },
+                match<APath<*>> { it.name.contains(".butler-save-bak-") },
+            )
+        } throws IOException("backup refused")
+        val writer = AtomicFileWriter(gateway, "test")
+
+        val thrown = shouldThrow<IOException> {
+            writer.replace(LocalPath.build(target), AtomicFileWriter.OriginalAccess.None) { context ->
+                context.sink.writeUtf8("NEW")
+            }
+        }
+
+        thrown.message shouldBe "backup refused"
+        coVerify(exactly = 0) {
+            gateway.move(
+                match<APath<*>> { it.name.contains(".butler-save-bak-") },
+                match<APath<*>> { it.name == "doc.txt" },
+            )
+        }
+        target.readText() shouldBe "ORIGINAL"
+        tempDir.artifacts() shouldBe emptyList()
+    }
+
+    @Test
+    fun `a present target ends the recovery even when the backup cannot be inspected`(@TempDir tempDir: File) = runTest {
+        val target = File(tempDir, "doc.txt").apply { writeText("ORIGINAL") }
+        val gateway = createMockGateway()
+        // As far as the probes can tell the target is occupied and the backup is unreadable. A
+        // restore move cannot succeed onto an occupied target, and attempting it would report an
+        // integrity loss on top of the error that actually happened.
+        strictAnswer = {
+            when {
+                it.name.contains(AtomicFileWriter.BACKUP_INFIX) -> Existence.UNKNOWN
+                it.name == "doc.txt" -> Existence.PRESENT
+                else -> null
+            }
+        }
+        coEvery {
+            gateway.move(
+                match<APath<*>> { it.name == "doc.txt" },
+                match<APath<*>> { it.name.contains(".butler-save-bak-") },
+            )
+        } coAnswers {
+            (firstArg<APath<*>>() as LocalPath).file.renameTo((secondArg<APath<*>>() as LocalPath).file)
+            throw IOException("lost reply")
+        }
+        val writer = AtomicFileWriter(gateway, "test")
+
+        val thrown = shouldThrow<IOException> {
+            writer.replace(LocalPath.build(target), AtomicFileWriter.OriginalAccess.None) { context ->
+                context.sink.writeUtf8("NEW")
+            }
+        }
+
+        thrown.message shouldBe "lost reply"
+        coVerify(exactly = 0) {
+            gateway.move(
+                match<APath<*>> { it.name.contains(".butler-save-bak-") },
+                match<APath<*>> { it.name == "doc.txt" },
+            )
+        }
+        tempDir.artifacts().single().startsWith("doc.txt.butler-save-bak-") shouldBe true
+        File(tempDir, tempDir.artifacts().single()).readText() shouldBe "ORIGINAL"
+    }
+
+    @Test
+    fun `a target that cannot be inspected aborts before anything is moved`(@TempDir tempDir: File) = runTest {
+        val target = File(tempDir, "doc.txt").apply { writeText("ORIGINAL") }
+        val gateway = createMockGateway()
+        strictAnswer = { if (it.name == "doc.txt") Existence.UNKNOWN else null }
+        val writer = AtomicFileWriter(gateway, "test")
+
+        shouldThrow<WriteException> {
+            writer.replace(LocalPath.build(target), AtomicFileWriter.OriginalAccess.None) { context ->
+                context.sink.writeUtf8("NEW")
+            }
+        }
+
+        target.readText() shouldBe "ORIGINAL"
+        tempDir.artifacts() shouldBe emptyList()
+        coVerify(exactly = 0) { gateway.move(any<APath<*>>(), any<APath<*>>()) }
+    }
 
     // ==================== in-place strategy (SAF-analog, exercised directly) ====================
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/pkgs/installer/AppInstallerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/pkgs/installer/AppInstallerTest.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.adb.AdbManager
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.archive.ArchiveEntryMeta
 import eu.darken.butler.common.files.archive.ArchiveFormat
 import eu.darken.butler.common.files.archive.ArchiveIndex
@@ -48,6 +50,8 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
+import okio.FileSystem
+import okio.Path.Companion.toPath
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [30])
@@ -92,6 +96,12 @@ class AppInstallerTest : BaseTest() {
 
     /** Paths a run tried to remove through the gateway, whether or not the removal worked. */
     private val gatewayRemovals = mutableListOf<String>()
+
+    /** Moves a run issued through the gateway, as source to destination. */
+    private val gatewayMoves = mutableListOf<Pair<String, String>>()
+
+    /** Overrides what the strict probe answers per path; `null` falls back to what [exists] says. */
+    private var strictAnswer: (String) -> Existence? = { null }
 
     private val systemInstallGate = SystemInstallGate()
 
@@ -191,6 +201,24 @@ class AppInstallerTest : BaseTest() {
         coEvery { gatewaySwitch.exists(any()) } answers {
             val path = firstArg<LocalPath>().path
             path in shellStagingChildren || path in obbDirChildren || path.endsWith(PARTIAL_SUFFIX)
+        }
+        coEvery { gatewaySwitch.existsStrict(any()) } answers {
+            val path = firstArg<LocalPath>().path
+            strictAnswer(path) ?: when {
+                path in shellStagingChildren || path in obbDirChildren || path.endsWith(PARTIAL_SUFFIX) ->
+                    Existence.PRESENT
+
+                else -> Existence.ABSENT
+            }
+        }
+        // Expansion payloads are streamed through a handle, which needs a real file to land in.
+        coEvery { gatewaySwitch.file(any(), any()) } answers {
+            val scratch = File(workDir, firstArg<LocalPath>().name).apply { createNewFile() }
+            FileSystem.SYSTEM.openReadWrite(scratch.path.toPath())
+        }
+        coEvery { gatewaySwitch.move(any<APath<*>>(), any<APath<*>>()) } answers {
+            gatewayMoves += firstArg<LocalPath>().path to secondArg<LocalPath>().path
+            MoveOutcome.Moved
         }
         coEvery { gatewaySwitch.delete(any<APath<*>>(), any<Boolean>()) } answers {
             gatewayRemovals += firstArg<LocalPath>().path
@@ -688,6 +716,71 @@ class AppInstallerTest : BaseTest() {
     }
 
     @Test
+    fun `a staged expansion lands on its destination`() = runTest2 {
+        stubBundleArchive(withObb = true)
+        val inspected = baseInfo(certSha256 = "aa")
+        coEvery { apkArchiveParser.parseFile(any(), any()) } returns inspected
+
+        val events = installer().install(obbBundlePlan(inspected), AppInstaller.Mode.ROOT).toList()
+
+        events.none { it is AppInstallEvent.ObbFailed } shouldBe true
+        events.last().shouldBeInstanceOf<AppInstallEvent.Success>().obbPlaced shouldBe true
+        val partial = gatewayWrites.single { it.endsWith(PARTIAL_SUFFIX) }
+        gatewayMoves shouldContainExactly listOf(partial to "$OBB_DIR/$OBB_NAME")
+    }
+
+    @Test
+    fun `an expansion backup that cannot be inspected is neither moved nor dropped`() = runTest2 {
+        // For a sideloaded game the backup is usually the only obtainable copy of the expansion.
+        stubBundleArchive(withObb = true)
+        val inspected = baseInfo(certSha256 = "aa")
+        coEvery { apkArchiveParser.parseFile(any(), any()) } returns inspected
+        strictAnswer = { if (it.endsWith(BACKUP_SUFFIX)) Existence.UNKNOWN else null }
+
+        val events = installer().install(obbBundlePlan(inspected), AppInstaller.Mode.ROOT).toList()
+
+        events.filterIsInstance<AppInstallEvent.ObbFailed>().single().reason shouldContain "Cannot tell whether backup"
+        coVerify { gatewaySwitch.existsStrict(match<APath<*>> { it.path.endsWith(BACKUP_SUFFIX) }) }
+        gatewayMoves.none { it.first.endsWith(BACKUP_SUFFIX) || it.second.endsWith(BACKUP_SUFFIX) } shouldBe true
+        gatewayRemovals.none { it.endsWith(BACKUP_SUFFIX) } shouldBe true
+    }
+
+    @Test
+    fun `an expansion destination that cannot be inspected is not overwritten`() = runTest2 {
+        stubBundleArchive(withObb = true)
+        val inspected = baseInfo(certSha256 = "aa")
+        coEvery { apkArchiveParser.parseFile(any(), any()) } returns inspected
+        strictAnswer = { if (it == "$OBB_DIR/$OBB_NAME") Existence.UNKNOWN else null }
+
+        val events = installer().install(obbBundlePlan(inspected), AppInstaller.Mode.ROOT).toList()
+
+        events.filterIsInstance<AppInstallEvent.ObbFailed>().single().reason shouldContain "$OBB_DIR/$OBB_NAME"
+        gatewayMoves.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a staging root that cannot be inspected stays sweepable`() = runTest2 {
+        shellStagingChildren = listOf(SHELL_ROOT, "$SHELL_ROOT/$LEFTOVER_NAME")
+        var firstProbe = true
+        strictAnswer = {
+            when {
+                it == SHELL_ROOT && firstProbe -> Existence.UNKNOWN.also { firstProbe = false }
+                else -> null
+            }
+        }
+        val installer = installer()
+
+        installer.install(plan(), AppInstaller.Mode.ADB).toList()
+
+        // Nothing was looked at, so the root must not count as swept.
+        executed.count { it.second == "rm -rf '$SHELL_ROOT/$LEFTOVER_NAME'" } shouldBe 0
+
+        installer.install(plan(), AppInstaller.Mode.ADB).toList()
+
+        executed.count { it.second == "rm -rf '$SHELL_ROOT/$LEFTOVER_NAME'" } shouldBe 1
+    }
+
+    @Test
     fun `an expansion partial that could not be removed stops being protected`() = runTest2 {
         stubBundleArchive(withObb = true)
         val inspected = baseInfo(certSha256 = "aa")
@@ -784,5 +877,6 @@ class AppInstallerTest : BaseTest() {
         private const val OBB_DIR = "$OBB_ROOT/com.example.app"
         private const val OBB_NAME = "main.1.obb"
         private const val PARTIAL_SUFFIX = ".part"
+        private const val BACKUP_SUFFIX = ".btlbak"
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/trash/TrashRepoSyncTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/trash/TrashRepoSyncTest.kt
@@ -1,0 +1,155 @@
+package eu.darken.butler.common.trash
+
+import androidx.room.Room
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.room.APathConverter
+import eu.darken.butler.common.files.room.APathLookupConverter
+import eu.darken.butler.common.serialization.SerializationIOModule
+import eu.darken.butler.common.trash.db.TrashDatabase
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * What [TrashRepo.syncWithFileSystem] does to the database rows for each answer of the strict
+ * existence probe. A row stands for a file that was moved into the trash, so dropping it on a
+ * probe that only failed to reach the volume orphans that file.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TrashRepoSyncTest : BaseTest() {
+
+    private val json = SerializationIOModule().json()
+    private val gatewaySwitch: GatewaySwitch = mockk()
+
+    private lateinit var database: TrashDatabase
+    private lateinit var appScope: CoroutineScope
+
+    @Before
+    fun setup() {
+        database = Room
+            .inMemoryDatabaseBuilder(RuntimeEnvironment.getApplication(), TrashDatabase::class.java)
+            .addTypeConverter(APathConverter(json))
+            .addTypeConverter(APathLookupConverter(json))
+            .allowMainThreadQueries()
+            .build()
+        appScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+        appScope.cancel()
+    }
+
+    /**
+     * The constructor launches an initial sync; waiting for it keeps its probes out of the
+     * verifications below.
+     */
+    private suspend fun createRepo(): TrashRepo {
+        val repo = TrashRepo(
+            appScope = appScope,
+            dispatcherProvider = TestDispatcherProvider(),
+            gatewaySwitch = gatewaySwitch,
+            database = database,
+        )
+        appScope.coroutineContext.job.children.toList().forEach { it.join() }
+        return repo
+    }
+
+    private fun trashItem(name: String): TrashRepo.TrashItem {
+        val originalPath = LocalPath.build("data", "local", "tmp", name)
+        val trashPath = LocalPath.build(
+            "storage", "emulated", "0", "Android", "data", "eu.darken.butler", ".trash", "${name}_x",
+        )
+        return TrashRepo.TrashItem(
+            id = Uuid.random(),
+            originalLookup = LocalPathLookup(
+                lookedUp = originalPath,
+                fileType = FileType.FILE,
+                size = 34L,
+                modifiedAt = Instant.fromEpochMilliseconds(0),
+            ),
+            trashPath = trashPath,
+            trashLookup = null,
+            size = 34L,
+        )
+    }
+
+    private suspend fun storedIds(): List<Uuid> = database.trashDao().getAll().first().map { it.id }
+
+    @Test
+    fun `a trashed file that is definitely gone is dropped`() = runTest {
+        val repo = createRepo()
+        val item = trashItem("gone.txt")
+        repo.insert(item)
+        coEvery { gatewaySwitch.existsStrict(item.trashPath) } returns Existence.ABSENT
+
+        repo.syncWithFileSystem()
+
+        storedIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun `a trashed file that is still there is kept`() = runTest {
+        val repo = createRepo()
+        val item = trashItem("present.txt")
+        repo.insert(item)
+        coEvery { gatewaySwitch.existsStrict(item.trashPath) } returns Existence.PRESENT
+
+        repo.syncWithFileSystem()
+
+        storedIds() shouldContainExactlyInAnyOrder listOf(item.id)
+    }
+
+    @Test
+    fun `a trashed file that cannot be checked is kept`() = runTest {
+        val repo = createRepo()
+        val item = trashItem("unknown.txt")
+        repo.insert(item)
+        coEvery { gatewaySwitch.existsStrict(item.trashPath) } returns Existence.UNKNOWN
+
+        repo.syncWithFileSystem()
+
+        storedIds() shouldContainExactlyInAnyOrder listOf(item.id)
+    }
+
+    @Test
+    fun `a cancelled probe stops the sync instead of dropping the remaining rows`() = runTest {
+        val repo = createRepo()
+        val items = listOf(trashItem("one.txt"), trashItem("two.txt"), trashItem("three.txt"))
+        items.forEach { repo.insert(it) }
+        coEvery { gatewaySwitch.existsStrict(any()) } throws CancellationException("cancelled")
+
+        shouldThrow<CancellationException> { repo.syncWithFileSystem() }
+
+        coVerify(exactly = 1) { gatewaySwitch.existsStrict(any()) }
+        storedIds() shouldContainExactlyInAnyOrder items.map { it.id }
+    }
+}

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceContentPathTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceContentPathTest.kt
@@ -51,6 +51,7 @@ class EditorWorkspaceContentPathTest : BaseTest() {
         }
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceDiscardTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceDiscardTest.kt
@@ -47,6 +47,7 @@ class EditorWorkspaceDiscardTest : BaseTest() {
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceSaveAsTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/EditorWorkspaceSaveAsTest.kt
@@ -51,6 +51,7 @@ class EditorWorkspaceSaveAsTest : BaseTest() {
         }
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferEncodingRoundTripTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferEncodingRoundTripTest.kt
@@ -36,6 +36,7 @@ class DocumentBufferEncodingRoundTripTest : BaseTest() {
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferLargeFileTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferLargeFileTest.kt
@@ -37,6 +37,7 @@ class DocumentBufferLargeFileTest : BaseTest() {
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferParallelStressTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferParallelStressTest.kt
@@ -88,6 +88,7 @@ class DocumentBufferParallelStressTest : DocumentBufferTestBase() {
     ): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferSaveTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/DocumentBufferSaveTest.kt
@@ -50,6 +50,7 @@ class DocumentBufferSaveTest : BaseTest() {
     private fun createMockGateway(failTempWrites: Boolean = false): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineExternalChangeTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineExternalChangeTest.kt
@@ -45,6 +45,7 @@ class EditorEngineExternalChangeTest : BaseTest() {
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineLineEndingTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/engine/EditorEngineLineEndingTest.kt
@@ -45,6 +45,7 @@ class EditorEngineLineEndingTest : BaseTest() {
     private fun createMockGateway(): GatewaySwitch = mockk<GatewaySwitch>().apply {
         coEvery { canWrite(any()) } returns true
         coEvery { exists(any()) } coAnswers { fileSystemOps.exists(firstArg<APath<*>>() as LocalPath) }
+        coEvery { existsStrict(any()) } coAnswers { fileSystemOps.existsStrict(firstArg<APath<*>>() as LocalPath) }
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {
             fileSystemOps.lookup(firstArg<APath<*>>() as LocalPath, secondArg<LookupOptions>()) as APathLookup<APath<*>>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceEncodingTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceEncodingTest.kt
@@ -45,6 +45,10 @@ class FileDataSourceEncodingTest : BaseTest() {
             val path = firstArg<APath<*>>() as LocalPath
             fileSystemOps.exists(path)
         }
+        coEvery { existsStrict(any()) } coAnswers {
+            val path = firstArg<APath<*>>() as LocalPath
+            fileSystemOps.existsStrict(path)
+        }
 
         @Suppress("UNCHECKED_CAST")
         coEvery { lookup(any(), any()) } coAnswers {

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/core/sources/FileDataSourceTest.kt
@@ -43,6 +43,10 @@ class FileDataSourceTest : BaseTest() {
             val path = firstArg<APath<*>>() as LocalPath
             fileSystemOps.exists(path)
         }
+        coEvery { existsStrict(any()) } coAnswers {
+            val path = firstArg<APath<*>>() as LocalPath
+            fileSystemOps.existsStrict(path)
+        }
 
         // Mock lookup() - delegates to REAL file system operations
         @Suppress("UNCHECKED_CAST")

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/TrashLocationLoader.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/TrashLocationLoader.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.metadata.MetadataRepo
@@ -130,8 +131,9 @@ class TrashLocationLoader @AssistedInject constructor(
                 )
             }
 
-            // Verify the path exists in filesystem
-            if (!gatewaySwitch.exists(absolutePath)) {
+            // Only a definitive "not there" earns this wording. A folder that cannot be inspected
+            // falls through to the listing below, whose own failure names the real reason.
+            if (gatewaySwitch.existsStrict(absolutePath) == Existence.ABSENT) {
                 log(tag, ERROR) { "Trash path no longer exists: $absolutePath" }
                 throw IllegalStateException("Folder contents no longer available")
             }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/TrashLocationLoaderTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/TrashLocationLoaderTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.butler.explorer.core.engine
+
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.trash.TrashRepo
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.IOException
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * "Folder contents no longer available" is a statement about the folder, so only a definitive
+ * absence may produce it. A folder that cannot be inspected has to keep the listing's own error.
+ */
+class TrashLocationLoaderTest : BaseTest() {
+
+    private val gatewaySwitch = mockk<GatewaySwitch>(relaxed = true)
+    private val trashRepo = mockk<TrashRepo>()
+
+    private val trashPath = LocalPath.build("/storage/emulated/0/.butler-trash/folder")
+
+    private val parentRef = TrashItemReference(
+        itemId = Uuid.random(),
+        displayName = "folder".toCaString(),
+        originalPath = LocalPath.build("/storage/emulated/0/Documents/folder"),
+        trashPath = trashPath,
+        deletedAt = Instant.fromEpochMilliseconds(0),
+    )
+
+    private fun loader() = TrashLocationLoader(
+        workspaceId = Workspace.Id(),
+        trashRepo = trashRepo,
+        gatewaySwitch = gatewaySwitch,
+        metadataRepo = mockk(relaxed = true),
+    )
+
+    init {
+        coEvery { gatewaySwitch.useRes<Any?>(any()) } coAnswers {
+            firstArg<suspend (Any) -> Any?>().invoke(gatewaySwitch)
+        }
+        coEvery { trashRepo.getById(any()) } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `a folder that cannot be inspected surfaces the listing error`() = runTest {
+        val original = IOException("gateway gave up")
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.UNKNOWN
+        coEvery { gatewaySwitch.lookupFiles(any(), any<LookupOptions>()) } throws original
+
+        shouldThrow<IOException> { loader().loadNested(parentRef, "").toList() } shouldBe original
+    }
+
+    @Test
+    fun `a folder that is provably gone is reported as unavailable without listing it`() = runTest {
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
+
+        val error = shouldThrow<IllegalStateException> { loader().loadNested(parentRef, "").toList() }
+
+        error.message shouldBe "Folder contents no longer available"
+        coVerify(exactly = 0) { gatewaySwitch.lookupFiles(any(), any<LookupOptions>()) }
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerWorkspace.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerWorkspace.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MimeInfo
@@ -609,10 +610,14 @@ class ViewerWorkspace @AssistedInject constructor(
         ApkInstallState.Unknown
     }
 
-    /** Only a definitive "not there" counts; a failing check stays with the original error. */
+    /**
+     * Only a definitive "not there" counts. A path that merely cannot be inspected - denied access,
+     * dead provider, unreachable host - answers [Existence.UNKNOWN], and there the original error
+     * carries the signal the user needs.
+     */
     private suspend fun isGone(path: APath<*>?): Boolean = try {
         val filePath = path ?: return false
-        !gatewaySwitch.useRes { gatewaySwitch.exists(filePath) }
+        gatewaySwitch.existsStrict(filePath) == Existence.ABSENT
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceClassificationTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceClassificationTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.viewer.core
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.archive.ArchiveFormat
@@ -102,7 +103,7 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
                 else -> result as APathLookup<APath<*>>
             }
         }
-        coEvery { gatewaySwitch.exists(any()) } returns true
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.PRESENT
         coEvery { imageProbe.probe(any()) } returns ProbeResult.Probed(4032, 3024, "image/jpeg")
     }
 
@@ -158,7 +159,7 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
         // The gateway maps a vanished file to a permission error, which would send the user
         // looking for an access problem that does not exist.
         setupGateway(imagePath.path to PathPermissionDeniedException(imagePath, "lookup", Reason.NO_MECHANISM))
-        coEvery { gatewaySwitch.exists(any()) } returns false
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.ABSENT
 
         val state = workspace().state.first()
 
@@ -170,7 +171,7 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
     fun `a file that is there but unreadable keeps the original error`() = runTest2 {
         val denied = PathPermissionDeniedException(imagePath, "lookup", Reason.NO_MECHANISM)
         setupGateway(imagePath.path to denied)
-        coEvery { gatewaySwitch.exists(any()) } returns true
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.PRESENT
 
         val state = workspace().state.first()
 
@@ -181,7 +182,20 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
     fun `a failing existence check keeps the original error`() = runTest2 {
         val denied = PathPermissionDeniedException(imagePath, "lookup", Reason.NO_MECHANISM)
         setupGateway(imagePath.path to denied)
-        coEvery { gatewaySwitch.exists(any()) } throws ReadException("gateway gave up", imagePath)
+        coEvery { gatewaySwitch.existsStrict(any()) } throws ReadException("gateway gave up", imagePath)
+
+        val state = workspace().state.first()
+
+        state.content.shouldBeInstanceOf<ViewerContent.Failed>().error shouldBe denied
+    }
+
+    @Test
+    fun `an unverifiable file keeps the original error`() = runTest2 {
+        // Denied access, a dead provider or an unreachable host answer UNKNOWN, which is no evidence
+        // the file is gone - and a gone error would veto the permission classification.
+        val denied = PathPermissionDeniedException(imagePath, "lookup", Reason.NO_MECHANISM)
+        setupGateway(imagePath.path to denied)
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.UNKNOWN
 
         val state = workspace().state.first()
 

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceExternalChangeTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceExternalChangeTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.viewer.core
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.errors.ReadException
@@ -45,7 +46,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
 
     /** What the gateway finds per path right now: a lookup to return, or a throwable to throw. */
     private val disk = mutableMapOf<String, Any>()
-    private var exists: (String) -> Boolean = { true }
+    private var exists: (String) -> Existence = { Existence.PRESENT }
 
     /** One-shot: holds the next lookup of that path in flight, so a test can interleave around it. */
     private var lookupGate: Pair<String, CompletableDeferred<Unit>>? = null
@@ -56,7 +57,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
     @Suppress("UNCHECKED_CAST")
     fun setup() {
         disk.clear()
-        exists = { true }
+        exists = { Existence.PRESENT }
         lookupGate = null
         coEvery { gatewaySwitch.useRes(any<suspend (Any) -> Any?>()) } coAnswers {
             firstArg<suspend (Any) -> Any?>().invoke(gatewaySwitch)
@@ -73,7 +74,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
                 else -> result as APathLookup<APath<*>>
             }
         }
-        coEvery { gatewaySwitch.exists(any()) } answers { exists(firstArg<APath<*>>().path) }
+        coEvery { gatewaySwitch.existsStrict(any()) } answers { exists(firstArg<APath<*>>().path) }
         coEvery { imageProbe.probe(any()) } returns ProbeResult.Probed(4032, 3024, "image/jpeg")
     }
 
@@ -165,7 +166,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
     fun `a deleted file is reported as Gone`() = runTest2 {
         val ws = loadedWorkspace()
         disk[imagePath.path] = ReadException("Does not exist", imagePath)
-        exists = { false }
+        exists = { Existence.ABSENT }
 
         ws.checkExternalChange()
 
@@ -179,6 +180,19 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
         val ws = loadedWorkspace()
         disk[imagePath.path] = ReadException("gateway gave up", imagePath)
         exists = { throw ReadException("gateway gave up", imagePath) }
+
+        ws.checkExternalChange()
+
+        ws.state.value.externalChange shouldBe null
+    }
+
+    @Test
+    fun `a file that cannot be verified is no evidence of anything`() = runTest2 {
+        // A denied stat, a dead provider or an unreachable host answer UNKNOWN. The lookup failed,
+        // but nothing here says the file is gone.
+        val ws = loadedWorkspace()
+        disk[imagePath.path] = ReadException("gateway gave up", imagePath)
+        exists = { Existence.UNKNOWN }
 
         ws.checkExternalChange()
 
@@ -207,7 +221,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
         ws.state.value.externalChange shouldBe ViewerExternalChange.Modified
 
         disk[imagePath.path] = ReadException("Does not exist", imagePath)
-        exists = { false }
+        exists = { Existence.ABSENT }
         ws.checkExternalChange()
 
         ws.state.value.externalChange shouldBe ViewerExternalChange.Gone
@@ -217,13 +231,13 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
     fun `Gone never returns to Modified`() = runTest2 {
         val ws = loadedWorkspace()
         disk[imagePath.path] = ReadException("Does not exist", imagePath)
-        exists = { false }
+        exists = { Existence.ABSENT }
         ws.checkExternalChange()
         ws.state.value.externalChange shouldBe ViewerExternalChange.Gone
 
         // A file recreated under the same name is a different file, and nothing here reloaded it.
         disk[imagePath.path] = lookup(imagePath, size = 4096L)
-        exists = { true }
+        exists = { Existence.PRESENT }
         ws.checkExternalChange()
 
         ws.state.value.externalChange shouldBe ViewerExternalChange.Gone
@@ -260,7 +274,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
 
         // Queued behind the first one, which is still parked in its lookup.
         disk[imagePath.path] = ReadException("Does not exist", imagePath)
-        exists = { false }
+        exists = { Existence.ABSENT }
         val second = launch(Dispatchers.Unconfined) { ws.checkExternalChange() }
 
         gate.complete(Unit)
@@ -294,7 +308,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
         val ws = workspace()
 
         disk[target.path] = ReadException("Does not exist", target)
-        exists = { it != target.path }
+        exists = { if (it == target.path) Existence.ABSENT else Existence.PRESENT }
         ws.checkExternalChange()
 
         ws.state.value.externalChange shouldBe ViewerExternalChange.Gone

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceRelationshipTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceRelationshipTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.viewer.core
 
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.GatewaySwitch
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.local.LocalPathLookup
@@ -40,7 +41,7 @@ class ViewerWorkspaceRelationshipTest : BaseTest() {
                 modifiedAt = null,
             ) as APathLookup<APath<*>>
         }
-        coEvery { gatewaySwitch.exists(any()) } returns true
+        coEvery { gatewaySwitch.existsStrict(any()) } returns Existence.PRESENT
         coEvery { imageProbe.probe(any()) } returns ProbeResult.Probed(4032, 3024, "image/jpeg")
     }
 


### PR DESCRIPTION
## What changed

Several places treated a file that merely could not be checked (permission denied, a document provider that is not responding, an unreachable network share, an unmounted volume) as if it had been deleted, and acted on that. Now only a definite "not there" counts; when the answer is unknown, the app keeps the original error or leaves things alone.

- The viewer no longer shows the "file is gone" screen for a file it simply cannot read; the real error (and its permission fix) is shown instead.
- Trash entries are kept when their location cannot be checked at startup, instead of being dropped from the trash list while the files stay behind on disk.
- Saving in the editor to a file that cannot be inspected aborts cleanly before anything is touched, and a save that landed despite a later error is no longer reported as an integrity failure.
- Sideloaded expansion (OBB) files: a backup that cannot be checked is neither dropped nor moved onto a destination nobody could inspect, and a staging folder that could not be inspected is retried on the next install rather than marked as cleaned.
- Deleting with "ignore missing" no longer counts a permission failure as a successful delete.
- Opening a trashed folder that cannot be read reports the actual reason instead of "no longer available".
- Copying or moving onto a device node, FIFO or socket with overwrite off is refused as a conflict instead of writing into it.

## Technical Context

- Root cause: the plain existence check returns false both for "absent" and for "could not look", and its local lookup maps special files to an unknown type, which also reads as absent. The strict check (`PRESENT` / `ABSENT` / `UNKNOWN`) already existed and was used at three sites; this extends it to every site where a false "absent" drove a destructive or misleading decision. Collision pre-checks whose follow-up write fails on its own were left on the plain check on purpose.
- The trash database builder moved out of the repository class into a Hilt module (same shape as the SAF location database module) so the sync could be tested without the app-only build config class; no behaviour change.
- Worth a close look: the atomic writer's reconciliation block (a present target now ends recovery regardless of what the backup probe says) and the OBB settle logic (both unknown answers throw with the backup kept in place).
- Eleven editor tests gained a strict-probe stub because the atomic writer now probes through it; no assertions changed there.
