### PR TITLE
General: Fix long file names wrapping badly in confirmation dialogs

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/TextExtensions.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/TextExtensions.kt
@@ -51,3 +51,41 @@ fun Char.isProblematicInvisible(): Boolean {
         else -> false
     }
 }
+
+private const val ZERO_WIDTH_SPACE = '\u200B'
+private val SOFT_BREAK_AFTER = setOf('-', '_', '.', '+')
+
+/** Code points a break opportunity needs on either side of it to be worth offering. */
+private const val SOFT_BREAK_MIN_EDGE = 5
+
+/**
+ * Adds zero-width spaces after separator characters so a long token can wrap at its boundaries.
+ *
+ * Without them a name that is a single unbroken token gets filled to the line's edge and split
+ * there:
+ *
+ *     termux-app_v0.118.3+github-debug_universal.ap
+ *     k
+ *
+ * Line filling is greedy, so it takes the last opportunity that fits. An opportunity with almost
+ * nothing on one side of it produces a line with almost nothing on it, hence [SOFT_BREAK_MIN_EDGE]
+ * — a trailing extension and a leading dot are the two that show up in file names:
+ *
+ *     termux-app_v0.118.3+github-debug_        .AVeryLongNameWithoutOtherSeparators
+ *     universal.apk                            (no opportunity at all, better than "." alone)
+ *
+ * Display only: the inserted characters are invisible but real, so the result must not be fed back
+ * into anything that compares, resolves or stores paths.
+ */
+fun String.withSoftBreaks(): String {
+    val builder = StringBuilder(length)
+    forEachIndexed { index, char ->
+        builder.append(char)
+        if (char !in SOFT_BREAK_AFTER) return@forEachIndexed
+        val split = index + 1
+        val fitsBefore = codePointCount(0, split) >= SOFT_BREAK_MIN_EDGE
+        val fitsAfter = codePointCount(split, length) >= SOFT_BREAK_MIN_EDGE
+        if (fitsBefore && fitsAfter) builder.append(ZERO_WIDTH_SPACE)
+    }
+    return builder.toString()
+}

--- a/app-common/src/main/java/eu/darken/butler/common/compose/BulletListItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/BulletListItem.kt
@@ -1,0 +1,66 @@
+package eu.darken.butler.common.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.withSoftBreaks
+
+/**
+ * A bullet point whose text hangs indented rather than wrapping underneath the bullet.
+ *
+ * Intended for lists of names the user has to read to confirm a destructive action, so the text is
+ * never truncated. Long tokens are wrapped at their separators, see [withSoftBreaks].
+ */
+@Composable
+fun BulletListItem(
+    modifier: Modifier = Modifier,
+    text: String,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    color: Color = Color.Unspecified,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            // The bullet and the text are separate nodes, announce them as one item
+            .semantics(mergeDescendants = true) {},
+    ) {
+        Text(
+            text = "•",
+            style = style,
+            color = color,
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            modifier = Modifier.weight(1f),
+            text = text.withSoftBreaks(),
+            style = style,
+            color = color,
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun BulletListItemPreview() {
+    Column(modifier = Modifier.padding(16.dp)) {
+        BulletListItem(text = "termux-app_v0.118.3+github-debug_universal.apk")
+        BulletListItem(text = "short.txt")
+        BulletListItem(
+            text = "A name with ordinary spaces that also needs more than a single line to fit",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app-common/src/test/java/eu/darken/butler/common/TextExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/TextExtensionsTest.kt
@@ -137,4 +137,56 @@ class TextExtensionsTest : BaseTest() {
         val filename = "photo${rlo}gpj.exe"
         filename.any { it.isProblematicInvisible() } shouldBe true
     }
+
+    @Test
+    fun `soft breaks are added after separators`() {
+        val zwsp = '\u200B'
+        "aaaaa-bbbbb_ccccc.ddddd+eeeee".withSoftBreaks() shouldBe
+            "aaaaa-${zwsp}bbbbb_${zwsp}ccccc.${zwsp}ddddd+${zwsp}eeeee"
+    }
+
+    @Test
+    fun `soft breaks leave text without separators alone`() {
+        "plainname".withSoftBreaks() shouldBe "plainname"
+        "with spaces only".withSoftBreaks() shouldBe "with spaces only"
+        "".withSoftBreaks() shouldBe ""
+    }
+
+    @Test
+    fun `soft breaks keep a short tail attached`() {
+        // Line filling is greedy, so a break offered before the extension would take it and strand
+        // the extension on a line of its own
+        "termux-app_v0.118.3+github-debug_universal.apk".withSoftBreaks() shouldBe
+            "termux-\u200Bapp_\u200Bv0.\u200B118.\u200B3+\u200Bgithub-\u200Bdebug_\u200Buniversal.apk"
+    }
+
+    @Test
+    fun `soft breaks keep a short head attached`() {
+        // A break after a leading dot would put the dot alone on the first line, which is the
+        // orphaned-bullet defect all over again
+        ".AVeryLongNameWithoutOtherSeparators".withSoftBreaks() shouldBe
+            ".AVeryLongNameWithoutOtherSeparators"
+        // Separators further in are still offered
+        ".hidden_config_name_here".withSoftBreaks() shouldBe ".hidden_\u200Bconfig_\u200Bname_here"
+    }
+
+    @Test
+    fun `soft breaks measure the tail in code points`() {
+        // Three code points, but five Chars: counting Chars would offer a break here
+        "name-😀😀a".withSoftBreaks() shouldBe "name-😀😀a"
+    }
+
+    @Test
+    fun `soft breaks never trail the text`() {
+        // A trailing zero-width space would let the line wrap after the last character, producing an
+        // empty final line
+        "archive.tar.".withSoftBreaks() shouldBe "archive.tar."
+        "-".withSoftBreaks() shouldBe "-"
+    }
+
+    @Test
+    fun `soft breaks preserve the visible text`() {
+        val name = "termux-app_v0.118.3+github-debug_universal.apk"
+        name.withSoftBreaks().filterNot { it == '\u200B' } shouldBe name
+    }
 }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/dialogs/ConfirmationDialog.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/dialogs/ConfirmationDialog.kt
@@ -12,10 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.apps.R
 import eu.darken.butler.apps.core.engine.AppItem
+import eu.darken.butler.common.compose.BulletListItem
 import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
 
 @Composable
@@ -65,19 +67,19 @@ fun ConfirmationDialog(
 
                 // Show first 5 app names
                 apps.take(5).forEach { app ->
-                    Text(
-                        text = "• ${app.label.get(context)}",
+                    BulletListItem(
+                        modifier = Modifier.padding(vertical = 2.dp),
+                        text = app.label.get(context),
                         style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(vertical = 2.dp)
                     )
                 }
 
                 if (apps.size > 5) {
-                    Text(
-                        text = "• … and ${apps.size - 5} more",
+                    BulletListItem(
+                        modifier = Modifier.padding(vertical = 2.dp),
+                        text = stringResource(R.string.apps_components_and_more, apps.size - 5),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(vertical = 2.dp)
                     )
                 }
             }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/components/ComponentsConfirmDialog.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/components/ComponentsConfirmDialog.kt
@@ -19,6 +19,7 @@ import eu.darken.butler.apps.R
 import eu.darken.butler.apps.core.details.components.ComponentEnabledState
 import eu.darken.butler.apps.core.details.components.ComponentEntry
 import eu.darken.butler.apps.core.details.components.ComponentKind
+import eu.darken.butler.common.compose.BulletListItem
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -85,19 +86,19 @@ fun ComponentsConfirmDialog(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 entries.take(5).forEach { entry ->
-                    Text(
-                        text = "• ${entry.simpleName}",
-                        style = MaterialTheme.typography.bodySmall,
+                    BulletListItem(
                         modifier = Modifier.padding(vertical = 2.dp),
+                        text = entry.simpleName,
+                        style = MaterialTheme.typography.bodySmall,
                     )
                 }
 
                 if (entries.size > 5) {
-                    Text(
-                        text = "• ${stringResource(R.string.apps_components_and_more, entries.size - 5)}",
+                    BulletListItem(
+                        modifier = Modifier.padding(vertical = 2.dp),
+                        text = stringResource(R.string.apps_components_and_more, entries.size - 5),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(vertical = 2.dp),
                     )
                 }
             }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/RemoveLocationConfirmationDialog.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/RemoveLocationConfirmationDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.BulletListItem
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -82,10 +83,9 @@ fun RemoveLocationConfirmationDialog(
                         modifier = Modifier.padding(start = 8.dp)
                     ) {
                         items.forEach { item ->
-                            Text(
-                                text = "• ${item.displayName.get(context)}",
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(vertical = 2.dp)
+                            BulletListItem(
+                                modifier = Modifier.padding(vertical = 2.dp),
+                                text = item.displayName.get(context),
                             )
                         }
                     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/DeleteConfirmationDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/DeleteConfirmationDialog.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.BulletListItem
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -104,10 +105,9 @@ fun DeleteConfirmationDialog(
                     modifier = Modifier.padding(start = 8.dp)
                 ) {
                     itemsToShow.forEach { item ->
-                        Text(
-                            text = "• ${item.name}",
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.padding(vertical = 2.dp)
+                        BulletListItem(
+                            modifier = Modifier.padding(vertical = 2.dp),
+                            text = item.name,
                         )
                     }
 
@@ -273,6 +273,21 @@ private fun DeleteConfirmationDialogPartialTrashPreview() {
         items = setOf(
             LocalPath.build("/test/file1.txt"),
             SAFPath.build("content://com.android.externalstorage.documents/tree/primary", "file2.txt"),
+        ),
+        trashEnabled = true,
+        onDismiss = {},
+        onConfirm = { _, _ -> },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DeleteConfirmationDialogLongNamesPreview() {
+    DeleteConfirmationDialog(
+        items = setOf(
+            LocalPath.build("/test/termux-app_v0.118.3+github-debug_universal.apk"),
+            LocalPath.build("/test/AVeryLongNameWithoutAnySeparatorsAtAllThatCannotBeWrappedNicely"),
         ),
         trashEnabled = true,
         onDismiss = {},


### PR DESCRIPTION
## What changed

Long file names in the confirmation dialogs are readable again. A name like `termux-app_v0.118.3+github-debug_universal.apk` used to leave the bullet stranded alone on the first line, fill the second line edge to edge, and push a single leftover letter onto a third. It now hangs indented under the bullet and wraps at one of the name's own separators:

```
• termux-app_v0.118.3+github-debug_
  universal.apk
```

This covers the four dialogs that list names before a destructive action: move to trash / delete, remove a storage location, the app-management confirmation, and the component enable/disable confirmation.

The app-management dialog's "…and N more" overflow line was untranslated and always appeared in English. It now uses the same localized string its sibling dialog already used, so it follows the app language.

## Technical Context

- Root cause: each row was one `Text` holding `"• " + name`. The space after the bullet was the only break opportunity the layout took, and the name itself is a single token with no opportunities, so it character-wrapped at the line edge. `BulletListItem` (`app-common`) splits the bullet into its own `Text` and gives the name `Modifier.weight(1f)`.
- `withSoftBreaks()` supplies the missing opportunities by inserting U+200B after `-` `_` `.` `+`. Line filling is greedy and takes the last opportunity that fits, so an opportunity with almost nothing on one side of it produces a line with almost nothing on it. Both edges are therefore held to a minimum: without the tail minimum the break lands before the extension (`universal.` / `apk`), without the head minimum a leading dot is stranded alone on a line.
- Edges are measured in code points, not `Char`s, so a name ending in astral characters is not miscounted. An inserted break can never split a surrogate pair, since every separator is ASCII.
- The inserted characters are invisible but real. They are display-only and must not reach anything that compares, resolves or stores paths. Worth a close look at the call sites for that reason.
- Names containing no separators at all still character-wrap. No break-opportunity strategy can change that, and truncating instead was rejected: this is a destructive-action confirmation, where the full name is the point.
