### PR TITLE
General: Align spacing across screens and use the full pane width

### DIFF
--- a/.claude/rules/ui-guidelines.md
+++ b/.claude/rules/ui-guidelines.md
@@ -12,12 +12,15 @@ paths: ["**/ui/**", "**/common/compose/**", "**/common/theming/**", "**/common/n
 
 ## Pane Edge Padding
 
-Horizontal insets from the pane edge come from `WorkspacePaddings` (`app-workspace`, package `eu.darken.butler.workspace.ui.common`):
+Spacing comes from `WorkspacePaddings` (`app-workspace`, package `eu.darken.butler.workspace.ui.common`). Pick by what the item is, not by which screen it is on:
 
-- `BarHorizontal` (16.dp): applied automatically by `FloatingBarStack` to every bar. Never add `Modifier.padding(horizontal = …)` to a `FloatingBar` — override the stack's `horizontalPadding` instead.
-- `ContentHorizontal` (12.dp): page content (lists, card columns) below/behind the bars.
+- `BarHorizontal` (16.dp): applied automatically by `FloatingBarStack` to every bar, and to floating chrome that lines up with one (the Explorer error cards). Never add `Modifier.padding(horizontal = …)` to a `FloatingBar` — override the stack's `horizontalPadding` instead.
+- `ContentHorizontal` (12.dp): full-width page content (lists, card columns) below/behind the bars.
+- `GridHorizontal` / `GridGutter` (both 4.dp): tile grids. The outer inset matches the gutter, so the side margins read as wide as the gaps between tiles. Change them together.
+- `ListGap` (8.dp) between standalone cards, `ListGapDense` (4.dp) between full-bleed rows that carry their own interior padding.
+- `ScreenHorizontal` (24.dp): full-window surfaces that are not a workspace pane (workspace manager, Upgrade).
 
-Exceptions: the Templates picker layout (24.dp), the Explorer grid branch (2.dp) and the Apps grid branch (8.dp). Card-internal paddings are not pane-edge insets and stay as they are.
+Card-internal paddings are not pane-edge insets and stay as they are; toolbar cards use `CutoutCardDefaults`. The Editor is deliberately full-bleed (0) because `LazyTextEditor` supplies its own gutter, and the Searcher results list spaces rows by the user's density setting rather than a token.
 
 ## Pull to Refresh
 

--- a/.claude/rules/ui-guidelines.md
+++ b/.claude/rules/ui-guidelines.md
@@ -22,6 +22,8 @@ Spacing comes from `WorkspacePaddings` (`app-workspace`, package `eu.darken.butl
 
 Card-internal paddings are not pane-edge insets and stay as they are; toolbar cards use `CutoutCardDefaults`. The Editor is deliberately full-bleed (0) because `LazyTextEditor` supplies its own gutter, and the Searcher results list spaces rows by the user's density setting rather than a token.
 
+Metadata grids (`InfoBlock` / `groupInfoEntries` in `app-common`) size themselves: pass `infoGridColumns(availableWidth)` rather than capping the content with `widthIn`.
+
 ## Pull to Refresh
 
 Workspace pages use `WorkspacePullToRefreshBox` (`app-workspace`, package `eu.darken.butler.workspace.ui.common`) and pass their top `FloatingBarStackState`. Never use `PullToRefreshBox` + `PullToRefreshDefaults.Indicator` directly: the default indicator translates vertically as the user pulls, so it emerges from behind the floating bar stack.

--- a/app-common/src/main/java/eu/darken/butler/common/compose/InfoBlock.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/InfoBlock.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 data class InfoEntry(
@@ -31,14 +32,40 @@ data class InfoEntry(
     enum class ValueStyle { DEFAULT, PATH }
 }
 
-/** Groups consecutive pairable entries two-per-row; non-pairable entries get a row of their own. */
-fun groupInfoEntries(entries: List<InfoEntry>): List<List<InfoEntry>> {
+/** Gap between the columns of a metadata grid. */
+val InfoGridGutter = 12.dp
+
+/**
+ * Narrowest a metadata column may get before [infoGridColumns] drops one. Low enough that a card
+ * inside a floating bar still pairs on a 320dp pane, which is the narrowest layout that pairs
+ * today: 320dp less the bar's two 16dp insets and the card's two 12dp insets leaves 264dp.
+ */
+val InfoGridMinColumnWidth = 120.dp
+
+/**
+ * How many columns fit into [availableWidth] with every column at least [minColumnWidth] wide.
+ *
+ * At the default width and gutter: 264dp (a bar card in a 320dp pane) and 312dp (a content card
+ * on a 360dp phone) both give 2, 700dp gives 5, 1150dp gives 8. Never fewer than one.
+ */
+fun infoGridColumns(
+    availableWidth: Dp,
+    minColumnWidth: Dp = InfoGridMinColumnWidth,
+    gutter: Dp = InfoGridGutter,
+): Int {
+    if (availableWidth <= 0.dp || minColumnWidth <= 0.dp) return 1
+    return ((availableWidth + gutter) / (minColumnWidth + gutter)).toInt().coerceAtLeast(1)
+}
+
+/** Groups consecutive pairable entries [columns]-per-row; non-pairable entries get a row of their own. */
+fun groupInfoEntries(entries: List<InfoEntry>, columns: Int = 2): List<List<InfoEntry>> {
+    val perRow = columns.coerceAtLeast(1)
     val rows = mutableListOf<List<InfoEntry>>()
     var pending = mutableListOf<InfoEntry>()
     entries.forEach { entry ->
         if (entry.pairable) {
             pending.add(entry)
-            if (pending.size == 2) {
+            if (pending.size == perRow) {
                 rows.add(pending)
                 pending = mutableListOf()
             }

--- a/app-common/src/test/java/eu/darken/butler/common/compose/InfoBlockGroupingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/InfoBlockGroupingTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.compose
 
+import androidx.compose.ui.unit.dp
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -38,6 +39,62 @@ class InfoBlockGroupingTest : BaseTest() {
             listOf(size, modified),
             listOf(created),
         )
+    }
+
+    @Test
+    fun `a wider grid packs more pairable entries per row`() {
+        val size = pairable("Size")
+        val modified = pairable("Modified")
+        val created = pairable("Created")
+        val format = pairable("Format")
+
+        groupInfoEntries(listOf(size, modified, created, format), columns = 3) shouldBe listOf(
+            listOf(size, modified, created),
+            listOf(format),
+        )
+    }
+
+    @Test
+    fun `a single column grid gives every entry its own row`() {
+        val size = pairable("Size")
+        val modified = pairable("Modified")
+
+        groupInfoEntries(listOf(size, modified), columns = 1) shouldBe listOf(
+            listOf(size),
+            listOf(modified),
+        )
+    }
+
+    @Test
+    fun `a column count below one is treated as one`() {
+        val size = pairable("Size")
+
+        groupInfoEntries(listOf(size), columns = 0) shouldBe listOf(listOf(size))
+    }
+
+    @Test
+    fun `columns follow the width available for them`() {
+        // The two narrowest cards that pair today: one in a floating bar on a 320dp pane (320
+        // less two 16dp bar insets and two 12dp card insets), one in page content on a 360dp
+        // phone (360 less two 12dp content insets and two 12dp card insets).
+        infoGridColumns(264.dp) shouldBe 2
+        infoGridColumns(312.dp) shouldBe 2
+        infoGridColumns(700.dp) shouldBe 5
+        infoGridColumns(1150.dp) shouldBe 8
+    }
+
+    @Test
+    fun `a grid too narrow for one full column still gets one`() {
+        infoGridColumns(60.dp) shouldBe 1
+        infoGridColumns(0.dp) shouldBe 1
+        infoGridColumns((-20).dp) shouldBe 1
+    }
+
+    @Test
+    fun `a narrower minimum column width fits more columns`() {
+        // The operation overview pairs from 240dp on, which is what its own minimum encodes.
+        infoGridColumns(240.dp, minColumnWidth = 114.dp) shouldBe 2
+        infoGridColumns(239.dp, minColumnWidth = 114.dp) shouldBe 1
     }
 
     @Test

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsReadyContent.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsReadyContent.kt
@@ -59,8 +59,8 @@ internal fun AppsReadyContent(
     val gridContentPadding = rememberFloatingBarContentPadding(
         topStackState = topBarStackState,
         bottomStackState = bottomBarStackState,
-        start = 8.dp,
-        end = 8.dp,
+        start = WorkspacePaddings.GridHorizontal,
+        end = WorkspacePaddings.GridHorizontal,
     )
 
     WorkspacePullToRefreshBox(
@@ -89,6 +89,7 @@ internal fun AppsReadyContent(
                             onSelectionChange = { onPageAction(AppsPageAction.Selection.SetSelection(it)) },
                         ),
                     contentPadding = listContentPadding,
+                    verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.ListGapDense),
                 ) {
                     when {
                         state.isLoading && state.apps.isEmpty() -> {
@@ -147,8 +148,8 @@ internal fun AppsReadyContent(
                             contentPadding = gridContentPadding,
                         ),
                     contentPadding = gridContentPadding,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(WorkspacePaddings.GridGutter),
+                    verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.GridGutter),
                 ) {
                     when {
                         state.isLoading && state.apps.isEmpty() -> {

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -196,7 +196,7 @@ fun BugReportWorkspacePage(
                     .fillMaxSize()
                     .nestedScroll(topBarStackState.nestedScrollConnection),
                 contentPadding = listContentPadding,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.ListGap),
             ) {
                 items(listReports, key = { it.id }) { info ->
                     ReportCard(info = info, onClick = { onReportClick(info) })

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
@@ -37,6 +37,7 @@ import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
 import eu.darken.butler.explorer.ui.explorer.items.ExplorerItemRenderer
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 
@@ -84,8 +85,8 @@ internal fun ExplorerGridContent(
             enabled = { id -> explorerDragSelectClaims(state, id, dragPayloadFactory) },
             contentPadding = contentPadding,
         ),
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.GridGutter),
+        horizontalArrangement = Arrangement.spacedBy(WorkspacePaddings.GridGutter),
         contentPadding = contentPadding,
     ) {
         if (state.items == null) {
@@ -183,7 +184,7 @@ private fun ExplorerGridContentPreview() {
             vm = null,
             contentFocusedItem = null,
             gridState = rememberLazyGridState(),
-            contentPadding = PaddingValues(2.dp),
+            contentPadding = PaddingValues(WorkspacePaddings.GridHorizontal),
         )
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
@@ -59,7 +59,7 @@ internal fun ExplorerListContent(
             onSelectionChange = { ids -> vm?.setSelection(explorerDragSelectItems(state, ids)) },
             enabled = { id -> explorerDragSelectClaims(state, id, dragPayloadFactory) },
         ),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.ListGapDense),
         contentPadding = contentPadding,
     ) {
         if (state.items == null) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
@@ -94,8 +94,8 @@ internal fun ExplorerReadyContent(
     val gridContentPadding = rememberFloatingBarContentPadding(
         topStackState = topBarStackState,
         bottomStackState = bottomBarStackState,
-        start = 2.dp,
-        end = 2.dp,
+        start = WorkspacePaddings.GridHorizontal,
+        end = WorkspacePaddings.GridHorizontal,
     )
 
     val isDragHovered = remember { mutableStateOf(false) }
@@ -192,7 +192,7 @@ internal fun ExplorerReadyContent(
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .offset { IntOffset(x = 0, y = topBarStackState.contentPaddingPx.roundToInt()) }
-                        .padding(horizontal = 16.dp),
+                        .padding(horizontal = WorkspacePaddings.BarHorizontal),
                     archiveName = error.container.name,
                     busy = archiveBusy,
                     onExtract = { vm?.extractUnbrowsableArchive(error.container) },
@@ -205,7 +205,7 @@ internal fun ExplorerReadyContent(
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .offset { IntOffset(x = 0, y = topBarStackState.contentPaddingPx.roundToInt()) }
-                        .padding(horizontal = 16.dp),
+                        .padding(horizontal = WorkspacePaddings.BarHorizontal),
                     title = stringResource(R.string.explorer_navigation_error_title),
                     error = error,
                     onShareError = { vm?.shareNavigationError() },

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspacePage.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspacePage.kt
@@ -119,7 +119,7 @@ fun HistoryWorkspacePage(
                 top = topBarStackState.contentPaddingDp(),
                 bottom = navBarInset + 16.dp,
             ),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.ListGap),
         ) {
             if (state.entryCount == 0) {
                 item(key = "empty") {

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -262,6 +262,12 @@ fun SearcherWorkspacePage(
             start = WorkspacePaddings.ContentHorizontal,
             end = WorkspacePaddings.ContentHorizontal,
         )
+        val gridContentPaddingValues = rememberFloatingBarContentPadding(
+            topStackState = topBarStackState,
+            bottomStackState = bottomBarStackState,
+            start = WorkspacePaddings.GridHorizontal,
+            end = WorkspacePaddings.GridHorizontal,
+        )
 
         // Conditional rendering: Idle state (templates + history) vs Results mode
         val hasNoQuery = currentState.filenameQuery.isBlank() &&
@@ -473,11 +479,11 @@ fun SearcherWorkspacePage(
                                         !currentState.selectionState.isSelectionMode ||
                                         key !in currentState.selectionState.selectedResultIds
                                 },
-                                contentPadding = contentPaddingValues,
+                                contentPadding = gridContentPaddingValues,
                             ),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = contentPaddingValues
+                        verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.GridGutter),
+                        horizontalArrangement = Arrangement.spacedBy(WorkspacePaddings.GridGutter),
+                        contentPadding = gridContentPaddingValues
                     ) {
                         // Show setup card if needed
                         if (currentState.needsSetup && currentState.workspaceState.searchTargets.isNotEmpty()) {

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
@@ -69,6 +69,7 @@ import eu.darken.butler.templates.ui.preview.TemplatesMockDataProvider
 import eu.darken.butler.templates.ui.tour.TemplatesTour
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.insets.paneInsets
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -167,7 +168,7 @@ fun TemplatesWorkspacePage(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 24.dp),
+                .padding(horizontal = WorkspacePaddings.ContentHorizontal),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.Start,
             contentPadding = PaddingValues(

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ApkFileContent.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ApkFileContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -50,8 +50,10 @@ import androidx.core.graphics.createBitmap
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.InfoBlock
 import eu.darken.butler.common.compose.InfoEntry
+import eu.darken.butler.common.compose.InfoGridGutter
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.groupInfoEntries
+import eu.darken.butler.common.compose.infoGridColumns
 import eu.darken.butler.common.pkgs.apk.ApkArchiveInfo
 import eu.darken.butler.common.pkgs.apk.ApkSignature
 import eu.darken.butler.common.pkgs.apk.apkVersionText
@@ -59,6 +61,7 @@ import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.viewer.R
 import eu.darken.butler.viewer.core.ApkInstallState
 import eu.darken.butler.viewer.core.VersionComparison
+import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 
 /**
  * What an APK archive says about itself. A lazy list, not a scrolling column: the permission list
@@ -85,9 +88,7 @@ fun ApkFileContent(
 ) {
     var permissionsExpanded by rememberSaveable { mutableStateOf(initiallyPermissionsExpanded) }
     val permissions = remember(apkInfo) { apkInfo.requestedPermissions.distinct().sorted() }
-    val itemModifier = Modifier
-        .widthIn(max = 480.dp)
-        .fillMaxWidth()
+    val itemModifier = Modifier.fillMaxWidth()
 
     LazyColumn(
         modifier = modifier
@@ -100,8 +101,7 @@ fun ApkFileContent(
                 else base.pointerInput(onToggleChrome) { detectTapGestures { onToggleChrome() } }
             },
         contentPadding = contentPadding,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(WorkspacePaddings.ListGap),
     ) {
         item {
             ApkHeader(
@@ -298,20 +298,29 @@ private fun ApkInfoCard(
         ),
     ) {
         SelectionContainer {
-            Column(
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 12.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                groupInfoEntries(entries).forEach { row ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.Top,
-                    ) {
-                        row.forEach { InfoBlock(entry = it, modifier = Modifier.weight(1f)) }
-                        if (row.size == 1 && row.first().pairable) Spacer(modifier = Modifier.weight(1f))
+                val columns = infoGridColumns(maxWidth)
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    groupInfoEntries(entries, columns).forEach { row ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(InfoGridGutter),
+                            verticalAlignment = Alignment.Top,
+                        ) {
+                            row.forEach { InfoBlock(entry = it, modifier = Modifier.weight(1f)) }
+                            // Keeps a short trailing run of pairable entries in their columns so
+                            // the grid stays aligned down the card.
+                            if (row.first().pairable) {
+                                repeat(columns - row.size) { Spacer(modifier = Modifier.weight(1f)) }
+                            }
+                        }
                     }
                 }
             }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/FileInfoCard.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/FileInfoCard.kt
@@ -33,8 +33,10 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.InfoBlock
 import eu.darken.butler.common.compose.InfoEntry
+import eu.darken.butler.common.compose.InfoGridGutter
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.groupInfoEntries
+import eu.darken.butler.common.compose.infoGridColumns
 import eu.darken.butler.common.files.metadata.Ownership
 import eu.darken.butler.common.files.metadata.Permissions
 import eu.darken.butler.common.DateTimeStyle
@@ -81,6 +83,7 @@ fun FileInfoCard(
             fileInfo = fileInfo,
             initiallyExpanded = initiallyExpanded,
             pairPermissions = permissionsFitHalfWidth(maxWidth),
+            columns = infoGridColumns(maxWidth - CardHorizontalPadding * 2),
         )
     }
 }
@@ -90,6 +93,7 @@ private fun FileInfoCardContent(
     fileInfo: ViewerFileInfo,
     initiallyExpanded: Boolean,
     pairPermissions: Boolean,
+    columns: Int,
 ) {
     val entries = buildList<InfoEntry> {
         fileInfo.size?.let {
@@ -187,8 +191,6 @@ private fun FileInfoCardContent(
     }
 
     var expanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
-    val rows = groupInfoEntries(entries)
-    val canCollapse = rows.size > 1
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -197,10 +199,12 @@ private fun FileInfoCardContent(
         ),
     ) {
         Box(modifier = Modifier.fillMaxWidth()) {
+            val rows = groupInfoEntries(entries, columns)
+            val canCollapse = rows.size > 1
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .padding(horizontal = CardHorizontalPadding, vertical = 8.dp)
                     .animateContentSize(),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
@@ -211,12 +215,15 @@ private fun FileInfoCardContent(
                             // The toggle floats over the card's top end corner, so only the row it
                             // would overlap gets out of its way.
                             .padding(end = if (index == 0 && canCollapse) ToggleReservedWidth else 0.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(InfoGridGutter),
                         verticalAlignment = Alignment.Top,
                     ) {
                         row.forEach { InfoBlock(entry = it, modifier = Modifier.weight(1f)) }
-                        // Keeps an odd trailing pairable entry at half width so the grid stays aligned.
-                        if (row.size == 1 && row.first().pairable) Spacer(modifier = Modifier.weight(1f))
+                        // Keeps a short trailing run of pairable entries in their columns so the
+                        // grid stays aligned down the card.
+                        if (row.first().pairable) {
+                            repeat(columns - row.size) { Spacer(modifier = Modifier.weight(1f)) }
+                        }
                     }
                 }
             }
@@ -247,6 +254,8 @@ private fun FileInfoCardContent(
 
 /** Footprint of the expand/collapse button, and the end inset the first row reserves for it. */
 private val ToggleReservedWidth = 40.dp
+
+private val CardHorizontalPadding = 12.dp
 
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/common/WorkspacePaddings.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/common/WorkspacePaddings.kt
@@ -6,6 +6,22 @@ object WorkspacePaddings {
     /** Inset from the pane edge to a floating bar. Applied automatically by FloatingBarStack. */
     val BarHorizontal = 16.dp
 
-    /** Inset from the pane edge to page content (lists, card columns). */
+    /** Inset from the pane edge to full-width page content (lists, card columns). */
     val ContentHorizontal = 12.dp
+
+    /** Inset from the pane edge to a tile grid. Matches [GridGutter] so the margins read as wide
+     * as the gaps between tiles. */
+    val GridHorizontal = 4.dp
+
+    /** Gap between grid tiles, horizontally and vertically. */
+    val GridGutter = 4.dp
+
+    /** Gap between standalone cards in a list. */
+    val ListGap = 8.dp
+
+    /** Gap between full-bleed rows, which carry their own interior padding. */
+    val ListGapDense = 4.dp
+
+    /** Inset from the window edge on full-window surfaces that are not a workspace pane. */
+    val ScreenHorizontal = 24.dp
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -24,9 +24,11 @@ import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.InfoBlock
 import eu.darken.butler.common.compose.InfoEntry
+import eu.darken.butler.common.compose.InfoGridGutter
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.asComposable
 import eu.darken.butler.common.compose.groupInfoEntries
+import eu.darken.butler.common.compose.infoGridColumns
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.formatDuration
 import eu.darken.butler.common.formatRelativeTime
@@ -38,8 +40,11 @@ import eu.darken.butler.workspace.ui.operations.bar.operationStateVisuals
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
-/** Below this the two-column grid leaves ~48dp per column; every entry goes full width instead. */
+/** Below this a two-column grid leaves ~48dp per column, so the section drops to one column. */
 internal val OverviewPairingMinWidth = 240.dp
+
+/** Half of [OverviewPairingMinWidth] less the gutter, so the second column appears exactly there. */
+private val OverviewMinColumnWidth = (OverviewPairingMinWidth - InfoGridGutter) / 2
 
 /**
  * Result is never paired and never capped: a move/copy summary concatenates up to four plural
@@ -150,19 +155,16 @@ private fun OperationOverviewGrid(
     )
 
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
-        val entries = when {
-            maxWidth >= OverviewPairingMinWidth -> baseEntries
-            else -> baseEntries.map { it.copy(pairable = false) }
-        }
+        val columns = infoGridColumns(maxWidth, minColumnWidth = OverviewMinColumnWidth)
         // Status is always first, and referential identity is what carries the state icon -
         // identity cannot collide, whereas a label comparison breaks once two entries share a label.
-        val statusEntry = entries.first()
+        val statusEntry = baseEntries.first()
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            groupInfoEntries(entries).forEach { row ->
+            groupInfoEntries(baseEntries, columns).forEach { row ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(InfoGridGutter),
                     verticalAlignment = Alignment.Top,
                 ) {
                     row.forEach { entry ->
@@ -184,8 +186,11 @@ private fun OperationOverviewGrid(
                             },
                         )
                     }
-                    // Keeps an odd trailing pairable entry at half width so the grid stays aligned.
-                    if (row.size == 1 && row.first().pairable) Spacer(modifier = Modifier.weight(1f))
+                    // Keeps a short trailing run of pairable entries in their columns so the grid
+                    // stays aligned down the section.
+                    if (row.first().pairable) {
+                        repeat(columns - row.size) { Spacer(modifier = Modifier.weight(1f)) }
+                    }
                 }
             }
         }

--- a/app/src/gplay/java/eu/darken/butler/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/butler/upgrade/ui/UpgradeScreen.kt
@@ -40,6 +40,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.navigation.NavigationEventHandler
+import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 
 @Composable
 fun UpgradeScreenHost(
@@ -214,7 +215,12 @@ internal fun UpgradeScreen(
     ) { paddingValues ->
         UpgradeScreenContent(
             paddingValues = paddingValues,
-            contentPadding = PaddingValues(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 32.dp),
+            contentPadding = PaddingValues(
+                start = WorkspacePaddings.ScreenHorizontal,
+                top = 16.dp,
+                end = WorkspacePaddings.ScreenHorizontal,
+                bottom = 32.dp,
+            ),
         ) {
             if (ownedState == null) {
                 // Owners get the mascot inside the congrats hero card instead. Once a grace

--- a/app/src/main/java/eu/darken/butler/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/butler/upgrade/ui/UpgradeContent.kt
@@ -53,6 +53,7 @@ import eu.darken.butler.common.compose.ButlerMascotMode
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.brandTitle
+import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 
 // Shared upgrade-screen primitives used by both the gplay and foss upgrade screens, mirroring
 // SD Maid SE's upgrade design system: a centered, max-width scrolling column of tonal "section"
@@ -154,7 +155,10 @@ internal fun UpgradeScreenScaffold(
 internal fun UpgradeScreenContent(
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+    contentPadding: PaddingValues = PaddingValues(
+        horizontal = WorkspacePaddings.ScreenHorizontal,
+        vertical = 24.dp,
+    ),
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Box(

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
@@ -26,6 +26,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.manager.rows.WorkspaceBadgeExplanationCard
 import eu.darken.butler.workspace.ui.manager.rows.WorkspaceGridItem
 import eu.darken.butler.workspace.ui.manager.rows.WorkspaceStatusCard
@@ -106,8 +107,8 @@ fun WorkspaceManagerGridLayout(
         contentPadding = PaddingValues(
             top = paddingValues.calculateTopPadding(),
             bottom = paddingValues.calculateBottomPadding(),
-            start = 24.dp,
-            end = 24.dp
+            start = WorkspacePaddings.ScreenHorizontal,
+            end = WorkspacePaddings.ScreenHorizontal
         ),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)


### PR DESCRIPTION
## What changed

Spacing was picked per screen, so screens that show the same kind of content did not line up. The tile grids in Explorer, Apps and Searcher each used a different combination of outer margin and gap between tiles, which left two of them looking inset on one side, and the Templates page sat further from the edge than every other workspace page. Spacing now follows what is being shown rather than which screen shows it, so grids have even margins, Templates matches its neighbours, and the Apps list gets the small gap between rows it was missing.

The APK and app bundle details also stopped being a narrow strip. They were capped at a fixed width and centred, so opening one on a tablet or in a wide pane wasted most of the space on empty margins. Details now use the pane they are given, and the metadata blocks (version, SDK levels, size, permissions and the file info card) add columns as the pane widens instead of stretching a short value across half a screen. The same applies to the file info card in the viewer and to the operation details overview.

## Technical Context

- `WorkspacePaddings` gains `GridHorizontal`/`GridGutter` (4dp, deliberately equal so a grid's outer margin matches its gutters), `ListGap`/`ListGapDense` (8/4dp) and `ScreenHorizontal` (24dp). `ContentHorizontal` and `BarHorizontal` keep their values. The Editor stays full-bleed and the Searcher results list keeps its user-selected density; neither becomes a token.
- The 480dp cap in the APK viewer had no recorded rationale and was masking a real problem: `groupInfoEntries` paired entries two-per-row at any width, so each block grew with the pane while holding a short label and value. It now takes a column count from `infoGridColumns`, and the cap is gone.
- `InfoGridMinColumnWidth` is 120dp because that is the narrowest column that ships today: a `FileInfoCard` lives inside a `FloatingBar`, so a 320dp pane leaves 264dp after the bar's and the card's insets, and that has to keep holding two columns. A larger floor silently drops those panes to one column.
- Worth a close look: the trailing `Spacer` logic now fills every unused column rather than assuming a half-width row, and `OperationOverviewSection`'s old `OverviewPairingMinWidth` branch became a minimum column width that preserves 240dp as the exact point where its second column appears.
- Known limit, pre-existing and unchanged here: when the file info card is collapsible, its first row gives up another 40dp to the expand toggle, so that row's columns are narrower than the rows below it. Computing columns from the toggle-inset width would fix the alignment but drop a 320dp pane back to one column, so it is left as is.
