### PR TITLE
Explorer: Suggest only openable storage apps and show their icons

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/StorageProviderSuggester.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/storage/saf/StorageProviderSuggester.kt
@@ -6,26 +6,51 @@ import android.content.pm.ProviderInfo
 import android.provider.DocumentsContract
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.butler.common.ca.CaDrawable
+import eu.darken.butler.common.ca.CaString
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.getPackageInfo2
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.withContext
 
+/**
+ * A launchable third-party app that serves storage through a documents provider.
+ *
+ * [lastUpdateTime] is what tells an icon cached before an app update from the current one.
+ */
+data class StorageProviderApp(
+    override val packageName: String,
+    val appLabel: String,
+    val lastUpdateTime: Long,
+) : Pkg {
+    override val id: Pkg.Id get() = Pkg.Id(packageName)
+    override val label: CaString get() = appLabel.toCaString()
+    override val icon: CaDrawable? get() = null
+}
+
 data class StorageProviderSuggestion(
-    val packageName: String,
+    val app: StorageProviderApp,
     val authority: String,
-    val label: String,
-    /** Non-null means the picker can be opened directly at this app's storage root. */
-    val known: KnownStorageProvider?,
-)
+    val known: KnownStorageProvider,
+) {
+    val packageName: String get() = app.packageName
+    val label: String get() = app.appLabel
+}
 
 /**
- * Finds installed apps that expose storage through a documents provider, so they can be offered
- * as add-storage shortcuts instead of leaving the user to find them in the system picker.
+ * Finds installed apps whose storage the system picker can be opened at directly, so they can be
+ * offered as add-storage shortcuts.
+ *
+ * Only curated providers qualify: whether a provider's roots can be picked as a folder at all is
+ * only visible to the picker itself, so an uncurated app would be offered without knowing if the
+ * picker can even show it.
  */
 @Reusable
 class StorageProviderSuggester @Inject constructor(
@@ -55,22 +80,21 @@ class StorageProviderSuggester @Inject constructor(
                     null
                 }
             }
-            .groupBy { it.packageName }
-            .map { (_, candidates) -> candidates.preferred() }
-            .sortedWith(compareBy({ it.known == null }, { it.label.lowercase() }))
+            .distinctBy { it.packageName }
+            .sortedBy { it.label.lowercase() }
             .also { log(TAG) { "getSuggestions(): $it" } }
     }
 
     /**
-     * Label of the app owning [authority], or null when that app would not be suggested either.
+     * The app owning [authority], or null for platform providers and apps without a launcher entry.
      *
-     * Used to pre-fill the location name after a grant, so an ordinary folder picked through the
-     * system picker keeps its path-derived default name instead of being labelled after the
-     * platform provider that served it.
+     * Lets a location granted through the system picker be labelled and iconed after the app that
+     * serves it, while an ordinary folder keeps its path-derived default name instead of being
+     * labelled after the platform provider.
      */
-    suspend fun labelForAuthority(authority: String): String? = withContext(dispatcherProvider.IO) {
+    suspend fun appForAuthority(authority: String): StorageProviderApp? = withContext(dispatcherProvider.IO) {
         try {
-            context.packageManager.resolveContentProvider(authority, 0)?.toSuggestion()?.label
+            context.packageManager.resolveContentProvider(authority, 0)?.toApp()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -79,7 +103,7 @@ class StorageProviderSuggester @Inject constructor(
         }
     }
 
-    private fun ProviderInfo.toSuggestion(): StorageProviderSuggestion? {
+    private fun ProviderInfo.toApp(): StorageProviderApp? {
         val authority = authority ?: return null
         if (!exported) return null
         if (packageName == context.packageName) return null
@@ -88,17 +112,23 @@ class StorageProviderSuggester @Inject constructor(
         // and none of them has a launcher entry the user could act on.
         if (context.packageManager.getLaunchIntentForPackage(packageName) == null) return null
 
-        return StorageProviderSuggestion(
+        val packageInfo = context.packageManager.getPackageInfo2(Pkg.Id(packageName)) ?: return null
+
+        return StorageProviderApp(
             packageName = packageName,
-            authority = authority,
-            label = context.packageManager.getApplicationLabel(applicationInfo).toString(),
-            known = KnownStorageProvider.forPackage(packageName),
+            appLabel = context.packageManager.getApplicationLabel(applicationInfo).toString(),
+            lastUpdateTime = packageInfo.lastUpdateTime,
         )
     }
 
-    /** An app may declare several providers, prefer the one we can deep-link into. */
-    private fun List<StorageProviderSuggestion>.preferred(): StorageProviderSuggestion =
-        firstOrNull { it.known != null && it.authority == it.known.authorityFor(it.packageName) } ?: first()
+    /** An app may declare several providers, only the one we can deep-link into is a suggestion. */
+    private fun ProviderInfo.toSuggestion(): StorageProviderSuggestion? {
+        val known = KnownStorageProvider.forPackage(packageName) ?: return null
+        if (authority != known.authorityFor(packageName)) return null
+        val app = toApp() ?: return null
+
+        return StorageProviderSuggestion(app = app, authority = authority, known = known)
+    }
 
     companion object {
         private val TAG = logTag("SAF", "ProviderSuggester")

--- a/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/storage/saf/StorageProviderSuggesterTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.common.storage.saf
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ProviderInfo
 import android.content.pm.ResolveInfo
@@ -54,6 +55,12 @@ class StorageProviderSuggesterTest : BaseTest() {
             val pkg = firstArg<ApplicationInfo>().packageName
             fakes.first { it.pkg == pkg }.label ?: throw IllegalStateException("No label for $pkg")
         }
+        every { pm.getPackageInfo(any<String>(), any<Int>()) } answers {
+            PackageInfo().apply {
+                packageName = firstArg()
+                lastUpdateTime = UPDATED_AT
+            }
+        }
         every { pm.resolveContentProvider(any<String>(), any<Int>()) } answers {
             val authority = firstArg<String>()
             resolveInfos.firstOrNull { it.providerInfo.authority == authority }?.providerInfo
@@ -66,110 +73,131 @@ class StorageProviderSuggesterTest : BaseTest() {
     }
 
     @Test
-    fun `third party provider with a launcher is suggested`() = runTest {
-        val suggester = create(FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"))
+    fun `curated provider with a launcher is suggested`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"))
 
         suggester.getSuggestions() shouldBe listOf(
             StorageProviderSuggestion(
-                packageName = "com.tabby",
-                authority = "com.tabby.documents",
-                label = "Tabby",
-                known = null,
+                app = StorageProviderApp(packageName = "com.termux", appLabel = "Termux", lastUpdateTime = UPDATED_AT),
+                authority = "com.termux.documents",
+                known = KnownStorageProvider.TERMUX,
             )
         )
     }
 
     @Test
-    fun `our own provider is excluded`() = runTest {
-        val suggester = create(FakeProvider(pkg = OUR_PKG, authority = "$OUR_PKG.provider.documents"))
+    fun `uncurated third party provider is not suggested`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"))
 
         suggester.getSuggestions().shouldBeEmpty()
     }
 
     @Test
-    fun `platform providers are excluded`() = runTest {
+    fun `curated app's other providers are not suggested`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.termux", authority = "com.termux.files", label = "Termux"),
+            FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"),
+        )
+
+        suggester.getSuggestions().map { it.authority } shouldBe listOf("com.termux.documents")
+    }
+
+    @Test
+    fun `curated provider without a launcher entry is excluded`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.termux", authority = "com.termux.documents", hasLauncher = false),
+        )
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `non exported curated provider is excluded`() = runTest {
+        val suggester = create(
+            FakeProvider(pkg = "com.termux", authority = "com.termux.documents", exported = false),
+        )
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `a failing curated provider is skipped`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = null))
+
+        suggester.getSuggestions().shouldBeEmpty()
+    }
+
+    @Test
+    fun `app lookup resolves a third party authority`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"))
+
+        suggester.appForAuthority("com.tabby.documents") shouldBe StorageProviderApp(
+            packageName = "com.tabby",
+            appLabel = "Tabby",
+            lastUpdateTime = UPDATED_AT,
+        )
+    }
+
+    @Test
+    fun `app lookup returns null for a failing provider`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = null))
+
+        suggester.appForAuthority("com.tabby.documents").shouldBeNull()
+    }
+
+    @Test
+    fun `app lookup returns null for an unknown authority`() = runTest {
+        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"))
+
+        suggester.appForAuthority("com.example.documents").shouldBeNull()
+    }
+
+    @Test
+    fun `app lookup returns null for our own provider`() = runTest {
+        val suggester = create(FakeProvider(pkg = OUR_PKG, authority = "$OUR_PKG.provider.documents"))
+
+        suggester.appForAuthority("$OUR_PKG.provider.documents").shouldBeNull()
+    }
+
+    @Test
+    fun `app lookup returns null for platform authorities`() = runTest {
         val suggester = create(
             FakeProvider(pkg = "com.android.externalstorage", authority = "com.android.externalstorage.documents"),
             FakeProvider(pkg = "com.android.providers.downloads", authority = "com.android.providers.downloads.documents"),
             FakeProvider(pkg = "com.android.providers.media.module", authority = "com.android.providers.media.documents"),
             FakeProvider(pkg = "com.android.mtp", authority = "com.android.mtp.documents"),
             FakeProvider(pkg = "com.android.documentsui", authority = "com.android.documentsui.archives"),
-            FakeProvider(pkg = "com.google.android.documentsui", authority = "com.android.documentsui.archives"),
         )
 
-        suggester.getSuggestions().shouldBeEmpty()
+        listOf(
+            "com.android.externalstorage.documents",
+            "com.android.providers.downloads.documents",
+            "com.android.providers.media.documents",
+            "com.android.mtp.documents",
+            "com.android.documentsui.archives",
+        ).forEach { suggester.appForAuthority(it).shouldBeNull() }
     }
 
     @Test
-    fun `provider without a launcher entry is excluded`() = runTest {
+    fun `app lookup returns null for a provider without a launcher entry`() = runTest {
         val suggester = create(
             FakeProvider(pkg = "com.android.shell", authority = "com.android.shell.documents", hasLauncher = false),
         )
 
-        suggester.getSuggestions().shouldBeEmpty()
+        suggester.appForAuthority("com.android.shell.documents").shouldBeNull()
     }
 
     @Test
-    fun `non exported provider is excluded`() = runTest {
+    fun `app lookup returns null for a non exported provider`() = runTest {
         val suggester = create(
             FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", exported = false),
         )
 
-        suggester.getSuggestions().shouldBeEmpty()
-    }
-
-    @Test
-    fun `curated providers are tagged and sorted first`() = runTest {
-        val suggester = create(
-            FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"),
-            FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"),
-        )
-
-        val suggestions = suggester.getSuggestions()
-
-        suggestions.map { it.packageName } shouldBe listOf("com.termux", "com.tabby")
-        suggestions[0].known shouldBe KnownStorageProvider.TERMUX
-        suggestions[1].known.shouldBeNull()
-    }
-
-    @Test
-    fun `a failing provider does not remove the others`() = runTest {
-        val suggester = create(
-            FakeProvider(pkg = "com.broken", authority = "com.broken.documents", label = null),
-            FakeProvider(pkg = "com.tabby", authority = "com.tabby.documents", label = "Tabby"),
-        )
-
-        suggester.getSuggestions().map { it.packageName } shouldBe listOf("com.tabby")
-    }
-
-    @Test
-    fun `label lookup resolves a third party authority`() = runTest {
-        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"))
-
-        suggester.labelForAuthority("com.termux.documents") shouldBe "Termux"
-    }
-
-    @Test
-    fun `label lookup returns null for an unknown authority`() = runTest {
-        val suggester = create(FakeProvider(pkg = "com.termux", authority = "com.termux.documents", label = "Termux"))
-
-        suggester.labelForAuthority("com.example.documents").shouldBeNull()
-    }
-
-    @Test
-    fun `label lookup returns null for a platform authority`() = runTest {
-        val suggester = create(
-            FakeProvider(
-                pkg = "com.android.externalstorage",
-                authority = "com.android.externalstorage.documents",
-                label = "External Storage",
-            ),
-        )
-
-        suggester.labelForAuthority("com.android.externalstorage.documents").shouldBeNull()
+        suggester.appForAuthority("com.tabby.documents").shouldBeNull()
     }
 
     companion object {
         private const val OUR_PKG = "eu.darken.butler.debug"
+        private const val UPDATED_AT = 1000L
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/DeviceLocationLoader.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/DeviceLocationLoader.kt
@@ -32,6 +32,7 @@ import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.common.root.canUseRootNow
 import eu.darken.butler.common.storage.StorageEnvironment
 import eu.darken.butler.common.storage.StorageManager2
+import eu.darken.butler.common.storage.saf.StorageProviderSuggester
 import eu.darken.butler.explorer.R
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.permissions.core.PathRequirements
@@ -49,6 +50,7 @@ class DeviceLocationLoader @AssistedInject constructor(
     private val gatewaySwitch: GatewaySwitch,
     private val storageManager2: StorageManager2,
     private val safLocationManager: SAFLocationManager,
+    private val storageProviderSuggester: StorageProviderSuggester,
     private val rootManager: RootManager,
     private val adbManager: AdbManager,
 ) {
@@ -175,6 +177,7 @@ class DeviceLocationLoader @AssistedInject constructor(
 
         // Convert SAF locations to storage items (without filesystem info)
         val safStorage = safLocations.map { location ->
+            val providerApp = location.treeUri.authority?.let { storageProviderSuggester.appForAuthority(it) }
             ExplorerItem.Storage.SAF(
                 location = location,
                 displayIcon = Icons.TwoTone.FolderShared,
@@ -182,6 +185,7 @@ class DeviceLocationLoader @AssistedInject constructor(
                 target = ExplorerNavigation.Target.Directory(location.path),
                 totalBytes = null,
                 availableBytes = null,
+                providerApp = providerApp,
             )
         }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/ExplorerItem.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/ExplorerItem.kt
@@ -13,6 +13,7 @@ import eu.darken.butler.common.files.saf.location.SAFLocation
 import eu.darken.butler.common.files.smb.SmbEndpointState
 import eu.darken.butler.common.files.smb.credentials.SmbCredentialStore
 import eu.darken.butler.common.files.smb.location.SmbLocation
+import eu.darken.butler.common.storage.saf.StorageProviderApp
 import eu.darken.butler.explorer.core.ExplorerNavigation
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -67,6 +68,7 @@ sealed interface ExplorerItem {
             override val id: String get() = "local-$localId"
         }
 
+        /** [providerApp] is the app serving this location, null when a platform provider does. */
         data class SAF(
             val location: SAFLocation,
             override val displayName: CaString,
@@ -74,6 +76,7 @@ sealed interface ExplorerItem {
             override val target: ExplorerNavigation.Target.Directory,
             override val totalBytes: Long? = null,
             override val availableBytes: Long? = null,
+            val providerApp: StorageProviderApp? = null,
         ) : Storage {
             override val id: String get() = "saf-${location.id}"
             override val canWrite: Boolean? get() = location.hasWritePermission

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationController.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -54,12 +55,19 @@ class ExplorerSafLocationController(
     /**
      * Derived from the sheet, never written by a side job: [flatMapLatest] cancels a load whose
      * sheet was closed or reopened, so a stale list can neither overwrite a newer one nor be shown
-     * again after an app was uninstalled.
+     * again after an app was uninstalled. An app whose provider is already granted is not offered
+     * again.
      */
     val storageSuggestions: StateFlow<List<StorageProviderSuggestion>> = showAddStorageSheetFlow
         .flatMapLatest { visible ->
             when {
-                visible -> flow { emit(storageProviderSuggester.getSuggestions()) }
+                visible -> combine(
+                    flow { emit(storageProviderSuggester.getSuggestions()) },
+                    safLocationManager.locations,
+                ) { suggestions, locations ->
+                    val granted = locations.mapNotNull { it.treeUri.authority }.toSet()
+                    suggestions.filter { it.authority !in granted }
+                }
                 else -> flowOf(emptyList())
             }
         }
@@ -97,16 +105,10 @@ class ExplorerSafLocationController(
     fun addSuggestedSAFLocation(suggestion: StorageProviderSuggestion) = doLaunch {
         log(tag) { "addSuggestedSAFLocation($suggestion)" }
         _pendingSAFPickerGrant.value = null
-        val known = suggestion.known
-        val intent = when {
-            known != null -> safPickerIntentBuilder.buildPickerIntent(
-                authority = known.authorityFor(suggestion.packageName),
-                rootId = known.rootIdFor(suggestion.packageName),
-            )
-            else -> Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
-                putExtra("android.content.extra.SHOW_ADVANCED", true)
-            }
-        }
+        val intent = safPickerIntentBuilder.buildPickerIntent(
+            authority = suggestion.authority,
+            rootId = suggestion.known.rootIdFor(suggestion.packageName),
+        )
         safPickerEvents.emit(intent)
     }
 
@@ -121,7 +123,7 @@ class ExplorerSafLocationController(
 
             val locationId = safLocationManager.grantPermission(treeUri)
 
-            val providerLabel = treeUri.authority?.let { storageProviderSuggester.labelForAuthority(it) }
+            val providerLabel = treeUri.authority?.let { storageProviderSuggester.appForAuthority(it)?.appLabel }
             // Seed the label before the refresh below, otherwise the list renders the path-derived
             // fallback name until the naming dialog is confirmed. Re-granting a location the user
             // renamed keeps that name, which is what gets offered in the dialog then.

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/AddDeviceStorageSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/AddDeviceStorageSheet.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.FolderShared
-import androidx.compose.material.icons.twotone.Terminal
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -30,8 +29,10 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.storage.saf.KnownStorageProvider
+import eu.darken.butler.common.storage.saf.StorageProviderApp
 import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.R
+import eu.darken.butler.explorer.ui.explorer.items.AppIconImage
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 
 @Composable
@@ -144,23 +145,27 @@ private fun SuggestionRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
+        AppIconImage(
             modifier = Modifier
                 .size(40.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .background(MaterialTheme.colorScheme.secondaryContainer),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = when {
-                    suggestion.known != null -> Icons.TwoTone.Terminal
-                    else -> Icons.TwoTone.FolderShared
-                },
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                modifier = Modifier.size(22.dp)
-            )
-        }
+                .clip(RoundedCornerShape(12.dp)),
+            pkg = suggestion.app,
+            fallback = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(MaterialTheme.colorScheme.secondaryContainer),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.TwoTone.FolderShared,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            },
+        )
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -168,11 +173,7 @@ private fun SuggestionRow(
                 style = MaterialTheme.typography.bodyLarge,
             )
             Text(
-                // Only a curated provider gets navigated to, the generic path just opens the picker
-                text = when {
-                    suggestion.known != null -> stringResource(R.string.explorer_add_device_storage_suggestion_desc_direct)
-                    else -> stringResource(R.string.explorer_add_device_storage_suggestion_desc_pick)
-                },
+                text = stringResource(R.string.explorer_add_device_storage_suggestion_desc_direct),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -199,16 +200,9 @@ private fun AddDeviceStorageSheetSuggestionsPreview() {
         onContinue = {},
         suggestions = listOf(
             StorageProviderSuggestion(
-                packageName = "com.termux",
+                app = StorageProviderApp(packageName = "com.termux", appLabel = "Termux", lastUpdateTime = 0L),
                 authority = "com.termux.documents",
-                label = "Termux",
                 known = KnownStorageProvider.TERMUX,
-            ),
-            StorageProviderSuggestion(
-                packageName = "com.mixplorer",
-                authority = "com.mixplorer.documents",
-                label = "MiXplorer",
-                known = null,
             ),
         ),
     )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/AppIconImage.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/AppIconImage.kt
@@ -1,0 +1,43 @@
+package eu.darken.butler.explorer.ui.explorer.items
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.FolderShared
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.storage.saf.StorageProviderApp
+
+/** An app's launcher icon; [fallback] is drawn until it has loaded and when it can't be. */
+@Composable
+fun AppIconImage(
+    modifier: Modifier = Modifier,
+    pkg: Pkg,
+    fallback: @Composable () -> Unit,
+) {
+    SubcomposeAsyncImage(
+        model = pkg,
+        contentDescription = null,
+        modifier = modifier,
+        loading = { fallback() },
+        error = { fallback() },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AppIconImagePreview() {
+    AppIconImage(
+        modifier = Modifier.size(40.dp),
+        pkg = StorageProviderApp(packageName = "com.termux", appLabel = "Termux", lastUpdateTime = 0L),
+        fallback = { Icon(imageVector = Icons.TwoTone.FolderShared, contentDescription = null) },
+    )
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/grid/StorageGrid.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/grid/StorageGrid.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.Icons
@@ -17,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -29,9 +31,11 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.icons.NetworkOffline
 import eu.darken.butler.common.compose.icons.NetworkOnline
 import eu.darken.butler.common.rememberMinuteTick
+import eu.darken.butler.explorer.ui.explorer.items.AppIconImage
 import eu.darken.butler.explorer.ui.explorer.items.ItemDecorations
 import eu.darken.butler.common.files.saf.location.SAFLocation
 import eu.darken.butler.common.files.smb.SmbEndpointState
+import eu.darken.butler.common.storage.saf.StorageProviderApp
 import eu.darken.butler.explorer.R
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.items.statusLabel
@@ -104,12 +108,18 @@ fun StorageGrid(
         isEnabled = isEnabled,
         decorations = decorations,
         icon = {
-            Icon(
-                imageVector = item.displayIcon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(20.dp)
-            )
+            val providerApp = (item as? ExplorerItem.Storage.SAF)?.providerApp
+            if (providerApp != null) {
+                AppIconImage(
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clip(RoundedCornerShape(5.dp)),
+                    pkg = providerApp,
+                    fallback = { StorageIcon(item) },
+                )
+            } else {
+                StorageIcon(item)
+            }
         },
         primaryText = item.displayName.get(context),
         secondaryText = run {
@@ -146,6 +156,16 @@ fun StorageGrid(
 
             else -> null
         }
+    )
+}
+
+@Composable
+private fun StorageIcon(item: ExplorerItem.Storage) {
+    Icon(
+        imageVector = item.displayIcon,
+        contentDescription = null,
+        tint = Color.White,
+        modifier = Modifier.size(20.dp)
     )
 }
 
@@ -275,6 +295,29 @@ private fun StorageGridSAFPreview() {
         items(3) {
             StorageGrid(
                 item = MockDataProvider.createMockStorageSAF(),
+                onClick = {}
+            )
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun StorageGridSAFAppPreview() {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(3) {
+            StorageGrid(
+                item = MockDataProvider.createMockStorageSAF(
+                    name = "Termux",
+                    treeUri = "content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome",
+                    providerApp = StorageProviderApp(packageName = "com.termux", appLabel = "Termux", lastUpdateTime = 0L),
+                ),
                 onClick = {}
             )
         }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/row/StorageRow.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/row/StorageRow.kt
@@ -26,9 +26,11 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.icons.NetworkOffline
 import eu.darken.butler.common.compose.icons.NetworkOnline
 import eu.darken.butler.common.rememberMinuteTick
+import eu.darken.butler.explorer.ui.explorer.items.AppIconImage
 import eu.darken.butler.explorer.ui.explorer.items.ItemDecorations
 import eu.darken.butler.common.files.saf.location.SAFLocation
 import eu.darken.butler.common.files.smb.SmbEndpointState
+import eu.darken.butler.common.storage.saf.StorageProviderApp
 import eu.darken.butler.explorer.R
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.items.statusLabel
@@ -59,19 +61,17 @@ fun StorageRow(
         isEnabled = isEnabled,
         decorations = decorations,
         leadingContent = {
-            Box(
-                modifier = Modifier
-                    .size(32.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = item.displayIcon,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(16.dp)
+            val providerApp = (item as? ExplorerItem.Storage.SAF)?.providerApp
+            if (providerApp != null) {
+                AppIconImage(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    pkg = providerApp,
+                    fallback = { StorageIcon(item) },
                 )
+            } else {
+                StorageIcon(item)
             }
         },
         primaryText = item.displayName.get(context),
@@ -115,6 +115,24 @@ fun StorageRow(
             else -> null
         }
     )
+}
+
+@Composable
+private fun StorageIcon(item: ExplorerItem.Storage) {
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = item.displayIcon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(16.dp)
+        )
+    }
 }
 
 /** Nothing is drawn while the probe is still checking, so the row does not flash a wrong verdict. */
@@ -261,6 +279,20 @@ private fun StorageRowNetworkSignInRequiredPreview() {
 private fun StorageRowSAFPreview() {
     StorageRow(
         item = MockDataProvider.createMockStorageSAF(),
+        onClick = {}
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun StorageRowSAFAppPreview() {
+    StorageRow(
+        item = MockDataProvider.createMockStorageSAF(
+            name = "Termux",
+            treeUri = "content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome",
+            providerApp = StorageProviderApp(packageName = "com.termux", appLabel = "Termux", lastUpdateTime = 0L),
+        ),
         onClick = {}
     )
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
@@ -31,6 +31,7 @@ import eu.darken.butler.common.files.smb.credentials.SmbCredentialStore
 import eu.darken.butler.common.files.smb.location.SmbLocation
 import eu.darken.butler.common.formatFileSize
 import eu.darken.butler.common.progress.Progress
+import eu.darken.butler.common.storage.saf.StorageProviderApp
 import eu.darken.butler.explorer.R
 import eu.darken.butler.explorer.core.ExplorerBreadcrumb
 import eu.darken.butler.explorer.core.ExplorerNavigation
@@ -532,6 +533,7 @@ object MockDataProvider {
         treeUri: String = SAF_TREE_URI_DOCUMENTS,
         totalBytes: Long = MockSizes.gb(999),
         availableBytes: Long = MockSizes.gb(555),
+        providerApp: StorageProviderApp? = null,
     ): ExplorerItem.Storage.SAF {
         return ExplorerItem.Storage.SAF(
             location = SAFLocation(
@@ -548,6 +550,7 @@ object MockDataProvider {
             totalBytes = totalBytes,
             availableBytes = availableBytes,
             target = ExplorerNavigation.Target.Directory(SAFPath.build(treeUri)),
+            providerApp = providerApp,
         )
     }
 

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -247,7 +247,6 @@
     <string name="explorer_add_device_storage_cancel">Cancel</string>
     <string name="explorer_add_device_storage_suggestions_title">Apps with storage</string>
     <string name="explorer_add_device_storage_suggestion_desc_direct">Opens this app\'s folder</string>
-    <string name="explorer_add_device_storage_suggestion_desc_pick">Select it in the system picker</string>
 
     <!-- Device Storage Actions -->
     <string name="explorer_device_action_remove_location">Remove location</string>

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSafLocationControllerTest.kt
@@ -3,9 +3,12 @@ package eu.darken.butler.explorer.ui.explorer
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import eu.darken.butler.common.SafUri
+import eu.darken.butler.common.files.saf.location.SAFLocation
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
 import eu.darken.butler.common.storage.saf.KnownStorageProvider
 import eu.darken.butler.common.storage.saf.SAFPickerIntentBuilder
+import eu.darken.butler.common.storage.saf.StorageProviderApp
 import eu.darken.butler.common.storage.saf.StorageProviderSuggester
 import eu.darken.butler.common.storage.saf.StorageProviderSuggestion
 import eu.darken.butler.explorer.core.ExplorerNavigation
@@ -22,6 +25,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -41,8 +45,12 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         }
     }
 
-    private fun mockLocationManager(locationId: String = "loc-1"): SAFLocationManager =
+    private fun mockLocationManager(
+        locationId: String = "loc-1",
+        granted: List<SAFLocation> = emptyList(),
+    ): SAFLocationManager =
         mockk<SAFLocationManager>().apply {
+            every { locations } returns flowOf(granted)
             coEvery { grantPermission(any()) } returns locationId
             coEvery { revokePermission(any()) } just Runs
             coEvery { setLocationLabel(any(), any()) } just Runs
@@ -62,9 +70,9 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         suggestions: List<StorageProviderSuggestion> = emptyList(),
     ): StorageProviderSuggester = mockk<StorageProviderSuggester>().apply {
         coEvery { getSuggestions() } returns suggestions
-        coEvery { labelForAuthority(any()) } answers {
+        coEvery { appForAuthority(any()) } answers {
             when (firstArg<String>()) {
-                "com.termux.documents" -> "Termux"
+                "com.termux.documents" -> StorageProviderApp(packageName = "com.termux", appLabel = "Termux", lastUpdateTime = 0L)
                 else -> null
             }
         }
@@ -295,14 +303,31 @@ class ExplorerSafLocationControllerTest : BaseTest() {
         controller.storageSuggestions.value shouldBe listOf(fresh)
     }
 
+    @Test
+    fun `an app whose provider is already granted is not suggested`() = runTest {
+        val termux = suggestion("com.termux", "Termux")
+        val other = suggestion("com.other", "Other")
+        val granted = mockk<SAFLocation>().apply {
+            every { treeUri } returns SafUri.parse("content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome")
+        }
+        val controller = controller(
+            locationManager = mockLocationManager(granted = listOf(granted)),
+            suggester = mockSuggester(listOf(termux, other)),
+        )
+
+        controller.showAddStorageSheet()
+        runCurrent()
+
+        controller.storageSuggestions.value shouldBe listOf(other)
+    }
+
     private fun suggestion(
         packageName: String,
         label: String,
-        known: KnownStorageProvider? = null,
+        known: KnownStorageProvider = KnownStorageProvider.TERMUX,
     ) = StorageProviderSuggestion(
-        packageName = packageName,
+        app = StorageProviderApp(packageName = packageName, appLabel = label, lastUpdateTime = 0L),
         authority = "$packageName.documents",
-        label = label,
         known = known,
     )
 }

--- a/app/src/main/java/eu/darken/butler/common/coil/CoilModule.kt
+++ b/app/src/main/java/eu/darken/butler/common/coil/CoilModule.kt
@@ -51,6 +51,7 @@ class CoilModule {
         sharedContentPreviewKeyer: SharedContentPreviewKeyer,
         workspacePreviewKeyer: WorkspacePreviewKeyer,
         pkgIconKeyer: PkgIconKeyer,
+        storageProviderIconKeyer: StorageProviderIconKeyer,
         viewerImageKeyer: ViewerImageKeyer,
         dispatcherProvider: DispatcherProvider,
     ): ImageLoader = ImageLoader.Builder(context).apply {
@@ -80,6 +81,7 @@ class CoilModule {
             add(sharedContentPreviewKeyer)
             add(workspacePreviewKeyer)
             add(pkgIconKeyer)
+            add(storageProviderIconKeyer)
             add(viewerImageKeyer)
 
             // Fetchers - load images from various sources

--- a/app/src/main/java/eu/darken/butler/common/coil/StorageProviderIconKeyer.kt
+++ b/app/src/main/java/eu/darken/butler/common/coil/StorageProviderIconKeyer.kt
@@ -1,0 +1,32 @@
+package eu.darken.butler.common.coil
+
+import coil3.key.Keyer
+import coil3.request.Options
+import eu.darken.butler.common.storage.saf.StorageProviderApp
+import javax.inject.Inject
+
+/**
+ * Cache keyer for the apps behind SAF storage locations, so their icons are memory cached and
+ * a list does not flash the fallback on every recomposition.
+ *
+ * Kept apart from [PkgIconKeyer] so such an app never aliases a real installation's entry. The
+ * update time keeps an icon cached before an app update from being served after it.
+ */
+class StorageProviderIconKeyer @Inject constructor() : Keyer<StorageProviderApp> {
+
+    override fun key(data: StorageProviderApp, options: Options): String = buildString {
+        append("storage-provider-icon-")
+        append(data.packageName)
+        append("-")
+        append(data.lastUpdateTime)
+        append("-")
+        val rasterSize = options.iconRasterSize()
+        if (rasterSize != null) {
+            append(rasterSize.width)
+            append("x")
+            append(rasterSize.height)
+        } else {
+            append("intrinsic")
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/butler/common/coil/StorageProviderIconKeyerTest.kt
+++ b/app/src/test/java/eu/darken/butler/common/coil/StorageProviderIconKeyerTest.kt
@@ -1,0 +1,56 @@
+package eu.darken.butler.common.coil
+
+import coil3.request.Options
+import coil3.size.Size
+import eu.darken.butler.common.storage.saf.StorageProviderApp
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class StorageProviderIconKeyerTest : BaseTest() {
+
+    private val keyer = StorageProviderIconKeyer()
+
+    private fun options(sizePx: Int): Options = mockk<Options>().apply {
+        every { size } returns Size(sizePx, sizePx)
+    }
+
+    private fun app(
+        packageName: String = "com.termux",
+        lastUpdateTime: Long = 1000L,
+    ) = StorageProviderApp(packageName = packageName, appLabel = "Termux", lastUpdateTime = lastUpdateTime)
+
+    @Test
+    fun `key is stable for an unchanged app`() {
+        keyer.key(app(), options(96)) shouldBe keyer.key(app(), options(96))
+    }
+
+    @Test
+    fun `key differs per package`() {
+        keyer.key(app("com.termux"), options(96)) shouldNotBe keyer.key(app("com.other"), options(96))
+    }
+
+    @Test
+    fun `key changes when the app is updated`() {
+        keyer.key(app(lastUpdateTime = 1000L), options(96)) shouldNotBe keyer.key(app(lastUpdateTime = 2000L), options(96))
+    }
+
+    @Test
+    fun `key differs per raster size`() {
+        keyer.key(app(), options(60)) shouldNotBe keyer.key(app(), options(120))
+    }
+
+    @Test
+    fun `key never collides with an installed package's key`() {
+        keyer.key(app(), options(96)) shouldStartWith "storage-provider-icon-"
+    }
+}


### PR DESCRIPTION
## What changed

The "Add storage location" sheet now only suggests apps whose storage folder Butler can open the system picker at (currently Termux). Other apps used to be listed too, but tapping them opened the picker wherever it was last used, so after adding Termux every other app appeared to open Termux again, and some of them (Dropbox, for example) are not selectable in the folder picker at all. Those apps remain reachable through the Continue button.

An app that has already been added is no longer suggested again.

Storage locations served by another app now show that app's icon, in the storage list, the grid, and the suggestion sheet.

## Technical Context

- Whether a provider's roots can be picked as a folder is only visible to the picker: querying roots needs `MANAGE_DOCUMENTS`, and pre-navigating needs a concrete root id. Neither can be discovered at runtime, so the suggestion list is curated-only rather than reworded.
- Already-granted apps are filtered by combining the loaded suggestions with the granted locations' tree URI authorities. The manager's location flow excludes hidden locations, which nothing in the UI can currently create, so a hidden grant would still be suggested.
- The icon model implements `Pkg` so the existing Coil app icon fetcher serves it. A dedicated keyer includes the package's last update time, so a cached icon does not survive an app update.
- The row and grid draw the previous vector icon as loading and error fallback, so a location whose app was uninstalled looks as before.
