### PR TITLE
History: Select multiple operations to delete or share them

### DIFF
--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryLabels.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryLabels.kt
@@ -1,0 +1,73 @@
+package eu.darken.butler.history.core
+
+import androidx.annotation.StringRes
+import eu.darken.butler.history.R
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+
+/*
+ * Resource ids rather than resolved strings: the share text is built in the ViewModel with a
+ * Context, where a @Composable `stringResource` can't be called, while the UI resolves the same ids
+ * through `stringResource`.
+ */
+
+@get:StringRes
+internal val HistoryOutcome.labelRes: Int
+    get() = when (this) {
+        HistoryOutcome.COMPLETED -> R.string.history_filter_outcome_completed
+        HistoryOutcome.PARTIAL -> R.string.history_filter_outcome_partial
+        HistoryOutcome.FAILED -> R.string.history_filter_outcome_failed
+        HistoryOutcome.CANCELLED -> R.string.history_filter_outcome_cancelled
+    }
+
+@get:StringRes
+internal val Operation.Metadata.Kind.labelRes: Int
+    get() = when (this) {
+        Operation.Metadata.Kind.COPY -> R.string.history_filter_kind_copy
+        Operation.Metadata.Kind.MOVE -> R.string.history_filter_kind_move
+        Operation.Metadata.Kind.DELETE -> R.string.history_filter_kind_delete
+        Operation.Metadata.Kind.CREATE_FILE -> R.string.history_filter_kind_create_file
+        Operation.Metadata.Kind.CREATE_FOLDER -> R.string.history_filter_kind_create_folder
+        Operation.Metadata.Kind.SAVE -> R.string.history_filter_kind_save
+        Operation.Metadata.Kind.COMPRESS -> R.string.history_filter_kind_compress
+        Operation.Metadata.Kind.EXTRACT -> R.string.history_filter_kind_extract
+        Operation.Metadata.Kind.RESTORE -> R.string.history_filter_kind_restore
+        Operation.Metadata.Kind.INSTALL -> R.string.history_filter_kind_install
+    }
+
+@get:StringRes
+internal val HistoryEntry.OriginType.labelRes: Int
+    get() = when (this) {
+        HistoryEntry.OriginType.EXPLORER -> R.string.history_origin_explorer
+        HistoryEntry.OriginType.SEARCHER -> R.string.history_origin_searcher
+        HistoryEntry.OriginType.SAVER -> R.string.history_origin_saver
+        HistoryEntry.OriginType.DEVELOPER -> R.string.history_origin_developer
+        HistoryEntry.OriginType.VIEWER -> R.string.history_origin_viewer
+    }
+
+/** Past tense, unlike [labelRes]: the row headline reads as what happened, not as a filter value. */
+@get:StringRes
+internal val Operation.Metadata.Kind.headlineLabelRes: Int
+    get() = when (this) {
+        Operation.Metadata.Kind.COPY -> R.string.history_entry_kind_copy
+        Operation.Metadata.Kind.MOVE -> R.string.history_entry_kind_move
+        Operation.Metadata.Kind.DELETE -> R.string.history_entry_kind_delete
+        Operation.Metadata.Kind.CREATE_FILE -> R.string.history_entry_kind_create_file
+        Operation.Metadata.Kind.CREATE_FOLDER -> R.string.history_entry_kind_create_folder
+        Operation.Metadata.Kind.SAVE -> R.string.history_entry_kind_save
+        Operation.Metadata.Kind.COMPRESS -> R.string.history_entry_kind_compress
+        Operation.Metadata.Kind.EXTRACT -> R.string.history_entry_kind_extract
+        Operation.Metadata.Kind.RESTORE -> R.string.history_entry_kind_restore
+        Operation.Metadata.Kind.INSTALL -> R.string.history_entry_kind_install
+    }
+
+@get:StringRes
+internal val Operation.Metadata.Intent.headlineLabelRes: Int
+    get() = when (this) {
+        Operation.Metadata.Intent.RENAME -> R.string.history_entry_intent_rename
+        Operation.Metadata.Intent.PASTE_COPY -> R.string.history_entry_intent_paste_copy
+        Operation.Metadata.Intent.PASTE_MOVE -> R.string.history_entry_intent_paste_move
+        Operation.Metadata.Intent.DROP_COPY -> R.string.history_entry_intent_drop_copy
+        Operation.Metadata.Intent.DROP_MOVE -> R.string.history_entry_intent_drop_move
+    }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
@@ -20,8 +20,8 @@ private const val TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss"
 /**
  * Renders [entries] as markdown, one block per entry.
  *
- * [attemptedPaths] belongs to a single entry and is only passed by the detail sheet, which has
- * already loaded it; a bulk share leaves it null rather than issuing one query per entry.
+ * [attemptedPaths] describes one specific entry, so it is only applied to a single-entry share; a
+ * bulk share leaves it null rather than issuing one query per entry.
  *
  * [zone] is a parameter because the `Completed` line is a fixed pattern rather than a locale
  * format: a record meant to be pasted elsewhere should read the same everywhere, and a test can
@@ -34,11 +34,12 @@ internal fun buildHistoryShareText(
     zone: ZoneId = ZoneId.systemDefault(),
 ): String {
     val timestamps = DateTimeFormatter.ofPattern(TIMESTAMP_PATTERN).withZone(zone)
+    val entryPaths = attemptedPaths?.takeIf { entries.size == 1 }
     val document = StringBuilder()
     var written = 0
 
     for (entry in entries) {
-        val block = entry.toShareBlock(context, attemptedPaths, timestamps)
+        val block = entry.toShareBlock(context, entryPaths, timestamps)
         val separator = if (document.isEmpty()) "" else "\n\n"
         // Budgeted per document, so one pathological entry is bounded too.
         if (document.length + separator.length + block.length > SHARE_TEXT_MAX_CHARS) break

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
@@ -17,6 +17,8 @@ internal const val SHARE_TEXT_MAX_CHARS = 100_000
 
 private const val TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss"
 
+private const val BLOCK_SEPARATOR = "\n\n"
+
 /**
  * Renders [entries] as markdown, one block per entry.
  *
@@ -40,16 +42,24 @@ internal fun buildHistoryShareText(
 
     for (entry in entries) {
         val block = entry.toShareBlock(context, entryPaths, timestamps)
-        val separator = if (document.isEmpty()) "" else "\n\n"
-        // Budgeted per document, so one pathological entry is bounded too.
-        if (document.length + separator.length + block.length > SHARE_TEXT_MAX_CHARS) break
+        val separator = if (document.isEmpty()) "" else BLOCK_SEPARATOR
+        val remaining = entries.size - (written + 1)
+        // Budgeted per document, so one pathological entry is bounded too. A block that leaves
+        // others behind also has to leave room for the notice announcing them, which is appended
+        // after the loop and would otherwise push the document past the cap.
+        val reserved = if (remaining > 0) {
+            BLOCK_SEPARATOR.length + context.truncationNotice(remaining).length
+        } else {
+            0
+        }
+        if (document.length + separator.length + block.length + reserved > SHARE_TEXT_MAX_CHARS) break
         document.append(separator).append(block)
         written++
     }
 
     if (written < entries.size) {
-        if (document.isNotEmpty()) document.append("\n\n")
-        document.append(context.getString(R.string.history_share_truncated, entries.size - written))
+        if (document.isNotEmpty()) document.append(BLOCK_SEPARATOR)
+        document.append(context.truncationNotice(entries.size - written))
     }
 
     return document.toString()
@@ -118,6 +128,9 @@ private fun HistoryEntry.toShareBlock(
         }
     }
 }.trimEnd('\n')
+
+private fun Context.truncationNotice(remaining: Int): String =
+    getString(R.string.history_share_truncated, remaining)
 
 private fun StringBuilder.metaLine(label: String, value: String) {
     append("- **").append(label).append(":** ").append(value).append('\n')

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
@@ -165,8 +165,11 @@ private fun codeSpan(value: String): String {
     return "$fence$padding$escaped$padding$fence"
 }
 
-/** A raw newline turns the rest of a single-line field into a stray paragraph, heading or list item. */
+/**
+ * A raw line break turns the rest of a single-line field into a stray paragraph, heading or list
+ * item. CommonMark ends a line on a lone CR too, not just on LF and CRLF.
+ */
 private fun singleLine(value: String): String = value.replace(LINE_BREAK, " ")
 
 private val BACKTICK_RUN = Regex("`+")
-private val LINE_BREAK = Regex("\\r?\\n")
+private val LINE_BREAK = Regex("\\r\\n?|\\n")

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
@@ -149,12 +149,20 @@ private fun Context.formatDuration(entry: HistoryEntry): String {
  * Paths and error text are arbitrary user data. A backtick inside a value would otherwise close the
  * span and corrupt the rest of the document, so the fence is one backtick longer than the longest
  * run in the value, padded when the value itself starts or ends with one.
+ *
+ * A line break ends the span outright and would leave the rendered path a truncated one, so CR and
+ * LF are written as escapes instead. The backslash is escaped first, so `we\nird.txt` and a path
+ * with a real newline stay distinguishable.
  */
 private fun codeSpan(value: String): String {
-    val longestRun = BACKTICK_RUN.findAll(value).maxOfOrNull { it.value.length } ?: 0
+    val escaped = value
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    val longestRun = BACKTICK_RUN.findAll(escaped).maxOfOrNull { it.value.length } ?: 0
     val fence = "`".repeat(longestRun + 1)
-    val padding = if (value.startsWith('`') || value.endsWith('`')) " " else ""
-    return "$fence$padding$value$padding$fence"
+    val padding = if (escaped.startsWith('`') || escaped.endsWith('`')) " " else ""
+    return "$fence$padding$escaped$padding$fence"
 }
 
 /** A raw newline turns the rest of a single-line field into a stray paragraph, heading or list item. */

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
@@ -47,6 +47,8 @@ internal fun buildHistoryShareText(
         // Budgeted per document, so one pathological entry is bounded too. A block that leaves
         // others behind also has to leave room for the notice announcing them, which is appended
         // after the loop and would otherwise push the document past the cap.
+        // The reservation holds for every smaller count only because the notice is a plain <string>,
+        // so its length grows with the number; as <plurals> a singular wording could be longer.
         val reserved = if (remaining > 0) {
             BLOCK_SEPARATOR.length + context.truncationNotice(remaining).length
         } else {

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryShareText.kt
@@ -1,0 +1,150 @@
+package eu.darken.butler.history.core
+
+import android.content.Context
+import eu.darken.butler.history.R
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.OperationHistoryRepo
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.time.toJavaInstant
+
+/**
+ * Upper bound on the shared document. `EXTRA_TEXT` crosses the Binder boundary on `startActivity`,
+ * whose transaction buffer is about 1 MB, and a select-all share can otherwise hold 2000 entries of
+ * up to [OperationHistoryRepo.MAX_PATHS_PER_OP] paths each - tens of megabytes and a crash.
+ */
+internal const val SHARE_TEXT_MAX_CHARS = 100_000
+
+private const val TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss"
+
+/**
+ * Renders [entries] as markdown, one block per entry.
+ *
+ * [attemptedPaths] belongs to a single entry and is only passed by the detail sheet, which has
+ * already loaded it; a bulk share leaves it null rather than issuing one query per entry.
+ *
+ * [zone] is a parameter because the `Completed` line is a fixed pattern rather than a locale
+ * format: a record meant to be pasted elsewhere should read the same everywhere, and a test can
+ * pin the zone instead of depending on the machine's.
+ */
+internal fun buildHistoryShareText(
+    context: Context,
+    entries: List<HistoryEntry>,
+    attemptedPaths: OperationHistoryRepo.AttemptedPaths? = null,
+    zone: ZoneId = ZoneId.systemDefault(),
+): String {
+    val timestamps = DateTimeFormatter.ofPattern(TIMESTAMP_PATTERN).withZone(zone)
+    val document = StringBuilder()
+    var written = 0
+
+    for (entry in entries) {
+        val block = entry.toShareBlock(context, attemptedPaths, timestamps)
+        val separator = if (document.isEmpty()) "" else "\n\n"
+        // Budgeted per document, so one pathological entry is bounded too.
+        if (document.length + separator.length + block.length > SHARE_TEXT_MAX_CHARS) break
+        document.append(separator).append(block)
+        written++
+    }
+
+    if (written < entries.size) {
+        if (document.isNotEmpty()) document.append("\n\n")
+        document.append(context.getString(R.string.history_share_truncated, entries.size - written))
+    }
+
+    return document.toString()
+}
+
+private fun HistoryEntry.toShareBlock(
+    context: Context,
+    attemptedPaths: OperationHistoryRepo.AttemptedPaths?,
+    timestamps: DateTimeFormatter,
+): String = buildString {
+    append("## ").append(singleLine(title)).append('\n')
+    append(singleLine(description)).append('\n')
+    append('\n')
+
+    metaLine(context.getString(R.string.history_share_label_outcome), context.getString(outcome.labelRes))
+    metaLine(context.getString(R.string.history_share_label_kind), context.getString(kind.labelRes))
+    metaLine(context.getString(R.string.history_share_label_origin), context.getString(originType.labelRes))
+    summary?.takeIf { it.isNotBlank() }?.let {
+        metaLine(context.getString(R.string.history_share_label_summary), singleLine(it))
+    }
+    metaLine(
+        context.getString(R.string.history_share_label_completed),
+        timestamps.format(completedAt.toJavaInstant()),
+    )
+    metaLine(context.getString(R.string.history_share_label_duration), context.formatDuration(this@toShareBlock))
+    errorMessage?.takeIf { it.isNotBlank() }?.let {
+        metaLine(context.getString(R.string.history_share_label_error), singleLine(it))
+    }
+    if (partialErrorCount > 0) {
+        metaLine(context.getString(R.string.history_share_label_failed_items), "$partialErrorCount")
+    }
+
+    append('\n')
+    if (paths.isEmpty()) {
+        append(context.getString(R.string.history_detail_paths_empty)).append('\n')
+        val attempted = attemptedPaths?.paths.orEmpty()
+        if (attempted.isNotEmpty()) {
+            append('\n')
+            append("**").append(context.getString(R.string.history_detail_label_attempted_paths)).append("**\n")
+            val attemptedTotal = attemptedPaths?.totalCount ?: attempted.size
+            if (attemptedTotal > attempted.size) {
+                append(
+                    context.getString(
+                        R.string.history_detail_attempted_paths_truncated_callout,
+                        attempted.size,
+                        attemptedTotal,
+                    )
+                ).append('\n')
+            }
+            attempted.forEach { append("- ").append(codeSpan(it)).append('\n') }
+        }
+    } else {
+        append("**").append(context.getString(R.string.history_share_label_paths, affectedPathsCount)).append("**\n")
+        paths.forEach { change ->
+            val previousPath = change.previousPath
+            append("- ")
+            if (previousPath != null) {
+                append(codeSpan(previousPath)).append(" → ").append(codeSpan(change.path))
+            } else {
+                append(change.change.name.lowercase()).append(": ").append(codeSpan(change.path))
+            }
+            append('\n')
+        }
+        if (pathsTruncated) {
+            append(context.getString(R.string.history_share_paths_more, affectedPathsCount - paths.size)).append('\n')
+        }
+    }
+}.trimEnd('\n')
+
+private fun StringBuilder.metaLine(label: String, value: String) {
+    append("- **").append(label).append(":** ").append(value).append('\n')
+}
+
+private fun Context.formatDuration(entry: HistoryEntry): String {
+    val ms = entry.duration.inWholeMilliseconds
+    return if (ms < 1000L) {
+        getString(R.string.history_duration_ms, ms.toInt())
+    } else {
+        getString(R.string.history_duration_seconds, ms / 1000.0f)
+    }
+}
+
+/**
+ * Paths and error text are arbitrary user data. A backtick inside a value would otherwise close the
+ * span and corrupt the rest of the document, so the fence is one backtick longer than the longest
+ * run in the value, padded when the value itself starts or ends with one.
+ */
+private fun codeSpan(value: String): String {
+    val longestRun = BACKTICK_RUN.findAll(value).maxOfOrNull { it.value.length } ?: 0
+    val fence = "`".repeat(longestRun + 1)
+    val padding = if (value.startsWith('`') || value.endsWith('`')) " " else ""
+    return "$fence$padding$value$padding$fence"
+}
+
+/** A raw newline turns the rest of a single-line field into a stray paragraph, heading or list item. */
+private fun singleLine(value: String): String = value.replace(LINE_BREAK, " ")
+
+private val BACKTICK_RUN = Regex("`+")
+private val LINE_BREAK = Regex("\\r?\\n")

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryActionBarItem.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryActionBarItem.kt
@@ -1,0 +1,64 @@
+package eu.darken.butler.history.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.Deselect
+import androidx.compose.material.icons.twotone.SelectAll
+import androidx.compose.material.icons.twotone.Share
+import androidx.compose.ui.graphics.vector.ImageVector
+import eu.darken.butler.common.ca.CaString
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.history.R
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.ui.actions.WorkspaceActionBarItem
+import eu.darken.butler.common.R as CommonR
+
+sealed interface HistoryActionBarItem : WorkspaceActionBarItem {
+    override val icon: ImageVector
+    override val label: CaString
+    override val isVisible: Boolean get() = true
+    override val isEnabled: Boolean get() = true
+    override val isDestructive: Boolean get() = false
+    override val group: WorkspaceActionBarItem.Group get() = WorkspaceActionBarItem.Group.PRIMARY
+    override val badge: Boolean get() = false
+
+    /**
+     * Carries the ids it would select. The ViewModel's state is a plain `Flow`, so it cannot read
+     * the visible entries back synchronously when the action is clicked.
+     */
+    data class SelectAll(val ids: Set<String>) : HistoryActionBarItem {
+        override val icon = Icons.TwoTone.SelectAll
+        override val label = R.string.history_action_select_all.toCaString()
+    }
+
+    data object DeselectAll : HistoryActionBarItem {
+        override val icon = Icons.TwoTone.Deselect
+        override val label = R.string.history_action_deselect_all.toCaString()
+    }
+
+    data class Share(val entries: List<HistoryEntry>) : HistoryActionBarItem {
+        override val icon = Icons.TwoTone.Share
+        override val label = CommonR.string.general_share_action.toCaString()
+    }
+
+    data class Delete(val entries: List<HistoryEntry>) : HistoryActionBarItem {
+        override val icon = Icons.TwoTone.Delete
+        override val label = CommonR.string.general_delete_action.toCaString()
+        override val isDestructive = true
+    }
+}
+
+internal fun historyActionsFor(
+    selected: List<HistoryEntry>,
+    visible: List<HistoryEntry>,
+): List<HistoryActionBarItem> {
+    if (selected.isEmpty()) return emptyList()
+    return buildList {
+        if (selected.size < visible.size) {
+            add(HistoryActionBarItem.SelectAll(visible.map { it.id }.toSet()))
+        }
+        add(HistoryActionBarItem.DeselectAll)
+        add(HistoryActionBarItem.Share(selected))
+        add(HistoryActionBarItem.Delete(selected))
+    }
+}

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryDeleteConfirmationDialog.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryDeleteConfirmationDialog.kt
@@ -1,0 +1,73 @@
+package eu.darken.butler.history.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.history.R
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
+import eu.darken.butler.common.R as CommonR
+
+@Composable
+fun HistoryDeleteConfirmationDialog(
+    entryCount: Int,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    PaneBoundAlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = pluralStringResource(R.plurals.history_delete_dialog_title, entryCount, entryCount),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
+            Text(
+                text = stringResource(R.string.history_delete_dialog_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(CommonR.string.general_delete_action),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryDeleteConfirmationDialogPreview() {
+    HistoryDeleteConfirmationDialog(
+        entryCount = 3,
+        onDismiss = {},
+        onConfirm = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryDeleteConfirmationDialogSinglePreview() {
+    HistoryDeleteConfirmationDialog(
+        entryCount = 1,
+        onDismiss = {},
+        onConfirm = {},
+    )
+}

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryDetailsBottomSheet.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryDetailsBottomSheet.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.history.R
+import eu.darken.butler.history.core.labelRes
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 import kotlin.time.Duration
@@ -275,15 +276,7 @@ private fun PathRow(p: HistoryEntry.PathChange) {
 }
 
 @Composable
-internal fun HistoryEntry.OriginType.label(): String = stringResource(
-    when (this) {
-        HistoryEntry.OriginType.EXPLORER -> R.string.history_origin_explorer
-        HistoryEntry.OriginType.SEARCHER -> R.string.history_origin_searcher
-        HistoryEntry.OriginType.SAVER -> R.string.history_origin_saver
-        HistoryEntry.OriginType.DEVELOPER -> R.string.history_origin_developer
-        HistoryEntry.OriginType.VIEWER -> R.string.history_origin_viewer
-    }
-)
+internal fun HistoryEntry.OriginType.label(): String = stringResource(labelRes)
 
 @Composable
 private fun formatDuration(duration: Duration): String {

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryDetailsBottomSheet.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryDetailsBottomSheet.kt
@@ -9,12 +9,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Error
 import androidx.compose.material.icons.twotone.Schedule
+import androidx.compose.material.icons.twotone.Share
 import androidx.compose.material.icons.twotone.Source
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -35,6 +38,7 @@ import eu.darken.butler.history.core.labelRes
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 import kotlin.time.Duration
+import eu.darken.butler.common.R as CommonR
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -45,6 +49,7 @@ fun HistoryEntryDetailsBottomSheet(
     topInset: Dp = 0.dp,
     bottomInset: Dp,
     onDismiss: () -> Unit,
+    onShare: () -> Unit = {},
 ) {
     PaneScopedBottomSheet(
         visible = entry != null,
@@ -60,11 +65,22 @@ fun HistoryEntryDetailsBottomSheet(
                 .padding(horizontal = 20.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = entry.title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = entry.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                IconButton(onClick = onShare) {
+                    Icon(
+                        imageVector = Icons.TwoTone.Share,
+                        contentDescription = stringResource(CommonR.string.general_share_action),
+                    )
+                }
+            }
             Text(
                 text = entry.description,
                 style = MaterialTheme.typography.bodyMedium,
@@ -96,11 +112,13 @@ fun HistoryEntryDetailsBottomSheet(
             }
 
             entry.summary?.takeIf { it.isNotBlank() }?.let { summary ->
-                Text(
-                    text = summary,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                SelectionContainer {
+                    Text(
+                        text = summary,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
             if (entry.partialErrorCount > 0) {
@@ -120,6 +138,7 @@ fun HistoryEntryDetailsBottomSheet(
                     icon = Icons.TwoTone.Error,
                     iconTint = MaterialTheme.colorScheme.error,
                     text = error,
+                    selectable = true,
                 )
             }
 
@@ -150,15 +169,17 @@ fun HistoryEntryDetailsBottomSheet(
                             ),
                         )
                     }
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        attemptedPaths.forEach { path ->
-                            Text(
-                                text = path,
-                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.MiddleEllipsis,
-                            )
+                    SelectionContainer {
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            attemptedPaths.forEach { path ->
+                                Text(
+                                    text = path,
+                                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.MiddleEllipsis,
+                                )
+                            }
                         }
                     }
                 }
@@ -174,9 +195,11 @@ fun HistoryEntryDetailsBottomSheet(
                         ),
                     )
                 }
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    entry.paths.forEach { p ->
-                        PathRow(p)
+                SelectionContainer {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        entry.paths.forEach { p ->
+                            PathRow(p)
+                        }
                     }
                 }
             }
@@ -219,6 +242,7 @@ private fun Callout(
     icon: ImageVector,
     iconTint: Color,
     text: String,
+    selectable: Boolean = false,
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -236,13 +260,25 @@ private fun Callout(
                 tint = iconTint,
                 modifier = Modifier.size(18.dp),
             )
-            Text(
-                text = text,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.fillMaxWidth(),
-            )
+            SelectableIf(selectable) {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
+    }
+}
+
+/** Only the callouts carrying user text are selectable; the rest keep their plain touch behaviour. */
+@Composable
+private fun SelectableIf(enabled: Boolean, content: @Composable () -> Unit) {
+    if (enabled) {
+        SelectionContainer(content = content)
+    } else {
+        content()
     }
 }
 

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
@@ -1,6 +1,8 @@
 package eu.darken.butler.history.ui
 
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,6 +26,7 @@ import androidx.compose.material.icons.twotone.Restore
 import androidx.compose.material.icons.twotone.Save
 import androidx.compose.material.icons.twotone.Unarchive
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -35,9 +38,11 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -46,6 +51,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.formatRelativeTime
 import eu.darken.butler.history.R
+import eu.darken.butler.history.core.headlineLabelRes
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
@@ -53,24 +59,39 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+/** A checkbox carries no semantics without a click handler, so the tag is how a test finds it. */
+const val HISTORY_ROW_CHECKBOX_TAG = "history-row-checkbox"
+
 @Composable
 fun HistoryEntryRow(
     modifier: Modifier = Modifier,
     entry: HistoryEntry,
     onClick: () -> Unit,
+    onLongClick: () -> Unit = {},
+    isSelected: Boolean = false,
+    selectionActive: Boolean = false,
 ) {
     val accentColor = entry.outcome.color()
     ElevatedCard(
-        onClick = onClick,
         modifier = modifier
             .fillMaxWidth(),
         colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            containerColor = if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainer
+            },
         ),
     ) {
         Row(
+            // Clickable before the padding: appended after it, the gesture area would stop at the
+            // padding and leave dead bands plus an inset ripple at the card edges.
             modifier = Modifier
                 .fillMaxWidth()
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                )
                 .drawBehind {
                     drawRect(
                         color = accentColor,
@@ -80,12 +101,25 @@ fun HistoryEntryRow(
                 .padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(
-                imageVector = entry.kind.icon(),
-                contentDescription = entry.kind.name,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
-            )
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (selectionActive) {
+                    Checkbox(
+                        modifier = Modifier.testTag(HISTORY_ROW_CHECKBOX_TAG),
+                        checked = isSelected,
+                        onCheckedChange = null,
+                    )
+                } else {
+                    Icon(
+                        imageVector = entry.kind.icon(),
+                        contentDescription = entry.kind.name,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
             Spacer(Modifier.width(10.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -102,6 +136,16 @@ fun HistoryEntryRow(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                entry.displayPath()?.takeIf { it.isNotBlank() }?.let { path ->
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = path,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.MiddleEllipsis,
+                    )
+                }
             }
             Spacer(Modifier.width(8.dp))
             Column(
@@ -149,40 +193,24 @@ private fun CountText(entry: HistoryEntry) {
     )
 }
 
+@Composable
 private fun HistoryEntry.headline(): String {
-    val intentLabel = when (intent) {
-        Operation.Metadata.Intent.RENAME -> "Renamed"
-        Operation.Metadata.Intent.PASTE_COPY -> "Pasted"
-        Operation.Metadata.Intent.PASTE_MOVE -> "Pasted (move)"
-        Operation.Metadata.Intent.DROP_COPY -> "Dropped (copy)"
-        Operation.Metadata.Intent.DROP_MOVE -> "Dropped (move)"
-        null -> kind.entryHeadlineLabel()
-    }
+    val label = stringResource(intent?.headlineLabelRes ?: kind.headlineLabelRes)
     val target = displayPath()?.substringAfterLast('/')
-    return if (target.isNullOrBlank()) intentLabel else "$intentLabel  $target"
+    return if (target.isNullOrBlank()) {
+        label
+    } else {
+        stringResource(R.string.history_entry_headline_format, label, target)
+    }
 }
 
 private fun HistoryEntry.subline(timeAgo: String): String {
     val originLabel = originType.name.lowercase().replaceFirstChar { it.uppercaseChar() }
-    val pathHint = displayPath()?.substringBeforeLast('/').orEmpty()
-    return if (pathHint.isNotEmpty()) "$originLabel  ·  $timeAgo  ·  $pathHint" else "$originLabel  ·  $timeAgo"
+    return "$originLabel  ·  $timeAgo"
 }
 
 /** The reported changes are an audit trail, so they only stand in when no subject was stored. */
 private fun HistoryEntry.displayPath(): String? = primaryPath ?: paths.firstOrNull()?.path
-
-private fun Operation.Metadata.Kind.entryHeadlineLabel(): String = when (this) {
-    Operation.Metadata.Kind.COPY -> "Copied"
-    Operation.Metadata.Kind.MOVE -> "Moved"
-    Operation.Metadata.Kind.DELETE -> "Deleted"
-    Operation.Metadata.Kind.CREATE_FOLDER -> "Created folder"
-    Operation.Metadata.Kind.CREATE_FILE -> "Created file"
-    Operation.Metadata.Kind.SAVE -> "Saved"
-    Operation.Metadata.Kind.COMPRESS -> "Compressed"
-    Operation.Metadata.Kind.EXTRACT -> "Extracted"
-    Operation.Metadata.Kind.RESTORE -> "Restored"
-    Operation.Metadata.Kind.INSTALL -> "Installed"
-}
 
 internal fun Operation.Metadata.Kind.icon(): ImageVector = when (this) {
     Operation.Metadata.Kind.COPY -> Icons.TwoTone.CopyAll
@@ -349,5 +377,43 @@ private fun HistoryEntryRowNoChangesPreview() {
             primaryPath = "/storage/emulated/0/Movies/holiday.mp4",
         ),
         onClick = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryEntryRowSelectedPreview() {
+    val now = Clock.System.now()
+    HistoryEntryRow(
+        entry = HistoryEntry(
+            id = "5",
+            kind = Operation.Metadata.Kind.MOVE,
+            intent = Operation.Metadata.Intent.RENAME,
+            originType = HistoryEntry.OriginType.EXPLORER,
+            originWorkspaceId = "abc",
+            title = "Rename notes.txt",
+            description = "notes.txt to todo.txt",
+            summary = null,
+            startedAt = now - 10.seconds,
+            completedAt = now - 9.seconds,
+            duration = 1.seconds,
+            outcome = HistoryOutcome.COMPLETED,
+            errorMessage = null,
+            errorClass = null,
+            affectedPathsCount = 1,
+            partialErrorCount = 0,
+            pathsTruncated = false,
+            paths = listOf(
+                HistoryEntry.PathChange(
+                    path = "/storage/emulated/0/Documents/todo.txt",
+                    previousPath = "/storage/emulated/0/Documents/notes.txt",
+                    change = Operation.Report.PathChange.Change.MOVED,
+                ),
+            ),
+        ),
+        onClick = {},
+        isSelected = true,
+        selectionActive = true,
     )
 }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
@@ -204,10 +204,8 @@ private fun HistoryEntry.headline(): String {
     }
 }
 
-private fun HistoryEntry.subline(timeAgo: String): String {
-    val originLabel = originType.name.lowercase().replaceFirstChar { it.uppercaseChar() }
-    return "$originLabel  ·  $timeAgo"
-}
+@Composable
+private fun HistoryEntry.subline(timeAgo: String): String = "${originType.label()}  ·  $timeAgo"
 
 /** The reported changes are an audit trail, so they only stand in when no subject was stored. */
 private fun HistoryEntry.displayPath(): String? = primaryPath ?: paths.firstOrNull()?.path

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryFilterChips.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryFilterChips.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerChip
 import eu.darken.butler.common.compose.ButlerChipDefaults
 import eu.darken.butler.history.R
+import eu.darken.butler.history.core.labelRes
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryFilter
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
@@ -74,27 +75,7 @@ fun HistoryFilterChips(
 }
 
 @Composable
-internal fun HistoryOutcome.label(): String = stringResource(
-    when (this) {
-        HistoryOutcome.COMPLETED -> R.string.history_filter_outcome_completed
-        HistoryOutcome.PARTIAL -> R.string.history_filter_outcome_partial
-        HistoryOutcome.FAILED -> R.string.history_filter_outcome_failed
-        HistoryOutcome.CANCELLED -> R.string.history_filter_outcome_cancelled
-    }
-)
+internal fun HistoryOutcome.label(): String = stringResource(labelRes)
 
 @Composable
-internal fun Operation.Metadata.Kind.label(): String = stringResource(
-    when (this) {
-        Operation.Metadata.Kind.COPY -> R.string.history_filter_kind_copy
-        Operation.Metadata.Kind.MOVE -> R.string.history_filter_kind_move
-        Operation.Metadata.Kind.DELETE -> R.string.history_filter_kind_delete
-        Operation.Metadata.Kind.CREATE_FILE -> R.string.history_filter_kind_create_file
-        Operation.Metadata.Kind.CREATE_FOLDER -> R.string.history_filter_kind_create_folder
-        Operation.Metadata.Kind.SAVE -> R.string.history_filter_kind_save
-        Operation.Metadata.Kind.COMPRESS -> R.string.history_filter_kind_compress
-        Operation.Metadata.Kind.EXTRACT -> R.string.history_filter_kind_extract
-        Operation.Metadata.Kind.RESTORE -> R.string.history_filter_kind_restore
-        Operation.Metadata.Kind.INSTALL -> R.string.history_filter_kind_install
-    }
-)
+internal fun Operation.Metadata.Kind.label(): String = stringResource(labelRes)

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryPersistedKeys.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryPersistedKeys.kt
@@ -20,4 +20,5 @@ internal object HistoryScrollSlots {
  */
 internal object HistoryBarKeys {
     const val TOOLBAR = "toolbar"
+    const val ACTIONS = "actions"
 }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlays.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlays.kt
@@ -11,6 +11,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.core.operations.history.HistoryFilter
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
 import eu.darken.butler.workspace.ui.insets.paneInsets
@@ -44,6 +45,9 @@ fun HistoryWorkspaceOverlaysHost(
         onRemovePathScope = { vm.removePathScope(it) },
         onAddPathScopeRequested = { vm.openPathScopePicker() },
         onDismissEntryDetails = { vm.showEntryDetails(null) },
+        onShareEntry = { vm.shareEntry(it) },
+        onConfirmDelete = { vm.confirmDeleteSelected() },
+        onDismissDelete = { vm.dismissDeleteConfirm() },
         onDismissPathScope = { vm.closePathScopePicker() },
         onApplyPathScope = { newScope ->
             if (newScope != null) vm.addPathScope(newScope)
@@ -67,6 +71,9 @@ fun HistoryWorkspaceOverlays(
     onRemovePathScope: (String) -> Unit = {},
     onAddPathScopeRequested: () -> Unit = {},
     onDismissEntryDetails: () -> Unit = {},
+    onShareEntry: (HistoryEntry) -> Unit = {},
+    onConfirmDelete: () -> Unit = {},
+    onDismissDelete: () -> Unit = {},
     onDismissPathScope: () -> Unit = {},
     onApplyPathScope: (String?) -> Unit = {},
 ) {
@@ -88,14 +95,24 @@ fun HistoryWorkspaceOverlays(
         )
     }
 
+    val detailEntry = overlayState.detailEntry
     HistoryEntryDetailsBottomSheet(
-        entry = overlayState.detailEntry,
+        entry = detailEntry,
         attemptedPaths = overlayState.attemptedPaths,
         attemptedPathsTotal = overlayState.attemptedPathsTotal,
         topInset = statusBarInset,
         bottomInset = navBarInset,
         onDismiss = onDismissEntryDetails,
+        onShare = { if (detailEntry != null) onShareEntry(detailEntry) },
     )
+
+    if (overlayState.deleteConfirmEntries.isNotEmpty()) {
+        HistoryDeleteConfirmationDialog(
+            entryCount = overlayState.deleteConfirmEntries.size,
+            onDismiss = onDismissDelete,
+            onConfirm = onConfirmDelete,
+        )
+    }
 
     if (overlayState.pathScopeOpen) {
         PathScopeDialog(
@@ -123,5 +140,24 @@ private fun HistoryWorkspaceOverlaysPathScopePreview() {
     HistoryWorkspaceOverlays(
         filter = HistoryFilter(),
         overlayState = HistoryWorkspaceViewModel.OverlayState(pathScopeOpen = true),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryWorkspaceOverlaysDeleteConfirmPreview() {
+    HistoryWorkspaceOverlays(
+        filter = HistoryFilter(),
+        overlayState = HistoryWorkspaceViewModel.OverlayState(
+            deleteConfirmEntries = List(3) {
+                mockEntry(
+                    id = "$it",
+                    kind = Operation.Metadata.Kind.DELETE,
+                    outcome = HistoryOutcome.COMPLETED,
+                    path = "/sdcard/ButlerQA/file_$it.txt",
+                )
+            },
+        ),
     )
 }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspacePage.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspacePage.kt
@@ -38,15 +38,16 @@ import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.core.operations.history.HistoryFilter
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
 import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.contentPaddingDp
-import eu.darken.butler.workspace.ui.insets.paneInsets
 import eu.darken.butler.workspace.ui.insets.rememberPaneFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import eu.darken.butler.workspace.ui.scroll.rememberWorkspaceLazyListState
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
@@ -74,6 +75,9 @@ fun HistoryWorkspacePageHost(
             onAddFilter = { vm.setAddFilterOpen(true) },
             onClearFilter = { vm.clearFilter() },
             onEntryClick = { vm.showEntryDetails(it) },
+            onEntryLongClick = { vm.toggleSelection(it.id) },
+            onClearSelection = { vm.clearSelection() },
+            onActionClick = { vm.onActionClick(it) },
         )
     }
 }
@@ -90,10 +94,11 @@ fun HistoryWorkspacePage(
     onAddFilter: () -> Unit = {},
     onClearFilter: () -> Unit = {},
     onEntryClick: (HistoryEntry) -> Unit = {},
+    onEntryLongClick: (HistoryEntry) -> Unit = {},
+    onClearSelection: () -> Unit = {},
+    onActionClick: (HistoryActionBarItem) -> Unit = {},
 ) {
-    val paneInsets = design.paneInsets()
-    val navBarInset = paneInsets.bottom
-    val statusBarInset = paneInsets.top
+    WorkspaceBackHandler(enabled = state.selectionActive) { onClearSelection() }
 
     val topBarStackState = rememberPaneFloatingBarStackState(
         position = BarPosition.TOP,
@@ -105,19 +110,32 @@ fun HistoryWorkspacePage(
         estimatedContentPadding = 192.dp,
     )
 
+    val bottomBarStackState = rememberPaneFloatingBarStackState(
+        position = BarPosition.BOTTOM,
+        workspaceId = workspaceId,
+        defaultSpacing = 8.dp,
+        edgePadding = 8.dp,
+        contentPadding = 16.dp,
+        design = design,
+        estimatedContentPadding = 80.dp,
+    )
+
     val listState = rememberWorkspaceLazyListState(workspaceId, slot = HistoryScrollSlots.LIST)
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             state = listState,
+            // Both connections: the stack's own nestedScroll sits on a sibling of this list, so
+            // without the second one the bottom bar never sees the list's scroll.
             modifier = Modifier
                 .fillMaxSize()
-                .nestedScroll(topBarStackState.nestedScrollConnection),
+                .nestedScroll(topBarStackState.nestedScrollConnection)
+                .nestedScroll(bottomBarStackState.nestedScrollConnection),
             contentPadding = PaddingValues(
                 start = WorkspacePaddings.ContentHorizontal,
                 end = WorkspacePaddings.ContentHorizontal,
                 top = topBarStackState.contentPaddingDp(),
-                bottom = navBarInset + 16.dp,
+                bottom = bottomBarStackState.contentPaddingDp(),
             ),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -135,7 +153,16 @@ fun HistoryWorkspacePage(
                         DateGroupHeader(group = group)
                     }
                     items(group.entries, key = { it.id }) { entry ->
-                        HistoryEntryRow(entry = entry, onClick = { onEntryClick(entry) })
+                        HistoryEntryRow(
+                            entry = entry,
+                            // In selection mode a tap toggles the row instead of opening its sheet.
+                            onClick = {
+                                if (state.selectionActive) onEntryLongClick(entry) else onEntryClick(entry)
+                            },
+                            onLongClick = { onEntryLongClick(entry) },
+                            isSelected = entry.id in state.selectedIds,
+                            selectionActive = state.selectionActive,
+                        )
                     }
                 }
             }
@@ -164,6 +191,26 @@ fun HistoryWorkspacePage(
                         onRemovePathScope = onRemovePathScope,
                         onAddFilter = onAddFilter,
                         onClearFilter = onClearFilter,
+                    )
+                }
+            },
+        )
+
+        FloatingBarStack(
+            state = bottomBarStackState,
+            position = BarPosition.BOTTOM,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            bars = {
+                FloatingBar(
+                    key = HistoryBarKeys.ACTIONS,
+                    visible = state.availableActions.isNotEmpty(),
+                    scrollBehavior = BarScrollBehavior.HideOnScroll,
+                    animation = BarAnimation.Slide(),
+                    revealOn = state.selectedIds,
+                ) {
+                    WorkspaceActionBar(
+                        actions = state.availableActions,
+                        onActionClick = onActionClick,
                     )
                 }
             },
@@ -261,7 +308,7 @@ private fun HistoryWorkspaceViewModel.GroupKey.label(): String = stringResource(
     }
 )
 
-private fun mockEntry(
+internal fun mockEntry(
     id: String,
     kind: Operation.Metadata.Kind,
     outcome: HistoryOutcome,
@@ -323,6 +370,35 @@ private fun HistoryWorkspacePageWithEntriesPreview() {
             entryCount = entries.size,
             totalCount = entries.size,
             hasAnyHistory = true,
+        ),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryWorkspacePageSelectionPreview() {
+    val workspaceId = Workspace.Id()
+    val entries = listOf(
+        mockEntry("1", Operation.Metadata.Kind.COPY, HistoryOutcome.COMPLETED, path = "/sdcard/DCIM/photo.jpg", completedAgo = 30.seconds),
+        mockEntry("2", Operation.Metadata.Kind.MOVE, HistoryOutcome.COMPLETED, intent = Operation.Metadata.Intent.RENAME, path = "/sdcard/Documents/notes.txt", completedAgo = 5.minutes),
+        mockEntry("3", Operation.Metadata.Kind.DELETE, HistoryOutcome.FAILED, path = "/sdcard/Protected/secret.bin", completedAgo = 12.minutes),
+    )
+    HistoryWorkspacePage(
+        workspaceId = workspaceId,
+        state = HistoryWorkspaceViewModel.State(
+            id = workspaceId,
+            filter = HistoryFilter(),
+            groups = listOf(
+                HistoryWorkspaceViewModel.DateGroup(
+                    HistoryWorkspaceViewModel.GroupKey.TODAY,
+                    entries,
+                ),
+            ),
+            entryCount = entries.size,
+            totalCount = entries.size,
+            hasAnyHistory = true,
+            selectedIds = setOf("1", "3"),
         ),
     )
 }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -190,13 +190,19 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         _overlayState.update { it.copy(deleteConfirmEntries = emptyList()) }
     }
 
-    fun shareEntry(entry: HistoryEntry) {
-        val overlay = _overlayState.value
-        // The sheet has already loaded these for an entry that reported no changes; a bulk share
-        // has none and says so instead of issuing a query per entry.
-        val attempted = overlay.attemptedPaths
-            .takeIf { it.isNotEmpty() && overlay.detailEntry?.id == entry.id }
-            ?.let { OperationHistoryRepo.AttemptedPaths(it, overlay.attemptedPathsTotal) }
+    fun shareEntry(entry: HistoryEntry) = launch {
+        // An entry that reported no changes shares what the operation tried to touch instead. The
+        // sheet's own load may still be in flight, and an empty list there is indistinguishable
+        // from a finished one, so query rather than share a record that claims nothing happened.
+        val attempted = if (entry.paths.isNotEmpty()) {
+            null
+        } else {
+            val overlay = _overlayState.value
+            overlay.attemptedPaths
+                .takeIf { it.isNotEmpty() && overlay.detailEntry?.id == entry.id }
+                ?.let { OperationHistoryRepo.AttemptedPaths(it, overlay.attemptedPathsTotal) }
+                ?: historyRepo.getAttemptedPaths(entry.id)
+        }
         shareEntries(listOf(entry), attempted)
     }
 

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -1,15 +1,19 @@
 package eu.darken.butler.history.ui
 
+import android.content.Context
+import android.content.Intent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.ui.ViewModel3
 import eu.darken.butler.history.core.HistoryWorkspace
+import eu.darken.butler.history.core.buildHistoryShareText
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.operations.Operation
@@ -36,6 +40,7 @@ import kotlin.time.toJavaInstant
 @HiltViewModel(assistedFactory = HistoryWorkspaceViewModel.Factory::class)
 class HistoryWorkspaceViewModel @AssistedInject constructor(
     @Assisted private val id: Workspace.Id,
+    @ApplicationContext private val context: Context,
     dispatchers: DispatcherProvider,
     private val workspaceProvider: WorkspaceProvider,
     private val historyRepo: OperationHistoryRepo,
@@ -55,7 +60,13 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
             historyRepo.query(filter, max).map { entries -> filter to entries }
         }
 
-    val state = combine(filterAndEntries, historyRepo.observeCount()) { pair, totalCount ->
+    private val _selectedIds = MutableStateFlow<Set<String>>(emptySet())
+
+    val state = combine(
+        filterAndEntries,
+        historyRepo.observeCount(),
+        _selectedIds,
+    ) { pair, totalCount, rawSelected ->
         val (filter, entries) = pair
         State(
             id = id,
@@ -64,6 +75,10 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
             entryCount = entries.size,
             totalCount = totalCount,
             hasAnyHistory = totalCount > 0,
+            // Pruned on read: a retention trim or a delete in another history tab removes rows this
+            // tab still has ids for, and a stale id would keep the action bar showing a count that
+            // no longer exists.
+            selectedIds = rawSelected intersect entries.map { it.id }.toSet(),
         )
     }.asStateFlow()
 
@@ -138,12 +153,76 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         applyFilter { HistoryFilter() }
     }
 
-    fun deleteEntry(id: String) = launch {
-        log(tag, INFO) { "deleteEntry($id)" }
-        historyRepo.delete(id)
+    // Not `launch`, for the same call-order reason as showEntryDetails.
+    fun toggleSelection(entryId: String) {
+        _selectedIds.update { if (entryId in it) it - entryId else it + entryId }
     }
 
+    fun setSelection(ids: Set<String>) {
+        _selectedIds.value = ids
+    }
+
+    fun clearSelection() {
+        _selectedIds.value = emptySet()
+    }
+
+    fun onActionClick(item: HistoryActionBarItem) {
+        log(tag) { "onActionClick($item)" }
+        when (item) {
+            is HistoryActionBarItem.SelectAll -> setSelection(item.ids)
+            is HistoryActionBarItem.DeselectAll -> clearSelection()
+            is HistoryActionBarItem.Share -> shareEntries(item.entries)
+            is HistoryActionBarItem.Delete -> _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
+        }
+    }
+
+    // Selection and dialog are reset only after the delete returns: a failed delete has to leave
+    // both standing, so the error the handler shows still matches what the user sees.
+    fun confirmDeleteSelected() = launch {
+        val ids = _overlayState.value.deleteConfirmEntries.map { it.id }
+        log(tag, INFO) { "confirmDeleteSelected(): ${ids.size} entries" }
+        historyRepo.delete(ids)
+        clearSelection()
+        dismissDeleteConfirm()
+    }
+
+    fun dismissDeleteConfirm() {
+        _overlayState.update { it.copy(deleteConfirmEntries = emptyList()) }
+    }
+
+    fun shareEntry(entry: HistoryEntry) {
+        val overlay = _overlayState.value
+        // The sheet has already loaded these for an entry that reported no changes; a bulk share
+        // has none and says so instead of issuing a query per entry.
+        val attempted = overlay.attemptedPaths
+            .takeIf { it.isNotEmpty() && overlay.detailEntry?.id == entry.id }
+            ?.let { OperationHistoryRepo.AttemptedPaths(it, overlay.attemptedPathsTotal) }
+        shareEntries(listOf(entry), attempted)
+    }
+
+    private fun shareEntries(
+        entries: List<HistoryEntry>,
+        attemptedPaths: OperationHistoryRepo.AttemptedPaths? = null,
+    ) {
+        log(tag, INFO) { "shareEntries(): ${entries.size} entries" }
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, buildHistoryShareText(context, entries, attemptedPaths))
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(
+            Intent.createChooser(intent, null).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        )
+        clearSelection()
+    }
+
+    // Every filter mutation funnels through here, so this is what ends selection mode on a filter
+    // change. Pruning alone would empty the visible selection while keeping the raw ids, and
+    // resetting the filter would bring rows back already checked.
     private suspend fun applyFilter(transform: (HistoryFilter) -> HistoryFilter) {
+        _selectedIds.value = emptySet()
         val workspace = workspaceSource.first()
         workspace.updateFilter(transform)
     }
@@ -155,7 +234,16 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         val entryCount: Int,
         val totalCount: Int,
         val hasAnyHistory: Boolean,
-    )
+        val selectedIds: Set<String> = emptySet(),
+    ) {
+        val selectionActive: Boolean get() = selectedIds.isNotEmpty()
+
+        val selectedEntries: List<HistoryEntry>
+            get() = groups.flatMap { it.entries }.filter { it.id in selectedIds }
+
+        val availableActions: List<HistoryActionBarItem>
+            get() = historyActionsFor(selectedEntries, groups.flatMap { it.entries })
+    }
 
     data class OverlayState(
         val detailEntry: HistoryEntry? = null,
@@ -163,6 +251,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         val attemptedPathsTotal: Int = 0,
         val addFilterOpen: Boolean = false,
         val pathScopeOpen: Boolean = false,
+        val deleteConfirmEntries: List<HistoryEntry> = emptyList(),
     )
 
     data class DateGroup(

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -190,20 +191,29 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         _overlayState.update { it.copy(deleteConfirmEntries = emptyList()) }
     }
 
+    // The sheet's Share button stays live while the query below is awaited, so a second tap starts
+    // a second coroutine. Without this it would open its own chooser on top of the first one.
+    private val detailShareLock = Mutex()
+
     fun shareEntry(entry: HistoryEntry) = launch {
-        // An entry that reported no changes shares what the operation tried to touch instead. The
-        // sheet's own load may still be in flight, and an empty list there is indistinguishable
-        // from a finished one, so query rather than share a record that claims nothing happened.
-        val attempted = if (entry.paths.isNotEmpty()) {
-            null
-        } else {
-            val overlay = _overlayState.value
-            overlay.attemptedPaths
-                .takeIf { it.isNotEmpty() && overlay.detailEntry?.id == entry.id }
-                ?.let { OperationHistoryRepo.AttemptedPaths(it, overlay.attemptedPathsTotal) }
-                ?: historyRepo.getAttemptedPaths(entry.id)
+        if (!detailShareLock.tryLock()) return@launch
+        try {
+            // An entry that reported no changes shares what the operation tried to touch instead. The
+            // sheet's own load may still be in flight, and an empty list there is indistinguishable
+            // from a finished one, so query rather than share a record that claims nothing happened.
+            val attempted = if (entry.paths.isNotEmpty()) {
+                null
+            } else {
+                val overlay = _overlayState.value
+                overlay.attemptedPaths
+                    .takeIf { it.isNotEmpty() && overlay.detailEntry?.id == entry.id }
+                    ?.let { OperationHistoryRepo.AttemptedPaths(it, overlay.attemptedPathsTotal) }
+                    ?: historyRepo.getAttemptedPaths(entry.id)
+            }
+            shareEntries(listOf(entry), attempted)
+        } finally {
+            detailShareLock.unlock()
         }
-        shareEntries(listOf(entry), attempted)
     }
 
     private fun shareEntries(

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -172,7 +172,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         when (item) {
             is HistoryActionBarItem.SelectAll -> setSelection(item.ids)
             is HistoryActionBarItem.DeselectAll -> clearSelection()
-            is HistoryActionBarItem.Share -> shareEntries(item.entries)
+            is HistoryActionBarItem.Share -> shareEntries(item.entries, clearsSelection = true)
             is HistoryActionBarItem.Delete -> _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
         }
     }
@@ -210,14 +210,20 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
                     ?.let { OperationHistoryRepo.AttemptedPaths(it, overlay.attemptedPathsTotal) }
                     ?: historyRepo.getAttemptedPaths(entry.id)
             }
-            shareEntries(listOf(entry), attempted)
+            // The sheet may have been dismissed or moved on to another entry while the query ran,
+            // and this share belongs to the one that asked for it.
+            if (_overlayState.value.detailEntry?.id != entry.id) return@launch
+            shareEntries(listOf(entry), clearsSelection = false, attemptedPaths = attempted)
         } finally {
             detailShareLock.unlock()
         }
     }
 
+    // [clearsSelection] has no default so every caller has to state it: the action bar's share acts
+    // on the selection and ends it, the detail sheet's share does not own it.
     private fun shareEntries(
         entries: List<HistoryEntry>,
+        clearsSelection: Boolean,
         attemptedPaths: OperationHistoryRepo.AttemptedPaths? = null,
     ) {
         log(tag, INFO) { "shareEntries(): ${entries.size} entries" }
@@ -231,7 +237,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
         )
-        clearSelection()
+        if (clearsSelection) clearSelection()
     }
 
     // Every filter mutation funnels through here, so this is what ends selection mode on a filter

--- a/app-workspace-history/src/main/res/values/strings.xml
+++ b/app-workspace-history/src/main/res/values/strings.xml
@@ -60,6 +60,21 @@
     <string name="history_entry_intent_rename">Renamed</string>
     <string name="history_entry_intent_paste_copy">Pasted</string>
     <string name="history_entry_intent_paste_move">Pasted (move)</string>
+    <string name="history_entry_intent_drop_copy">Dropped (copy)</string>
+    <string name="history_entry_intent_drop_move">Dropped (move)</string>
+    <string name="history_entry_kind_copy">Copied</string>
+    <string name="history_entry_kind_move">Moved</string>
+    <string name="history_entry_kind_delete">Deleted</string>
+    <string name="history_entry_kind_create_file">Created file</string>
+    <string name="history_entry_kind_create_folder">Created folder</string>
+    <string name="history_entry_kind_save">Saved</string>
+    <string name="history_entry_kind_compress">Compressed</string>
+    <string name="history_entry_kind_extract">Extracted</string>
+    <string name="history_entry_kind_restore">Restored</string>
+    <string name="history_entry_kind_install">Installed</string>
+    <!-- Row headline: what happened, followed by the file or folder it happened to -->
+    <!-- Quoted so the double space survives the resource parser -->
+    <string name="history_entry_headline_format">"%1$s  %2$s"</string>
 
     <!-- Affected paths count -->
     <plurals name="history_entry_affected_paths">
@@ -147,4 +162,5 @@
     <string name="history_filter_kind_restore">Restore</string>
     <string name="history_workspace_title_kind_install">History: Install</string>
     <string name="history_filter_kind_install">Install</string>
+
 </resources>

--- a/app-workspace-history/src/main/res/values/strings.xml
+++ b/app-workspace-history/src/main/res/values/strings.xml
@@ -163,4 +163,16 @@
     <string name="history_workspace_title_kind_install">History: Install</string>
     <string name="history_filter_kind_install">Install</string>
 
+    <!-- Shared text -->
+    <string name="history_share_label_outcome">Outcome</string>
+    <string name="history_share_label_kind">Kind</string>
+    <string name="history_share_label_origin">Origin</string>
+    <string name="history_share_label_summary">Summary</string>
+    <string name="history_share_label_completed">Completed</string>
+    <string name="history_share_label_duration">Duration</string>
+    <string name="history_share_label_error">Error</string>
+    <string name="history_share_label_failed_items">Failed items</string>
+    <string name="history_share_label_paths">Affected paths (%1$d)</string>
+    <string name="history_share_paths_more">… and %1$d more</string>
+    <string name="history_share_truncated">… and %1$d more entries not included</string>
 </resources>

--- a/app-workspace-history/src/main/res/values/strings.xml
+++ b/app-workspace-history/src/main/res/values/strings.xml
@@ -163,6 +163,15 @@
     <string name="history_workspace_title_kind_install">History: Install</string>
     <string name="history_filter_kind_install">Install</string>
 
+    <!-- Selection actions -->
+    <string name="history_action_select_all">Select all</string>
+    <string name="history_action_deselect_all">Deselect all</string>
+    <plurals name="history_delete_dialog_title">
+        <item quantity="one">Delete %1$d entry</item>
+        <item quantity="other">Delete %1$d entries</item>
+    </plurals>
+    <string name="history_delete_dialog_message">Only the history records are removed, the files themselves are not touched.</string>
+
     <!-- Shared text -->
     <string name="history_share_label_outcome">Outcome</string>
     <string name="history_share_label_kind">Kind</string>

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
@@ -6,6 +6,7 @@ import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
 import eu.darken.butler.workspace.core.operations.history.OperationHistoryRepo
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldEndWith
@@ -251,4 +252,31 @@ class HistoryShareTextTest : BaseTest() {
 
         share(listOf(entry)) shouldContain "- **Duration:** 25.0 s\n"
     }
+
+    private fun added(path: String) = HistoryEntry.PathChange(
+        path = path,
+        previousPath = null,
+        change = Operation.Report.PathChange.Change.ADDED,
+    )
+
+    /**
+     * The loop stops at the first block that does not fit, so the truncation notice is appended to
+     * whatever headroom is left. Sized so the notice needs more room than remains: 101 identical
+     * blocks of [TARGET_BLOCK_CHARS], of which 100 fit exactly.
+     */
+    @Test
+    fun `the truncation notice stays inside the size budget`() {
+        val probePath = "/sdcard/pad/"
+        val padding = TARGET_BLOCK_CHARS - share(listOf(entry(paths = listOf(added(probePath))))).length
+        val path = probePath + "p".repeat(padding)
+        val entries = (1..101).map { entry(id = "entry-$it", paths = listOf(added(path))) }
+
+        val text = share(entries)
+
+        text shouldEndWith "more entries not included"
+        text.length shouldBeLessThanOrEqual SHARE_TEXT_MAX_CHARS
+    }
 }
+
+/** 101 of these leaves 2 chars of headroom, less than the truncation notice needs. */
+private const val TARGET_BLOCK_CHARS = 998

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
@@ -276,6 +276,35 @@ class HistoryShareTextTest : BaseTest() {
         text shouldEndWith "more entries not included"
         text.length shouldBeLessThanOrEqual SHARE_TEXT_MAX_CHARS
     }
+
+    @Test
+    fun `a newline in a path does not break out of its code span`() {
+        val text = share(listOf(entry(paths = listOf(added("/sdcard/we\nird.txt")))))
+
+        val pathLine = text.lines().single { it.startsWith("- added: ") }
+        pathLine shouldEndWith "`"
+        pathLine shouldContain "we\\nird.txt"
+    }
+
+    @Test
+    fun `a carriage return in a path does not break out of its code span`() {
+        val text = share(listOf(entry(paths = listOf(added("/sdcard/we\rird.txt")))))
+
+        val pathLine = text.lines().single { it.startsWith("- added: ") }
+        pathLine shouldEndWith "`"
+        pathLine shouldContain "we\\rird.txt"
+        text shouldNotContain "\r"
+    }
+
+    @Test
+    fun `a literal backslash-n in a path stays distinct from a real newline`() {
+        val literal = share(listOf(entry(paths = listOf(added("/sdcard/we\\nird.txt")))))
+        val real = share(listOf(entry(paths = listOf(added("/sdcard/we\nird.txt")))))
+
+        val literalLine = literal.lines().single { it.startsWith("- added: ") }
+        literalLine shouldBe "- added: `/sdcard/we\\\\nird.txt`"
+        (literalLine == real.lines().single { it.startsWith("- added: ") }) shouldBe false
+    }
 }
 
 /** 101 of these leaves 2 chars of headroom, less than the truncation notice needs. */

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
@@ -297,6 +297,22 @@ class HistoryShareTextTest : BaseTest() {
     }
 
     @Test
+    fun `a carriage return in an error does not split its meta line`() {
+        val text = share(
+            listOf(
+                entry(
+                    outcome = HistoryOutcome.FAILED,
+                    errorMessage = "cannot delete /sdcard/we\rird.txt",
+                )
+            )
+        )
+
+        val errorLine = text.lines().single { it.startsWith("- **Error:** ") }
+        errorLine shouldBe "- **Error:** cannot delete /sdcard/we ird.txt"
+        text shouldNotContain "\r"
+    }
+
+    @Test
     fun `a literal backslash-n in a path stays distinct from a real newline`() {
         val literal = share(listOf(entry(paths = listOf(added("/sdcard/we\\nird.txt")))))
         val real = share(listOf(entry(paths = listOf(added("/sdcard/we\nird.txt")))))

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
@@ -1,0 +1,254 @@
+package eu.darken.butler.history.core
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import eu.darken.butler.workspace.core.operations.history.OperationHistoryRepo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.time.ZoneOffset
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+/** The shared markdown is the record a user pastes elsewhere, arbitrary path text included. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HistoryShareTextTest : BaseTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val completedAt = Instant.parse("2026-09-02T14:31:05Z")
+
+    private fun entry(
+        id: String = "entry",
+        title: String = "Copy 5 items",
+        description: String = "5 items to /backup",
+        summary: String? = null,
+        outcome: HistoryOutcome = HistoryOutcome.COMPLETED,
+        errorMessage: String? = null,
+        partialErrorCount: Int = 0,
+        affectedPathsCount: Int = 1,
+        pathsTruncated: Boolean = false,
+        paths: List<HistoryEntry.PathChange> = listOf(
+            HistoryEntry.PathChange(
+                path = "/storage/emulated/0/DCIM/photo.jpg",
+                previousPath = null,
+                change = Operation.Report.PathChange.Change.ADDED,
+            ),
+        ),
+    ) = HistoryEntry(
+        id = id,
+        kind = Operation.Metadata.Kind.COPY,
+        intent = null,
+        originType = HistoryEntry.OriginType.EXPLORER,
+        originWorkspaceId = "ws",
+        title = title,
+        description = description,
+        summary = summary,
+        startedAt = completedAt - 1200.milliseconds,
+        completedAt = completedAt,
+        duration = 1200.milliseconds,
+        outcome = outcome,
+        errorMessage = errorMessage,
+        errorClass = null,
+        affectedPathsCount = affectedPathsCount,
+        partialErrorCount = partialErrorCount,
+        pathsTruncated = pathsTruncated,
+        paths = paths,
+    )
+
+    private fun share(
+        entries: List<HistoryEntry>,
+        attemptedPaths: OperationHistoryRepo.AttemptedPaths? = null,
+    ) = buildHistoryShareText(
+        context = context,
+        entries = entries,
+        attemptedPaths = attemptedPaths,
+        zone = ZoneOffset.UTC,
+    )
+
+    @Test
+    fun `a completed entry renders its heading, meta lines and paths`() {
+        val text = share(listOf(entry(summary = "5 files copied")))
+
+        text shouldContain "## Copy 5 items\n5 items to /backup\n"
+        text shouldContain "- **Outcome:** Completed\n"
+        text shouldContain "- **Kind:** Copy\n"
+        text shouldContain "- **Origin:** Explorer\n"
+        text shouldContain "- **Summary:** 5 files copied\n"
+        text shouldContain "- **Completed:** 2026-09-02 14:31:05\n"
+        text shouldContain "- **Duration:** 1.2 s\n"
+        text shouldContain "**Affected paths (1)**\n"
+        text shouldContain "- added: `/storage/emulated/0/DCIM/photo.jpg`"
+    }
+
+    @Test
+    fun `a renamed path renders both sides`() {
+        val text = share(
+            listOf(
+                entry(
+                    paths = listOf(
+                        HistoryEntry.PathChange(
+                            path = "/sdcard/new.txt",
+                            previousPath = "/sdcard/old.txt",
+                            change = Operation.Report.PathChange.Change.MOVED,
+                        ),
+                    ),
+                )
+            )
+        )
+
+        text shouldContain "- `/sdcard/old.txt` → `/sdcard/new.txt`"
+    }
+
+    @Test
+    fun `a truncated path list says how many are missing`() {
+        val text = share(
+            listOf(
+                entry(
+                    affectedPathsCount = 200,
+                    pathsTruncated = true,
+                    paths = (1..5).map {
+                        HistoryEntry.PathChange(
+                            path = "/sdcard/file_$it.bin",
+                            previousPath = null,
+                            change = Operation.Report.PathChange.Change.REMOVED,
+                        )
+                    },
+                )
+            )
+        )
+
+        text shouldContain "… and 195 more"
+    }
+
+    @Test
+    fun `only a failed entry carries an error line`() {
+        val failed = share(
+            listOf(
+                entry(
+                    outcome = HistoryOutcome.FAILED,
+                    errorMessage = "Permission denied",
+                    partialErrorCount = 3,
+                )
+            )
+        )
+        val completed = share(listOf(entry()))
+
+        failed shouldContain "- **Error:** Permission denied\n"
+        failed shouldContain "- **Failed items:** 3\n"
+        completed shouldNotContain "**Error:**"
+        completed shouldNotContain "**Failed items:**"
+    }
+
+    @Test
+    fun `two entries become two blocks separated by a blank line`() {
+        val text = share(listOf(entry(id = "a", title = "First"), entry(id = "b", title = "Second")))
+
+        text shouldContain "\n\n## Second"
+        text.split("## ").size shouldBe 3
+    }
+
+    @Test
+    fun `an entry without reported paths falls back to the attempted ones`() {
+        val text = share(
+            entries = listOf(entry(affectedPathsCount = 0, paths = emptyList())),
+            attemptedPaths = OperationHistoryRepo.AttemptedPaths(
+                paths = listOf("/sdcard/ButlerQA", "/sdcard/ButlerQA/notes.txt"),
+                totalCount = 12,
+            ),
+        )
+
+        text shouldContain "No affected paths recorded."
+        text shouldContain "**Attempted paths**"
+        text shouldContain "- `/sdcard/ButlerQA/notes.txt`"
+        text shouldContain "Showing first 2 of 12 attempted paths."
+    }
+
+    @Test
+    fun `an entry without any paths says so`() {
+        val text = share(listOf(entry(affectedPathsCount = 0, paths = emptyList())))
+
+        text shouldContain "No affected paths recorded."
+        text shouldNotContain "Attempted paths"
+    }
+
+    @Test
+    fun `a backtick in a path and a newline in an error do not break the document`() {
+        val text = share(
+            listOf(
+                entry(
+                    outcome = HistoryOutcome.FAILED,
+                    errorMessage = "Permission denied\n# not a heading\n- not a list item",
+                    paths = listOf(
+                        HistoryEntry.PathChange(
+                            path = "/sdcard/we`ird`.txt",
+                            previousPath = null,
+                            change = Operation.Report.PathChange.Change.ADDED,
+                        ),
+                    ),
+                )
+            )
+        )
+
+        text shouldContain "- **Error:** Permission denied # not a heading - not a list item\n"
+        text shouldContain "- added: ``/sdcard/we`ird`.txt``"
+        text.lines().none { it.startsWith("# ") } shouldBe true
+    }
+
+    @Test
+    fun `a select-all share stays within the size budget`() {
+        val entries = (1..2000).map { index ->
+            entry(
+                id = "entry-$index",
+                affectedPathsCount = 200,
+                paths = (1..200).map {
+                    HistoryEntry.PathChange(
+                        path = "/storage/emulated/0/DCIM/folder_$index/photo_$it.jpg",
+                        previousPath = null,
+                        change = Operation.Report.PathChange.Change.ADDED,
+                    )
+                },
+            )
+        }
+
+        val text = share(entries)
+
+        (text.length < SHARE_TEXT_MAX_CHARS) shouldBe true
+        text shouldEndWith "more entries not included"
+    }
+
+    @Test
+    fun `an entry sharing the same zone renders the completion time in it`() {
+        val text = buildHistoryShareText(
+            context = context,
+            entries = listOf(entry()),
+            zone = ZoneOffset.ofHours(2),
+        )
+
+        text shouldContain "- **Completed:** 2026-09-02 16:31:05\n"
+    }
+
+    @Test
+    fun `a duration below a second is rendered in milliseconds`() {
+        val entry = entry().copy(duration = 250.milliseconds)
+
+        share(listOf(entry)) shouldContain "- **Duration:** 250 ms\n"
+    }
+
+    @Test
+    fun `a long duration keeps one decimal`() {
+        val entry = entry().copy(duration = 25.seconds)
+
+        share(listOf(entry)) shouldContain "- **Duration:** 25.0 s\n"
+    }
+}

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
@@ -1,10 +1,14 @@
 package eu.darken.butler.history.ui
 
+import android.content.Context
+import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.history.core.labelRes
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
@@ -71,6 +75,36 @@ class HistoryEntryRowLabelTest : ComposeTest() {
             .assertCountEquals(2)
         composeTestRule.onNodeWithText("Extracted  backup.zip").assertIsDisplayed()
         composeTestRule.onNodeWithText("aaa.txt", substring = true).assertDoesNotExist()
+    }
+
+    /**
+     * Every other label on the row comes from a resource; an enum name here would leave the row
+     * disagreeing with the detail sheet in any translated locale.
+     */
+    @Test
+    fun `each row names its origin with the label resource`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Column {
+                    HistoryEntry.OriginType.entries.forEach { origin ->
+                        HistoryEntryRow(
+                            entry = entry(
+                                primaryPath = "/sdcard/ButlerQA/backup.zip",
+                                paths = emptyList(),
+                            ).copy(originType = origin),
+                            onClick = {},
+                        )
+                    }
+                }
+            }
+        }
+
+        HistoryEntry.OriginType.entries.forEach { origin ->
+            composeTestRule
+                .onAllNodesWithText(context.getString(origin.labelRes), substring = true, useUnmergedTree = true)
+                .assertCountEquals(1)
+        }
     }
 
     @Test

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.butler.history.ui
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.operations.Operation
@@ -64,7 +66,10 @@ class HistoryEntryRowLabelTest : ComposeTest() {
             )
         )
 
-        composeTestRule.onNodeWithText("backup.zip", substring = true).assertIsDisplayed()
+        // Headline and path line both name the subject, on separate nodes.
+        composeTestRule.onAllNodesWithText("backup.zip", substring = true, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule.onNodeWithText("Extracted  backup.zip").assertIsDisplayed()
         composeTestRule.onNodeWithText("aaa.txt", substring = true).assertDoesNotExist()
     }
 
@@ -72,6 +77,8 @@ class HistoryEntryRowLabelTest : ComposeTest() {
     fun `a row without a subject still names its first reported change`() {
         render(entry(primaryPath = null, paths = listOf("/sdcard/ButlerQA/backup/aaa.txt")))
 
-        composeTestRule.onNodeWithText("aaa.txt", substring = true).assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("aaa.txt", substring = true, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule.onNodeWithText("Extracted  aaa.txt").assertIsDisplayed()
     }
 }

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowSelectionTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowSelectionTest.kt
@@ -1,0 +1,97 @@
+package eu.darken.butler.history.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/** Selection mode is driven from the row: the long press starts it, a checkbox reports it. */
+class HistoryEntryRowSelectionTest : ComposeTest() {
+
+    private val completedAt = Clock.System.now()
+
+    private val entry = HistoryEntry(
+        id = "entry",
+        kind = Operation.Metadata.Kind.COPY,
+        intent = null,
+        originType = HistoryEntry.OriginType.EXPLORER,
+        originWorkspaceId = "ws",
+        title = "Copy",
+        description = "Copying",
+        summary = null,
+        startedAt = completedAt - 1.seconds,
+        completedAt = completedAt,
+        duration = 1.seconds,
+        outcome = HistoryOutcome.COMPLETED,
+        errorMessage = null,
+        errorClass = null,
+        affectedPathsCount = 1,
+        partialErrorCount = 0,
+        pathsTruncated = false,
+        paths = emptyList(),
+        primaryPath = "/sdcard/ButlerQA/backup.zip",
+    )
+
+    private fun render(
+        selectionActive: Boolean = false,
+        isSelected: Boolean = false,
+        onLongClick: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                HistoryEntryRow(
+                    entry = entry,
+                    onClick = {},
+                    onLongClick = onLongClick,
+                    isSelected = isSelected,
+                    selectionActive = selectionActive,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a long press on the row starts the selection`() {
+        var longClicks = 0
+        render(onLongClick = { longClicks++ })
+
+        composeTestRule.onNodeWithText("Copied  backup.zip").performTouchInput { longClick() }
+
+        longClicks shouldBe 1
+    }
+
+    @Test
+    fun `the kind icon labels the row while nothing is selected`() {
+        render(selectionActive = false)
+
+        composeTestRule.onNodeWithContentDescription("COPY").assertExists()
+        composeTestRule.onNodeWithTag(HISTORY_ROW_CHECKBOX_TAG, useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a checkbox replaces the kind icon in selection mode`() {
+        render(selectionActive = true, isSelected = true)
+
+        composeTestRule.onNodeWithTag(HISTORY_ROW_CHECKBOX_TAG, useUnmergedTree = true).assertExists()
+        composeTestRule.onNodeWithContentDescription("COPY").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the full path gets a line of its own`() {
+        render()
+
+        composeTestRule.onNodeWithText("/sdcard/ButlerQA/backup.zip", useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+}

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistorySelectionTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistorySelectionTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.butler.history.ui
+
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.BaseTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/** Which actions the bar offers is derived, so it can be checked without a device. */
+class HistorySelectionTest : BaseTest() {
+
+    private val completedAt = Clock.System.now()
+
+    private fun entry(id: String) = HistoryEntry(
+        id = id,
+        kind = Operation.Metadata.Kind.COPY,
+        intent = null,
+        originType = HistoryEntry.OriginType.EXPLORER,
+        originWorkspaceId = "ws",
+        title = "Copy",
+        description = "Copying",
+        summary = null,
+        startedAt = completedAt - 1.seconds,
+        completedAt = completedAt,
+        duration = 1.seconds,
+        outcome = HistoryOutcome.COMPLETED,
+        errorMessage = null,
+        errorClass = null,
+        affectedPathsCount = 0,
+        partialErrorCount = 0,
+        pathsTruncated = false,
+        paths = emptyList(),
+    )
+
+    private val visible = listOf(entry("a"), entry("b"), entry("c"))
+
+    @Test
+    fun `an empty selection offers no actions`() {
+        historyActionsFor(selected = emptyList(), visible = visible) shouldContainExactly emptyList()
+    }
+
+    @Test
+    fun `a partial selection can select the rest`() {
+        val actions = historyActionsFor(selected = visible.take(1), visible = visible)
+
+        val selectAll = actions.filterIsInstance<HistoryActionBarItem.SelectAll>().single()
+        selectAll.ids shouldBe setOf("a", "b", "c")
+    }
+
+    @Test
+    fun `a full selection drops the select-all action`() {
+        val actions = historyActionsFor(selected = visible, visible = visible)
+
+        actions.filterIsInstance<HistoryActionBarItem.SelectAll>() shouldContainExactly emptyList()
+        actions shouldContainExactly listOf(
+            HistoryActionBarItem.DeselectAll,
+            HistoryActionBarItem.Share(visible),
+            HistoryActionBarItem.Delete(visible),
+        )
+    }
+
+    @Test
+    fun `the delete action is marked destructive, the others are not`() {
+        val actions = historyActionsFor(selected = visible.take(2), visible = visible)
+
+        actions.single { it.isDestructive } shouldBe HistoryActionBarItem.Delete(visible.take(2))
+    }
+}

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
@@ -94,6 +94,13 @@ class HistoryWorkspaceShareTest : BaseTest() {
         return send.getStringExtra(Intent.EXTRA_TEXT)
     }
 
+    /** The shadow pops one intent per read, so draining it is how many launches are counted. */
+    private fun startedChooserCount(): Int {
+        var count = 0
+        while (shadowOf(application).nextStartedActivity != null) count++
+        return count
+    }
+
     @Test
     fun `sharing before the attempted paths arrive still includes them`() {
         val gate = CompletableDeferred<OperationHistoryRepo.AttemptedPaths>()
@@ -131,5 +138,22 @@ class HistoryWorkspaceShareTest : BaseTest() {
 
         val text = lastSharedText()!!
         text shouldContain "- `/sdcard/ButlerQA/notes.txt`"
+    }
+
+    @Test
+    fun `tapping share twice while the paths load starts only one chooser`() {
+        val gate = CompletableDeferred<OperationHistoryRepo.AttemptedPaths>()
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } coAnswers { gate.await() }
+
+        val vm = createVM()
+        vm.showEntryDetails(entry)
+
+        // The button stays enabled while the query is in flight, so a second tap is reachable.
+        vm.shareEntry(entry)
+        vm.shareEntry(entry)
+
+        gate.complete(attempted)
+
+        startedChooserCount() shouldBe 1
     }
 }

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
@@ -1,0 +1,135 @@
+package eu.darken.butler.history.ui
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import eu.darken.butler.workspace.core.operations.history.HistorySettings
+import eu.darken.butler.workspace.core.operations.history.OperationHistoryRepo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+
+/**
+ * The detail sheet loads the attempted paths asynchronously; sharing must not race that load.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HistoryWorkspaceShareTest : BaseTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val application = context as Application
+    private val completedAt = Instant.parse("2026-09-02T14:31:05Z")
+
+    private val workspaceProvider = mockk<WorkspaceProvider>().apply {
+        every { retrieve(any()) } returns flowOf(null)
+    }
+    private val historySettings = mockk<HistorySettings>(relaxed = true)
+    private val historyRepo = mockk<OperationHistoryRepo>(relaxed = true).apply {
+        every { observeCount() } returns flowOf(0)
+    }
+
+    /** An entry that reported no changes at all, so the sheet falls back to the attempted paths. */
+    private val entry = HistoryEntry(
+        id = "entry-1",
+        kind = Operation.Metadata.Kind.DELETE,
+        intent = null,
+        originType = HistoryEntry.OriginType.EXPLORER,
+        originWorkspaceId = "ws",
+        title = "Delete 2 items",
+        description = "2 items in /sdcard/ButlerQA",
+        summary = null,
+        startedAt = completedAt - 1200.milliseconds,
+        completedAt = completedAt,
+        duration = 1200.milliseconds,
+        outcome = HistoryOutcome.FAILED,
+        errorMessage = "Permission denied",
+        errorClass = null,
+        affectedPathsCount = 0,
+        partialErrorCount = 0,
+        pathsTruncated = false,
+        paths = emptyList(),
+    )
+
+    private val attempted = OperationHistoryRepo.AttemptedPaths(
+        paths = listOf("/sdcard/ButlerQA", "/sdcard/ButlerQA/notes.txt"),
+        totalCount = 2,
+    )
+
+    private fun createVM() = HistoryWorkspaceViewModel(
+        id = Workspace.Id(),
+        context = context,
+        dispatchers = TestDispatcherProvider(),
+        workspaceProvider = workspaceProvider,
+        historyRepo = historyRepo,
+        historySettings = historySettings,
+    )
+
+    /**
+     * `startActivity` hands Robolectric the chooser; the intent the ViewModel actually built is the
+     * `EXTRA_INTENT` payload inside it.
+     */
+    private fun lastSharedText(): String? {
+        val chooser = shadowOf(application).nextStartedActivity ?: return null
+        chooser.action shouldBe Intent.ACTION_CHOOSER
+        val send = chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)!!
+        return send.getStringExtra(Intent.EXTRA_TEXT)
+    }
+
+    @Test
+    fun `sharing before the attempted paths arrive still includes them`() {
+        val gate = CompletableDeferred<OperationHistoryRepo.AttemptedPaths>()
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } coAnswers { gate.await() }
+
+        val vm = createVM()
+
+        // The sheet opens and the load is still in flight
+        vm.showEntryDetails(entry)
+        vm.overlayState.value.detailEntry shouldBe entry
+        vm.overlayState.value.attemptedPaths shouldBe emptyList()
+
+        vm.shareEntry(entry)
+
+        // The query does return; this is about the ordering, not about a load that never finishes.
+        gate.complete(attempted)
+
+        val text = lastSharedText()!!
+        text shouldContain "## Delete 2 items"
+        text shouldContain "- `/sdcard/ButlerQA/notes.txt`"
+        text shouldContain "- `/sdcard/ButlerQA`"
+
+        vm.overlayState.value.attemptedPaths shouldBe attempted.paths
+    }
+
+    @Test
+    fun `sharing after the attempted paths arrive includes them`() {
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } returns attempted
+
+        val vm = createVM()
+        vm.showEntryDetails(entry)
+        vm.overlayState.value.attemptedPaths shouldBe attempted.paths
+
+        vm.shareEntry(entry)
+
+        val text = lastSharedText()!!
+        text shouldContain "- `/sdcard/ButlerQA/notes.txt`"
+    }
+}

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.history.core.HistoryWorkspace
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryFilter
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
 import eu.darken.butler.workspace.core.operations.history.HistorySettings
 import eu.darken.butler.workspace.core.operations.history.OperationHistoryRepo
@@ -17,7 +19,11 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -68,6 +74,13 @@ class HistoryWorkspaceShareTest : BaseTest() {
         pathsTruncated = false,
         paths = emptyList(),
     )
+
+    /** A second visible row, so a selection on it survives the state's prune-on-read. */
+    private val otherEntry = entry.copy(id = "some-id", title = "Copy 1 item")
+
+    private val historyWorkspace = mockk<HistoryWorkspace>().apply {
+        every { filter } returns flowOf(HistoryFilter())
+    }
 
     private val attempted = OperationHistoryRepo.AttemptedPaths(
         paths = listOf("/sdcard/ButlerQA", "/sdcard/ButlerQA/notes.txt"),
@@ -155,5 +168,49 @@ class HistoryWorkspaceShareTest : BaseTest() {
         gate.complete(attempted)
 
         startedChooserCount() shouldBe 1
+    }
+
+    @Test
+    fun `a selection made while the share waits survives it`() {
+        val gate = CompletableDeferred<OperationHistoryRepo.AttemptedPaths>()
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } coAnswers { gate.await() }
+        every { workspaceProvider.retrieve(any()) } returns flowOf(historyWorkspace)
+        every { historySettings.maxHistoryItems.flow } returns flowOf(200)
+        every { historyRepo.query(any(), any()) } returns flowOf(listOf(entry, otherEntry))
+        every { historyRepo.observeCount() } returns flowOf(2)
+
+        val vm = createVM()
+        val states = mutableListOf<HistoryWorkspaceViewModel.State?>()
+        val collector = CoroutineScope(Dispatchers.Unconfined).launch { vm.state.toList(states) }
+
+        try {
+            vm.showEntryDetails(entry)
+            vm.shareEntry(entry)
+
+            // Selection mode is still usable behind the sheet while the query is in flight.
+            vm.toggleSelection(otherEntry.id)
+            states.last()!!.selectedIds shouldBe setOf(otherEntry.id)
+
+            gate.complete(attempted)
+
+            states.last()!!.selectedIds shouldBe setOf(otherEntry.id)
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    @Test
+    fun `dismissing the sheet before the paths arrive drops the share`() {
+        val gate = CompletableDeferred<OperationHistoryRepo.AttemptedPaths>()
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } coAnswers { gate.await() }
+
+        val vm = createVM()
+        vm.showEntryDetails(entry)
+        vm.shareEntry(entry)
+
+        vm.showEntryDetails(null)
+        gate.complete(attempted)
+
+        startedChooserCount() shouldBe 0
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -318,6 +318,16 @@ class OperationHistoryRepo @Inject constructor(
             .onFailure { log(TAG, ERROR) { "delete($id) failed: ${it.asLog()}" } }
     }
 
+    /**
+     * Deliberately not wrapped in `runCatching`: a swallowed failure would tell the caller the
+     * delete succeeded while part of the selection is still there. Callers clear their selection
+     * only once this returns normally, and the thrown exception reaches the error handler.
+     */
+    suspend fun delete(ids: Collection<String>) {
+        log(TAG, INFO) { "delete(): ${ids.size} entries" }
+        dao.deleteByIdsChunked(ids)
+    }
+
     suspend fun clearAll() {
         log(TAG, INFO) { "clearAll()" }
         dao.deleteAll()

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.workspace.core.operations.history.db.OperationHistorySco
 import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryWithPaths
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -281,9 +282,28 @@ class OperationHistoryRepo @Inject constructor(
 
         return idsFlow.flatMapLatest { ids ->
             if (ids.isEmpty()) flowOf(emptyList())
-            else dao.loadByIds(ids).map { rows -> rows.map { it.toDomain() } }
+            else loadByIdsChunked(ids).map { rows -> rows.map { it.toDomain() } }
         }
     }
+
+    /**
+     * The id list can hold as many entries as the history cap allows (2000), which overruns the
+     * bind-argument limit of a single `IN (:ids)` on API 30 and below - see
+     * [OperationHistoryDao.MAX_BIND_ARGS]. Splitting also splits the per-chunk `ORDER BY`, so the
+     * combined result is re-sorted newest-first.
+     *
+     * The single-chunk branch is a behavior guarantee, not an optimization: [combine] emits nothing
+     * until every source has produced a value, and the common case keeps emitting exactly as the
+     * plain query does.
+     */
+    private fun loadByIdsChunked(ids: List<String>): Flow<List<OperationHistoryWithPaths>> =
+        if (ids.size <= OperationHistoryDao.MAX_BIND_ARGS) {
+            dao.loadByIds(ids)
+        } else {
+            combine(ids.chunked(OperationHistoryDao.MAX_BIND_ARGS).map { dao.loadByIds(it) }) { chunks ->
+                chunks.toList().flatten().sortedByDescending { it.entry.completedAt }
+            }
+        }
 
     private fun buildScopedIdsQuery(
         outcomes: List<String>,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryDao.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryDao.kt
@@ -138,6 +138,25 @@ interface OperationHistoryDao {
     @Query("DELETE FROM operation_history WHERE id = :id")
     suspend fun deleteById(id: String)
 
+    @Query("DELETE FROM operation_history WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: Collection<String>)
+
+    /** Deletes every id in one transaction, so a chunk failing rolls the whole delete back. */
+    @Transaction
+    suspend fun deleteByIdsChunked(ids: Collection<String>) {
+        ids.chunked(MAX_BIND_ARGS).forEach { deleteByIds(it) }
+    }
+
     @Query("DELETE FROM operation_history")
     suspend fun deleteAll()
+
+    companion object {
+        /**
+         * SQLite's `SQLITE_MAX_VARIABLE_NUMBER` is 999 on API 30 and below; API 31+ ships SQLite
+         * 3.32+ where it is 32766. `minSdk` is 26 and the history cap goes up to 2000, so a
+         * select-all delete would exceed the limit in a single `IN (:ids)` statement on the lower
+         * half of the range.
+         */
+        const val MAX_BIND_ARGS = 900
+    }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryBulkDeleteTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryBulkDeleteTest.kt
@@ -1,0 +1,153 @@
+package eu.darken.butler.workspace.core.operations.history
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.workspace.core.operations.CompletedOperationSnapshot
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryDao
+import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryDatabase
+import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryEntity
+import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryPathEntity
+import eu.darken.butler.workspace.core.operations.history.db.OperationHistoryScopeEntity
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Bulk delete and the list query executed against real SQLite. Both split their id list into
+ * chunks, and only a database that actually enforces `SQLITE_MAX_VARIABLE_NUMBER` semantics can
+ * show that the split covers every id and still orders the whole set.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OperationHistoryBulkDeleteTest : BaseTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val completedOperations = MutableSharedFlow<CompletedOperationSnapshot>(replay = 1)
+    private val appScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val baseTime = Clock.System.now() - 3.seconds * OVER_LIMIT
+
+    private lateinit var database: OperationHistoryDatabase
+    private lateinit var dao: OperationHistoryDao
+    private lateinit var repo: OperationHistoryRepo
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            context,
+            OperationHistoryDatabase::class.java,
+        ).build()
+        dao = database.operationHistoryDao()
+        repo = createHistoryRepo(
+            context = context,
+            database = database,
+            dao = dao,
+            appScope = appScope,
+            completedOperations = completedOperations,
+            maxItems = OVER_LIMIT * 2,
+        )
+    }
+
+    @After
+    fun teardown() {
+        appScope.cancel()
+        database.close()
+    }
+
+    /** One entry with one path row and one scope row each, oldest first. */
+    private suspend fun seed(id: String, ageSteps: Int) {
+        dao.insertEntry(
+            OperationHistoryEntity(
+                id = id,
+                kind = Operation.Metadata.Kind.COPY.name,
+                intent = null,
+                originType = HistoryEntry.OriginType.EXPLORER.name,
+                originWorkspaceId = "ws",
+                title = "title",
+                description = "description",
+                summary = null,
+                startedAt = baseTime + ageSteps.seconds,
+                completedAt = baseTime + ageSteps.seconds,
+                durationMs = 0,
+                outcome = HistoryOutcome.COMPLETED.name,
+                errorMessage = null,
+                errorClass = null,
+                affectedPathsCount = 1,
+            )
+        )
+        dao.insertPaths(
+            listOf(
+                OperationHistoryPathEntity(
+                    operationHistoryId = id,
+                    path = "/sdcard/$id.txt",
+                    previousPath = null,
+                    change = Operation.Report.PathChange.Change.ADDED.name,
+                    sortIndex = 0,
+                )
+            )
+        )
+        dao.insertScopePaths(
+            listOf(
+                OperationHistoryScopeEntity(
+                    operationHistoryId = id,
+                    path = "/sdcard/$id.txt",
+                    sortIndex = 0,
+                )
+            )
+        )
+    }
+
+    private suspend fun seedOverLimit(): List<String> {
+        val ids = (1..OVER_LIMIT).map { "op-%04d".format(it) }
+        ids.forEachIndexed { index, id -> seed(id, ageSteps = index) }
+        return ids
+    }
+
+    private fun rowCount(table: String): Int = database.openHelper.writableDatabase
+        .query("SELECT COUNT(*) FROM $table")
+        .use { cursor -> if (cursor.moveToFirst()) cursor.getInt(0) else 0 }
+
+    @Test
+    fun `deleting more entries than SQLite can bind removes all of them`() = runTest {
+        val doomed = seedOverLimit()
+        seed("op-keeper", ageSteps = OVER_LIMIT + 1)
+
+        dao.deleteByIdsChunked(doomed)
+
+        dao.getCount() shouldBe 1
+        rowCount("operation_history_paths") shouldBe 1
+        rowCount("operation_history_scope") shouldBe 1
+    }
+
+    @Test
+    fun `a query matching more entries than SQLite can bind returns them all newest-first`() = runTest {
+        val seeded = seedOverLimit()
+
+        val entries = repo.query(HistoryFilter(), limit = OVER_LIMIT).first()
+
+        entries.map { it.id } shouldContainExactly seeded.reversed()
+        entries.forEach { entry ->
+            entry.paths.map { it.path } shouldContainExactly listOf("/sdcard/${entry.id}.txt")
+        }
+    }
+
+    companion object {
+        private val OVER_LIMIT = OperationHistoryDao.MAX_BIND_ARGS + 100
+    }
+}


### PR DESCRIPTION
## What changed

The operation history gained bulk actions. Long-press an entry to enter selection mode, tap more entries to add them, and use the bar at the bottom to select all, delete the selected entries, or share them. Back leaves selection mode, and changing a filter ends it rather than leaving a hidden selection behind.

History rows now use three lines. The path gets a line of its own at full width and is middle-ellipsized, so the folder and the file name both stay readable instead of the path being squeezed in behind the origin and the time.

The details sheet is no longer read-only. Paths, error text and the summary can be selected and copied, and a share button in its header produces a Markdown record of the operation — what it was, how it ended, how long it took, and every path it touched. The same record is what bulk share sends, one block per selected entry.

Two long-standing problems in the history database are fixed along the way. Deleting many entries at once, and simply loading the list, both used to break once the history contained more entries than SQLite would accept in a single query — reachable on Android 8 through 11 by raising the history limit in settings. The row's origin label is now translated, matching the details sheet, instead of showing the untranslated internal name.

## Technical Context

- `deleteByIds` and the list query both chunk their id lists at 900. `SQLITE_MAX_VARIABLE_NUMBER` is 999 on API 30 and below, `minSdk` is 26, and the history cap goes to 2000, so a select-all delete or a large list load overran it. The delete chunks share one `@Transaction` so a failing chunk rolls the whole thing back; the query keeps a single-chunk fast path because `combine` would otherwise withhold the first emission until every chunk had produced one.
- Sharing an entry that reported no changes has to wait for its attempted-paths query. That made `shareEntry` suspend, which in turn needed a `Mutex` so a double tap cannot open two choosers, and a check that the sheet still shows the same entry so a late share cannot surface over a dismissed sheet. `shareEntries` takes `clearsSelection` with no default, so both callers must state whether they own the selection.
- The share text is capped at 100k characters. `EXTRA_TEXT` crosses the Binder boundary, and a select-all share of 2000 entries at up to 200 paths each would otherwise reach tens of megabytes and throw `TransactionTooLargeException`. The cap reserves room for its own truncation notice before accepting each block.
- Paths and error text are arbitrary user data going into a Markdown document, so backticks pick a longer fence and CR/LF are escaped rather than emitted raw. A file name containing a newline would otherwise leave the code span unterminated and rename the path in the rendered output.
- Worth close review: the `combine`-based chunked flow in `OperationHistoryRepo.loadByIdsChunked` (emission semantics and ordering across the chunk boundary), and the suspension window in `HistoryWorkspaceViewModel.shareEntry`.
