### PR TITLE
Workspace: Keep the closed-tab undo bar clear of the navigation rail

### DIFF
--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -4,9 +4,14 @@ import android.app.Activity
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.runtime.Composable
@@ -30,6 +35,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.systemBarsWithOptionalCutout
 import eu.darken.butler.common.compose.tour.LocalGuidedTourController
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.navigation.NavigationEventHandler
@@ -66,6 +72,7 @@ import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
 import eu.darken.butler.workspace.ui.manager.rememberWindowSizeInfo
 import eu.darken.butler.workspace.ui.scroll.LocalWorkspaceScrollPositions
 import eu.darken.butler.workspace.ui.workspaces.adaptive.DividerPositions
+import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceNavigationRailDefaults
 import eu.darken.butler.workspace.ui.workspaces.classic.ClassicWorkspaceContainer
 import eu.darken.butler.workspace.ui.workspaces.tour.FirstTabTour
 import kotlin.uuid.Uuid
@@ -88,11 +95,9 @@ fun WorkspaceScreen(
     onReviewNow: (Activity) -> Unit = {},
     onDismissBanner: (Workspace.Id) -> Unit = {},
     onShareError: (Workspace.Id, Throwable) -> Unit = { _, _ -> },
+    design: WorkspaceDesign = rememberWorkspaceDesign(state),
 ) {
     val workspaceActionHandler = LocalWorkspaceButtonProvider.current
-    val windowSizeInfo = rememberWindowSizeInfo()
-    val configuration = LocalConfiguration.current
-    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
     var showPaneNumbers by remember { mutableStateOf(false) }
     var showPaneOverlay by remember { mutableStateOf(false) }
@@ -104,27 +109,6 @@ fun WorkspaceScreen(
     var dividerPositions by rememberSaveable {
         mutableStateOf(DividerPositions())
     }
-
-    // Select panel mode based on orientation
-    val effectivePanelMode = if (isLandscape) {
-        state.landscapePanelMode
-    } else {
-        state.portraitPanelMode
-    }
-
-    val effectivePaneLayout = when (effectivePanelMode) {
-        WorkspacePanelMode.AUTO -> windowSizeInfo.recommendedLayout
-        WorkspacePanelMode.SINGLE -> WorkspaceDesign.Layout.SINGLE
-        WorkspacePanelMode.DUAL_VERTICAL -> WorkspaceDesign.Layout.DUAL_VERTICAL
-        WorkspacePanelMode.DUAL_HORIZONTAL -> WorkspaceDesign.Layout.DUAL_HORIZONTAL
-        WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT
-        WorkspacePanelMode.TRIPLE_SIDEBAR_RIGHT -> WorkspaceDesign.Layout.TRIPLE_MAIN_RIGHT
-        WorkspacePanelMode.QUAD_GRID -> WorkspaceDesign.Layout.QUAD_GRID
-    }
-
-    val design = WorkspaceDesign(
-        layout = effectivePaneLayout,
-    )
 
     // Update pane count when design changes
     LaunchedEffect(design.maxPanes) {
@@ -281,6 +265,36 @@ fun WorkspaceScreen(
 }
 
 /**
+ * The pane layout the window gets, from the orientation's panel mode setting and the window size.
+ * Shared by the screen and its host: the host draws chrome outside every pane (the close-undo bar)
+ * and has to know whether the navigation rail takes the start edge.
+ */
+@Composable
+fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
+    val windowSizeInfo = rememberWindowSizeInfo()
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    val effectivePanelMode = if (isLandscape) {
+        state.landscapePanelMode
+    } else {
+        state.portraitPanelMode
+    }
+
+    val effectivePaneLayout = when (effectivePanelMode) {
+        WorkspacePanelMode.AUTO -> windowSizeInfo.recommendedLayout
+        WorkspacePanelMode.SINGLE -> WorkspaceDesign.Layout.SINGLE
+        WorkspacePanelMode.DUAL_VERTICAL -> WorkspaceDesign.Layout.DUAL_VERTICAL
+        WorkspacePanelMode.DUAL_HORIZONTAL -> WorkspaceDesign.Layout.DUAL_HORIZONTAL
+        WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT
+        WorkspacePanelMode.TRIPLE_SIDEBAR_RIGHT -> WorkspaceDesign.Layout.TRIPLE_MAIN_RIGHT
+        WorkspacePanelMode.QUAD_GRID -> WorkspaceDesign.Layout.QUAD_GRID
+    }
+
+    return WorkspaceDesign(layout = effectivePaneLayout)
+}
+
+/**
  * Dismisses the tab manager overlay on back.
  *
  * Registered above the workspace content, so it loses every LIFO race against a handler inside a
@@ -417,9 +431,11 @@ fun WorkspacesScreenHost(
         LocalWorkspacePagerVisibility provides vm.pagerVisibility,
         LocalWorkspaceTitles provides workspaceTitles,
     ) {
+        val design = state?.let { rememberWorkspaceDesign(it) }
         state?.let { state ->
             WorkspaceScreen(
                 state = state,
+                design = design ?: WorkspaceDesign(),
                 bannerStates = bannerStates,
                 managerDialogStates = managerDialogStates,
                 managerDialogs = managerDialogs,
@@ -498,7 +514,16 @@ fun WorkspacesScreenHost(
         // most likely first use of this feature. The dialogs below still cover it, which is right:
         // anything asking the user a question outranks an offer they can also just ignore.
         closedFeedback?.let { feedback ->
-            Box(modifier = Modifier.fillMaxSize()) {
+            // The rail sits inside the window's start inset and is 80dp beyond it. Only while the
+            // manager is down: the overlay covers the rail, and a bar offset over a full-width grid
+            // would look misplaced.
+            val railVisible = design?.isSingle == false && !pageManagerState.isManagerOverlayVisible
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(systemBarsWithOptionalCutout().only(WindowInsetsSides.Horizontal))
+                    .padding(start = if (railVisible) WorkspaceNavigationRailDefaults.Width else 0.dp),
+            ) {
                 FloatingBarStack(
                     modifier = Modifier.align(Alignment.BottomCenter),
                     position = BarPosition.BOTTOM,
@@ -603,17 +628,25 @@ internal fun FloatingBarScope.WorkspaceClosedUndoBar(
     onDismiss: () -> Unit,
 ) {
     FloatingBar(key = "workspace-closed-undo") {
-        // A superseding entry can reach composition without an intervening null, which would leave
-        // the swipe state parked at the previous entry's dismissed anchor - the new bar arrives
-        // already swiped away and takes no further gesture.
-        key(feedback.closeToken) {
-            WorkspaceClosedFeedbackBar(
-                feedback = feedback,
-                onUndo = onUndo,
-                onDismiss = onDismiss,
-            )
+        // Start-aligned and capped: a card spanning a tablet-width window reads as a banner.
+        Box(modifier = Modifier.fillMaxWidth()) {
+            // A superseding entry can reach composition without an intervening null, which would
+            // leave the swipe state parked at the previous entry's dismissed anchor - the new bar
+            // arrives already swiped away and takes no further gesture.
+            key(feedback.closeToken) {
+                WorkspaceClosedFeedbackBar(
+                    modifier = Modifier.widthIn(max = WorkspaceClosedUndoBarDefaults.MaxWidth),
+                    feedback = feedback,
+                    onUndo = onUndo,
+                    onDismiss = onDismiss,
+                )
+            }
         }
     }
+}
+
+object WorkspaceClosedUndoBarDefaults {
+    val MaxWidth = 600.dp
 }
 
 @Preview2

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -94,6 +94,9 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapp
 import eu.darken.butler.common.R as CommonR
 
 object WorkspaceNavigationRailDefaults {
+    /** Width past the start window inset the rail pads for itself. */
+    val Width = 80.dp
+
     const val SURFACE_TEST_TAG = "workspace.rail.surface"
     const val CONTENT_TEST_TAG = "workspace.rail.content"
     const val LIST_TEST_TAG = "workspace.rail.list"
@@ -373,7 +376,7 @@ internal fun WorkspaceRailContainer(
                     systemBarsWithOptionalCutout()
                         .only(WindowInsetsSides.Start + WindowInsetsSides.Vertical)
                 )
-                .width(80.dp)
+                .width(WorkspaceNavigationRailDefaults.Width)
                 .testTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
                 // Inside the tagged 80dp, so the rail's own width is unaffected. Kept tight because
                 // the entry's spare width is what the pane glyph's notch is carved out of, and what
@@ -559,7 +562,7 @@ private fun WorkspaceRailItemRtlPreview() {
 private fun WorkspaceRailItemStates(layout: WorkspaceDesign.Layout) {
     Column(
         modifier = Modifier
-            .width(80.dp)
+            .width(WorkspaceNavigationRailDefaults.Width)
             .padding(horizontal = RailItemInset),
         verticalArrangement = Arrangement.spacedBy(RailItemSpacing),
     ) {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBarTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceClosedFeedbackBarTest.kt
@@ -1,16 +1,22 @@
 package eu.darken.butler.workspace.ui.workspaces
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceFeedback
@@ -132,6 +138,30 @@ class WorkspaceClosedFeedbackBarTest : ComposeTest() {
         composeTestRule.waitForIdle()
 
         dismissedTokens shouldBe listOf(1L, 2L)
+    }
+
+    @Test
+    fun `the bar is capped in a wide window and starts at the stack's start edge`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                // Required: the test window is narrower than the cap, and a plain width would be
+                // clamped to it.
+                Box(modifier = Modifier.requiredWidth(1000.dp).testTag("window")) {
+                    FloatingBarStack(position = BarPosition.BOTTOM, horizontalPadding = 0.dp) {
+                        WorkspaceClosedUndoBar(
+                            feedback = feedbackOf(1L),
+                            onUndo = {},
+                            onDismiss = {},
+                        )
+                    }
+                }
+            }
+        }
+
+        val window = composeTestRule.onNodeWithTag("window").getUnclippedBoundsInRoot()
+        val bounds = composeTestRule.onNodeWithText(MESSAGE).onParent().getUnclippedBoundsInRoot()
+        bounds.left shouldBe window.left
+        bounds.width shouldBe 600.dp
     }
 
     companion object {


### PR DESCRIPTION
## What changed

In multi-pane layouts, the "closed tab" undo bar spanned the whole screen and covered the navigation rail. It now sits to the right of the rail (or at the window's start edge while the tab manager is open, which covers the rail). The bar is also capped at a snackbar-like width and aligned to the start, so it no longer stretches edge to edge on tablets and phones in landscape.

## Technical Context

- The bar is composed at window level in the workspace host, above the manager overlay, so it never knew about the rail. The host now reads the pane layout via a shared helper extracted from the screen and insets the bar's container by the horizontal window insets plus the rail width when the rail is visible and the manager is closed.
- The layout decision moved into a defaulted `design` parameter on the screen composable, so existing callers and tests keep working unchanged.
- The rail width became a named constant on the rail's defaults object, used by both the rail and the host inset.
- The new Robolectric test forces a 1000dp wrapper (the test window is 320dp wide, so a plain width would be clamped) and asserts the card's start alignment and 600dp cap.
