### PR TITLE
Explorer: Drag files onto folders, favorites and breadcrumbs

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/autoscroll/EdgeAutoScroller.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/autoscroll/EdgeAutoScroller.kt
@@ -71,11 +71,18 @@ class EdgeAutoScroller(
         if (pointer == Offset.Unspecified) return 0f
         val viewport = target.viewportMainAxisSize.toFloat()
         if (viewport <= 0f) return 0f
+        if (viewport - startInset - endInset <= 0f) return 0f
         val toStart = pointer.y - startInset
         val toEnd = (viewport - endInset) - pointer.y
+        val nearStart = toStart < edgePx
+        val nearEnd = toEnd < edgePx
         return when {
-            toStart < edgePx -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
-            toEnd < edgePx -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)
+            nearStart && nearEnd -> when {
+                toStart <= toEnd -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
+                else -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)
+            }
+            nearStart -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
+            nearEnd -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)
             else -> 0f
         }
     }

--- a/app-common/src/main/java/eu/darken/butler/common/compose/autoscroll/EdgeAutoScroller.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/autoscroll/EdgeAutoScroller.kt
@@ -33,9 +33,16 @@ class EdgeAutoScroller(
 
     private var job: Job? = null
     private var pointer: Offset = Offset.Unspecified
+    private var startInset: Float = 0f
+    private var endInset: Float = 0f
 
-    fun update(pointer: Offset) {
+    /**
+     * The insets shrink the edge zones to the visible part of the viewport when bars overlay it.
+     */
+    fun update(pointer: Offset, startInset: Float = 0f, endInset: Float = 0f) {
         this.pointer = pointer
+        this.startInset = startInset
+        this.endInset = endInset
         if (speedFor(pointer) == 0f) {
             stop()
             return
@@ -64,8 +71,8 @@ class EdgeAutoScroller(
         if (pointer == Offset.Unspecified) return 0f
         val viewport = target.viewportMainAxisSize.toFloat()
         if (viewport <= 0f) return 0f
-        val toStart = pointer.y
-        val toEnd = viewport - pointer.y
+        val toStart = pointer.y - startInset
+        val toEnd = (viewport - endInset) - pointer.y
         return when {
             toStart < edgePx -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
             toEnd < edgePx -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)

--- a/app-common/src/main/java/eu/darken/butler/common/compose/autoscroll/EdgeAutoScroller.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/autoscroll/EdgeAutoScroller.kt
@@ -1,0 +1,135 @@
+package eu.darken.butler.common.compose.autoscroll
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * Scrolls the content while the pointer rests near a viewport edge, advancing by frame delta so the
+ * speed is refresh-rate independent. Stops as soon as the content bound is reached and is re-armed
+ * by the next drag event.
+ *
+ * [onScrolled] reports whether the session is still live: a pointer resting at the edge produces no
+ * events, so the frame loop is the only place that would notice the session ending. It receives the
+ * same container-relative pointer that was handed to [update].
+ */
+class EdgeAutoScroller(
+    private val scope: CoroutineScope,
+    private val target: AutoScrollTarget,
+    private val edgePx: Float,
+    private val maxSpeedPx: Float,
+    private val onScrolled: (Offset) -> Boolean,
+) {
+
+    private var job: Job? = null
+    private var pointer: Offset = Offset.Unspecified
+
+    fun update(pointer: Offset) {
+        this.pointer = pointer
+        if (speedFor(pointer) == 0f) {
+            stop()
+            return
+        }
+        if (job?.isActive == true) return
+        job = scope.launch {
+            var previousFrame = withFrameNanos { it }
+            while (true) {
+                val frame = withFrameNanos { it }
+                val seconds = (frame - previousFrame) / 1_000_000_000f
+                previousFrame = frame
+                val speed = speedFor(pointer)
+                if (speed == 0f) break
+                if (target.scrollableState.scrollBy(speed * seconds) == 0f) break
+                if (!onScrolled(pointer)) break
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    private fun speedFor(pointer: Offset): Float {
+        if (pointer == Offset.Unspecified) return 0f
+        val viewport = target.viewportMainAxisSize.toFloat()
+        if (viewport <= 0f) return 0f
+        val toStart = pointer.y
+        val toEnd = viewport - pointer.y
+        return when {
+            toStart < edgePx -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
+            toEnd < edgePx -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)
+            else -> 0f
+        }
+    }
+
+    companion object {
+        /** How close to a viewport edge the pointer has to get before the content starts scrolling. */
+        val DefaultEdge = 56.dp
+
+        /** Auto-scroll speed at the very edge of the viewport, scaled down with the distance to it. */
+        val DefaultMaxSpeed = 900.dp
+    }
+}
+
+/** The lazy container a session drives: hit-testing, viewport extent and scrolling. */
+interface AutoScrollTarget {
+    val scrollableState: ScrollableState
+
+    /** Main-axis extent of the viewport in pixels, content padding included. */
+    val viewportMainAxisSize: Int
+
+    /** The key of the item under [position], which is relative to the container's top left. */
+    fun keyAt(position: Offset): Any?
+}
+
+/**
+ * Item offsets are relative to the scrolled content, the pointer is relative to the container -
+ * `viewportStartOffset` is the difference (negative by the amount of leading content padding).
+ */
+class LazyListAutoScrollTarget(private val state: LazyListState) : AutoScrollTarget {
+
+    override val scrollableState: ScrollableState get() = state
+
+    override val viewportMainAxisSize: Int get() = state.layoutInfo.viewportSize.height
+
+    override fun keyAt(position: Offset): Any? {
+        val layoutInfo = state.layoutInfo
+        val mainAxis = position.y + layoutInfo.viewportStartOffset
+        return layoutInfo.visibleItemsInfo
+            .firstOrNull { mainAxis >= it.offset && mainAxis < it.offset + it.size }
+            ?.key
+    }
+}
+
+class LazyGridAutoScrollTarget(
+    private val state: LazyGridState,
+    private val startPaddingPx: Int = 0,
+) : AutoScrollTarget {
+
+    override val scrollableState: ScrollableState get() = state
+
+    override val viewportMainAxisSize: Int get() = state.layoutInfo.viewportSize.height
+
+    override fun keyAt(position: Offset): Any? {
+        val layoutInfo = state.layoutInfo
+        // Item cross-axis offsets exclude the leading content padding, so undo it on the pointer.
+        val point = IntOffset(
+            x = (position.x - startPaddingPx).roundToInt(),
+            y = (position.y + layoutInfo.viewportStartOffset).roundToInt(),
+        )
+        return layoutInfo.visibleItemsInfo
+            .firstOrNull { IntRect(it.offset, it.size).contains(point) }
+            ?.key
+    }
+}

--- a/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/dragselect/DragSelect.kt
@@ -1,10 +1,8 @@
 package eu.darken.butler.common.compose.dragselect
 
-import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.lazy.LazyListState
@@ -14,30 +12,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import eu.darken.butler.common.compose.autoscroll.AutoScrollTarget
+import eu.darken.butler.common.compose.autoscroll.EdgeAutoScroller
+import eu.darken.butler.common.compose.autoscroll.LazyGridAutoScrollTarget
+import eu.darken.butler.common.compose.autoscroll.LazyListAutoScrollTarget
 import kotlin.math.max
 import kotlin.math.min
-import kotlin.math.roundToInt
-
-/** How close to a viewport edge the pointer has to get before the content starts scrolling. */
-private val AutoScrollEdge = 56.dp
-
-/** Auto-scroll speed at the very edge of the viewport, scaled down with the distance to it. */
-private val AutoScrollMaxSpeed = 900.dp
 
 /**
  * Long-press-then-drag multi selection for a vertical [LazyListState] container.
@@ -62,7 +50,7 @@ fun <K : Any> Modifier.listDragSelect(
     onSelectionChange: (Set<K>) -> Unit,
     enabled: (K) -> Boolean = { true },
 ): Modifier {
-    val target = remember(state) { LazyListDragSelectTarget(state) }
+    val target = remember(state) { LazyListAutoScrollTarget(state) }
     return dragSelect(target, orderedKeys, currentSelection, onSelectionChange, enabled)
 }
 
@@ -86,7 +74,7 @@ fun <K : Any> Modifier.gridDragSelect(
     val startPaddingPx = with(LocalDensity.current) {
         contentPadding.calculateStartPadding(layoutDirection).roundToPx()
     }
-    val target = remember(state, startPaddingPx) { LazyGridDragSelectTarget(state, startPaddingPx) }
+    val target = remember(state, startPaddingPx) { LazyGridAutoScrollTarget(state, startPaddingPx) }
     return dragSelect(target, orderedKeys, currentSelection, onSelectionChange, enabled)
 }
 
@@ -101,7 +89,7 @@ fun <K : Any> Modifier.gridDragSelect(
  */
 @Composable
 private fun <K : Any> Modifier.dragSelect(
-    target: DragSelectTarget,
+    target: AutoScrollTarget,
     orderedKeys: () -> List<K>,
     currentSelection: () -> Set<K>,
     onSelectionChange: (Set<K>) -> Unit,
@@ -115,8 +103,8 @@ private fun <K : Any> Modifier.dragSelect(
     val scope = rememberCoroutineScope()
 
     return this.pointerInput(target) {
-        val edgePx = AutoScrollEdge.toPx()
-        val maxSpeedPx = AutoScrollMaxSpeed.toPx()
+        val edgePx = EdgeAutoScroller.DefaultEdge.toPx()
+        val maxSpeedPx = EdgeAutoScroller.DefaultMaxSpeed.toPx()
         awaitEachGesture {
             // The pane focus handler consumes the down on the initial pass, so an unconsumed down
             // would never arrive here.
@@ -135,7 +123,7 @@ private fun <K : Any> Modifier.dragSelect(
                 onSelectionChange = { currentOnSelectionChange(it) },
                 onEndpointChanged = { haptics.performHapticFeedback(HapticFeedbackType.SegmentTick) },
             )
-            val autoScroller = DragSelectAutoScroller(
+            val autoScroller = EdgeAutoScroller(
                 scope = scope,
                 target = target,
                 edgePx = edgePx,
@@ -215,116 +203,5 @@ private class DragSelectSession<K : Any>(
 
     fun end() {
         isActive = false
-    }
-}
-
-/**
- * Scrolls the content while the pointer rests near a viewport edge, advancing by frame delta so the
- * speed is refresh-rate independent. Stops as soon as the content bound is reached and is re-armed
- * by the next drag event.
- *
- * [onScrolled] reports whether the session is still live: a finger resting at the edge produces no
- * pointer events, so the frame loop is the only place that would notice the session ending.
- */
-private class DragSelectAutoScroller(
-    private val scope: CoroutineScope,
-    private val target: DragSelectTarget,
-    private val edgePx: Float,
-    private val maxSpeedPx: Float,
-    private val onScrolled: (Offset) -> Boolean,
-) {
-
-    private var job: Job? = null
-    private var pointer: Offset = Offset.Unspecified
-
-    fun update(pointer: Offset) {
-        this.pointer = pointer
-        if (speedFor(pointer) == 0f) {
-            stop()
-            return
-        }
-        if (job?.isActive == true) return
-        job = scope.launch {
-            var previousFrame = withFrameNanos { it }
-            while (true) {
-                val frame = withFrameNanos { it }
-                val seconds = (frame - previousFrame) / 1_000_000_000f
-                previousFrame = frame
-                val speed = speedFor(pointer)
-                if (speed == 0f) break
-                if (target.scrollableState.scrollBy(speed * seconds) == 0f) break
-                if (!onScrolled(pointer)) break
-            }
-        }
-    }
-
-    fun stop() {
-        job?.cancel()
-        job = null
-    }
-
-    private fun speedFor(pointer: Offset): Float {
-        if (pointer == Offset.Unspecified) return 0f
-        val viewport = target.viewportMainAxisSize.toFloat()
-        if (viewport <= 0f) return 0f
-        val toStart = pointer.y
-        val toEnd = viewport - pointer.y
-        return when {
-            toStart < edgePx -> -maxSpeedPx * ((edgePx - toStart.coerceAtLeast(0f)) / edgePx)
-            toEnd < edgePx -> maxSpeedPx * ((edgePx - toEnd.coerceAtLeast(0f)) / edgePx)
-            else -> 0f
-        }
-    }
-}
-
-/** The lazy container the session drives: hit-testing, viewport extent and scrolling. */
-internal interface DragSelectTarget {
-    val scrollableState: ScrollableState
-
-    /** Main-axis extent of the viewport in pixels, content padding included. */
-    val viewportMainAxisSize: Int
-
-    /** The key of the item under [position], which is relative to the container's top left. */
-    fun keyAt(position: Offset): Any?
-}
-
-/**
- * Item offsets are relative to the scrolled content, the pointer is relative to the container -
- * `viewportStartOffset` is the difference (negative by the amount of leading content padding).
- */
-internal class LazyListDragSelectTarget(private val state: LazyListState) : DragSelectTarget {
-
-    override val scrollableState: ScrollableState get() = state
-
-    override val viewportMainAxisSize: Int get() = state.layoutInfo.viewportSize.height
-
-    override fun keyAt(position: Offset): Any? {
-        val layoutInfo = state.layoutInfo
-        val mainAxis = position.y + layoutInfo.viewportStartOffset
-        return layoutInfo.visibleItemsInfo
-            .firstOrNull { mainAxis >= it.offset && mainAxis < it.offset + it.size }
-            ?.key
-    }
-}
-
-internal class LazyGridDragSelectTarget(
-    private val state: LazyGridState,
-    private val startPaddingPx: Int = 0,
-) : DragSelectTarget {
-
-    override val scrollableState: ScrollableState get() = state
-
-    override val viewportMainAxisSize: Int get() = state.layoutInfo.viewportSize.height
-
-    override fun keyAt(position: Offset): Any? {
-        val layoutInfo = state.layoutInfo
-        // Item cross-axis offsets exclude the leading content padding, so undo it on the pointer.
-        val point = IntOffset(
-            x = (position.x - startPaddingPx).roundToInt(),
-            y = (position.y + layoutInfo.viewportStartOffset).roundToInt(),
-        )
-        return layoutInfo.visibleItemsInfo
-            .firstOrNull { IntRect(it.offset, it.size).contains(point) }
-            ?.key
     }
 }

--- a/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectGridTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectGridTest.kt
@@ -32,7 +32,7 @@ import testhelpers.ComposeTest
 
 /**
  * A 3-column grid of 40dp cells in a 480dp viewport: index 0..2 sit in the top auto-scroll edge
- * zone ([AutoScrollEdge], 56dp), every index these tests touch is below it.
+ * zone ([EdgeAutoScroller.DefaultEdge], 56dp), every index these tests touch is below it.
  */
 class DragSelectGridTest : ComposeTest() {
 

--- a/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectListTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/dragselect/DragSelectListTest.kt
@@ -27,7 +27,7 @@ import testhelpers.ComposeTest
 
 /**
  * Item geometry is chosen so every index these tests touch sits outside the auto-scroll edge zone
- * ([AutoScrollEdge], 56dp): index 0 is inside it, indices 1..10 are not.
+ * ([EdgeAutoScroller.DefaultEdge], 56dp): index 0 is inside it, indices 1..10 are not.
  */
 class DragSelectListTest : ComposeTest() {
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspacePage.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspacePage.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -40,6 +41,8 @@ import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel.RevealRequest
 import eu.darken.butler.explorer.ui.explorer.actions.ExplorerActionBarItem
 import eu.darken.butler.explorer.ui.explorer.dnd.ExplorerDragPayloadFactory
+import eu.darken.butler.explorer.ui.explorer.dnd.explorerDropTarget
+import eu.darken.butler.explorer.ui.explorer.dnd.rememberExplorerDropState
 import eu.darken.butler.explorer.ui.explorer.elements.ExplorerReadyContent
 import eu.darken.butler.explorer.ui.explorer.elements.ExplorerTopBars
 import eu.darken.butler.explorer.ui.explorer.elements.PermissionRequestCard
@@ -53,6 +56,7 @@ import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
+import eu.darken.butler.workspace.ui.dnd.LocalDropZoneRegistry
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarContentPadding
@@ -170,13 +174,13 @@ fun ExplorerWorkspacePage(
         onClearSelection = { vm?.clearSelection() },
     )
 
-    // Dragging items to another pane needs a second pane to drop them on. The payload is built from
-    // the state this composition already holds, so a drag can't lose items to an in-flight update.
-    val dragPayloadFactory: ((ExplorerItem) -> WorkspaceDragPayload?)? = if (design.isSingle) {
-        null
-    } else {
-        { pressed -> ExplorerDragPayloadFactory.build(state, workspaceId, pressed) }
+    // The payload is built from the state this composition already holds, so a drag can't lose
+    // items to an in-flight update.
+    val dragPayloadFactory: (ExplorerItem) -> WorkspaceDragPayload? = { pressed ->
+        ExplorerDragPayloadFactory.build(state, workspaceId, pressed)
     }
+
+    val dropState = rememberExplorerDropState()
 
     // Grid columns for keyboard navigation (approximate for adaptive grid)
     val gridColumns = 3
@@ -223,59 +227,73 @@ fun ExplorerWorkspacePage(
                 },
             )
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            val topContentPadding = rememberFloatingBarContentPadding(topStackState = topBarStackState)
-
-            // Main content area
-            if (state.setupRequirements.needsAction) {
-                PermissionRequestCard(
-                    setupRequirements = state.setupRequirements,
-                    onNavigateToSetup = { vm?.navigateToSetup(state.setupRequirements) },
-                    nestedScrollConnection = topBarStackState.nestedScrollConnection,
-                    onLaunchSAFPicker = { grant -> vm?.launchAndroidDataSAFPicker(grant) },
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(topContentPadding),
-                )
-            } else {
-                ExplorerReadyContent(
-                    modifier = Modifier.fillMaxSize(),
-                    workspaceId = workspaceId,
-                    state = state,
-                    vm = vm,
-                    listState = listState,
-                    gridState = gridState,
-                    topBarStackState = topBarStackState,
-                    bottomBarStackState = bottomBarStackState,
-                    operationsState = operationsState,
-                    clipboardState = clipboardState,
-                    isRefreshing = rememberRefreshIndication(state.refreshId, state.isRefreshing),
-                    pullToRefreshState = pullToRefreshState,
-                    onRefresh = { vm?.onPullToRefresh() },
-                    initialOperationsExpanded = initialOperationsExpanded,
-                    initialClipboardExpanded = initialClipboardExpanded,
-                    onShowOperationDetails = { operationId -> vm?.showOperationDetails(operationId) },
-                    dragPayloadFactory = dragPayloadFactory,
-                )
-            }
-
-            // Top FloatingBarStack with toolbar and InfoBar - always visible
-            FloatingBarStack(
-                state = topBarStackState,
-                position = BarPosition.TOP,
-                modifier = Modifier.align(Alignment.TopCenter),
-                bars = {
-                    ExplorerTopBars(
+        CompositionLocalProvider(LocalDropZoneRegistry provides dropState.registry) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .explorerDropTarget(
+                        dropState = dropState,
                         workspaceId = workspaceId,
-                        design = design,
+                        state = state,
+                        listState = listState,
+                        gridState = gridState,
+                        onDrop = { payload, destination -> vm?.onDragDropped(payload, destination) },
+                    ),
+            ) {
+                val topContentPadding = rememberFloatingBarContentPadding(topStackState = topBarStackState)
+
+                // Main content area
+                if (state.setupRequirements.needsAction) {
+                    PermissionRequestCard(
+                        setupRequirements = state.setupRequirements,
+                        onNavigateToSetup = { vm?.navigateToSetup(state.setupRequirements) },
+                        nestedScrollConnection = topBarStackState.nestedScrollConnection,
+                        onLaunchSAFPicker = { grant -> vm?.launchAndroidDataSAFPicker(grant) },
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(topContentPadding),
+                    )
+                } else {
+                    ExplorerReadyContent(
+                        modifier = Modifier.fillMaxSize(),
+                        workspaceId = workspaceId,
                         state = state,
                         vm = vm,
-                        showProgress = showProgress,
+                        listState = listState,
+                        gridState = gridState,
+                        topBarStackState = topBarStackState,
+                        bottomBarStackState = bottomBarStackState,
+                        operationsState = operationsState,
+                        clipboardState = clipboardState,
+                        isRefreshing = rememberRefreshIndication(state.refreshId, state.isRefreshing),
+                        pullToRefreshState = pullToRefreshState,
+                        onRefresh = { vm?.onPullToRefresh() },
+                        initialOperationsExpanded = initialOperationsExpanded,
+                        initialClipboardExpanded = initialClipboardExpanded,
+                        onShowOperationDetails = { operationId -> vm?.showOperationDetails(operationId) },
+                        dragPayloadFactory = dragPayloadFactory,
+                        dropState = dropState,
                     )
-                },
-            )
+                }
 
-            // Dialogs and sheets live in the page host's overlay slot, see ExplorerWorkspaceOverlays
+                // Top FloatingBarStack with toolbar and InfoBar - always visible
+                FloatingBarStack(
+                    state = topBarStackState,
+                    position = BarPosition.TOP,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    bars = {
+                        ExplorerTopBars(
+                            workspaceId = workspaceId,
+                            design = design,
+                            state = state,
+                            vm = vm,
+                            showProgress = showProgress,
+                        )
+                    },
+                )
+
+                // Dialogs and sheets live in the page host's overlay slot, see ExplorerWorkspaceOverlays
+            }
         }
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.error.ErrorIncidentStore
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.storage.StorageEnvironment
 import eu.darken.butler.common.storage.saf.SAFPickerIntentBuilder
 import eu.darken.butler.common.storage.saf.StorageProviderSuggester
@@ -93,6 +94,7 @@ import eu.darken.butler.explorer.ui.explorer.dialogs.RevealedPassword
 import eu.darken.butler.explorer.ui.explorer.dialogs.SortOptionsResult
 import eu.darken.butler.explorer.ui.explorer.dialogs.SortScope
 import eu.darken.butler.explorer.ui.explorer.dnd.validateDropDestination
+import eu.darken.butler.explorer.ui.explorer.dnd.validateFolderDrop
 import eu.darken.butler.explorer.ui.explorer.dnd.validateTrashDrop
 import eu.darken.butler.explorer.ui.explorer.util.ExplorerSelectionState
 import eu.darken.butler.explorer.ui.explorer.util.ItemInfoCalculator
@@ -1887,19 +1889,50 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
-    /** Items dragged in from another workspace landed on this one, ask what to do with them. */
-    fun onDragDropped(payload: WorkspaceDragPayload) = launch {
-        log(tag) { "onDragDropped(${payload.items.size} items from ${payload.sourceWorkspaceId})" }
+    /**
+     * Items dropped on this workspace, ask what to do with them.
+     *
+     * [destination] is the folder the drop landed on - a row, favorite or breadcrumb; `null` means
+     * the content background, where the current listing is the destination.
+     */
+    fun onDragDropped(payload: WorkspaceDragPayload, destination: APath<*>? = null) = launch {
+        log(tag) { "onDragDropped($destination, ${payload.items.size} items from ${payload.sourceWorkspaceId})" }
+        if (destination != null) {
+            val folder = validateFolderDrop(getState(), payload, destination)
+            if (folder == null) {
+                log(tag) { "onDragDropped(): Folder drop is not valid, ignoring" }
+                return@launch
+            }
+            if (!checkDropDestination(folder)) return@launch
+            dialogs.show(DropConfirmation(payload, folder))
+            return@launch
+        }
         if (validateTrashDrop(getState(), id, payload)) {
             dialogs.show(TrashDropConfirmation(payload))
             return@launch
         }
-        val destination = validateDropDestination(getState(), id, payload)
-        if (destination == null) {
+        val paneDestination = validateDropDestination(getState(), id, payload)
+        if (paneDestination == null) {
             log(tag) { "onDragDropped(): Drop is not valid here, ignoring" }
             return@launch
         }
-        dialogs.show(DropConfirmation(payload, destination))
+        dialogs.show(DropConfirmation(payload, paneDestination))
+    }
+
+    /**
+     * Whether [destination] is a directory this app can write to right now. Only the gateway can
+     * answer that for a folder outside the current listing, and a stale answer would let the
+     * operation fail after the user already confirmed it.
+     */
+    private suspend fun checkDropDestination(destination: APath<*>): Boolean {
+        val writable = runCatching {
+            gatewaySwitch.lookup(destination, LookupOptions()).isDirectory && gatewaySwitch.canWrite(destination)
+        }.getOrDefault(false)
+        if (!writable) {
+            log(tag, WARN) { "checkDropDestination(): Not a writable directory: $destination" }
+            errorEvents.emit(WriteException("Drop destination is not writable", destination))
+        }
+        return writable
     }
 
     fun onTrashDropConfirmed(payload: WorkspaceDragPayload) {
@@ -1933,12 +1966,13 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
             return@launch
         }
 
-        val target = validateDropDestination(getState(), id, payload)
-        if (target == null || !target.matches(destination)) {
+        val target = validateFolderDrop(getState(), payload, destination)
+        if (target == null) {
             log(tag, WARN) { "onDropConfirmed(): Destination is no longer valid" }
             errorEvents.emit(WriteException("Drop destination is no longer available", destination))
             return@launch
         }
+        if (!checkDropDestination(target)) return@launch
 
         val sources = payload.items.map { it.path }.toSet()
         val command = if (move) {
@@ -1961,7 +1995,11 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 ?.filter { it.change == Operation.Report.PathChange.Change.ADDED || it.change == Operation.Report.PathChange.Change.MOVED }
                 ?.map { it.path }
                 ?: emptyList()
-            revealItems(addedPaths)
+            // Only the listing that shows the destination can reveal them; for a drop onto some
+            // other folder the reveal would wait for paths that never enter this listing.
+            if ((getState().currentLocation as? ExplorerLocation.Directory)?.path?.matches(target) == true) {
+                revealItems(addedPaths)
+            }
         }
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogState.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogState.kt
@@ -90,7 +90,7 @@ sealed interface ExplorerDialogState {
 
     data object EmptyTrashConfirmation : ExplorerDialogState
 
-    /** Items dropped from another workspace, waiting for the user to pick copy or move. */
+    /** Items dropped onto a folder or pane, waiting for the user to pick copy or move. */
     data class DropConfirmation(
         val payload: WorkspaceDragPayload,
         val destination: APath<*>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropTarget.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropTarget.kt
@@ -1,0 +1,228 @@
+package eu.darken.butler.explorer.ui.explorer.dnd
+
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import eu.darken.butler.common.compose.autoscroll.EdgeAutoScroller
+import eu.darken.butler.common.compose.autoscroll.LazyGridAutoScrollTarget
+import eu.darken.butler.common.compose.autoscroll.LazyListAutoScrollTarget
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.explorer.core.ExplorerViewStyle
+import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
+import eu.darken.butler.workspace.ui.dnd.DropHit
+import eu.darken.butler.workspace.ui.dnd.DropZoneRegistry
+import eu.darken.butler.workspace.ui.dnd.positionInRoot
+import eu.darken.butler.workspace.ui.dnd.resolveDropHit
+import eu.darken.butler.workspace.ui.dnd.workspaceDragPayload
+import eu.darken.butler.workspace.ui.modal.LocalLayerOnTopPath
+
+/**
+ * What the page's single drop target needs to know about the content below it: where the folder
+ * zones are, where the content band is and whether the pane itself is being hovered.
+ */
+class ExplorerDropState {
+
+    val registry = DropZoneRegistry()
+
+    /** Root-relative bounds of the ready content, floating bars included. */
+    var contentBounds: Rect = Rect.Zero
+
+    var topBarPaddingPx: Float = 0f
+    var bottomBarPaddingPx: Float = 0f
+
+    var isPaneHovered by mutableStateOf(false)
+
+    /** The content minus the areas the floating bars cover, where a drop means "this listing". */
+    val contentBand: Rect
+        get() {
+            val top = contentBounds.top + topBarPaddingPx
+            val bottom = contentBounds.bottom - bottomBarPaddingPx
+            if (bottom <= top) return Rect.Zero
+            return Rect(left = contentBounds.left, top = top, right = contentBounds.right, bottom = bottom)
+        }
+}
+
+@Composable
+fun rememberExplorerDropState(): ExplorerDropState = remember { ExplorerDropState() }
+
+/**
+ * The Explorer page's only drop target, covering content and floating bars alike.
+ *
+ * A drag session is handed to the targets that exist when it starts, so a row scrolled in while
+ * the drag is running could never own one. Folder rows, favorites and crumbs publish their bounds
+ * to [ExplorerDropState.registry] instead and this target hit-tests them on every move.
+ *
+ * @param onDrop a null destination means the content background, i.e. the current listing.
+ */
+@Composable
+fun Modifier.explorerDropTarget(
+    dropState: ExplorerDropState,
+    workspaceId: Workspace.Id,
+    state: ExplorerWorkspaceViewModel.State,
+    listState: LazyListState,
+    gridState: LazyGridState,
+    onDrop: (WorkspaceDragPayload, APath<*>?) -> Unit,
+): Modifier {
+    val currentState = rememberUpdatedState(state)
+    val currentOnDrop = rememberUpdatedState(onDrop)
+    // Same focus request AdaptiveWorkspaceLayout wires to WorkspaceScreenAction.Focus(info.id),
+    // republished by WorkspacePane. Focusing the target pane before the drop opens the confirmation
+    // dialog in an already-focused pane, so its first tap confirms instead of only focusing.
+    val currentFocusRequest = rememberUpdatedState(LocalWorkspaceFocusRequest.current)
+    val currentOnTopPath = rememberUpdatedState(LocalLayerOnTopPath.current)
+
+    val session = remember(dropState, workspaceId) {
+        ExplorerDropSession(
+            dropState = dropState,
+            workspaceId = workspaceId,
+            state = currentState,
+            onDropped = currentOnDrop,
+            focusRequest = currentFocusRequest,
+        )
+    }
+
+    val scope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val scroller = remember(session, state.viewStyle, listState, gridState, scope, density) {
+        val target = when (state.viewStyle) {
+            is ExplorerViewStyle.Grid -> LazyGridAutoScrollTarget(gridState)
+            is ExplorerViewStyle.List -> LazyListAutoScrollTarget(listState)
+        }
+        EdgeAutoScroller(
+            scope = scope,
+            target = target,
+            edgePx = with(density) { EdgeAutoScroller.DefaultEdge.toPx() },
+            maxSpeedPx = with(density) { EdgeAutoScroller.DefaultMaxSpeed.toPx() },
+            // A pointer resting at the edge produces no events while rows keep moving under it.
+            onScrolled = {
+                session.retestLastPosition()
+                true
+            },
+        )
+    }
+    // Navigation re-keys the list state and a view style switch swaps the whole container, so a
+    // replaced scroller must never be left driving the detached one.
+    DisposableEffect(session, scroller) {
+        session.scroller = scroller
+        onDispose {
+            scroller.stop()
+            if (session.scroller === scroller) session.scroller = null
+        }
+    }
+
+    val shouldStartDragAndDrop = remember(session) {
+        { event: DragAndDropEvent ->
+            event.workspaceDragPayload() != null &&
+                currentState.value.pickerConfig == null &&
+                currentOnTopPath.value
+        }
+    }
+
+    return this.dragAndDropTarget(
+        shouldStartDragAndDrop = shouldStartDragAndDrop,
+        target = session,
+    )
+}
+
+private class ExplorerDropSession(
+    private val dropState: ExplorerDropState,
+    private val workspaceId: Workspace.Id,
+    private val state: State<ExplorerWorkspaceViewModel.State>,
+    private val onDropped: State<(WorkspaceDragPayload, APath<*>?) -> Unit>,
+    private val focusRequest: State<(() -> Unit)?>,
+) : DragAndDropTarget {
+
+    var scroller: EdgeAutoScroller? = null
+
+    private var payload: WorkspaceDragPayload? = null
+    private var lastRootPointer: Offset = Offset.Unspecified
+
+    override fun onEntered(event: DragAndDropEvent) = onMoved(event)
+
+    override fun onMoved(event: DragAndDropEvent) {
+        val payload = event.workspaceDragPayload() ?: return
+        this.payload = payload
+        lastRootPointer = event.positionInRoot()
+        hitTest(payload, lastRootPointer)
+        scroller?.update(lastRootPointer - dropState.contentBounds.topLeft)
+    }
+
+    override fun onExited(event: DragAndDropEvent) = reset()
+
+    override fun onEnded(event: DragAndDropEvent) = reset()
+
+    override fun onDrop(event: DragAndDropEvent): Boolean {
+        val payload = event.workspaceDragPayload()
+        if (payload == null) {
+            reset()
+            return false
+        }
+        val hit = hitTest(payload, event.positionInRoot())
+        reset()
+        return when (hit) {
+            is DropHit.Explicit -> {
+                focusRequest.value?.invoke()
+                onDropped.value(payload, hit.destination)
+                true
+            }
+            DropHit.Pane -> {
+                focusRequest.value?.invoke()
+                onDropped.value(payload, null)
+                true
+            }
+            // A zone that refuses the payload swallows the drop instead of letting it through to
+            // the listing behind it, which is a different destination than the user aimed at.
+            DropHit.Blocked, DropHit.None -> false
+        }
+    }
+
+    /** Re-resolves the drop under a pointer that hasn't moved while auto-scroll shifted the rows. */
+    fun retestLastPosition() {
+        val payload = payload ?: return
+        if (lastRootPointer == Offset.Unspecified) return
+        hitTest(payload, lastRootPointer)
+    }
+
+    private fun hitTest(payload: WorkspaceDragPayload, position: Offset): DropHit {
+        val zone = dropState.registry.zoneAt(position)
+        val current = state.value
+        val hit = resolveDropHit(
+            positionInRoot = position,
+            zones = { zone },
+            contentBand = dropState.contentBand,
+            isValidExplicit = { validateFolderDrop(current, payload, it) != null },
+        )
+        dropState.registry.setHovered(if (hit is DropHit.Explicit) zone?.key else null)
+        dropState.isPaneHovered = hit is DropHit.Pane && (
+            validateDropDestination(current, workspaceId, payload) != null ||
+                validateTrashDrop(current, workspaceId, payload)
+            )
+        return hit
+    }
+
+    private fun reset() {
+        payload = null
+        lastRootPointer = Offset.Unspecified
+        dropState.registry.setHovered(null)
+        dropState.isPaneHovered = false
+        scroller?.stop()
+    }
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropTarget.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropTarget.kt
@@ -202,12 +202,16 @@ private class ExplorerDropSession(
     }
 
     private fun hitTest(payload: WorkspaceDragPayload, position: Offset): DropHit {
-        val zone = dropState.registry.zoneAt(position)
+        val contentBand = dropState.contentBand
+        val eligible = { zone: DropZoneRegistry.Zone ->
+            zone.allowOutsideContentBand || contentBand.contains(position)
+        }
+        val zone = dropState.registry.zoneAt(position, eligible)
         val current = state.value
         val hit = resolveDropHit(
             positionInRoot = position,
-            zones = { zone },
-            contentBand = dropState.contentBand,
+            zones = { _, _ -> zone },
+            contentBand = contentBand,
             isValidExplicit = { validateFolderDrop(current, payload, it) != null },
         )
         dropState.registry.setHovered(if (hit is DropHit.Explicit) zone?.key else null)

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropTarget.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropTarget.kt
@@ -162,7 +162,11 @@ private class ExplorerDropSession(
         this.payload = payload
         lastRootPointer = event.positionInRoot()
         hitTest(payload, lastRootPointer)
-        scroller?.update(lastRootPointer - dropState.contentBounds.topLeft)
+        scroller?.update(
+            pointer = lastRootPointer - dropState.contentBounds.topLeft,
+            startInset = dropState.topBarPaddingPx,
+            endInset = dropState.bottomBarPaddingPx,
+        )
     }
 
     override fun onExited(event: DragAndDropEvent) = reset()

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidator.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidator.kt
@@ -30,6 +30,24 @@ fun validateDropDestination(
 }
 
 /**
+ * Path-rule gate for a drop on an explicit folder (row, favorite or crumb); unlike a pane drop, a
+ * drop from the same workspace is fine, the destination is a different folder than the listing.
+ *
+ * Whether the folder can actually be written to is answered by the gateway at drop time: a crumb
+ * carries no such flag and a row's is a cached listing value.
+ */
+fun validateFolderDrop(
+    state: ExplorerWorkspaceViewModel.State,
+    payload: WorkspaceDragPayload,
+    destination: APath<*>,
+): APath<*>? {
+    if (state.pickerConfig != null) return null
+    if (destination is ArchivePath) return null
+    if (!validateDropPaths(payload.items, destination)) return null
+    return destination
+}
+
+/**
  * Gate for accepting a [payload] dropped onto the root Trash view. Trashing removes the items from
  * their source, so it is only offered when the source allows a move. Returns true when this
  * workspace's Trash root can take the drop.

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/BreadcrumbBar.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/BreadcrumbBar.kt
@@ -606,6 +606,7 @@ private fun BreadcrumbChip(
             destination = (breadcrumb.target as? ExplorerNavigation.Target.Directory)
                 ?.path
                 ?.takeUnless { it is ArchivePath },
+            allowOutsideContentBand = true,
         ),
     ) {
         Row(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/BreadcrumbBar.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/BreadcrumbBar.kt
@@ -74,6 +74,7 @@ import eu.darken.butler.explorer.core.ExplorerNavigation
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
+import eu.darken.butler.workspace.ui.dnd.dropZone
 import eu.darken.butler.workspace.ui.modal.DismissWhenPaneUnfocused
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import kotlinx.coroutines.delay
@@ -597,7 +598,16 @@ private fun BreadcrumbChip(
     onCopyPath: (() -> Unit)?,
 ) {
     val context = LocalContext.current
-    Box(modifier = modifier) {
+    Box(
+        modifier = modifier.dropZone(
+            key = "crumb:${breadcrumb.target}",
+            // Home, Device and Trash crumbs are no folder, so they register nothing and a drop on
+            // them resolves to nothing rather than falling through to the listing.
+            destination = (breadcrumb.target as? ExplorerNavigation.Target.Directory)
+                ?.path
+                ?.takeUnless { it is ArchivePath },
+        ),
+    ) {
         Row(
             modifier = Modifier
                 .clip(RoundedCornerShape(4.dp))

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerReadyContent.kt
@@ -8,20 +8,17 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draganddrop.DragAndDropEvent
-import androidx.compose.ui.draganddrop.DragAndDropTarget
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.IntOffset
@@ -36,16 +33,13 @@ import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.BrowsingAbortedException
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
-import eu.darken.butler.explorer.ui.explorer.dnd.validateDropDestination
-import eu.darken.butler.explorer.ui.explorer.dnd.validateTrashDrop
+import eu.darken.butler.explorer.ui.explorer.dnd.ExplorerDropState
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
-import eu.darken.butler.workspace.ui.LocalWorkspaceFocusRequest
 import eu.darken.butler.workspace.ui.clipboard.ClipboardDisplayState
 import eu.darken.butler.workspace.ui.dnd.dropTargetHighlight
-import eu.darken.butler.workspace.ui.dnd.workspaceDragPayload
 import eu.darken.butler.workspace.ui.common.WorkspacePaddings
 import eu.darken.butler.workspace.ui.common.WorkspacePullToRefreshBox
 import eu.darken.butler.workspace.ui.error.ErrorCard
@@ -81,6 +75,7 @@ internal fun ExplorerReadyContent(
     initialClipboardExpanded: Boolean,
     onShowOperationDetails: (Operation.Id) -> Unit,
     dragPayloadFactory: ((ExplorerItem) -> WorkspaceDragPayload?)? = null,
+    dropState: ExplorerDropState? = null,
 ) {
     // Focus state from ViewModel
     val contentFocusedItem = state.focusedItemIndex?.let { state.items?.getOrNull(it) }
@@ -98,51 +93,15 @@ internal fun ExplorerReadyContent(
         end = 2.dp,
     )
 
-    val isDragHovered = remember { mutableStateOf(false) }
-    val currentState by rememberUpdatedState(state)
-    val currentVm by rememberUpdatedState(vm)
-    // Same focus request AdaptiveWorkspaceLayout wires to WorkspaceScreenAction.Focus(info.id),
-    // republished by WorkspacePane. Focusing the target pane before the drop opens the confirmation
-    // dialog in an already-focused pane, so its first tap confirms instead of only focusing.
-    val currentFocusRequest by rememberUpdatedState(LocalWorkspaceFocusRequest.current)
-    val dropTarget = remember {
-        object : DragAndDropTarget {
-            override fun onEntered(event: DragAndDropEvent) {
-                isDragHovered.value = true
-            }
-
-            override fun onExited(event: DragAndDropEvent) {
-                isDragHovered.value = false
-            }
-
-            override fun onEnded(event: DragAndDropEvent) {
-                isDragHovered.value = false
-            }
-
-            override fun onDrop(event: DragAndDropEvent): Boolean {
-                isDragHovered.value = false
-                val payload = event.workspaceDragPayload() ?: return false
-                currentFocusRequest?.invoke()
-                currentVm?.onDragDropped(payload)
-                return true
-            }
-        }
-    }
+    // The page owns the drop target; this content only reports the geometry it hit-tests against.
+    dropState?.topBarPaddingPx = topBarStackState.contentPaddingPx
+    dropState?.bottomBarPaddingPx = bottomBarStackState.contentPaddingPx
 
     Box(
         modifier = modifier
             .fillMaxSize()
-            .dragAndDropTarget(
-                shouldStartDragAndDrop = { event ->
-                    val payload = event.workspaceDragPayload()
-                    payload != null && (
-                        validateDropDestination(currentState, workspaceId, payload) != null ||
-                            validateTrashDrop(currentState, workspaceId, payload)
-                        )
-                },
-                target = dropTarget,
-            )
-            .dropTargetHighlight(isDragHovered.value),
+            .onGloballyPositioned { dropState?.contentBounds = it.boundsInRoot() }
+            .dropTargetHighlight(dropState?.isPaneHovered == true),
     ) {
         // Main content with pull-to-refresh
         WorkspacePullToRefreshBox(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/FavoritesSection.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/FavoritesSection.kt
@@ -44,6 +44,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.extensions.matches
 import eu.darken.butler.common.files.local.LocalPathLookup
@@ -53,6 +54,7 @@ import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.core.engine.ExplorerItem.Path.Companion.toPathItemId
 import eu.darken.butler.explorer.core.favorites.FavoriteItem
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
+import eu.darken.butler.workspace.ui.dnd.dropZone
 
 /** List-scope variant: header item + a row per favorite. */
 fun LazyListScope.favoritesSection(
@@ -200,6 +202,7 @@ fun FavoriteRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .dropZone(key = favoriteKey(favorite), destination = favorite.dropDestination())
             .clip(RoundedCornerShape(8.dp))
             .background(highlightColor, RoundedCornerShape(8.dp))
             .clickable(enabled = !isResolving) { onClick() }
@@ -274,6 +277,12 @@ fun FavoriteRow(
             )
         }
     }
+}
+
+/** Only a resolved directory can take a drop; a file or an unavailable favorite has no destination. */
+private fun FavoriteItem.dropDestination(): APath<*>? {
+    val item = (state as? FavoriteItem.State.Available)?.item as? ExplorerItem.Directory ?: return null
+    return item.path.takeUnless { it is ArchivePath }
 }
 
 private fun pickIcon(favorite: FavoriteItem): ImageVector = when {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.extensions.matches
 import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.ExplorerItem
@@ -26,6 +28,7 @@ import eu.darken.butler.explorer.ui.explorer.items.row.StorageRow
 import eu.darken.butler.explorer.ui.explorer.items.row.TrashItemRow
 import eu.darken.butler.explorer.ui.explorer.items.row.TrashNestedItemRow
 import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.ui.dnd.dropZone
 import eu.darken.butler.workspace.ui.dnd.rememberWorkspaceDragSource
 
 /**
@@ -63,7 +66,11 @@ fun ExplorerItemRenderer(
     // to pick up the drag. A null payload means no drag.
     val dragSource = dragPayloadFactory?.let { factory -> rememberWorkspaceDragSource { factory(item) } }
 
-    Box(modifier = focusModifier.then(dragSource?.modifier ?: Modifier)) {
+    Box(
+        modifier = focusModifier
+            .then(dragSource?.modifier ?: Modifier)
+            .dropZone(key = item.id, destination = item.dropDestination()),
+    ) {
         ItemContent(
             item = item,
             viewStyle = viewStyle,
@@ -85,6 +92,14 @@ fun ExplorerItemRenderer(
             previewsSettled = previewsSettled,
         )
     }
+}
+
+/** Folders take drops; a read-only one or archive content has nothing to offer a drop. */
+private fun ExplorerItem.dropDestination(): APath<*>? = when {
+    this !is ExplorerItem.Directory -> null
+    canWrite == false -> null
+    path is ArchivePath -> null
+    else -> path
 }
 
 @Composable

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
@@ -68,8 +68,8 @@ fun ExplorerItemRenderer(
 
     Box(
         modifier = focusModifier
-            .then(dragSource?.modifier ?: Modifier)
-            .dropZone(key = item.id, destination = item.dropDestination()),
+            .dropZone(key = item.id, destination = item.dropDestination())
+            .then(dragSource?.modifier ?: Modifier),
     ) {
         ItemContent(
             item = item,

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidatorTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dnd/ExplorerDropValidatorTest.kt
@@ -151,4 +151,50 @@ class ExplorerDropValidatorTest : BaseTest() {
         validateTrashDrop(state(), workspaceId, payload()) shouldBe false
     }
 
+    @Test
+    fun `a folder takes a drop from the same workspace`() {
+        val folder = LocalPath.build("/storage/emulated/0/Download/reports")
+
+        validateFolderDrop(state(), payload(sourceWorkspaceId = workspaceId), folder) shouldBe folder
+    }
+
+    @Test
+    fun `a folder inside an archive refuses drops`() {
+        val folder = ArchivePath(container, listOf("sub"))
+
+        validateFolderDrop(state(), payload(), folder) shouldBe null
+    }
+
+    @Test
+    fun `picker mode refuses folder drops`() {
+        val folder = LocalPath.build("/storage/emulated/0/Download/reports")
+
+        validateFolderDrop(state(pickerConfig = mockk<PickerConfig>()), payload(), folder) shouldBe null
+    }
+
+    @Test
+    fun `a folder drop onto the items own parent is refused`() {
+        val folder = LocalPath.build("/storage/emulated/0/DCIM")
+
+        validateFolderDrop(state(), payload(path = folder.child("photo.jpg")), folder) shouldBe null
+    }
+
+    @Test
+    fun `a folder drop onto the dragged folder itself is refused`() {
+        val folder = LocalPath.build("/storage/emulated/0/DCIM")
+        val dragged = payload(path = folder, kind = WorkspaceDragPayload.Kind.DIRECTORY)
+
+        validateFolderDrop(state(), dragged, folder) shouldBe null
+    }
+
+    @Test
+    fun `a folder drop into the dragged folders own subtree is refused`() {
+        val dragged = payload(
+            path = LocalPath.build("/storage/emulated/0/DCIM"),
+            kind = WorkspaceDragPayload.Kind.DIRECTORY,
+        )
+
+        validateFolderDrop(state(), dragged, LocalPath.build("/storage/emulated/0/DCIM/raw")) shouldBe null
+    }
+
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropHitResolver.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropHitResolver.kt
@@ -16,11 +16,17 @@ sealed interface DropHit {
     /** Content background, so the pane's own rules decide. */
     data object Pane : DropHit
 
-    /** Neither a zone nor content: floating bars, non-directory crumbs, overlays. */
+    /**
+     * Neither a zone nor content: floating bars, non-directory crumbs, overlays. A zone outside the
+     * content band only counts if it registered with `allowOutsideContentBand`.
+     */
     data object None : DropHit
 }
 
 /**
+ * A zone outside [contentBand] is only a hit when it opted in, so rows scrolled behind a floating
+ * bar stay out of reach of the pointer that is over the bar.
+ *
  * @param contentBand the content bounds minus the floating-bar insets, i.e. the area where a drop
  *        means "the directory this page shows" rather than "the bar the pointer is over".
  */
@@ -31,6 +37,7 @@ fun resolveDropHit(
     isValidExplicit: (APath<*>) -> Boolean,
 ): DropHit {
     val zone = zones(positionInRoot)
+    if (zone != null && !zone.allowOutsideContentBand && !contentBand.contains(positionInRoot)) return DropHit.None
     if (zone != null) {
         return if (isValidExplicit(zone.destination)) DropHit.Explicit(zone.destination) else DropHit.Blocked
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropHitResolver.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropHitResolver.kt
@@ -24,20 +24,19 @@ sealed interface DropHit {
 }
 
 /**
- * A zone outside [contentBand] is only a hit when it opted in, so rows scrolled behind a floating
- * bar stay out of reach of the pointer that is over the bar.
+ * A zone outside [contentBand] is only eligible when it opted in, so rows scrolled behind a
+ * floating bar stay out of reach of the pointer that is over the bar and never shadow a crumb.
  *
  * @param contentBand the content bounds minus the floating-bar insets, i.e. the area where a drop
  *        means "the directory this page shows" rather than "the bar the pointer is over".
  */
 fun resolveDropHit(
     positionInRoot: Offset,
-    zones: (Offset) -> DropZoneRegistry.Zone?,
+    zones: (Offset, (DropZoneRegistry.Zone) -> Boolean) -> DropZoneRegistry.Zone?,
     contentBand: Rect,
     isValidExplicit: (APath<*>) -> Boolean,
 ): DropHit {
-    val zone = zones(positionInRoot)
-    if (zone != null && !zone.allowOutsideContentBand && !contentBand.contains(positionInRoot)) return DropHit.None
+    val zone = zones(positionInRoot) { it.allowOutsideContentBand || contentBand.contains(positionInRoot) }
     if (zone != null) {
         return if (isValidExplicit(zone.destination)) DropHit.Explicit(zone.destination) else DropHit.Blocked
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropHitResolver.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropHitResolver.kt
@@ -1,0 +1,38 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import eu.darken.butler.common.files.APath
+
+/** What the page's single drop target found under the pointer. */
+sealed interface DropHit {
+
+    /** A registered zone the payload may be dropped on. */
+    data class Explicit(val destination: APath<*>) : DropHit
+
+    /** A registered zone that refuses this payload; it never falls through to the pane below it. */
+    data object Blocked : DropHit
+
+    /** Content background, so the pane's own rules decide. */
+    data object Pane : DropHit
+
+    /** Neither a zone nor content: floating bars, non-directory crumbs, overlays. */
+    data object None : DropHit
+}
+
+/**
+ * @param contentBand the content bounds minus the floating-bar insets, i.e. the area where a drop
+ *        means "the directory this page shows" rather than "the bar the pointer is over".
+ */
+fun resolveDropHit(
+    positionInRoot: Offset,
+    zones: (Offset) -> DropZoneRegistry.Zone?,
+    contentBand: Rect,
+    isValidExplicit: (APath<*>) -> Boolean,
+): DropHit {
+    val zone = zones(positionInRoot)
+    if (zone != null) {
+        return if (isValidExplicit(zone.destination)) DropHit.Explicit(zone.destination) else DropHit.Blocked
+    }
+    return if (contentBand.contains(positionInRoot)) DropHit.Pane else DropHit.None
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropZones.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropZones.kt
@@ -28,6 +28,7 @@ class DropZoneRegistry {
         val key: Any,
         val destination: APath<*>,
         val bounds: Rect,
+        val allowOutsideContentBand: Boolean = false,
     )
 
     private val zones = mutableMapOf<Any, Zone>()
@@ -40,8 +41,13 @@ class DropZoneRegistry {
         if (hoveredKey != key) hoveredKey = key
     }
 
-    fun register(key: Any, destination: APath<*>, bounds: Rect) {
-        zones[key] = Zone(key = key, destination = destination, bounds = bounds)
+    fun register(key: Any, destination: APath<*>, bounds: Rect, allowOutsideContentBand: Boolean = false) {
+        zones[key] = Zone(
+            key = key,
+            destination = destination,
+            bounds = bounds,
+            allowOutsideContentBand = allowOutsideContentBand,
+        )
     }
 
     fun unregister(key: Any) {
@@ -67,7 +73,7 @@ val LocalDropZoneRegistry = compositionLocalOf<DropZoneRegistry?> { null }
  * registry instead of accepting a drop it can't perform.
  */
 @Composable
-fun Modifier.dropZone(key: Any, destination: APath<*>?): Modifier {
+fun Modifier.dropZone(key: Any, destination: APath<*>?, allowOutsideContentBand: Boolean = false): Modifier {
     val registry = LocalDropZoneRegistry.current ?: return this
 
     DisposableEffect(registry, key, destination) {
@@ -76,6 +82,6 @@ fun Modifier.dropZone(key: Any, destination: APath<*>?): Modifier {
 
     if (destination == null) return this
     return this
-        .onGloballyPositioned { registry.register(key, destination, it.boundsInRoot()) }
+        .onGloballyPositioned { registry.register(key, destination, it.boundsInRoot(), allowOutsideContentBand) }
         .dropTargetHighlight(registry.hoveredKey == key)
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropZones.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropZones.kt
@@ -1,0 +1,81 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import eu.darken.butler.common.files.APath
+
+/**
+ * Root-relative bounds of the individual drop destinations inside one page.
+ *
+ * A drag session only knows the targets that existed when it started, so a row scrolled in
+ * mid-drag could never own a target of its own. The page keeps a single target instead and
+ * hit-tests this registry on every move.
+ */
+@Stable
+class DropZoneRegistry {
+
+    data class Zone(
+        val key: Any,
+        val destination: APath<*>,
+        val bounds: Rect,
+    )
+
+    private val zones = mutableMapOf<Any, Zone>()
+
+    /** The zone the drag currently rests on, so it can draw itself as hovered. */
+    var hoveredKey: Any? by mutableStateOf(null)
+        private set
+
+    fun setHovered(key: Any?) {
+        if (hoveredKey != key) hoveredKey = key
+    }
+
+    fun register(key: Any, destination: APath<*>, bounds: Rect) {
+        zones[key] = Zone(key = key, destination = destination, bounds = bounds)
+    }
+
+    fun unregister(key: Any) {
+        zones.remove(key)
+        if (hoveredKey == key) hoveredKey = null
+    }
+
+    /**
+     * Zones may nest (a crumb inside a bar), so the smallest one containing the point wins.
+     */
+    fun zoneAt(positionInRoot: Offset): Zone? = zones.values
+        .filter { it.bounds.contains(positionInRoot) }
+        .minByOrNull { it.bounds.width * it.bounds.height }
+}
+
+/** The page's zone registry, or `null` where nothing hit-tests zones (previews, other pages). */
+val LocalDropZoneRegistry = compositionLocalOf<DropZoneRegistry?> { null }
+
+/**
+ * Publishes this composable's bounds as a drop destination and draws the hover affordance.
+ *
+ * A null [destination] registers nothing, so a folder that turns read-only drops out of the
+ * registry instead of accepting a drop it can't perform.
+ */
+@Composable
+fun Modifier.dropZone(key: Any, destination: APath<*>?): Modifier {
+    val registry = LocalDropZoneRegistry.current ?: return this
+
+    DisposableEffect(registry, key, destination) {
+        onDispose { registry.unregister(key) }
+    }
+
+    if (destination == null) return this
+    return this
+        .onGloballyPositioned { registry.register(key, destination, it.boundsInRoot()) }
+        .dropTargetHighlight(registry.hoveredKey == key)
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropZones.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/DropZones.kt
@@ -57,9 +57,11 @@ class DropZoneRegistry {
 
     /**
      * Zones may nest (a crumb inside a bar), so the smallest one containing the point wins.
+     *
+     * [isEligible] runs before that pick, so a zone the caller can't use never shadows one it can.
      */
-    fun zoneAt(positionInRoot: Offset): Zone? = zones.values
-        .filter { it.bounds.contains(positionInRoot) }
+    fun zoneAt(positionInRoot: Offset, isEligible: (Zone) -> Boolean = { true }): Zone? = zones.values
+        .filter { it.bounds.contains(positionInRoot) && isEligible(it) }
         .minByOrNull { it.bounds.width * it.bounds.height }
 }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
@@ -53,6 +53,9 @@ fun WorkspaceDragPayload.toTransferData(): DragAndDropTransferData = DragAndDrop
 fun DragAndDropEvent.workspaceDragPayload(): WorkspaceDragPayload? =
     toAndroidDragEvent().localState as? WorkspaceDragPayload
 
+/** Pointer position in pixels relative to the Compose root, matching `LayoutCoordinates.boundsInRoot()`. */
+fun DragAndDropEvent.positionInRoot(): Offset = toAndroidDragEvent().let { Offset(it.x, it.y) }
+
 /**
  * A drag that the caller starts itself, instead of leaving it to a built-in gesture detector.
  *

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayer.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayer.kt
@@ -73,6 +73,7 @@ fun PaneLayer(
     val layerState = LocalPaneLayerState.current
     val paneFocused = LocalPaneFocused.current
     val inheritedActive = LocalLayerActive.current
+    val inheritedOnTopPath = LocalLayerOnTopPath.current
     val parentToken = LocalPaneLayerParent.current
     val token = remember { Any() }
     val registered = enabled && layerState != null
@@ -156,6 +157,7 @@ fun PaneLayer(
         val boxScope = this
         CompositionLocalProvider(
             LocalLayerActive provides active,
+            LocalLayerOnTopPath provides if (registered) onTopPath else inheritedOnTopPath,
             LocalPaneLayerRank provides rank,
             LocalPaneLayerParent provides if (registered) token else parentToken,
         ) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/modal/PaneLayerState.kt
@@ -103,6 +103,14 @@ object PaneLayerRank {
  */
 val LocalLayerActive = compositionLocalOf { true }
 
+/**
+ * True when this composition is the topmost layer of its pane or encloses that layer.
+ *
+ * Differs from [LocalLayerActive] in ignoring pane focus, so a visible but unfocused pane still
+ * accepts a cross-pane drop while a covered layer refuses the drag session outright.
+ */
+val LocalLayerOnTopPath = compositionLocalOf { true }
+
 /** The pane's layer stack, or `null` outside a pane (previews, offscreen capture). */
 val LocalPaneLayerState = compositionLocalOf<PaneLayerState?> { null }
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
@@ -1,0 +1,66 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.LocalPath
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DropHitResolverTest : BaseTest() {
+
+    private val download = LocalPath.build("/storage/emulated/0/Download")
+    private val readOnly = LocalPath.build("/system")
+
+    // The page: a 400x800 content area whose top 100px are covered by the floating bar stack.
+    private val contentBand = Rect(0f, 100f, 400f, 800f)
+
+    private fun resolve(
+        position: Offset,
+        registry: DropZoneRegistry,
+        isValidExplicit: (APath<*>) -> Boolean = { true },
+    ) = resolveDropHit(
+        positionInRoot = position,
+        zones = registry::zoneAt,
+        contentBand = contentBand,
+        isValidExplicit = isValidExplicit,
+    )
+
+    @Test
+    fun `a valid zone resolves to its destination`() {
+        val registry = DropZoneRegistry().apply {
+            register("row", download, Rect(0f, 200f, 400f, 260f))
+        }
+
+        resolve(Offset(200f, 230f), registry) shouldBe DropHit.Explicit(download)
+    }
+
+    @Test
+    fun `an invalid zone blocks instead of falling through to the pane`() {
+        val registry = DropZoneRegistry().apply {
+            register("row", readOnly, Rect(0f, 200f, 400f, 260f))
+        }
+
+        resolve(Offset(200f, 230f), registry, isValidExplicit = { false }) shouldBe DropHit.Blocked
+    }
+
+    @Test
+    fun `content background inside the band is a pane drop`() {
+        resolve(Offset(200f, 400f), DropZoneRegistry()) shouldBe DropHit.Pane
+    }
+
+    @Test
+    fun `the bar band without a zone is not a drop at all`() {
+        resolve(Offset(200f, 40f), DropZoneRegistry()) shouldBe DropHit.None
+    }
+
+    @Test
+    fun `a crumb zone inside the bar band still resolves`() {
+        val registry = DropZoneRegistry().apply {
+            register("crumb", download, Rect(20f, 20f, 120f, 60f))
+        }
+
+        resolve(Offset(50f, 40f), registry) shouldBe DropHit.Explicit(download)
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
@@ -11,6 +11,7 @@ import testhelpers.BaseTest
 class DropHitResolverTest : BaseTest() {
 
     private val download = LocalPath.build("/storage/emulated/0/Download")
+    private val pictures = LocalPath.build("/storage/emulated/0/Pictures")
     private val readOnly = LocalPath.build("/system")
 
     // The page: a 400x800 content area whose top 100px are covered by the floating bar stack.
@@ -71,5 +72,15 @@ class DropHitResolverTest : BaseTest() {
         }
 
         resolve(Offset(200f, 40f), registry) shouldBe DropHit.None
+    }
+
+    @Test
+    fun `an eligible crumb wins over a hidden row it overlaps`() {
+        val registry = DropZoneRegistry().apply {
+            register("row", download, Rect(0f, 20f, 400f, 80f))
+            register("crumb", pictures, Rect(20f, 20f, 120f, 60f), allowOutsideContentBand = true)
+        }
+
+        resolve(Offset(50f, 40f), registry) shouldBe DropHit.Explicit(pictures)
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
@@ -58,9 +58,18 @@ class DropHitResolverTest : BaseTest() {
     @Test
     fun `a crumb zone inside the bar band still resolves`() {
         val registry = DropZoneRegistry().apply {
-            register("crumb", download, Rect(20f, 20f, 120f, 60f))
+            register("crumb", download, Rect(20f, 20f, 120f, 60f), allowOutsideContentBand = true)
         }
 
         resolve(Offset(50f, 40f), registry) shouldBe DropHit.Explicit(download)
+    }
+
+    @Test
+    fun `a row zone under the bar band resolves to nothing`() {
+        val registry = DropZoneRegistry().apply {
+            register("row", download, Rect(0f, 20f, 400f, 80f))
+        }
+
+        resolve(Offset(200f, 40f), registry) shouldBe DropHit.None
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropHitResolverTest.kt
@@ -77,8 +77,8 @@ class DropHitResolverTest : BaseTest() {
     @Test
     fun `an eligible crumb wins over a hidden row it overlaps`() {
         val registry = DropZoneRegistry().apply {
-            register("row", download, Rect(0f, 20f, 400f, 80f))
-            register("crumb", pictures, Rect(20f, 20f, 120f, 60f), allowOutsideContentBand = true)
+            register("row", download, Rect(30f, 20f, 90f, 80f))
+            register("crumb", pictures, Rect(0f, 20f, 300f, 60f), allowOutsideContentBand = true)
         }
 
         resolve(Offset(50f, 40f), registry) shouldBe DropHit.Explicit(pictures)

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneModifierTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneModifierTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.LocalPath
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class DropZoneModifierTest : ComposeTest() {
+
+    private val download = LocalPath.build("/storage/emulated/0/Download")
+
+    @Test
+    fun `a zone registers its bounds`() {
+        val registry = DropZoneRegistry()
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDropZoneRegistry provides registry) {
+                Box(modifier = Modifier.fillMaxSize().dropZone(key = "row", destination = download))
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        registry.zoneAt(Offset(1f, 1f))?.destination shouldBe download
+    }
+
+    @Test
+    fun `a zone unregisters when its destination goes away`() {
+        val registry = DropZoneRegistry()
+        var destination by mutableStateOf<APath<*>?>(download)
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDropZoneRegistry provides registry) {
+                Box(modifier = Modifier.fillMaxSize().dropZone(key = "row", destination = destination))
+            }
+        }
+        composeTestRule.waitForIdle()
+        registry.zoneAt(Offset(1f, 1f))?.destination shouldBe download
+
+        destination = null
+        composeTestRule.waitForIdle()
+
+        registry.zoneAt(Offset(1f, 1f)) shouldBe null
+    }
+
+    @Test
+    fun `a zone unregisters when it leaves the composition`() {
+        val registry = DropZoneRegistry()
+        var present by mutableStateOf(true)
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDropZoneRegistry provides registry) {
+                if (present) {
+                    Box(modifier = Modifier.fillMaxSize().dropZone(key = "row", destination = download))
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        registry.zoneAt(Offset(1f, 1f))?.destination shouldBe download
+
+        present = false
+        composeTestRule.waitForIdle()
+
+        registry.zoneAt(Offset(1f, 1f)) shouldBe null
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneRegistryTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneRegistryTest.kt
@@ -1,0 +1,82 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import eu.darken.butler.common.files.LocalPath
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DropZoneRegistryTest : BaseTest() {
+
+    private val download = LocalPath.build("/storage/emulated/0/Download")
+    private val pictures = LocalPath.build("/storage/emulated/0/Pictures")
+
+    @Test
+    fun `a registered zone is found by a point inside it`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 100f, 50f))
+
+        registry.zoneAt(Offset(50f, 25f))?.destination shouldBe download
+    }
+
+    @Test
+    fun `a point outside every zone finds nothing`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 100f, 50f))
+
+        registry.zoneAt(Offset(150f, 25f)) shouldBe null
+    }
+
+    @Test
+    fun `registering the same key again replaces the zone`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 100f, 50f))
+        registry.register("row", pictures, Rect(0f, 100f, 100f, 150f))
+
+        registry.zoneAt(Offset(50f, 25f)) shouldBe null
+        registry.zoneAt(Offset(50f, 125f))?.destination shouldBe pictures
+    }
+
+    @Test
+    fun `unregistering removes the zone`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 100f, 50f))
+        registry.unregister("row")
+
+        registry.zoneAt(Offset(50f, 25f)) shouldBe null
+    }
+
+    @Test
+    fun `nested zones resolve to the smallest one`() {
+        val registry = DropZoneRegistry()
+        registry.register("bar", download, Rect(0f, 0f, 400f, 100f))
+        registry.register("crumb", pictures, Rect(10f, 10f, 90f, 60f))
+
+        registry.zoneAt(Offset(50f, 25f))?.key shouldBe "crumb"
+        registry.zoneAt(Offset(200f, 25f))?.key shouldBe "bar"
+    }
+
+    @Test
+    fun `hover is set and cleared`() {
+        val registry = DropZoneRegistry()
+        registry.hoveredKey shouldBe null
+
+        registry.setHovered("row")
+        registry.hoveredKey shouldBe "row"
+
+        registry.setHovered(null)
+        registry.hoveredKey shouldBe null
+    }
+
+    @Test
+    fun `unregistering the hovered zone clears the hover`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 100f, 50f))
+        registry.setHovered("row")
+
+        registry.unregister("row")
+
+        registry.hoveredKey shouldBe null
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneRegistryTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneRegistryTest.kt
@@ -68,6 +68,18 @@ class DropZoneRegistryTest : BaseTest() {
     }
 
     @Test
+    fun `zoneAt skips zones the predicate rejects`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 400f, 100f))
+        registry.register("crumb", pictures, Rect(10f, 10f, 90f, 60f), allowOutsideContentBand = true)
+
+        registry.zoneAt(Offset(50f, 25f))?.key shouldBe "crumb"
+        registry.zoneAt(Offset(50f, 25f)) { it.allowOutsideContentBand }?.key shouldBe "crumb"
+        registry.zoneAt(Offset(50f, 25f)) { !it.allowOutsideContentBand }?.key shouldBe "row"
+        registry.zoneAt(Offset(50f, 25f)) { false } shouldBe null
+    }
+
+    @Test
     fun `hover is set and cleared`() {
         val registry = DropZoneRegistry()
         registry.hoveredKey shouldBe null

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneRegistryTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DropZoneRegistryTest.kt
@@ -21,6 +21,16 @@ class DropZoneRegistryTest : BaseTest() {
     }
 
     @Test
+    fun `register keeps the outside-band flag`() {
+        val registry = DropZoneRegistry()
+        registry.register("row", download, Rect(0f, 0f, 100f, 50f))
+        registry.register("crumb", pictures, Rect(0f, 100f, 100f, 150f), allowOutsideContentBand = true)
+
+        registry.zoneAt(Offset(50f, 25f))?.allowOutsideContentBand shouldBe false
+        registry.zoneAt(Offset(50f, 125f))?.allowOutsideContentBand shouldBe true
+    }
+
+    @Test
     fun `a point outside every zone finds nothing`() {
         val registry = DropZoneRegistry()
         registry.register("row", download, Rect(0f, 0f, 100f, 50f))


### PR DESCRIPTION
## What changed

Files and folders can now be dragged onto a folder row, onto a directory favorite on the Home screen, or onto a breadcrumb crumb, and the usual Copy/Move dialog asks what to do. This works inside a single pane as well as across panes, so drag and drop no longer needs a second pane to be useful. While a drag rests near the top or bottom of the visible listing, the list scrolls so folders further away can be reached. The folder under the finger is highlighted while hovering, folders hidden under the floating toolbar or bottom bar are never targeted, and a drop onto a folder that is read-only or has disappeared is refused before the dialog opens.

## Technical Context

- Compose registers drop targets once per drag session and dispatches exclusively to the first matching descendant, so a target per folder row would go dead for rows scrolled in by auto-scroll and crumbs would be shadowed by the content target. The Explorer page therefore owns a single drop target; rows, favorites and crumbs publish their root-space bounds into a `DropZoneRegistry`, and a pure `resolveDropHit` decides between an explicit folder, a blocked zone, the pane background, or nothing (bars, non-directory crumbs). Zones outside the visible content band are eligible only when they opt in (crumbs), and eligibility is applied before the smallest-zone pick.
- The drop zone must sit outside the drag-source modifier: that modifier caches the row into a graphics layer and replays it, so anything drawn inside it never updates. Worth a look in `ExplorerItemRenderer`.
- Auto-scroll reuses the edge scroller extracted from drag-select (`EdgeAutoScroller`), with insets so the edge zones start at the visible content edge rather than under the floating bars, and a nearer-edge pick for very short bands.
- A workspace covered by a stacked sub-workspace stays composed and would otherwise accept drops through the modal; the page target refuses the drag session when its layer is not on the pane's top path (`LocalLayerOnTopPath`).
- Writability of the destination is checked through the gateway at drop time and again on confirmation, since crumbs carry no writability flag and a row's cached flag can go stale.
