### PR TITLE
Viewer: Preview text files without opening the editor

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/text/TextDecoder.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/text/TextDecoder.kt
@@ -1,0 +1,81 @@
+package eu.darken.butler.common.files.text
+
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+
+/**
+ * Turns a byte range into text, or says it is not text at all.
+ *
+ * Owns the decision every caller that shows file content has to make the same way: honour a BOM,
+ * decode strictly as UTF-8, fall back to ISO-8859-1 for legacy encodings, and refuse content that
+ * only decoded because Latin-1 maps every byte.
+ */
+object TextDecoder {
+
+    sealed interface Result {
+        data class Decoded(val text: String, val charset: Charset) : Result
+
+        /** The bytes are not text. Callers decide what to say about that. */
+        data object Binary : Result
+    }
+
+    fun decode(bytes: ByteArray): Result {
+        val bom = CharsetDetector.detectBom(bytes)
+        if (bom != null && (bom.charset == Charsets.UTF_16LE || bom.charset == Charsets.UTF_16BE)) {
+            val text = String(bytes, bom.bomSize, bytes.size - bom.bomSize, bom.charset)
+            return Result.Decoded(text, bom.charset)
+        }
+
+        val body = if (bom != null) bytes.copyOfRange(bom.bomSize, bytes.size) else bytes
+
+        // Checked before decoding, and only once a UTF-16 BOM has been ruled out above: UTF-16 text
+        // legitimately contains 0x00, everything else that does is binary.
+        if (body.any { it == 0.toByte() }) return Result.Binary
+
+        // Strict UTF-8 first so multibyte sequences aren't mistaken for raw C1 control bytes; only
+        // genuinely non-UTF-8 content falls back.
+        val strict = try {
+            Charsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(body))
+                .toString()
+        } catch (e: CharacterCodingException) {
+            null
+        }
+
+        val charset = if (strict != null) Charsets.UTF_8 else Charsets.ISO_8859_1
+        val text = strict ?: String(body, Charsets.ISO_8859_1)
+
+        // Backstop against the ISO-8859-1 fallback (and null-free binaries) decoding to control-char
+        // garbage. Run on the decoded text so C1 controls (0x80..0x9F) are counted too.
+        if (looksBinary(text)) return Result.Binary
+
+        return Result.Decoded(text, charset)
+    }
+
+    /**
+     * Counts Unicode control characters (C0, DEL and C1 0x80..0x9F) that are not legitimate text
+     * controls. Real text has essentially none; a high ratio means the ISO-8859-1 fallback decoded
+     * control-char garbage. The minimum count keeps a lone stray control in a short snippet from
+     * tripping the ratio. High-byte-only binaries that decode to legible Latin-1 are an accepted
+     * miss.
+     */
+    fun looksBinary(text: String): Boolean {
+        if (text.isEmpty()) return false
+        var suspicious = 0
+        for (c in text) {
+            if (c.isISOControl() && c !in ALLOWED_CONTROLS) suspicious++
+        }
+        return suspicious >= MIN_BINARY_CONTROL_COUNT &&
+            suspicious.toDouble() / text.length > BINARY_CONTROL_RATIO
+    }
+
+    private const val BINARY_CONTROL_RATIO = 0.10
+    private const val MIN_BINARY_CONTROL_COUNT = 4
+
+    /** Control chars that legitimately appear in text/logs (tab, LF, CR, FF, ANSI ESC). */
+    private val ALLOWED_CONTROLS = setOf('\t', '\n', '\r', '\u000C', '\u001B')
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/text/TextDecoderTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/text/TextDecoderTest.kt
@@ -1,0 +1,78 @@
+package eu.darken.butler.common.files.text
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The decode rules themselves are also exercised through `PasteFileReaderTest`, which owns the
+ * paste-specific behaviour. What is pinned here is the part that wrapper drops: which charset the
+ * decode settled on, which is what a caller has to report to the user.
+ */
+class TextDecoderTest : BaseTest() {
+
+    private val utf8Bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+    private val utf16LeBom = byteArrayOf(0xFF.toByte(), 0xFE.toByte())
+
+    private fun decoded(bytes: ByteArray) =
+        TextDecoder.decode(bytes).shouldBeInstanceOf<TextDecoder.Result.Decoded>()
+
+    @Test
+    fun `plain utf-8 reports utf-8`() {
+        val result = decoded("Grüße, 世界".toByteArray(Charsets.UTF_8))
+
+        result.text shouldBe "Grüße, 世界"
+        result.charset shouldBe Charsets.UTF_8
+    }
+
+    @Test
+    fun `a utf-8 BOM is stripped and not part of the text`() {
+        val result = decoded(utf8Bom + "Hello".toByteArray(Charsets.UTF_8))
+
+        result.text shouldBe "Hello"
+        result.charset shouldBe Charsets.UTF_8
+    }
+
+    /** UTF-16 text is full of 0x00, so the BOM has to be honoured before the null-byte check. */
+    @Test
+    fun `utf-16 survives the binary check and reports its own charset`() {
+        val result = decoded(utf16LeBom + "Hi".toByteArray(Charsets.UTF_16LE))
+
+        result.text shouldBe "Hi"
+        result.charset shouldBe Charsets.UTF_16LE
+    }
+
+    @Test
+    fun `legacy bytes fall back to latin-1 and say so`() {
+        val result = decoded("café".toByteArray(Charsets.ISO_8859_1))
+
+        result.text shouldBe "café"
+        result.charset shouldBe Charsets.ISO_8859_1
+    }
+
+    @Test
+    fun `null bytes are binary`() {
+        TextDecoder.decode(byteArrayOf(0x48, 0x00, 0x49)) shouldBe TextDecoder.Result.Binary
+    }
+
+    @Test
+    fun `control-character garbage is binary even without null bytes`() {
+        val garbage = ByteArray(64) { (0x01 + (it % 8)).toByte() }
+
+        TextDecoder.decode(garbage) shouldBe TextDecoder.Result.Binary
+    }
+
+    @Test
+    fun `empty content decodes to empty text, not binary`() {
+        val result = decoded(ByteArray(0))
+
+        result.text shouldBe ""
+    }
+
+    /** Logs carry tabs and ANSI escapes; those must not read as binary. */
+    @Test
+    fun `text controls do not trip the binary guard`() {
+        TextDecoder.looksBinary("col\tone\n\u001B[31mred\u001B[0m\r\n") shouldBe false
+    }
+}

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/PasteFileReader.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/PasteFileReader.kt
@@ -1,20 +1,16 @@
 package eu.darken.butler.editor.core
 
 import eu.darken.butler.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.GatewaySwitch
-import eu.darken.butler.common.files.text.CharsetDetector
+import eu.darken.butler.common.files.text.TextDecoder
 import kotlinx.coroutines.CancellationException
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
-import java.nio.ByteBuffer
-import java.nio.charset.CharacterCodingException
-import java.nio.charset.CodingErrorAction
 import javax.inject.Inject
 
 /**
@@ -68,60 +64,13 @@ class PasteFileReader @Inject constructor(
         return out.toByteArray()
     }
 
-    internal fun decodeBytes(bytes: ByteArray): String {
-        val bom = CharsetDetector.detectBom(bytes)
-        if (bom != null && (bom.charset == Charsets.UTF_16LE || bom.charset == Charsets.UTF_16BE)) {
-            return String(bytes, bom.bomSize, bytes.size - bom.bomSize, bom.charset)
-        }
-        val body = if (bom != null) bytes.copyOfRange(bom.bomSize, bytes.size) else bytes
-        // Null bytes are a hard binary signal.
-        if (body.any { it == 0.toByte() }) {
-            throw PasteBinaryException()
-        }
-        // Decode UTF-8 strictly first so multibyte sequences aren't mistaken for raw C1 control
-        // bytes; only genuinely non-UTF-8 content falls back to ISO-8859-1.
-        val decoded = try {
-            Charsets.UTF_8.newDecoder()
-                .onMalformedInput(CodingErrorAction.REPORT)
-                .onUnmappableCharacter(CodingErrorAction.REPORT)
-                .decode(ByteBuffer.wrap(body))
-                .toString()
-        } catch (e: CharacterCodingException) {
-            log(TAG, WARN) { "Strict UTF-8 decode failed, falling back to ISO-8859-1" }
-            String(body, Charsets.ISO_8859_1)
-        }
-        // Backstop against the ISO-8859-1 fallback (and null-free binaries) decoding to control-char
-        // garbage: run the check on the decoded text so C1 controls (0x80..0x9F) are also counted.
-        if (looksBinary(decoded)) {
-            throw PasteBinaryException()
-        }
-        return decoded
-    }
-
-    /**
-     * Heuristic binary guard for the decoded text: counts Unicode control characters (C0, DEL and
-     * C1 0x80..0x9F) that are not legitimate text controls (tab/LF/CR/FF and the ANSI ESC used in
-     * captured logs). Real text has essentially none; a high ratio means the ISO-8859-1 fallback
-     * decoded control-char garbage. The minimum-count guard keeps a lone stray control in a short
-     * snippet from tripping the ratio. High-byte-only binaries that decode to legible Latin-1 are
-     * an accepted miss for a paste convenience.
-     */
-    internal fun looksBinary(text: String): Boolean {
-        if (text.isEmpty()) return false
-        var suspicious = 0
-        for (c in text) {
-            if (c.isISOControl() && c !in ALLOWED_CONTROLS) suspicious++
-        }
-        return suspicious >= MIN_BINARY_CONTROL_COUNT &&
-            suspicious.toDouble() / text.length > BINARY_CONTROL_RATIO
+    internal fun decodeBytes(bytes: ByteArray): String = when (val result = TextDecoder.decode(bytes)) {
+        is TextDecoder.Result.Decoded -> result.text
+        TextDecoder.Result.Binary -> throw PasteBinaryException()
     }
 
     companion object {
         const val MAX_PASTE_FILE_SIZE = 1024 * 1024L // 1 MB
-        private const val BINARY_CONTROL_RATIO = 0.10
-        private const val MIN_BINARY_CONTROL_COUNT = 4
-        /** Control chars that legitimately appear in text/logs (tab, LF, CR, FF, ANSI ESC). */
-        private val ALLOWED_CONTROLS = setOf('\t', '\n', '\r', '\u000C', '\u001B')
         private val TAG = logTag("Editor", "PasteFileReader")
     }
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -1175,7 +1175,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
             is ExplorerActionBarItem.File.Open -> {
                 try {
                     // The viewer opens as a drill-down of this workspace: an overlay in the same
-                    // pane that returns here on back. Text files still go to the Editor as a tab.
+                    // pane that returns here on back.
                     openFile(item = action.item, asDrillDown = true)
                 } catch (e: Exception) {
                     log(tag, ERROR) { "Failed to open ${action.item.lookup.name}: ${e.asLog()}" }
@@ -1465,7 +1465,6 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 isText = TextFileDetector.isTextFile(item.mimeType),
             ),
             createExplorerArguments = { ExplorerArguments.Default(startPath = it) },
-            createEditorArguments = { EditorArguments.Default(filePath = it) },
             createViewerArguments = {
                 ViewerArguments.Default(
                     filePath = it,
@@ -1488,7 +1487,6 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         val requests = openInNewTabsUseCase.createRequests(
             analysis = analysis,
             createExplorerArguments = { path -> ExplorerArguments.Default(startPath = path) },
-            createEditorArguments = { path -> EditorArguments.Default(filePath = path) },
             createViewerArguments = { path ->
                 ViewerArguments.Default(filePath = path, listingSourceId = id)
             },

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
@@ -277,17 +277,7 @@ private fun FileOptionsContent(
             FileActionRow(
                 icon = Workspace.Type.VIEWER.icon,
                 title = stringResource(R.string.explorer_file_action_open),
-                // Only a Viewer stacks inside this tab and returns here on back. A text file
-                // routes to the Editor, which is a tab of its own, making this row do exactly
-                // what the "open in new tab" row below does. Routing pinned by
-                // OpenInNewTabsUseCaseTest.
-                subtitle = stringResource(
-                    if (isTextFile) {
-                        R.string.explorer_file_action_open_in_tab_subtitle
-                    } else {
-                        R.string.explorer_file_action_open_subtitle
-                    },
-                ),
+                subtitle = stringResource(R.string.explorer_file_action_open_subtitle),
                 onClick = { onAction(ExplorerActionBarItem.File.Open(item)) },
             )
 

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -406,7 +406,7 @@
     <string name="explorer_file_action_open_in_tab">Open in new tab</string>
     <string name="explorer_file_action_open_in_tab_subtitle">View in Butler as its own tab</string>
     <string name="explorer_file_action_open_in_editor">Open in editor</string>
-    <string name="explorer_file_action_open_in_editor_subtitle">Edit in Butler\'s text editor</string>
+    <string name="explorer_file_action_open_in_editor_subtitle">Edit in a new tab</string>
     <string name="explorer_file_action_open_with">Open with</string>
     <string name="explorer_file_action_open_with_subtitle">Choose an external app to open</string>
     <string name="explorer_file_action_share">Share</string>

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
@@ -935,17 +935,15 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
 
     /**
      * Routes a single result to the workspace type that fits it - the same classification the
-     * multi-select path uses, so a text file reaches the Editor instead of a Viewer that can only
-     * say it does not support the type.
+     * multi-select path uses.
      *
      * [asDrillDown] only affects the Viewer: it is the one target whose whole content is this file,
-     * so it can live as an overlay in this pane. The Editor always opens as a tab of its own.
+     * so it can live as an overlay in this pane. A directory opens as an Explorer tab of its own.
      */
     private suspend fun openResult(result: SearchItem, asDrillDown: Boolean) {
         val request = openInNewTabsUseCase.createRequest(
             item = result.toOpenInNewTabsItem(),
             createExplorerArguments = { ExplorerArguments.Default(startPath = it) },
-            createEditorArguments = { EditorArguments.Default(filePath = it) },
             createViewerArguments = {
                 ViewerArguments.Default(
                     filePath = it,
@@ -967,7 +965,6 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
         val requests = openInNewTabsUseCase.createRequests(
             analysis = analysis,
             createExplorerArguments = { path -> ExplorerArguments.Default(startPath = path) },
-            createEditorArguments = { path -> EditorArguments.Default(filePath = path) },
             createViewerArguments = { path -> ViewerArguments.Default(filePath = path) },
         )
 

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/util/SearchItemOpenTargetTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/util/SearchItemOpenTargetTest.kt
@@ -4,7 +4,6 @@ import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.searcher.core.SearchItem
-import eu.darken.butler.workspace.contracts.editor.EditorArguments
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
 import eu.darken.butler.workspace.core.OpenInNewTabsUseCase
@@ -31,17 +30,17 @@ class SearchItemOpenTargetTest : BaseTest() {
     private fun request(item: SearchItem) = useCase.createRequest(
         item = item.toOpenInNewTabsItem(),
         createExplorerArguments = { ExplorerArguments.Default(startPath = it) },
-        createEditorArguments = { EditorArguments.Default(filePath = it) },
         createViewerArguments = { ViewerArguments.Default(filePath = it) },
     )
 
+    /** "Open" shows the file; the Editor is what the "Open in editor" row is for. */
     @Test
-    fun `a text file opens in the editor`() {
+    fun `a text file opens in the viewer`() {
         val target = item("/storage/emulated/0/Documents/notes.txt")
 
         val request = request(target)
-        request.type shouldBe Workspace.Type.EDITOR
-        request.arguments shouldBe EditorArguments.Default(filePath = target.path)
+        request.type shouldBe Workspace.Type.VIEWER
+        request.arguments shouldBe ViewerArguments.Default(filePath = target.path)
     }
 
     @Test
@@ -87,8 +86,7 @@ class SearchItemOpenTargetTest : BaseTest() {
             ),
         )
 
-        analysis.textFilesToOpen.size shouldBe 1
-        analysis.viewerFilesToOpen.size shouldBe 2
+        analysis.viewerFilesToOpen.size shouldBe 3
         analysis.directoriesToOpen.size shouldBe 1
 
         targets.forEach { target ->

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/TextPreviewLoader.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/TextPreviewLoader.kt
@@ -86,8 +86,14 @@ class TextPreviewLoader @Inject constructor(
         return TextPreview(
             lines = lines,
             charset = decoded.charset,
-            isTruncated = cutByBytes || cutByLines || cutByWidth,
-            limitBytes = MAX_PREVIEW_BYTES.toLong(),
+            // Outermost bound first: reading stopped before the line bounds ever saw the rest, so
+            // naming a line limit for a file cut at the byte cap would name the wrong one.
+            truncation = when {
+                cutByBytes -> TextPreview.Truncation.Bytes(MAX_PREVIEW_BYTES.toLong())
+                cutByLines -> TextPreview.Truncation.Lines(MAX_LINES)
+                cutByWidth -> TextPreview.Truncation.LineWidth(MAX_LINE_CHARS)
+                else -> null
+            },
         )
     }
 
@@ -195,8 +201,19 @@ data class TextPreview(
     /** Already bounded in both count and width - the UI renders these as they are. */
     val lines: List<String>,
     val charset: Charset,
-    /** True when any of the three bounds cut something, whichever one it was. */
-    val isTruncated: Boolean,
-    /** The byte cap, for the banner that explains it. */
-    val limitBytes: Long,
-)
+    /** Null when this is the whole file. */
+    val truncation: Truncation? = null,
+) {
+    val isTruncated: Boolean get() = truncation != null
+
+    /**
+     * Which bound cut the preview, and where it sits. The UI names the one that actually applied: a
+     * 42 kB minified file cut at the line width has not been "limited to the first 1 MB", and
+     * saying so sends the reader looking for a megabyte that was never there.
+     */
+    sealed interface Truncation {
+        data class Bytes(val limit: Long) : Truncation
+        data class Lines(val limit: Int) : Truncation
+        data class LineWidth(val limit: Int) : Truncation
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/TextPreviewLoader.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/TextPreviewLoader.kt
@@ -1,0 +1,202 @@
+package eu.darken.butler.viewer.core
+
+import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.asLog
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.text.CharsetDetector
+import eu.darken.butler.common.files.text.TextDecoder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.charset.Charset
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reads the head of a text file for the viewer's preview.
+ *
+ * Three separate bounds, because one is not enough: [MAX_PREVIEW_BYTES] on what is read, since the
+ * viewer holds the whole preview in memory and the Explorer will hand it a file of any size;
+ * [MAX_LINES] and [MAX_LINE_CHARS] on what is handed to the UI, because a megabyte is also a million
+ * bare newlines, or one minified line a million characters wide, and neither is something Compose
+ * can lay out. Everything it cannot serve - a read failure, or content that turns out to be binary -
+ * resolves to null and falls back to the unsupported placeholder.
+ */
+@Singleton
+class TextPreviewLoader @Inject constructor(
+    private val contentReader: ViewerContentReader,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    /**
+     * Whether [source] really holds text, read from its head only. The counterpart to [ImageProbe]:
+     * a name says `.txt` but the bytes decide, and announcing text for a binary would render
+     * mojibake instead of the unsupported placeholder.
+     */
+    suspend fun probe(source: ViewerSource): Boolean = try {
+        withContext(dispatcherProvider.IO) {
+            val head = contentReader.readInput(source) { it.readCapped(PROBE_BYTES) }
+            // Trimmed exactly like the preview is. Without it the probe's own cut decides the
+            // verdict: a file of four-byte emoji ends the head mid-sequence, the strict decode
+            // fails, and the Latin-1 fallback's C1 controls report perfectly good text as binary.
+            TextDecoder.decode(trimToBoundary(head)) is TextDecoder.Result.Decoded
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "Cannot probe $source as text: ${e.asLog()}" }
+        false
+    }
+
+    suspend fun preview(source: ViewerSource): TextPreview? = try {
+        withContext(dispatcherProvider.IO) { read(source) }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "Cannot read $source as text: ${e.asLog()}" }
+        null
+    }
+
+    private suspend fun read(source: ViewerSource): TextPreview? {
+        val bytes = contentReader.readInput(source) { it.readCapped(MAX_PREVIEW_BYTES) }
+        // readCapped stops one byte past the cap, so a full buffer is the signal that there is more
+        // - the reported size is not consulted, a provider is free to lie about it.
+        val cutByBytes = bytes.size > MAX_PREVIEW_BYTES
+        val body = if (cutByBytes) trimToBoundary(bytes.copyOf(MAX_PREVIEW_BYTES)) else bytes
+
+        val decoded = when (val result = TextDecoder.decode(body)) {
+            is TextDecoder.Result.Decoded -> result
+            TextDecoder.Result.Binary -> {
+                log(TAG, INFO) { "$source is named as text but reads as binary" }
+                return null
+            }
+        }
+
+        // One past the limit, so a file that ends exactly on it is not reported as cut.
+        val all = decoded.text.lineSequence().take(MAX_LINES + 1).toList()
+        val cutByLines = all.size > MAX_LINES
+        var cutByWidth = false
+        val lines = all.take(MAX_LINES).map { line ->
+            if (line.length <= MAX_LINE_CHARS) line else line.take(MAX_LINE_CHARS).also { cutByWidth = true }
+        }
+
+        return TextPreview(
+            lines = lines,
+            charset = decoded.charset,
+            isTruncated = cutByBytes || cutByLines || cutByWidth,
+            limitBytes = MAX_PREVIEW_BYTES.toLong(),
+        )
+    }
+
+    /**
+     * Cuts a truncated buffer back to a character boundary, BEFORE it is decoded.
+     *
+     * The cap lands on an arbitrary byte, and a UTF-8 sequence split across it does not merely lose
+     * one character: the strict decode fails, the whole buffer falls back to ISO-8859-1, and the
+     * mojibake that produces trips the binary guard - so a perfectly good file would have no preview
+     * at all. Cutting at a line break also spares the reader half a line of data that is not there.
+     */
+    private fun trimToBoundary(bytes: ByteArray): ByteArray {
+        val bom = CharsetDetector.detectBom(bytes)
+        if (bom?.charset == Charsets.UTF_16LE || bom?.charset == Charsets.UTF_16BE) {
+            return trimUtf16(bytes, bom.charset)
+        }
+
+        val lastBreak = bytes.lastIndexOf(NEWLINE)
+        if (lastBreak >= 0) return bytes.copyOf(lastBreak)
+
+        return trimPartialUtf8(bytes)
+    }
+
+    /**
+     * A single line longer than the whole cap. Drops a trailing incomplete UTF-8 sequence, and only
+     * that: the scan is bounded by the longest sequence there is and requires a real lead byte at
+     * the end of it, so a single-byte encoding - where every high byte looks like a continuation -
+     * is left alone. Without that bound, a Latin-1 line of `£` (0xA3) would trim away to nothing.
+     */
+    private fun trimPartialUtf8(bytes: ByteArray): ByteArray {
+        var continuations = 0
+        while (continuations < MAX_UTF8_SEQUENCE - 1) {
+            val index = bytes.size - 1 - continuations
+            if (index < 0 || (bytes[index].toInt() and 0xC0) != 0x80) break
+            continuations++
+        }
+        val leadIndex = bytes.size - 1 - continuations
+        if (leadIndex < 0) return bytes
+
+        val lead = bytes[leadIndex].toInt() and 0xFF
+        val expected = when {
+            lead and 0x80 == 0x00 -> 1
+            lead and 0xE0 == 0xC0 -> 2
+            lead and 0xF0 == 0xE0 -> 3
+            lead and 0xF8 == 0xF0 -> 4
+            // Not a lead byte at all, so this is not UTF-8 and any cut in it is already safe.
+            else -> return bytes
+        }
+        return if (continuations + 1 < expected) bytes.copyOf(leadIndex) else bytes
+    }
+
+    /**
+     * UTF-16 carries 0x0A inside a code unit, so the newline scan would cut mid-character here. Its
+     * units are fixed width instead, which makes an even length enough - except for a cut between
+     * the halves of a surrogate pair, which would decode to a replacement character.
+     */
+    private fun trimUtf16(bytes: ByteArray, charset: Charset): ByteArray {
+        val even = if (bytes.size % 2 == 0) bytes else bytes.copyOf(bytes.size - 1)
+        if (even.size < 2) return even
+
+        val first = even[even.size - 2].toInt() and 0xFF
+        val second = even[even.size - 1].toInt() and 0xFF
+        val unit = if (charset == Charsets.UTF_16LE) (second shl 8) or first else (first shl 8) or second
+        return if (unit in 0xD800..0xDBFF) even.copyOf(even.size - 2) else even
+    }
+
+    /** Reads one byte past [cap], so the caller can tell "exactly full" from "there is more". */
+    private fun InputStream.readCapped(cap: Int): ByteArray {
+        val out = ByteArrayOutputStream()
+        val buf = ByteArray(64 * 1024)
+        val limit = cap + 1
+        while (out.size() < limit) {
+            val read = read(buf, 0, minOf(buf.size, limit - out.size()))
+            if (read == -1) break
+            out.write(buf, 0, read)
+        }
+        return out.toByteArray()
+    }
+
+    companion object {
+        private val TAG = logTag("Viewer", "TextPreviewLoader")
+
+        const val MAX_PREVIEW_BYTES = 1024 * 1024
+
+        /** A megabyte of bare newlines is a million of them, and every one would be a list entry. */
+        const val MAX_LINES = 50_000
+
+        /** Minified JSON is one line; handing Compose a megabyte of it to shape is not viable. */
+        const val MAX_LINE_CHARS = 2_000
+
+        /**
+         * How much of the head [probe] decides on. Large enough that a text file's first lines
+         * cannot all be legitimate control characters, small enough to stay off the critical path
+         * of classifying a multi-hundred-MB file.
+         */
+        private const val PROBE_BYTES = 64 * 1024
+
+        private const val NEWLINE = '\n'.code.toByte()
+        private const val MAX_UTF8_SEQUENCE = 4
+    }
+}
+
+/** What the viewer shows for a text file, and what it had to leave out to stay bounded. */
+data class TextPreview(
+    /** Already bounded in both count and width - the UI renders these as they are. */
+    val lines: List<String>,
+    val charset: Charset,
+    /** True when any of the three bounds cut something, whichever one it was. */
+    val isTruncated: Boolean,
+    /** The byte cap, for the banner that explains it. */
+    val limitBytes: Long,
+)

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerContent.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerContent.kt
@@ -14,6 +14,13 @@ sealed interface ViewerContent {
 
     data class Image(val mime: MimeInfo) : ViewerContent
 
+    /**
+     * A file the text preview can render. The text itself is not part of the state, only the fact
+     * that there is some - the same split [PdfPreview] makes, and for the same reason: a paused tab
+     * must not keep the payload alive.
+     */
+    data class Text(val mime: MimeInfo) : ViewerContent
+
     data class Apk(
         val mime: MimeInfo,
         val apkInfo: ApkArchiveInfo,

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerSupport.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerSupport.kt
@@ -27,6 +27,7 @@ object ViewerSupport {
         mime.isApk -> true
         mime.isPdf -> true
         mime.isImage -> true
+        mime.isText -> true
         else -> false
     }
 
@@ -44,6 +45,7 @@ object ViewerSupport {
             mime.isApk -> named.isApk
             mime.isPdf -> named.isPdf
             mime.isImage -> named.isImage
+            mime.isText -> named.isText
             else -> false
         }
     }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerWorkspace.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/ViewerWorkspace.kt
@@ -76,6 +76,7 @@ class ViewerWorkspace @AssistedInject constructor(
     private val pkgRepo: PkgRepo,
     private val userManager2: UserManager2,
     private val pdfPreviewLoader: PdfPreviewLoader,
+    private val textPreviewLoader: TextPreviewLoader,
     private val operationsManager: OperationsManager,
     private val issueHandler: IssueHandler,
     private val deleteOperationFactory: DeleteOperation.Factory,
@@ -449,6 +450,30 @@ class ViewerWorkspace @AssistedInject constructor(
             return
         }
 
+        // The probe doubles as the decode check, the way the image branch below uses ImageProbe: a
+        // name claiming text over bytes that are not would render mojibake instead of saying the
+        // type is unsupported.
+        if (mime.isText) {
+            if (!textPreviewLoader.probe(source)) {
+                log(tag, INFO) { "$source is named as text but does not read as text" }
+                stateFlow.value = State(
+                    content = ViewerContent.Unsupported(mime),
+                    fileInfo = fileInfo,
+                    lookup = lookup,
+                    contentLookup = contentLookup,
+                )
+                return
+            }
+            log(tag, INFO) { "$source is text ($mime)" }
+            stateFlow.value = State(
+                content = ViewerContent.Text(mime),
+                fileInfo = fileInfo,
+                lookup = lookup,
+                contentLookup = contentLookup,
+            )
+            return
+        }
+
         if (!mime.isImage) {
             log(tag, INFO) { "$source is not an image ($mime)" }
             stateFlow.value = State(
@@ -654,9 +679,13 @@ class ViewerWorkspace @AssistedInject constructor(
 
     private suspend fun validate(filePath: APath<*>, lookup: APathLookup<APath<*>>): Validation =
         when (lookup.fileType) {
-            FileType.FILE -> when (lookup.size) {
-                0L -> Validation.Rejected(ViewerEmptyFileException(filePath), contentLookup = lookup)
-                else -> Validation.Accepted(lookup)
+            // An empty file has nothing to decode, which is a failure for every renderer except the
+            // text one: an empty text file is a legitimate thing to look at, and rejecting it here
+            // would also withhold the "Open in editor" action that is the way to put something in it.
+            FileType.FILE -> when {
+                lookup.size != 0L -> Validation.Accepted(lookup)
+                MimeInfo.fromFileName(filePath.name).isText -> Validation.Accepted(lookup)
+                else -> Validation.Rejected(ViewerEmptyFileException(filePath), contentLookup = lookup)
             }
 
             FileType.DIRECTORY, FileType.UNKNOWN -> Validation.Rejected(ViewerNotAFileException(filePath))
@@ -714,7 +743,8 @@ class ViewerWorkspace @AssistedInject constructor(
             log(tag, WARN) { "Cannot read $streamed: ${e.asLog()}" }
             return ViewerContentUnreadableException(streamed.displayName, e)
         }
-        if (!hasBytes) return ViewerEmptyFileException(streamed.displayName)
+        // Same exemption [validate] makes: empty text is content, not a failure.
+        if (!hasBytes && !streamed.mime.isText) return ViewerEmptyFileException(streamed.displayName)
 
         return null
     }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/TextFileContent.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/TextFileContent.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,9 +33,11 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -95,16 +98,25 @@ fun TextFileContent(
             contentPadding = contentPadding,
         ) {
             items(preview.lines.size) { index ->
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState())
-                        .padding(horizontal = 12.dp),
-                    text = preview.lines[index],
-                    style = MaterialTheme.typography.bodySmall,
-                    fontFamily = FontFamily.Monospace,
-                    softWrap = false,
-                )
+                // Each line is laid out left to right whatever the UI's direction is, and only the
+                // line: the list keeps the UI's direction, so its insets stay where the chrome put
+                // them. A line's own script still decides how its glyphs run - Arabic inside a line
+                // still reads right to left - but the line as a whole starts at the left edge, which
+                // is where a line of a log or a config begins. Under an RTL UI they would start at
+                // the right instead, so every line opened scrolled to its far end and a log could
+                // not be read without dragging each one of them back.
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(horizontal = 12.dp),
+                        text = preview.lines[index],
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        softWrap = false,
+                    )
+                }
             }
         }
     }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/TextFileContent.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/TextFileContent.kt
@@ -4,12 +4,9 @@ import android.text.format.Formatter
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -20,26 +17,21 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.DriveFileRenameOutline
 import androidx.compose.material.icons.twotone.WarningAmber
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -48,6 +40,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.viewer.R
 import eu.darken.butler.viewer.core.TextPreview
+import java.text.NumberFormat
 
 /**
  * A read-only look at a text file.
@@ -67,6 +60,7 @@ fun TextFileContent(
      * Editor to open, and neither has a file that is gone - a button for either does nothing at all.
      */
     editorAvailable: Boolean = true,
+
     contentPadding: PaddingValues = PaddingValues(0.dp),
     barScrollConnections: List<NestedScrollConnection> = emptyList(),
     onOpenInEditor: () -> Unit = {},
@@ -87,92 +81,65 @@ fun TextFileContent(
         return
     }
 
-    // The banner floats over the list like the bars do, so the list has to inset for it as well or
-    // its last lines would sit underneath it. Measured rather than assumed: the text wraps on a
-    // narrow pane and at large font scales.
-    val layoutDirection = LocalLayoutDirection.current
-    val density = LocalDensity.current
-    var bannerHeight by remember { mutableStateOf(0.dp) }
-    // bannerHeight is measured with the bar inset already inside it, so it REPLACES the bottom
-    // inset rather than adding to it. Zero unless the banner is actually on screen, or a preview
-    // that stopped being truncated would keep its gap.
-    val listBottom = if (preview.isTruncated && bannerHeight > 0.dp) {
-        bannerHeight
-    } else {
-        contentPadding.calculateBottomPadding()
-    }
-    val listPadding = remember(contentPadding, listBottom, layoutDirection) {
-        PaddingValues(
-            start = contentPadding.calculateStartPadding(layoutDirection),
-            top = contentPadding.calculateTopPadding(),
-            end = contentPadding.calculateEndPadding(layoutDirection),
-            bottom = listBottom,
-        )
-    }
-
-    Box(modifier = modifier.fillMaxSize()) {
-        SelectionContainer {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .let { base -> barScrollConnections.fold(base) { acc, c -> acc.nestedScroll(c) } }
-                    // Not `clickable`: this is a whole scrolling list, and a click role plus a
-                    // ripple on it would be wrong.
-                    .let { base ->
-                        if (onToggleChrome == null) base
-                        else base.pointerInput(onToggleChrome) { detectTapGestures { onToggleChrome() } }
-                    },
-                contentPadding = listPadding,
-            ) {
-                items(preview.lines.size) { index ->
-                    Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .horizontalScroll(rememberScrollState())
-                            .padding(horizontal = 12.dp),
-                        text = preview.lines[index],
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Monospace,
-                        softWrap = false,
-                    )
-                }
+    SelectionContainer(modifier = modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .let { base -> barScrollConnections.fold(base) { acc, c -> acc.nestedScroll(c) } }
+                // Not `clickable`: this is a whole scrolling list, and a click role plus a ripple
+                // on it would be wrong.
+                .let { base ->
+                    if (onToggleChrome == null) base
+                    else base.pointerInput(onToggleChrome) { detectTapGestures { onToggleChrome() } }
+                },
+            contentPadding = contentPadding,
+        ) {
+            items(preview.lines.size) { index ->
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 12.dp),
+                    text = preview.lines[index],
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    softWrap = false,
+                )
             }
-        }
-
-        if (preview.isTruncated) {
-            TruncationBanner(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .onSizeChanged { bannerHeight = with(density) { it.height.toDp() } }
-                    // Only the bottom inset: the banner sits above the bottom bar, and the other
-                    // three would pad its own box rather than move it.
-                    .padding(bottom = contentPadding.calculateBottomPadding()),
-                limitBytes = preview.limitBytes,
-                onOpenInEditor = onOpenInEditor.takeIf { editorAvailable },
-            )
         }
     }
 }
 
 /**
- * Says the preview stops short and offers the one thing that does not. Anchored to the bottom rather
- * than placed at the end of the list: the cut is a property of the whole preview, and a reader who
- * never scrolls to the end would otherwise take a partial file for the whole one.
+ * Says the preview stops short and offers the one thing that does not.
+ *
+ * A bar in the viewer's chrome rather than an item at the end of the list: the cut is a property of
+ * the whole preview, and a reader who never scrolls to the end would otherwise take a partial file
+ * for the whole one. [onOpenInEditor] is null where the Editor has nothing to open.
  */
 @Composable
-private fun TruncationBanner(
+fun TextTruncationBar(
     modifier: Modifier = Modifier,
-    limitBytes: Long,
+    truncation: TextPreview.Truncation,
     onOpenInEditor: (() -> Unit)?,
 ) {
     val context = LocalContext.current
-    val limitText = remember(limitBytes) { Formatter.formatShortFileSize(context, limitBytes) }
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        tonalElevation = 3.dp,
-    ) {
+    val notice = remember(truncation, context) {
+        when (truncation) {
+            is TextPreview.Truncation.Bytes -> context.getString(
+                R.string.viewer_text_truncated_bytes,
+                Formatter.formatShortFileSize(context, truncation.limit),
+            )
+
+            is TextPreview.Truncation.Lines -> context.getString(
+                R.string.viewer_text_truncated_lines,
+                NumberFormat.getIntegerInstance().format(truncation.limit),
+            )
+
+            is TextPreview.Truncation.LineWidth -> context.getString(R.string.viewer_text_truncated_width)
+        }
+    }
+    Card(modifier = modifier) {
         Row(
             modifier = Modifier.padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -185,7 +152,7 @@ private fun TruncationBanner(
             )
             Text(
                 modifier = Modifier.weight(1f),
-                text = stringResource(R.string.viewer_text_truncated_notice, limitText),
+                text = notice,
                 style = MaterialTheme.typography.bodySmall,
             )
             if (onOpenInEditor != null) {
@@ -249,8 +216,6 @@ private fun TextFileContentPreview() {
         preview = TextPreview(
             lines = previewLines,
             charset = Charsets.UTF_8,
-            isTruncated = false,
-            limitBytes = 1024 * 1024,
         ),
     )
 }
@@ -258,15 +223,31 @@ private fun TextFileContentPreview() {
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun TextFileContentTruncatedPreview() {
-    TextFileContent(
-        preview = TextPreview(
-            lines = previewLines,
-            charset = Charsets.UTF_8,
-            isTruncated = true,
-            limitBytes = 1024 * 1024,
-        ),
-    )
+private fun TextTruncationBarPreview() {
+    TextTruncationBar(truncation = TextPreview.Truncation.Bytes(1024 * 1024), onOpenInEditor = {})
+}
+
+/** A 42 kB minified file is not "limited to the first 1 MB" - the width bound is what cut it. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextTruncationBarWidthPreview() {
+    TextTruncationBar(truncation = TextPreview.Truncation.LineWidth(2_000), onOpenInEditor = {})
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextTruncationBarLinesPreview() {
+    TextTruncationBar(truncation = TextPreview.Truncation.Lines(50_000), onOpenInEditor = {})
+}
+
+/** Streamed content has no path for the Editor, so the bar states the limit and offers nothing. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextTruncationBarNoEditorPreview() {
+    TextTruncationBar(truncation = TextPreview.Truncation.Bytes(1024 * 1024), onOpenInEditor = null)
 }
 
 @Preview2
@@ -277,8 +258,6 @@ private fun TextFileContentEmptyPreview() {
         preview = TextPreview(
             lines = listOf(""),
             charset = Charsets.UTF_8,
-            isTruncated = false,
-            limitBytes = 1024 * 1024,
         ),
     )
 }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/TextFileContent.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/TextFileContent.kt
@@ -1,0 +1,298 @@
+package eu.darken.butler.viewer.ui.viewer
+
+import android.text.format.Formatter
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.DriveFileRenameOutline
+import androidx.compose.material.icons.twotone.WarningAmber
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.viewer.R
+import eu.darken.butler.viewer.core.TextPreview
+
+/**
+ * A read-only look at a text file.
+ *
+ * Lines are their own list items rather than one long [Text]: a log file runs to hundreds of
+ * thousands of lines, and a single text node would lay all of them out at once. That is also why
+ * each line scrolls horizontally on its own instead of wrapping - a wrapped line breaks the column
+ * alignment that makes a log or a config readable in the first place.
+ */
+@Composable
+fun TextFileContent(
+    modifier: Modifier = Modifier,
+    preview: TextPreview?,
+    failed: Boolean = false,
+    /**
+     * Gated by the same applicability the action bar uses. Streamed content has no path for the
+     * Editor to open, and neither has a file that is gone - a button for either does nothing at all.
+     */
+    editorAvailable: Boolean = true,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    barScrollConnections: List<NestedScrollConnection> = emptyList(),
+    onOpenInEditor: () -> Unit = {},
+    onRetry: () -> Unit = {},
+    onToggleChrome: (() -> Unit)? = null,
+) {
+    if (preview == null) {
+        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            if (failed) {
+                TextPreviewFailure(
+                    onRetry = onRetry,
+                    onOpenInEditor = onOpenInEditor.takeIf { editorAvailable },
+                )
+            } else {
+                CircularProgressIndicator()
+            }
+        }
+        return
+    }
+
+    // The banner floats over the list like the bars do, so the list has to inset for it as well or
+    // its last lines would sit underneath it. Measured rather than assumed: the text wraps on a
+    // narrow pane and at large font scales.
+    val layoutDirection = LocalLayoutDirection.current
+    val density = LocalDensity.current
+    var bannerHeight by remember { mutableStateOf(0.dp) }
+    // bannerHeight is measured with the bar inset already inside it, so it REPLACES the bottom
+    // inset rather than adding to it. Zero unless the banner is actually on screen, or a preview
+    // that stopped being truncated would keep its gap.
+    val listBottom = if (preview.isTruncated && bannerHeight > 0.dp) {
+        bannerHeight
+    } else {
+        contentPadding.calculateBottomPadding()
+    }
+    val listPadding = remember(contentPadding, listBottom, layoutDirection) {
+        PaddingValues(
+            start = contentPadding.calculateStartPadding(layoutDirection),
+            top = contentPadding.calculateTopPadding(),
+            end = contentPadding.calculateEndPadding(layoutDirection),
+            bottom = listBottom,
+        )
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        SelectionContainer {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .let { base -> barScrollConnections.fold(base) { acc, c -> acc.nestedScroll(c) } }
+                    // Not `clickable`: this is a whole scrolling list, and a click role plus a
+                    // ripple on it would be wrong.
+                    .let { base ->
+                        if (onToggleChrome == null) base
+                        else base.pointerInput(onToggleChrome) { detectTapGestures { onToggleChrome() } }
+                    },
+                contentPadding = listPadding,
+            ) {
+                items(preview.lines.size) { index ->
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(horizontal = 12.dp),
+                        text = preview.lines[index],
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        softWrap = false,
+                    )
+                }
+            }
+        }
+
+        if (preview.isTruncated) {
+            TruncationBanner(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .onSizeChanged { bannerHeight = with(density) { it.height.toDp() } }
+                    // Only the bottom inset: the banner sits above the bottom bar, and the other
+                    // three would pad its own box rather than move it.
+                    .padding(bottom = contentPadding.calculateBottomPadding()),
+                limitBytes = preview.limitBytes,
+                onOpenInEditor = onOpenInEditor.takeIf { editorAvailable },
+            )
+        }
+    }
+}
+
+/**
+ * Says the preview stops short and offers the one thing that does not. Anchored to the bottom rather
+ * than placed at the end of the list: the cut is a property of the whole preview, and a reader who
+ * never scrolls to the end would otherwise take a partial file for the whole one.
+ */
+@Composable
+private fun TruncationBanner(
+    modifier: Modifier = Modifier,
+    limitBytes: Long,
+    onOpenInEditor: (() -> Unit)?,
+) {
+    val context = LocalContext.current
+    val limitText = remember(limitBytes) { Formatter.formatShortFileSize(context, limitBytes) }
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        tonalElevation = 3.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                modifier = Modifier.size(20.dp),
+                imageVector = Icons.TwoTone.WarningAmber,
+                contentDescription = null,
+            )
+            Text(
+                modifier = Modifier.weight(1f),
+                text = stringResource(R.string.viewer_text_truncated_notice, limitText),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            if (onOpenInEditor != null) {
+                TextButton(onClick = onOpenInEditor) {
+                    Text(text = stringResource(R.string.viewer_open_in_editor_action))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextPreviewFailure(
+    modifier: Modifier = Modifier,
+    onRetry: () -> Unit,
+    onOpenInEditor: (() -> Unit)?,
+) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            modifier = Modifier.size(48.dp),
+            imageVector = Icons.TwoTone.DriveFileRenameOutline,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = stringResource(R.string.viewer_text_unreadable_label),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            TextButton(onClick = onRetry) {
+                Text(text = stringResource(eu.darken.butler.common.R.string.general_retry_action))
+            }
+            if (onOpenInEditor != null) {
+                TextButton(onClick = onOpenInEditor) {
+                    Text(text = stringResource(R.string.viewer_open_in_editor_action))
+                }
+            }
+        }
+    }
+}
+
+private val previewLines = listOf(
+    "# Butler config",
+    "theme = system",
+    "root.enabled = true",
+    "",
+    "[explorer]",
+    "show_hidden = false",
+    "sort = name",
+)
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextFileContentPreview() {
+    TextFileContent(
+        preview = TextPreview(
+            lines = previewLines,
+            charset = Charsets.UTF_8,
+            isTruncated = false,
+            limitBytes = 1024 * 1024,
+        ),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextFileContentTruncatedPreview() {
+    TextFileContent(
+        preview = TextPreview(
+            lines = previewLines,
+            charset = Charsets.UTF_8,
+            isTruncated = true,
+            limitBytes = 1024 * 1024,
+        ),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextFileContentEmptyPreview() {
+    TextFileContent(
+        preview = TextPreview(
+            lines = listOf(""),
+            charset = Charsets.UTF_8,
+            isTruncated = false,
+            limitBytes = 1024 * 1024,
+        ),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextFileContentLoadingPreview() {
+    TextFileContent(preview = null)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TextFileContentFailedPreview() {
+    TextFileContent(preview = null, failed = true)
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerActionBarItem.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerActionBarItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.automirrored.twotone.OpenInNew
 import androidx.compose.material.icons.twotone.ContentCopy
 import androidx.compose.material.icons.twotone.ContentCut
 import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.DriveFileRenameOutline
 import androidx.compose.material.icons.twotone.DeleteForever
 import androidx.compose.material.icons.twotone.FolderZip
 import androidx.compose.material.icons.twotone.InstallMobile
@@ -74,6 +75,15 @@ sealed interface ViewerActionBarItem : WorkspaceActionBarItem {
     data object BrowseArchive : ViewerActionBarItem {
         override val icon = Icons.TwoTone.FolderZip
         override val label = R.string.viewer_browse_archive_action.toCaString()
+    }
+
+    /**
+     * Open the text file in an Editor tab. The viewer's own preview is read-only and capped, so this
+     * is both how the file gets edited and how the part beyond the cap gets read.
+     */
+    data object OpenInEditor : ViewerActionBarItem {
+        override val icon = Icons.TwoTone.DriveFileRenameOutline
+        override val label = R.string.viewer_open_in_editor_action.toCaString()
     }
 
     /**

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerPersistedKeys.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerPersistedKeys.kt
@@ -17,4 +17,5 @@ internal object ViewerBarKeys {
     const val ACTIONS = "actions"
     const val FILEINFO = "fileinfo"
     const val PDF_HINT = "pdfhint"
+    const val TEXT_TRUNCATED = "texttruncated"
 }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
@@ -121,12 +121,14 @@ fun ViewerWorkspacePageHost(
                     is ViewerActionBarItem.Delete -> vm.requestDelete()
                     ViewerActionBarItem.SaveCopy -> vm.saveCopy()
                     ViewerActionBarItem.BrowseArchive -> vm.browseArchive()
+                    ViewerActionBarItem.OpenInEditor -> vm.openInEditor()
                     ViewerActionBarItem.Install -> vm.install()
                 }
             },
             onOpenWith = { vm.openWith() },
             onSaveCopy = { vm.saveCopy() },
             onBrowseArchive = { vm.browseArchive() },
+            onOpenInEditor = { vm.openInEditor() },
             onRetry = { vm.retry() },
             onShareError = { error -> vm.shareError(error) },
             onShowIcon = { vm.showIconPreview() },
@@ -155,6 +157,7 @@ fun ViewerWorkspacePage(
     onOpenWith: () -> Unit = {},
     onSaveCopy: () -> Unit = {},
     onBrowseArchive: () -> Unit = {},
+    onOpenInEditor: () -> Unit = {},
     onRetry: () -> Unit = {},
     onShareError: (Throwable) -> Unit = {},
     onShowIcon: () -> Unit = {},
@@ -297,6 +300,7 @@ fun ViewerWorkspacePage(
                     onOpenWith = onOpenWith,
                     onSaveCopy = onSaveCopy,
                     onBrowseArchive = onBrowseArchive,
+                    onOpenInEditor = onOpenInEditor,
                     onRetry = onRetry,
                     onShareError = onShareError,
                     onShowIcon = onShowIcon,
@@ -440,6 +444,7 @@ private fun ViewerContentArea(
     onOpenWith: () -> Unit,
     onSaveCopy: () -> Unit = {},
     onBrowseArchive: () -> Unit = {},
+    onOpenInEditor: () -> Unit = {},
     onRetry: () -> Unit,
     onShareError: (Throwable) -> Unit,
     onShowIcon: () -> Unit = {},
@@ -492,6 +497,19 @@ private fun ViewerContentArea(
                 zoomableState = zoomableState,
                 onClick = onToggleChrome,
                 onRetry = onRetry,
+            )
+
+            is ViewerContent.Text -> TextFileContent(
+                preview = state.textPreview?.preview,
+                failed = state.textPreview?.failed == true,
+                // Asked of the action bar rather than re-derived: it already knows when the Editor
+                // has nothing to open, and two answers to that would drift apart.
+                editorAvailable = state.actions.contains(ViewerActionBarItem.OpenInEditor),
+                contentPadding = contentPadding,
+                barScrollConnections = barScrollConnections,
+                onOpenInEditor = onOpenInEditor,
+                onRetry = onRetry,
+                onToggleChrome = onToggleChrome,
             )
 
             is ViewerContent.Archive -> ArchivePlaceholder(

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePage.kt
@@ -380,6 +380,27 @@ fun ViewerWorkspacePage(
                             }
                         }
 
+                        // A cut preview is a property of the whole file, so it belongs in the
+                        // chrome with the other bars rather than at the end of a list the reader
+                        // may never scroll to.
+                        val truncated = state.content is ViewerContent.Text &&
+                            state.textPreview?.preview?.isTruncated == true
+                        FloatingBar(
+                            key = ViewerBarKeys.TEXT_TRUNCATED,
+                            visible = chromeShown && truncated,
+                            scrollBehavior = BarScrollBehavior.HideOnScroll,
+                            animation = BarAnimation.Slide(),
+                        ) {
+                            state.textPreview?.preview?.truncation?.let {
+                                TextTruncationBar(
+                                    truncation = it,
+                                    onOpenInEditor = onOpenInEditor.takeIf {
+                                        state.actions.contains(ViewerActionBarItem.OpenInEditor)
+                                    },
+                                )
+                            }
+                        }
+
                         // Metadata read before the failure describes a file that is no longer
                         // there, so next to the error it would read as current.
                         val fileInfo = state.fileInfo?.takeIf { state.content !is ViewerContent.Failed }

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
@@ -36,6 +36,8 @@ import eu.darken.butler.viewer.core.GatewayZoomableImageSource
 import eu.darken.butler.viewer.core.IconSaveDecision
 import eu.darken.butler.viewer.core.decideIconSave
 import eu.darken.butler.viewer.core.PdfPreviewLoader
+import eu.darken.butler.viewer.core.TextPreview
+import eu.darken.butler.viewer.core.TextPreviewLoader
 import eu.darken.butler.viewer.core.ViewerBrokenSymlinkException
 import eu.darken.butler.viewer.core.ViewerContent
 import eu.darken.butler.viewer.core.ViewerSource
@@ -45,6 +47,7 @@ import eu.darken.butler.viewer.core.ViewerFileGoneException
 import eu.darken.butler.viewer.core.ViewerIconUnavailableException
 import eu.darken.butler.viewer.core.ViewerShareUnavailableException
 import eu.darken.butler.viewer.core.ViewerWorkspace
+import eu.darken.butler.workspace.contracts.editor.EditorArguments
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.contracts.saver.SaverArguments
 import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
@@ -105,6 +108,7 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
     private val workspaceRemote: WorkspaceRemote,
     private val imageSourceFactory: GatewayZoomableImageSource.Factory,
     private val pdfPreviewLoader: PdfPreviewLoader,
+    private val textPreviewLoader: TextPreviewLoader,
     private val openWithIntentUseCase: OpenWithIntentUseCase,
     private val shareIntentUseCase: ShareIntentUseCase,
     private val clipboardRepo: ClipboardRepo,
@@ -218,6 +222,41 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         }
 
     /**
+     * The text is read here, not in the workspace: the preview is capped but still up to a megabyte,
+     * and a paused tab must not keep holding it. Emits an empty result first so the page shows its
+     * spinner while the read runs.
+     *
+     * A read that fails after the file classified as text stays in this flow rather than reaching
+     * [renderErrorFlow]: the tab is not broken, only this preview is, and it offers its own retry.
+     */
+    private val textPreviewFlow = combine(workspaceSource, attemptFlow) { workspace, attempt ->
+        workspace to attempt
+    }
+        .distinctUntilChanged()
+        .flatMapLatest { (workspace, _) ->
+            workspace.state
+                .map { it.content as? ViewerContent.Text }
+                .distinctUntilChanged()
+                .flatMapLatest { text ->
+                    if (text == null) {
+                        flowOf<TextPreviewResult?>(null)
+                    } else {
+                        flow {
+                            emit(TextPreviewResult(source = workspace.source, preview = null))
+                            val preview = textPreviewLoader.preview(workspace.source)
+                            emit(
+                                TextPreviewResult(
+                                    source = workspace.source,
+                                    preview = preview,
+                                    failed = preview == null,
+                                ),
+                            )
+                        }
+                    }
+                }
+        }
+
+    /**
      * What [snapshots] last carried, for the failure handler below: by then the source flow has
      * already thrown, and recollecting it to name the file would run the failing lookup again.
      */
@@ -278,9 +317,10 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         renderErrorFlow,
         imageSourceFlow,
         pdfPageFlow,
+        textPreviewFlow,
         trashSettings.enabled.flow,
         neighboursFlow,
-    ) { snapshot, renderFailure, imageSource, pdfPage, trashEnabled, rawNeighbours ->
+    ) { snapshot, renderFailure, imageSource, pdfPage, textPreview, trashEnabled, rawNeighbours ->
         val (source, workspaceState) = snapshot
         // Only the failure of what is on display now: one recorded for a source this tab has since
         // been rebound away from would hide the new content behind the old one's error.
@@ -318,6 +358,10 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
             source = source,
             imageSource = imageSource.takeIf { content is ViewerContent.Image },
             pdfPage = pdfPage.takeIf { content is ViewerContent.PdfPreview },
+            // Tagged with its source, not merely gated on the content type: combine keeps the last
+            // value of every input, so a step from one text file to the next would otherwise show
+            // the previous file's text under the new file's name until the read catches up.
+            textPreview = textPreview?.takeIf { content is ViewerContent.Text && it.source == source },
             actions = viewerActions(
                 source = source,
                 trashEnabled = trashEnabled,
@@ -761,6 +805,20 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
     }
 
     /**
+     * Opens the file in an Editor tab. Always a tab of its own: the Editor is not a drill-down
+     * target, and this viewer stays where it is so back still returns to whatever opened it.
+     */
+    fun openInEditor() = launch {
+        val path = workspaceSource.first().storedPath ?: return@launch
+        log(tag, INFO) { "openInEditor($path)" }
+        workspaceRemote.createAndFocus(
+            type = Workspace.Type.EDITOR,
+            arguments = EditorArguments.Default(filePath = path),
+            sourceWorkspaceId = id,
+        )
+    }
+
+    /**
      * Installs the APK or app bundle this tab is showing.
      *
      * Inspection runs here rather than inside the operation so an unreadable, protected or
@@ -1097,6 +1155,14 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         val index: Int,
     )
 
+    /** One loaded text preview. A null [preview] with [failed] false means the read is still running. */
+    data class TextPreviewResult(
+        /** Which file this was read from, so a result outliving its source can be dropped. */
+        val source: ViewerSource,
+        val preview: TextPreview?,
+        val failed: Boolean = false,
+    )
+
     /** One rendered PDF page. A null [bitmap] with [failed] false means the render is still running. */
     data class PdfPage(
         val index: Int,
@@ -1115,6 +1181,7 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
             val source: ViewerSource,
             val imageSource: ZoomableImageSource?,
             val pdfPage: PdfPage? = null,
+            val textPreview: TextPreviewResult? = null,
             val neighbours: ViewerNeighbours? = null,
             val actions: List<ViewerActionBarItem> = viewerActions(
                 source,
@@ -1188,6 +1255,11 @@ internal fun viewerActions(
                 ViewerContent.Archive.Access.BROWSABLE
             if (browsable || content is ViewerContent.AppBundle) {
                 add(ViewerActionBarItem.BrowseArchive)
+            }
+            // Leads for the same reason: the preview here is read-only and stops at a cap, so the
+            // Editor is where both editing and the rest of a large file live.
+            if (content is ViewerContent.Text) {
+                add(ViewerActionBarItem.OpenInEditor)
             }
             // Handing a file to another app needs a file:// or content:// URI, which a file on a
             // server does not have, so those two are not offered for it.

--- a/app-workspace-viewer/src/main/res/values/strings.xml
+++ b/app-workspace-viewer/src/main/res/values/strings.xml
@@ -106,6 +106,8 @@
     <string name="viewer_error_content_unreadable_description">The app that shared %1$s is no longer letting Butler read it. Ask that app to share it again.</string>
     <string name="viewer_save_copy_action">Save a copy…</string>
     <string name="viewer_open_in_editor_action">Open in editor</string>
-    <string name="viewer_text_truncated_notice">Preview limited to the first %1$s of this file.</string>
+    <string name="viewer_text_truncated_bytes">Preview limited to the first %1$s of this file.</string>
+    <string name="viewer_text_truncated_lines">Preview limited to the first %1$s lines of this file.</string>
+    <string name="viewer_text_truncated_width">Long lines are shortened in this preview.</string>
     <string name="viewer_text_unreadable_label">This file couldn\'t be read</string>
 </resources>

--- a/app-workspace-viewer/src/main/res/values/strings.xml
+++ b/app-workspace-viewer/src/main/res/values/strings.xml
@@ -105,4 +105,7 @@
     <string name="viewer_error_content_unreadable_label">Can\'t read this file</string>
     <string name="viewer_error_content_unreadable_description">The app that shared %1$s is no longer letting Butler read it. Ask that app to share it again.</string>
     <string name="viewer_save_copy_action">Save a copy…</string>
+    <string name="viewer_open_in_editor_action">Open in editor</string>
+    <string name="viewer_text_truncated_notice">Preview limited to the first %1$s of this file.</string>
+    <string name="viewer_text_unreadable_label">This file couldn\'t be read</string>
 </resources>

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/TextPreviewLoaderTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/TextPreviewLoaderTest.kt
@@ -63,7 +63,7 @@ class TextPreviewLoaderTest : BaseTest() {
         val preview = loaderFor(content).preview(source)!!
 
         preview.isTruncated shouldBe true
-        preview.limitBytes shouldBe TextPreviewLoader.MAX_PREVIEW_BYTES.toLong()
+        preview.truncation shouldBe TextPreview.Truncation.Bytes(TextPreviewLoader.MAX_PREVIEW_BYTES.toLong())
         preview.lines.all { it.length == 999 } shouldBe true
     }
 
@@ -89,7 +89,7 @@ class TextPreviewLoaderTest : BaseTest() {
         val preview = loaderFor(content).preview(source)!!
 
         preview.lines.size shouldBe TextPreviewLoader.MAX_LINES
-        preview.isTruncated shouldBe true
+        preview.truncation shouldBe TextPreview.Truncation.Lines(TextPreviewLoader.MAX_LINES)
     }
 
     @Test
@@ -110,7 +110,9 @@ class TextPreviewLoaderTest : BaseTest() {
         val preview = loaderFor(content).preview(source)!!
 
         preview.lines.single().length shouldBe TextPreviewLoader.MAX_LINE_CHARS
-        preview.isTruncated shouldBe true
+        // Not the byte cap: this file is nowhere near it, and naming it would send the reader
+        // looking for a megabyte that was never there.
+        preview.truncation shouldBe TextPreview.Truncation.LineWidth(TextPreviewLoader.MAX_LINE_CHARS)
     }
 
     // ==================== charset-aware trimming ====================

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/TextPreviewLoaderTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/TextPreviewLoaderTest.kt
@@ -1,0 +1,201 @@
+package eu.darken.butler.viewer.core
+
+import eu.darken.butler.common.files.GatewaySwitch
+import eu.darken.butler.common.files.LocalPath
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.io.ByteArrayInputStream
+
+class TextPreviewLoaderTest : BaseTest() {
+
+    private val path = LocalPath.build("/storage/emulated/0/Documents/notes.txt")
+    private val source = ViewerSource.Stored(path)
+    private val gatewaySwitch = mockk<GatewaySwitch>()
+
+    private fun loaderFor(content: ByteArray): TextPreviewLoader {
+        coEvery { gatewaySwitch.useRes(any<suspend (Any) -> Any?>()) } coAnswers {
+            firstArg<suspend (Any) -> Any?>().invoke(gatewaySwitch)
+        }
+        // A fresh stream per open: the reader documents that gateway streams do not rewind, and a
+        // shared one would let the probe consume what the preview is supposed to read.
+        coEvery { gatewaySwitch.openInputStream(any()) } answers { ByteArrayInputStream(content) }
+        return TextPreviewLoader(
+            contentReader = readerFor(gatewaySwitch),
+            dispatcherProvider = TestDispatcherProvider(),
+        )
+    }
+
+    private fun loaderFor(content: String) = loaderFor(content.toByteArray())
+
+    // ==================== the byte cap ====================
+
+    @Test
+    fun `a small file is served whole and unmarked`() = runTest2 {
+        val preview = loaderFor("one\ntwo\nthree").preview(source)!!
+
+        preview.lines shouldBe listOf("one", "two", "three")
+        preview.charset shouldBe Charsets.UTF_8
+        preview.isTruncated shouldBe false
+    }
+
+    @Test
+    fun `a file exactly at the cap is not reported as truncated`() = runTest2 {
+        val line = "a".repeat(999) + "\n"
+        val content = ByteArray(TextPreviewLoader.MAX_PREVIEW_BYTES) {
+            line[it % line.length].code.toByte()
+        }
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.isTruncated shouldBe false
+    }
+
+    @Test
+    fun `a file past the cap is cut back to a whole line`() = runTest2 {
+        // Lines of a length the cap cannot land on, so the cut is always mid-line.
+        val content = ("a".repeat(999) + "\n").repeat(2000).toByteArray()
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.isTruncated shouldBe true
+        preview.limitBytes shouldBe TextPreviewLoader.MAX_PREVIEW_BYTES.toLong()
+        preview.lines.all { it.length == 999 } shouldBe true
+    }
+
+    /** A cut in the middle of a multi-byte sequence must not survive into the rendered text. */
+    @Test
+    fun `truncation never leaves a replacement character`() = runTest2 {
+        val content = "世界\n".repeat(TextPreviewLoader.MAX_PREVIEW_BYTES / 7 + 100).toByteArray()
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.isTruncated shouldBe true
+        preview.lines.none { it.contains('�') } shouldBe true
+        preview.charset shouldBe Charsets.UTF_8
+    }
+
+    // ==================== the render bounds ====================
+
+    /** A megabyte of bare newlines would otherwise be a million list entries. */
+    @Test
+    fun `a file with more lines than the cap is cut to it`() = runTest2 {
+        val content = "\n".repeat(TextPreviewLoader.MAX_LINES + 500).toByteArray()
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.lines.size shouldBe TextPreviewLoader.MAX_LINES
+        preview.isTruncated shouldBe true
+    }
+
+    @Test
+    fun `a file with exactly the line cap is not reported as truncated`() = runTest2 {
+        val content = "x\n".repeat(TextPreviewLoader.MAX_LINES - 1) + "x"
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.lines.size shouldBe TextPreviewLoader.MAX_LINES
+        preview.isTruncated shouldBe false
+    }
+
+    /** Minified JSON is one line; Compose cannot shape a million characters of it. */
+    @Test
+    fun `an over-wide line is clipped and reported`() = runTest2 {
+        val content = "b".repeat(TextPreviewLoader.MAX_LINE_CHARS + 500)
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.lines.single().length shouldBe TextPreviewLoader.MAX_LINE_CHARS
+        preview.isTruncated shouldBe true
+    }
+
+    // ==================== charset-aware trimming ====================
+
+    /**
+     * Every high byte of a single-byte encoding looks like a UTF-8 continuation byte. A backoff that
+     * does not check for a real lead byte would trim this whole line away.
+     */
+    @Test
+    fun `a latin-1 line longer than the cap is not trimmed away`() = runTest2 {
+        val content = ByteArray(TextPreviewLoader.MAX_PREVIEW_BYTES + 500) { 0xA3.toByte() }
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.isTruncated shouldBe true
+        preview.charset shouldBe Charsets.ISO_8859_1
+        preview.lines.single().length shouldBe TextPreviewLoader.MAX_LINE_CHARS
+        preview.lines.single().all { it == '£' } shouldBe true
+    }
+
+    /** No newline anywhere, so the byte cut lands inside a character and has to be backed off. */
+    @Test
+    fun `a single utf-8 line longer than the cap keeps whole characters`() = runTest2 {
+        val content = "世".repeat(TextPreviewLoader.MAX_PREVIEW_BYTES).toByteArray()
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.isTruncated shouldBe true
+        preview.charset shouldBe Charsets.UTF_8
+        preview.lines.single().all { it == '世' } shouldBe true
+    }
+
+    @Test
+    fun `utf-16 is decoded as itself rather than cut on a byte`() = runTest2 {
+        val bom = byteArrayOf(0xFF.toByte(), 0xFE.toByte())
+        val content = bom + "alpha\nbravo".toByteArray(Charsets.UTF_16LE)
+
+        val preview = loaderFor(content).preview(source)!!
+
+        preview.charset shouldBe Charsets.UTF_16LE
+        preview.lines shouldBe listOf("alpha", "bravo")
+    }
+
+    // ==================== binary and empty ====================
+
+    @Test
+    fun `binary content has no preview`() = runTest2 {
+        val content = ByteArray(64) { (0x01 + (it % 8)).toByte() }
+
+        loaderFor(content).preview(source) shouldBe null
+    }
+
+    @Test
+    fun `an empty file previews as empty rather than failing`() = runTest2 {
+        val preview = loaderFor(ByteArray(0)).preview(source)!!
+
+        preview.lines shouldBe listOf("")
+        preview.isTruncated shouldBe false
+    }
+
+    // ==================== the probe ====================
+
+    @Test
+    fun `the probe accepts text and rejects binary`() = runTest2 {
+        loaderFor("hello\nworld").probe(source) shouldBe true
+        loaderFor(ByteArray(64) { (0x01 + (it % 8)).toByte() }).probe(source) shouldBe false
+    }
+
+    @Test
+    fun `the probe accepts a file far larger than the cap`() = runTest2 {
+        val content = "line\n".repeat(TextPreviewLoader.MAX_PREVIEW_BYTES)
+
+        loaderFor(content).probe(source) shouldBe true
+    }
+
+    /**
+     * The probe's own cut must not decide the verdict. Four-byte characters and no line breaks put a
+     * split sequence at the end of every fixed-size head, and an untrimmed decode of that reports
+     * perfectly good text as binary.
+     */
+    @Test
+    fun `the probe accepts wide characters whose sequence its cap splits`() = runTest2 {
+        val content = "😀".repeat(TextPreviewLoader.MAX_PREVIEW_BYTES / 4)
+
+        loaderFor(content).probe(source) shouldBe true
+        loaderFor(content).preview(source)!!.lines.single().isNotEmpty() shouldBe true
+    }
+}

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerSupportTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerSupportTest.kt
@@ -17,7 +17,7 @@ class ViewerSupportTest : BaseTest() {
 
     /**
      * The types [ViewerWorkspace] branches on before falling through to
-     * [ViewerContent.Unsupported]: APK, PDF and images.
+     * [ViewerContent.Unsupported]: APK, PDF, text and images.
      */
     private val classifiedTypes = listOf(
         "application/vnd.android.package-archive",
@@ -27,11 +27,13 @@ class ViewerSupportTest : BaseTest() {
         "image/gif",
         "image/webp",
         "image/svg+xml",
+        "text/plain",
+        "text/x-log",
+        "application/json",
+        "application/xml",
     )
 
     private val unclassifiedTypes = listOf(
-        "text/plain",
-        "application/json",
         "video/mp4",
         "audio/mpeg",
         "application/zip",
@@ -67,6 +69,9 @@ class ViewerSupportTest : BaseTest() {
             MimeInfo("application/vnd.android.package-archive"),
             "app.apk",
         ) shouldBe true
+        ViewerSupport.hasMatchingName(MimeInfo("text/plain"), "notes.txt") shouldBe true
+        // Both sides answer from MimeInfo's table, so a json name satisfies a text/* type.
+        ViewerSupport.hasMatchingName(MimeInfo("text/plain"), "data.json") shouldBe true
     }
 
     @Test
@@ -78,11 +83,12 @@ class ViewerSupportTest : BaseTest() {
             "app.zip",
         ) shouldBe false
         ViewerSupport.hasMatchingName(MimeInfo("application/pdf"), "invoice") shouldBe false
+        ViewerSupport.hasMatchingName(MimeInfo("text/plain"), "photo.png") shouldBe false
     }
 
     @Test
     fun `a type the viewer cannot show never matches a name`() {
-        ViewerSupport.hasMatchingName(MimeInfo("text/plain"), "notes.txt") shouldBe false
         ViewerSupport.hasMatchingName(MimeInfo("video/mp4"), "clip.mp4") shouldBe false
+        ViewerSupport.hasMatchingName(MimeInfo("audio/mpeg"), "song.mp3") shouldBe false
     }
 }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceClassificationTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceClassificationTest.kt
@@ -48,6 +48,7 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
     private val pkgRepo = mockk<PkgRepo>()
     private val userManager2 = mockk<UserManager2>()
     private val pdfPreviewLoader = mockk<PdfPreviewLoader>()
+    private val textPreviewLoader = mockk<TextPreviewLoader>()
 
     private val apkInfo = ApkArchiveInfo(
         id = "eu.darken.butler".toPkgId(),
@@ -118,10 +119,49 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
         pkgRepo = pkgRepo,
         userManager2 = userManager2,
         pdfPreviewLoader = pdfPreviewLoader,
+        textPreviewLoader = textPreviewLoader,
         operationsManager = mockk(relaxed = true),
         issueHandler = mockk(relaxed = true),
         deleteOperationFactory = mockk(relaxed = true),
     )
+
+    private val textPath = LocalPath.build("/storage/emulated/0/Documents/notes.txt")
+
+    @Test
+    fun `a readable text file resolves to Text`() = runTest2 {
+        setupGateway(textPath.path to lookup(textPath))
+        coEvery { textPreviewLoader.probe(any()) } returns true
+
+        val state = workspace(textPath).state.first()
+
+        state.content.shouldBeInstanceOf<ViewerContent.Text>()
+    }
+
+    /**
+     * Empty is a failure for every renderer except the text one: an empty text file is a legitimate
+     * thing to look at, and the error card would also withhold the "Open in editor" action that is
+     * the way to put something in it.
+     */
+    @Test
+    fun `an empty text file resolves to Text rather than the empty-file error`() = runTest2 {
+        setupGateway(textPath.path to lookup(textPath, size = 0L))
+        coEvery { textPreviewLoader.probe(any()) } returns true
+
+        val state = workspace(textPath).state.first()
+
+        state.content.shouldBeInstanceOf<ViewerContent.Text>()
+    }
+
+    /** A name promising text over bytes that are not must say "unsupported", not render mojibake. */
+    @Test
+    fun `a text name over binary bytes resolves to Unsupported`() = runTest2 {
+        setupGateway(textPath.path to lookup(textPath))
+        coEvery { textPreviewLoader.probe(any()) } returns false
+
+        val state = workspace(textPath).state.first()
+
+        state.content.shouldBeInstanceOf<ViewerContent.Unsupported>()
+    }
 
     @Test
     fun `a readable image resolves to Image`() = runTest2 {
@@ -307,6 +347,7 @@ class ViewerWorkspaceClassificationTest : BaseTest() {
             pkgRepo = pkgRepo,
             userManager2 = userManager2,
             pdfPreviewLoader = pdfPreviewLoader,
+            textPreviewLoader = mockk(relaxed = true),
             operationsManager = mockk(relaxed = true),
             issueHandler = mockk(relaxed = true),
             deleteOperationFactory = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceDisplayTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceDisplayTest.kt
@@ -68,6 +68,7 @@ class ViewerWorkspaceDisplayTest {
             pkgRepo = mockk(relaxed = true),
             userManager2 = mockk(relaxed = true),
             pdfPreviewLoader = mockk(relaxed = true),
+            textPreviewLoader = mockk(relaxed = true),
             operationsManager = mockk(relaxed = true),
             issueHandler = mockk(relaxed = true),
             deleteOperationFactory = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceExternalChangeTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceExternalChangeTest.kt
@@ -103,6 +103,7 @@ class ViewerWorkspaceExternalChangeTest : BaseTest() {
         pkgRepo = pkgRepo,
         userManager2 = userManager2,
         pdfPreviewLoader = pdfPreviewLoader,
+        textPreviewLoader = mockk(relaxed = true),
         operationsManager = mockk(relaxed = true),
         issueHandler = mockk(relaxed = true),
         deleteOperationFactory = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceRelationshipTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceRelationshipTest.kt
@@ -56,6 +56,7 @@ class ViewerWorkspaceRelationshipTest : BaseTest() {
         pkgRepo = mockk(relaxed = true),
         userManager2 = mockk(relaxed = true),
         pdfPreviewLoader = mockk(relaxed = true),
+        textPreviewLoader = mockk(relaxed = true),
         operationsManager = mockk(relaxed = true),
         issueHandler = mockk(relaxed = true),
         deleteOperationFactory = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceStreamedTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/core/ViewerWorkspaceStreamedTest.kt
@@ -91,6 +91,7 @@ class ViewerWorkspaceStreamedTest : BaseTest() {
         pkgRepo = pkgRepo,
         userManager2 = userManager2,
         pdfPreviewLoader = pdfPreviewLoader,
+        textPreviewLoader = mockk(relaxed = true),
         operationsManager = mockk(relaxed = true),
         issueHandler = mockk(relaxed = true),
         deleteOperationFactory = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/TextFileContentTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/TextFileContentTest.kt
@@ -17,15 +17,16 @@ class TextFileContentTest : ComposeTest() {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
-    private fun preview(vararg lines: String, isTruncated: Boolean = false) = TextPreview(
+    private fun preview(vararg lines: String, truncation: TextPreview.Truncation? = null) = TextPreview(
         lines = lines.toList(),
         charset = Charsets.UTF_8,
-        isTruncated = isTruncated,
-        limitBytes = 1024 * 1024,
+        truncation = truncation,
     )
 
+    private val byteLimit = TextPreview.Truncation.Bytes(1024 * 1024)
+
     private fun truncationNotice() = context.getString(
-        R.string.viewer_text_truncated_notice,
+        R.string.viewer_text_truncated_bytes,
         android.text.format.Formatter.formatShortFileSize(context, 1024 * 1024),
     )
 
@@ -48,16 +49,25 @@ class TextFileContentTest : ComposeTest() {
         composeTestRule.onAllNodesWithText(truncationNotice()).fetchSemanticsNodes().size shouldBe 0
     }
 
-    /** The cut has to be stated where the reader is, not at the end of a list they may never reach. */
+    /** The notice is a bar in the viewer's chrome now, so the content itself carries none of it. */
     @Test
-    fun `a truncated file says so and offers the editor`() {
+    fun `a truncated file's content shows no notice of its own`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TextFileContent(preview = preview("alpha", "bravo", truncation = byteLimit))
+            }
+        }
+
+        composeTestRule.onNodeWithText("alpha").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(truncationNotice()).fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `the truncation bar states the limit and offers the editor`() {
         var opened = false
         composeTestRule.setContent {
             PreviewWrapper {
-                TextFileContent(
-                    preview = preview("alpha", "bravo", isTruncated = true),
-                    onOpenInEditor = { opened = true },
-                )
+                TextTruncationBar(truncation = byteLimit, onOpenInEditor = { opened = true })
             }
         }
 
@@ -71,13 +81,10 @@ class TextFileContentTest : ComposeTest() {
 
     /** The Editor needs a path, so a stream must not be offered a button that does nothing. */
     @Test
-    fun `a truncated stream offers no editor button`() {
+    fun `the truncation bar offers no editor button without a path`() {
         composeTestRule.setContent {
             PreviewWrapper {
-                TextFileContent(
-                    preview = preview("alpha", isTruncated = true),
-                    editorAvailable = false,
-                )
+                TextTruncationBar(truncation = byteLimit, onOpenInEditor = null)
             }
         }
 
@@ -135,5 +142,47 @@ class TextFileContentTest : ComposeTest() {
         }
 
         composeTestRule.onAllNodesWithText(truncationNotice()).fetchSemanticsNodes().size shouldBe 0
+    }
+
+    /**
+     * A 42 kB minified file cut at the line width has not been "limited to the first 1 MB", and
+     * saying so sends the reader looking for a megabyte that was never there.
+     */
+    @Test
+    fun `the bar names the bound that actually cut`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TextTruncationBar(
+                    truncation = TextPreview.Truncation.LineWidth(2_000),
+                    onOpenInEditor = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.viewer_text_truncated_width))
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(truncationNotice()).fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `a line-count cut names the line limit`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TextTruncationBar(
+                    truncation = TextPreview.Truncation.Lines(50_000),
+                    onOpenInEditor = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(
+                context.getString(
+                    R.string.viewer_text_truncated_lines,
+                    java.text.NumberFormat.getIntegerInstance().format(50_000),
+                ),
+            )
+            .assertIsDisplayed()
     }
 }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/TextFileContentTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/TextFileContentTest.kt
@@ -1,0 +1,139 @@
+package eu.darken.butler.viewer.ui.viewer
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.viewer.R
+import eu.darken.butler.viewer.core.TextPreview
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class TextFileContentTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun preview(vararg lines: String, isTruncated: Boolean = false) = TextPreview(
+        lines = lines.toList(),
+        charset = Charsets.UTF_8,
+        isTruncated = isTruncated,
+        limitBytes = 1024 * 1024,
+    )
+
+    private fun truncationNotice() = context.getString(
+        R.string.viewer_text_truncated_notice,
+        android.text.format.Formatter.formatShortFileSize(context, 1024 * 1024),
+    )
+
+    @Test
+    fun `the file's lines are shown`() {
+        composeTestRule.setContent {
+            PreviewWrapper { TextFileContent(preview = preview("alpha", "bravo")) }
+        }
+
+        composeTestRule.onNodeWithText("alpha").assertIsDisplayed()
+        composeTestRule.onNodeWithText("bravo").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a whole file carries no truncation notice`() {
+        composeTestRule.setContent {
+            PreviewWrapper { TextFileContent(preview = preview("alpha", "bravo")) }
+        }
+
+        composeTestRule.onAllNodesWithText(truncationNotice()).fetchSemanticsNodes().size shouldBe 0
+    }
+
+    /** The cut has to be stated where the reader is, not at the end of a list they may never reach. */
+    @Test
+    fun `a truncated file says so and offers the editor`() {
+        var opened = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TextFileContent(
+                    preview = preview("alpha", "bravo", isTruncated = true),
+                    onOpenInEditor = { opened = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(truncationNotice()).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.viewer_open_in_editor_action))
+            .performClick()
+
+        opened shouldBe true
+    }
+
+    /** The Editor needs a path, so a stream must not be offered a button that does nothing. */
+    @Test
+    fun `a truncated stream offers no editor button`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TextFileContent(
+                    preview = preview("alpha", isTruncated = true),
+                    editorAvailable = false,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(truncationNotice()).assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithText(context.getString(R.string.viewer_open_in_editor_action))
+            .fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `a failed read offers retry and the editor`() {
+        var retried = false
+        var opened = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                TextFileContent(
+                    preview = null,
+                    failed = true,
+                    onRetry = { retried = true },
+                    onOpenInEditor = { opened = true },
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.viewer_text_unreadable_label))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(context.getString(eu.darken.butler.common.R.string.general_retry_action))
+            .performClick()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.viewer_open_in_editor_action))
+            .performClick()
+
+        retried shouldBe true
+        opened shouldBe true
+    }
+
+    /** Still loading is not a failure: no error copy, and nothing that suggests one. */
+    @Test
+    fun `a pending read shows neither the failure nor the notice`() {
+        composeTestRule.setContent {
+            PreviewWrapper { TextFileContent(preview = null) }
+        }
+
+        composeTestRule
+            .onAllNodesWithText(context.getString(R.string.viewer_text_unreadable_label))
+            .fetchSemanticsNodes().size shouldBe 0
+    }
+
+    @Test
+    fun `an empty file renders without crashing`() {
+        composeTestRule.setContent {
+            PreviewWrapper { TextFileContent(preview = preview("")) }
+        }
+
+        composeTestRule.onAllNodesWithText(truncationNotice()).fetchSemanticsNodes().size shouldBe 0
+    }
+}

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerActionsTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerActionsTest.kt
@@ -84,6 +84,35 @@ class ViewerActionsTest : BaseTest() {
             .contains(ViewerActionBarItem.Install) shouldBe false
     }
 
+    private val text = ViewerContent.Text(MimeInfo("text/plain"))
+
+    @Test
+    fun `text leads with the editor`() {
+        viewerActions(stored, trashEnabled = false, content = text)
+            .first() shouldBe ViewerActionBarItem.OpenInEditor
+    }
+
+    @Test
+    fun `the editor is not offered for anything else`() {
+        viewerActions(stored, trashEnabled = false, content = apk)
+            .contains(ViewerActionBarItem.OpenInEditor) shouldBe false
+        viewerActions(stored, trashEnabled = false, content = ViewerContent.Image(MimeInfo("image/jpeg")))
+            .contains(ViewerActionBarItem.OpenInEditor) shouldBe false
+    }
+
+    /** The Editor needs a path, and there is nothing left to edit anyway. */
+    @Test
+    fun `a text file that is gone is not offered to the editor`() {
+        viewerActions(stored, trashEnabled = false, content = text, isGone = true)
+            .contains(ViewerActionBarItem.OpenInEditor) shouldBe false
+    }
+
+    @Test
+    fun `streamed text has no path for the editor`() {
+        viewerActions(streamed, trashEnabled = false, content = text)
+            .contains(ViewerActionBarItem.OpenInEditor) shouldBe false
+    }
+
     @Test
     fun `streamed content keeps its single action`() {
         viewerActions(streamed, trashEnabled = false, content = apk) shouldBe

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileStepTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileStepTest.kt
@@ -155,6 +155,7 @@ class ViewerFileStepTest : BaseTest() {
             workspaceRemote = remote,
             imageSourceFactory = mockk(relaxed = true),
             pdfPreviewLoader = mockk(relaxed = true),
+            textPreviewLoader = mockk(relaxed = true),
             openWithIntentUseCase = mockk(relaxed = true),
             shareIntentUseCase = mockk(relaxed = true),
             clipboardRepo = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerRenderFailureTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerRenderFailureTest.kt
@@ -138,6 +138,7 @@ class ViewerRenderFailureTest : BaseTest() {
                 }
             },
             pdfPreviewLoader = mockk(relaxed = true),
+            textPreviewLoader = mockk(relaxed = true),
             openWithIntentUseCase = mockk(relaxed = true),
             shareIntentUseCase = mockk(relaxed = true),
             clipboardRepo = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerSaveCopyTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerSaveCopyTest.kt
@@ -120,6 +120,7 @@ class ViewerSaveCopyTest : BaseTest() {
             workspaceRemote = remote,
             imageSourceFactory = mockk(relaxed = true),
             pdfPreviewLoader = mockk(relaxed = true),
+            textPreviewLoader = mockk(relaxed = true),
             openWithIntentUseCase = mockk(relaxed = true),
             shareIntentUseCase = mockk(relaxed = true),
             clipboardRepo = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCollapseTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCollapseTest.kt
@@ -45,4 +45,11 @@ class ViewerToolbarCollapseTest : BaseTest() {
         shouldCollapseToolbar(ViewerContent.Unsupported(MimeInfo("application/pdf")), isZoomedIn = true) shouldBe false
         shouldCollapseToolbar(ViewerContent.Loading, isZoomedIn = true) shouldBe false
     }
+
+    /** Text scrolls, it does not zoom, so a stale zoom must not collapse the chrome over it. */
+    @Test
+    fun `text never collapses the toolbar`() {
+        shouldCollapseToolbar(ViewerContent.Text(MimeInfo("text/plain")), isZoomedIn = true) shouldBe false
+        shouldCollapseToolbar(ViewerContent.Text(MimeInfo("text/plain")), isZoomedIn = false) shouldBe false
+    }
 }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelExternalChangeTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelExternalChangeTest.kt
@@ -110,6 +110,7 @@ class ViewerWorkspaceViewModelExternalChangeTest : BaseTest() {
                 }
             },
             pdfPreviewLoader = mockk(relaxed = true),
+            textPreviewLoader = mockk(relaxed = true),
             openWithIntentUseCase = mockk(relaxed = true),
             shareIntentUseCase = mockk(relaxed = true),
             clipboardRepo = mockk(relaxed = true),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
@@ -131,6 +131,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
             },
             imageSourceFactory = mockk(relaxed = true),
             pdfPreviewLoader = loader,
+            textPreviewLoader = mockk(relaxed = true),
             openWithIntentUseCase = mockk(relaxed = true),
             shareIntentUseCase = mockk(relaxed = true),
             clipboardRepo = mockk(relaxed = true),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/OpenInNewTabsUseCase.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/OpenInNewTabsUseCase.kt
@@ -25,12 +25,16 @@ class OpenInNewTabsUseCase @Inject constructor() {
         val path: APath<*>
 
         data class Directory(override val path: APath<*>) : Item
+
+        /**
+         * [isText] no longer picks the workspace - it says what the item IS, which callers still
+         * need for things that are not routing (the drag payload's kind, for one).
+         */
         data class File(override val path: APath<*>, val isText: Boolean) : Item
     }
 
     data class AnalysisResult(
         val directoriesToOpen: List<APath<*>>,
-        val textFilesToOpen: List<APath<*>>,
         val viewerFilesToOpen: List<APath<*>>,
         val skippedCount: Int,
         val totalOpenableCount: Int,
@@ -41,13 +45,16 @@ class OpenInNewTabsUseCase @Inject constructor() {
     }
 
     /**
-     * The routing rule shared by every "open this" entry point: a directory goes to the Explorer,
-     * a text file to the Editor, and everything else to the Viewer, which shows images and explains
-     * the rest. Single source of truth for both the single-item and the multi-select path.
+     * The routing rule shared by every "open this" entry point: a directory goes to the Explorer and
+     * a file to the Viewer, which renders images, PDFs, packages and text and explains the rest.
+     * Single source of truth for both the single-item and the multi-select path.
+     *
+     * A text file lands here too rather than in the Editor: "open" means look at it, and the Editor
+     * is reached by the action that says so. Pinned by [OpenInNewTabsUseCaseTest].
      */
     fun classify(item: Item): Workspace.Type = when (item) {
         is Item.Directory -> Workspace.Type.EXPLORER
-        is Item.File -> if (item.isText) Workspace.Type.EDITOR else Workspace.Type.VIEWER
+        is Item.File -> Workspace.Type.VIEWER
     }
 
     /**
@@ -57,28 +64,25 @@ class OpenInNewTabsUseCase @Inject constructor() {
         log(tag) { "analyze(): ${request.items.size} items from workspace ${request.sourceWorkspaceId.shortTag}" }
 
         val directories = mutableListOf<APath<*>>()
-        val textFiles = mutableListOf<APath<*>>()
         val viewerFiles = mutableListOf<APath<*>>()
 
         request.items.forEach { item ->
             when (classify(item)) {
                 Workspace.Type.EXPLORER -> directories.add(item.path)
-                Workspace.Type.EDITOR -> textFiles.add(item.path)
                 else -> viewerFiles.add(item.path)
             }
         }
 
-        val totalOpenableCount = directories.size + textFiles.size + viewerFiles.size
+        val totalOpenableCount = directories.size + viewerFiles.size
         val needsConfirmation = totalOpenableCount >= CONFIRMATION_THRESHOLD
 
         log(tag) {
-            "Analysis: ${directories.size} directories, ${textFiles.size} text files, " +
-                "${viewerFiles.size} viewer files, confirmation: $needsConfirmation"
+            "Analysis: ${directories.size} directories, ${viewerFiles.size} viewer files, " +
+                "confirmation: $needsConfirmation"
         }
 
         return AnalysisResult(
             directoriesToOpen = directories,
-            textFilesToOpen = textFiles,
             viewerFilesToOpen = viewerFiles,
             skippedCount = 0,
             totalOpenableCount = totalOpenableCount,
@@ -88,12 +92,11 @@ class OpenInNewTabsUseCase @Inject constructor() {
 
     /**
      * Single-item counterpart to [analyze] + [createRequests], used by the "Open" action so it
-     * routes through the exact same classification instead of always landing in the Viewer.
+     * routes through the exact same classification.
      */
     fun createRequest(
         item: Item,
         createExplorerArguments: (APath<*>) -> Workspace.Arguments,
-        createEditorArguments: (APath<*>) -> Workspace.Arguments,
         createViewerArguments: (APath<*>) -> Workspace.Arguments,
     ): WorkspaceAction.Create {
         val type = classify(item)
@@ -102,7 +105,6 @@ class OpenInNewTabsUseCase @Inject constructor() {
             type = type,
             arguments = when (type) {
                 Workspace.Type.EXPLORER -> createExplorerArguments(item.path)
-                Workspace.Type.EDITOR -> createEditorArguments(item.path)
                 else -> createViewerArguments(item.path)
             },
         )
@@ -115,13 +117,11 @@ class OpenInNewTabsUseCase @Inject constructor() {
     fun createRequests(
         analysis: AnalysisResult,
         createExplorerArguments: (APath<*>) -> Workspace.Arguments,
-        createEditorArguments: (APath<*>) -> Workspace.Arguments,
         createViewerArguments: (APath<*>) -> Workspace.Arguments,
     ): List<WorkspaceAction.Create> {
         log(tag) {
             "createRequests(): Creating ${analysis.totalOpenableCount} workspace requests " +
-                "(${analysis.directoriesToOpen.size} Explorer, ${analysis.textFilesToOpen.size} Editor, " +
-                "${analysis.viewerFilesToOpen.size} Viewer)"
+                "(${analysis.directoriesToOpen.size} Explorer, ${analysis.viewerFilesToOpen.size} Viewer)"
         }
 
         return buildList {
@@ -130,15 +130,6 @@ class OpenInNewTabsUseCase @Inject constructor() {
                     WorkspaceAction.Create(
                         type = Workspace.Type.EXPLORER,
                         arguments = createExplorerArguments(path),
-                    )
-                )
-            }
-
-            analysis.textFilesToOpen.forEach { path ->
-                add(
-                    WorkspaceAction.Create(
-                        type = Workspace.Type.EDITOR,
-                        arguments = createEditorArguments(path),
                     )
                 )
             }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/OpenInNewTabsUseCaseTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/OpenInNewTabsUseCaseTest.kt
@@ -4,7 +4,6 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MimeInfo
 import eu.darken.butler.common.files.TextFileDetector
-import eu.darken.butler.workspace.contracts.editor.EditorArguments
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
 import io.kotest.matchers.collections.shouldContainExactly
@@ -29,7 +28,6 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
     private fun requests(analysis: OpenInNewTabsUseCase.AnalysisResult) = useCase.createRequests(
         analysis = analysis,
         createExplorerArguments = { ExplorerArguments.Default(startPath = it) },
-        createEditorArguments = { EditorArguments.Default(filePath = it) },
         createViewerArguments = { ViewerArguments.Default(filePath = it) },
     )
 
@@ -38,7 +36,6 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
         val analysis = analyze(OpenInNewTabsUseCase.Item.Directory(directory))
 
         analysis.directoriesToOpen shouldContainExactly listOf<APath<*>>(directory)
-        analysis.textFilesToOpen.isEmpty() shouldBe true
         analysis.viewerFilesToOpen.isEmpty() shouldBe true
 
         val request = requests(analysis).single()
@@ -46,16 +43,17 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
         request.arguments shouldBe ExplorerArguments.Default(startPath = directory)
     }
 
+    /** "Open" means look at it. The Editor is reached by the row that says so, not by this one. */
     @Test
-    fun `text files route to the editor`() {
+    fun `text files route to the viewer`() {
         val analysis = analyze(OpenInNewTabsUseCase.Item.File(textFile, isText = true))
 
-        analysis.textFilesToOpen shouldContainExactly listOf<APath<*>>(textFile)
-        analysis.viewerFilesToOpen.isEmpty() shouldBe true
+        analysis.viewerFilesToOpen shouldContainExactly listOf<APath<*>>(textFile)
+        analysis.directoriesToOpen.isEmpty() shouldBe true
 
         val request = requests(analysis).single()
-        request.type shouldBe Workspace.Type.EDITOR
-        request.arguments shouldBe EditorArguments.Default(filePath = textFile)
+        request.type shouldBe Workspace.Type.VIEWER
+        request.arguments shouldBe ViewerArguments.Default(filePath = textFile)
     }
 
     @Test
@@ -82,16 +80,15 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
     private fun request(item: OpenInNewTabsUseCase.Item) = useCase.createRequest(
         item = item,
         createExplorerArguments = { ExplorerArguments.Default(startPath = it) },
-        createEditorArguments = { EditorArguments.Default(filePath = it) },
         createViewerArguments = { ViewerArguments.Default(filePath = it) },
     )
 
     @Test
-    fun `a single text file opens in the editor`() {
+    fun `a single text file opens in the viewer`() {
         val request = request(OpenInNewTabsUseCase.Item.File(textFile, isText = true))
 
-        request.type shouldBe Workspace.Type.EDITOR
-        request.arguments shouldBe EditorArguments.Default(filePath = textFile)
+        request.type shouldBe Workspace.Type.VIEWER
+        request.arguments shouldBe ViewerArguments.Default(filePath = textFile)
     }
 
     @Test
@@ -133,21 +130,22 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
     }
 
     /**
-     * The plain "Open" row routes by the same predicate, so a yaml file must not land in the viewer.
-     * The Explorer feeds the [MimeInfo] overload, the Searcher the name one - both have to answer
-     * the same here.
+     * [OpenInNewTabsUseCase.Item.File.isText] no longer steers the routing, and no caller may make
+     * it do so again by the back door: whichever way text-ness was decided, a file is a file here.
+     * The Explorer feeds the [MimeInfo] overload, the Searcher the name one.
      */
     @Test
-    fun `a yaml file routes to the editor`() {
+    fun `text-ness does not change where a file opens`() {
         val yamlFile = LocalPath.build("/storage/emulated/0/Documents/notes.yaml")
 
         listOf(
             TextFileDetector.isTextFile(MimeInfo.fromFileName("notes.yaml")),
             TextFileDetector.isTextFile("notes.yaml"),
+            false,
         ).forEach { isText ->
             useCase.classify(
                 OpenInNewTabsUseCase.Item.File(yamlFile, isText = isText),
-            ) shouldBe Workspace.Type.EDITOR
+            ) shouldBe Workspace.Type.VIEWER
         }
     }
 
@@ -165,7 +163,7 @@ class OpenInNewTabsUseCaseTest : BaseTest() {
 
         requests(analysis).map { it.type } shouldContainExactly listOf(
             Workspace.Type.EXPLORER,
-            Workspace.Type.EDITOR,
+            Workspace.Type.VIEWER,
             Workspace.Type.VIEWER,
             Workspace.Type.VIEWER,
         )

--- a/app/src/main/java/eu/darken/butler/main/core/external/ExternalContentImporter.kt
+++ b/app/src/main/java/eu/darken/butler/main/core/external/ExternalContentImporter.kt
@@ -186,6 +186,10 @@ class ExternalContentImporter @Inject constructor(
 
         val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime.rawType)
             ?: VIEWABLE_EXTENSIONS[mime.rawType]
+            // Every other viewable type names one specific format, but "text" is open-ended: a
+            // sender may declare text/x-anything, and the copy has to land on a name the viewer
+            // still classifies as text rather than as an unsupported blob.
+            ?: "txt".takeIf { mime.isText }
             ?: return sanitized
 
         return "$sanitized.$extension"

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -26,7 +26,6 @@ import eu.darken.butler.main.core.motd.MotdRepo
 import eu.darken.butler.main.core.motd.MotdState
 import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.contracts.bugreport.BugReportArguments
-import eu.darken.butler.workspace.contracts.editor.EditorArguments
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
 import eu.darken.butler.workspace.core.OpenInNewTabsUseCase
@@ -505,7 +504,6 @@ class WorkspacesViewModel @Inject constructor(
                 val request = openInNewTabsUseCase.createRequest(
                     item = item.toOpenInNewTabsItem(),
                     createExplorerArguments = { ExplorerArguments.Default(startPath = it) },
-                    createEditorArguments = { EditorArguments.Default(filePath = it) },
                     createViewerArguments = { ViewerArguments.Default(filePath = it) },
                 )
                 when (val result = workspaceRepo.execute(request)) {

--- a/app/src/test/java/eu/darken/butler/main/core/external/ExternalContentImporterTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/core/external/ExternalContentImporterTest.kt
@@ -101,6 +101,41 @@ class ExternalContentImporterTest : BaseTest() {
     }
 
     @Test
+    fun `an extensionless text file gets an extension from its type`() = runTest {
+        register(uri) { ByteArrayInputStream("x".toByteArray()) }
+
+        val imported = create().importToCache(uri, "transcript", MimeInfo("text/plain")).shouldNotBeNull()
+
+        imported.file.name shouldBe "transcript.txt"
+    }
+
+    /** MimeInfo knows the extensionless text names, so those already reach the right renderer. */
+    @Test
+    fun `a text file named readme keeps its name`() = runTest {
+        register(uri) { ByteArrayInputStream("x".toByteArray()) }
+
+        val imported = create().importToCache(uri, "readme", MimeInfo("text/plain")).shouldNotBeNull()
+
+        imported.file.name shouldBe "readme"
+    }
+
+    /**
+     * Every other viewable type names one specific format, but senders declare text as anything from
+     * text/x-log to text/x-vendor-format. Without a generic fallback the copy keeps a name the
+     * viewer then classifies as an unsupported blob.
+     */
+    @Test
+    fun `an unrecognized text subtype still lands on a text name`() = runTest {
+        register(uri) { ByteArrayInputStream("x".toByteArray()) }
+
+        val imported = create()
+            .importToCache(uri, "payload.data", MimeInfo("text/x-vendor-format"))
+            .shouldNotBeNull()
+
+        imported.file.name shouldBe "payload.data.txt"
+    }
+
+    @Test
     fun `an extensionless pdf gets an extension from its type`() = runTest {
         register(uri) { ByteArrayInputStream("x".toByteArray()) }
 


### PR DESCRIPTION
## What changed

Text files now open in Butler's viewer instead of landing on "This file type is not supported yet". Tapping **Open** shows the file right where you are, and back returns to the folder you came from; **Open in editor** is what takes you to the editor, in a tab of its own.

That also fixes the file options sheet. For a text file it used to offer "Open", "Open in new tab" and "Open in editor" as three separate rows that all did the same thing, and described two of them with the same sentence, because opening a text file anywhere always created an editor tab.

The preview is read-only and deliberately bounded, so a multi-hundred-megabyte log opens as fast as a small one. When a bound cuts something, a bar says so and offers the editor, which has no such limit. Empty text files open as an empty preview rather than an error, and a file that claims to be text but holds binary still says the type is unsupported instead of showing mojibake.

The same routing now applies in the searcher: opening a text result shows it rather than opening an editor on it.

## Technical Context

- The duplicate rows were not a copy-paste slip in the strings. `OpenInNewTabsUseCase.classify()` routed text to the EDITOR, and `EditorArguments` carries no `callerWorkspaceId`, so the editor can never render as an in-pane drill-down. "Open it here" had nowhere to go and silently became "open it in a tab". Fixing the labels alone would have left three rows doing one thing, so `classify()` now sends every file to the viewer and the editor is reached only by the row that names it.
- Three bounds, not one: 1 MB read, 50k lines, 2k characters per line. The byte cap alone is not enough — a megabyte is also a million bare newlines, or one minified JSON line a million characters wide, and Compose lays out neither. `TextPreview` records which bound applied so the bar names that one; a 42 kB minified file is not "limited to the first 1 MB".
- A truncated buffer is trimmed to a character boundary *before* decoding. A UTF-8 sequence split at the cap fails the strict decode, drops the whole buffer to ISO-8859-1, and the resulting mojibake trips the binary guard, so one cut character would cost the entire preview. The trim is charset-aware: its UTF-8 backoff requires a real lead byte, or a Latin-1 line of `£` (0xA3), where every byte looks like a continuation, would trim away to nothing.
- `TextDecoder` is lifted out of the editor's `PasteFileReader` into `app-common-io` rather than copied. Workspace modules cannot depend on each other, and a second copy of a binary-detection heuristic would drift from the first. `PasteFileReader` now delegates; its paste-specific exception stays in the editor.
- Worth a close read: the preview lines are pinned to LTR even under an RTL UI. Left to follow the UI they started at the right edge, so every line opened scrolled to its far end and a log could not be read without dragging each line back. The cost is that an all-RTL file is left-aligned; bidi within a line is unaffected. Robolectric cannot cover this — it gives the line a full-width node either way — so it was verified on an ar-EG device.
