### PR TITLE
General: Rewrite the Play Store "What's new" text

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,8 +1,5 @@
-Butler 🤵 is actively developed and getting frequent updates.
-I'm adding new stuff all the time! Got ideas? Let me know 😊
+Bug fixes and small improvements, so managing files on your device stays fast and gets out of your way.
 
-This update may contain bug fixes 🐛, performance boosts 🚀, and even new features ✨.
-A detailed list of changes can be found here: https://butler.darken.eu/changelog
+What changed in this version: butler.darken.eu/changelog
 
-Questions? Just mail me!
-Note: It’s just me here, sometimes replies might take a bit. Sorry for that!
+Something broke or behaves oddly after updating? Tell me via Settings > Support. It's a one-person project, so replies can take a little while, but every report gets read.


### PR DESCRIPTION
## What changed

The default "What's new" text shown on Google Play now tells users what an update does for them, where the full list of changes lives, and how to reach support from inside the app (Settings > Support). The old text listed generic categories with emoji and asked people to mail instead.

New text:

> Bug fixes and small improvements, so managing files on your device stays fast and gets out of your way.
>
> What changed in this version: butler.darken.eu/changelog
>
> Something broke or behaves oddly after updating? Tell me via Settings > Support. It's a one-person project, so replies can take a little while, but every report gets read.

## Technical Context

- Play truncates release notes after roughly the first line on the listing, so the first sentence carries the whole message and the link and support path come after.
- `changelogs/default.txt` is not covered by `crowdin.yml` (only title, short and full description are) and `en-US` is currently the only fastlane locale in the repo, so there are no translations to update.
- 335 characters, under Play's 500-character release-notes limit.
