### PR TITLE
IO: Say a file is gone instead of blaming permissions

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathNotFoundException.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/errors/PathNotFoundException.kt
@@ -10,9 +10,12 @@ import eu.darken.butler.common.io.R
 /**
  * The path is positively known not to exist, as opposed to being unreadable.
  *
- * Constructed locally after an existence check answered false, never thrown across the IPC
- * boundary, and deliberately without a cause: the failure it replaces would otherwise be found
- * again when the cause chain is classified (see `PermissionErrorClassifierTest`).
+ * Constructed after an existence check answered a definitive ABSENT, both by the in-process lookup
+ * and by the one running inside a privileged host, where it crosses the binder as
+ * `IpcErrorCode.PATH_NOT_FOUND`.
+ *
+ * Deliberately without a cause: the failure it replaces would otherwise be found again when the
+ * cause chain is classified (see `PermissionErrorClassifierTest`).
  */
 class PathNotFoundException(
     path: APath<*>,

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalFileSystemOps.kt
@@ -14,6 +14,7 @@ import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.extensions.toFile
@@ -123,7 +124,10 @@ class LocalFileSystemOps @Inject constructor(
                 FileType.UNKNOWN
             }
 
-            else -> throw ReadException("Does not exist or can't be read :(", path)
+            else -> throw when (existsStrict(path)) {
+                Existence.ABSENT -> PathNotFoundException(path)
+                else -> ReadException("Does not exist or can't be read :(", path)
+            }
         }
 
         var size: Long? = null
@@ -202,6 +206,10 @@ class LocalFileSystemOps @Inject constructor(
             createdAt = createdAt,
             error = errors.takeIf { it.isNotEmpty() }?.joinToString("; "),
         )
+    } catch (e: PathNotFoundException) {
+        // Must stay the top-level exception, a wrapper hides the gone marker
+        // (`PermissionErrorClassifierTest`).
+        throw e
     } catch (e: Exception) {
         throw ReadException(path = path, cause = e)
     }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalGateway.kt
@@ -23,7 +23,6 @@ import eu.darken.butler.common.files.actions.DeleteAction
 import eu.darken.butler.common.files.actions.MoveAction
 import eu.darken.butler.common.files.actions.PathActionIssue
 import eu.darken.butler.common.files.errors.PathException
-import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
 import eu.darken.butler.common.files.errors.ServiceConnectionLostException
@@ -341,9 +340,6 @@ class LocalGateway @Inject constructor(
                         try {
                             directOp().also { log(TAG, VERBOSE) { "$operation(AUTO:DIRECT) -> $path" } }
                         } catch (e: IOException) {
-                            // A definitive absence is not something a privileged route can improve on,
-                            // and escalating it lets a service failure replace the correct error.
-                            if (e is PathGoneError) throw e
                             log(TAG, VERBOSE) { "$operation(AUTO) failed: ${e.message}" }
                             try {
                                 escalation()

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/LocalGateway.kt
@@ -23,6 +23,7 @@ import eu.darken.butler.common.files.actions.DeleteAction
 import eu.darken.butler.common.files.actions.MoveAction
 import eu.darken.butler.common.files.actions.PathActionIssue
 import eu.darken.butler.common.files.errors.PathException
+import eu.darken.butler.common.files.errors.PathGoneError
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException.Reason
 import eu.darken.butler.common.files.errors.ServiceConnectionLostException
@@ -340,6 +341,9 @@ class LocalGateway @Inject constructor(
                         try {
                             directOp().also { log(TAG, VERBOSE) { "$operation(AUTO:DIRECT) -> $path" } }
                         } catch (e: IOException) {
+                            // A definitive absence is not something a privileged route can improve on,
+                            // and escalating it lets a service failure replace the correct error.
+                            if (e is PathGoneError) throw e
                             log(TAG, VERBOSE) { "$operation(AUTO) failed: ${e.message}" }
                             try {
                                 escalation()

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
@@ -24,6 +24,10 @@ import java.io.IOException
 object PermissionErrorClassifier {
 
     fun classify(error: Throwable): Reason? {
+        // Pass 0: A top-level gone-error answers for itself before any message matching. PathException
+        // renders the path into its message, so a file called "permission-notes.txt" would otherwise
+        // read as a denial in pass 2 and never reach the gone check in pass 4.
+        if (error is PathGoneError) return null
         // Pass 1: Our own typed exceptions are authoritative — their reason is set deliberately
         // and message-matching against them would re-classify (their message contains "permission").
         for (t in error.causeChain) {

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCode.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCode.kt
@@ -19,6 +19,7 @@ package eu.darken.butler.common.ipc
  */
 enum class IpcErrorCode {
     PATH_READ,
+    PATH_NOT_FOUND,
     PATH_WRITE,
     PATH_ALREADY_EXISTS,
     PATH_PERMISSION_DENIED,

--- a/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCodec.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/ipc/IpcErrorCodec.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
 import eu.darken.butler.common.files.errors.PathException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.UnknownFileTypeException
@@ -156,6 +157,7 @@ object IpcErrorCodec {
         is PathAlreadyExistsException -> IpcErrorCode.PATH_ALREADY_EXISTS
         is PathPermissionDeniedException -> IpcErrorCode.PATH_PERMISSION_DENIED
         is UnknownFileTypeException -> IpcErrorCode.PATH_UNKNOWN_FILE_TYPE
+        is PathNotFoundException -> IpcErrorCode.PATH_NOT_FOUND
         is ReadException -> IpcErrorCode.PATH_READ
         is WriteException -> IpcErrorCode.PATH_WRITE
         is SecurityException -> IpcErrorCode.SECURITY
@@ -212,6 +214,8 @@ object IpcErrorCodec {
     /** Null when the payload lacks something the code needs, e.g. a [PathException] without a path. */
     private fun IpcErrorPayload.rebuild(cause: Throwable?): Throwable? = when (code) {
         IpcErrorCode.PATH_READ -> ReadException(rawMessage, localPath() ?: return null, cause)
+        // Cause-less and with a fixed message by design, so only the path is rebuilt from.
+        IpcErrorCode.PATH_NOT_FOUND -> PathNotFoundException(localPath() ?: return null)
         IpcErrorCode.PATH_WRITE -> WriteException(rawMessage, localPath() ?: return null, cause)
         IpcErrorCode.PATH_ALREADY_EXISTS -> PathAlreadyExistsException(rawMessage, localPath() ?: return null, cause)
         IpcErrorCode.PATH_PERMISSION_DENIED -> PathPermissionDeniedException(

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalFileSystemOpsTest.kt
@@ -5,6 +5,8 @@ import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.MoveOutcome
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.PathGoneError
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.metadata.FileType
@@ -87,11 +89,35 @@ class LocalFileSystemOpsTest : BaseTest() {
     }
 
     @Test
-    fun `lookup throws ReadException for non-existent file`() = runTest {
+    fun `lookup throws a gone error for non-existent file`() = runTest {
         val nonExistentPath = LocalPath.build("/tmp/non-existent-file-${System.currentTimeMillis()}")
 
-        shouldThrow<ReadException> {
+        val error = shouldThrow<PathNotFoundException> {
             fileSystemOps.lookup(nonExistentPath, LookupOptions())
+        }
+
+        error.shouldBeInstanceOf<PathGoneError>()
+    }
+
+    @Test
+    fun `lookup on a stat-denied file throws ReadException, not a gone error`(@TempDir tempDir: File) = runTest {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"))
+        val locked = File(tempDir, "locked").apply { mkdirs() }
+        val target = File(locked, "secret.txt").apply { writeText("content") }
+        val originalPermissions = Files.getPosixFilePermissions(locked.toPath())
+
+        try {
+            Files.setPosixFilePermissions(locked.toPath(), emptySet())
+            // Root ignores the permission bits, there is nothing to observe then.
+            assumeTrue(!Files.isReadable(locked.toPath()))
+
+            val error = shouldThrow<ReadException> {
+                fileSystemOps.lookup(LocalPath.build(target), LookupOptions())
+            }
+
+            (error is PathGoneError) shouldBe false
+        } finally {
+            Files.setPosixFilePermissions(locked.toPath(), originalPermissions)
         }
     }
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalGatewayTest.kt
@@ -9,6 +9,7 @@ import eu.darken.butler.common.files.actions.MoveAction
 import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.local.accessibility.LocalPathAccessChecker
+import eu.darken.butler.common.files.local.ipc.FileOpsClient
 import eu.darken.butler.common.files.local.routing.AccessMode
 import eu.darken.butler.common.files.local.routing.LocalPathRoutingPolicy
 import eu.darken.butler.common.files.local.routing.ModeSession
@@ -17,6 +18,8 @@ import eu.darken.butler.common.files.local.routing.RouteDecision
 import eu.darken.butler.common.files.local.service.IsolatedServiceClient
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.root.RootManager
+import eu.darken.butler.common.root.service.RootServiceClient
+import eu.darken.butler.common.sharedresource.Resource
 import eu.darken.butler.common.storage.StorageEnvironment
 import eu.darken.butler.common.storage.StorageManager2
 import io.kotest.assertions.throwables.shouldThrow
@@ -332,17 +335,37 @@ class LocalGatewayTest : BaseTest() {
     }
 
     @Test
-    fun `AUTO mode does not escalate a gone source to root`() = runTest2 {
-        val path = LocalPath.build("/sdcard/vanished.txt")
+    fun `AUTO mode escalates a gone-from-direct path that root can read`() = runTest2 {
+        val path = LocalPath.build("/proc/4242/status")
 
+        every { mockAccessibilityChecker.shouldTryNormalAccess(path, any()) } returns true
         coEvery { mockFileSystemOps.lookup(path, any()) } throws PathNotFoundException(path)
         every { mockRootManager.useRoot } returns flowOf(true)
 
-        shouldThrow<PathNotFoundException> {
-            gateway.lookup(path, LookupOptions.BASE, mode = LocalGateway.Mode.AUTO)
+        val rootFileOpsClient = mockk<FileOpsClient>()
+        coEvery { rootFileOpsClient.lookup(path, any()) } returns LocalPathLookup(
+            lookedUp = path,
+            fileType = FileType.FILE,
+            size = null,
+            modifiedAt = null,
+        )
+        val rootConnection = mockk<RootServiceClient.Connection> {
+            every { clientModules } returns listOf(rootFileOpsClient)
         }
+        val rootServiceClient = mockk<RootServiceClient>(relaxed = true)
+        coEvery { rootServiceClient.get() } answers {
+            mockk<Resource<RootServiceClient.Connection>> {
+                every { item } returns rootConnection
+                every { close() } just Runs
+            }
+        }
+        every { mockRootManager.serviceClient } returns rootServiceClient
 
-        coVerify(exactly = 0) { mockRootManager.serviceClient.get() }
+        val result = gateway.lookup(path, LookupOptions.BASE, mode = LocalGateway.Mode.AUTO)
+
+        result.fileType shouldBe FileType.FILE
+        coVerify(exactly = 1) { mockFileSystemOps.lookup(path, any()) }
+        coVerify(exactly = 1) { rootFileOpsClient.lookup(path, any()) }
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalGatewayTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalGatewayTest.kt
@@ -4,14 +4,22 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import eu.darken.butler.common.adb.AdbManager
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.files.actions.CopyAction
+import eu.darken.butler.common.files.actions.MoveAction
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.local.accessibility.LocalPathAccessChecker
+import eu.darken.butler.common.files.local.routing.AccessMode
 import eu.darken.butler.common.files.local.routing.LocalPathRoutingPolicy
+import eu.darken.butler.common.files.local.routing.ModeSession
 import eu.darken.butler.common.files.local.routing.ModeSessionFactory
+import eu.darken.butler.common.files.local.routing.RouteDecision
 import eu.darken.butler.common.files.local.service.IsolatedServiceClient
+import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.common.storage.StorageEnvironment
 import eu.darken.butler.common.storage.StorageManager2
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -20,6 +28,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Test
@@ -96,6 +105,25 @@ class LocalGatewayTest : BaseTest() {
             modeSessionFactory = mockModeSessionFactory,
         )
     }
+
+    /** Keeps the routed copy/move path in-process, so the mocked ops answer for every path. */
+    private fun routeEverythingDirect() {
+        coEvery { mockRoutingPolicy.classify(any(), any(), any()) } returns RouteDecision.Allowed(AccessMode.DIRECT)
+        every { mockRoutingPolicy.proactiveChildren(any()) } returns emptySet()
+        coEvery { mockModeSessionFactory.open(AccessMode.DIRECT) } returns ModeSession(
+            mode = AccessMode.DIRECT,
+            ops = mockFileSystemOps,
+            batch = null,
+            lease = null,
+        )
+    }
+
+    private fun directoryLookup(path: LocalPath) = LocalPathLookup(
+        lookedUp = path,
+        fileType = FileType.DIRECTORY,
+        size = null,
+        modifiedAt = null,
+    )
 
     // ========================================================================
     // AUTO Mode - Normal First Tests
@@ -290,6 +318,59 @@ class LocalGatewayTest : BaseTest() {
         exceptionThrown shouldBe true
         // Verify normal was tried
         coVerify(exactly = 1) { mockFileSystemOps.createFile(path) }
+    }
+
+    @Test
+    fun `AUTO mode surfaces a gone source as gone, not as a denial`() = runTest2 {
+        val path = LocalPath.build("/sdcard/vanished.txt")
+
+        coEvery { mockFileSystemOps.lookup(path, any()) } throws PathNotFoundException(path)
+
+        shouldThrow<PathNotFoundException> {
+            gateway.lookup(path, LookupOptions.BASE, mode = LocalGateway.Mode.AUTO)
+        }
+    }
+
+    @Test
+    fun `AUTO mode does not escalate a gone source to root`() = runTest2 {
+        val path = LocalPath.build("/sdcard/vanished.txt")
+
+        coEvery { mockFileSystemOps.lookup(path, any()) } throws PathNotFoundException(path)
+        every { mockRootManager.useRoot } returns flowOf(true)
+
+        shouldThrow<PathNotFoundException> {
+            gateway.lookup(path, LookupOptions.BASE, mode = LocalGateway.Mode.AUTO)
+        }
+
+        coVerify(exactly = 0) { mockRootManager.serviceClient.get() }
+    }
+
+    @Test
+    fun `AUTO copy surfaces a gone source as gone, not as a denial`() = runTest2 {
+        val source = LocalPath.build("/sdcard/vanished.txt")
+        val destination = LocalPath.build("/sdcard/dest")
+        routeEverythingDirect()
+
+        coEvery { mockFileSystemOps.lookup(destination, any()) } returns directoryLookup(destination)
+        coEvery { mockFileSystemOps.lookup(source, any()) } throws PathNotFoundException(source)
+
+        shouldThrow<PathNotFoundException> {
+            gateway.copy(setOf(source), destination, onIssue = null, options = CopyAction.Options()).last()
+        }
+    }
+
+    @Test
+    fun `AUTO move surfaces a gone source as gone, not as a denial`() = runTest2 {
+        val source = LocalPath.build("/sdcard/vanished.txt")
+        val destination = LocalPath.build("/sdcard/dest")
+        routeEverythingDirect()
+
+        coEvery { mockFileSystemOps.lookup(destination, any()) } returns directoryLookup(destination)
+        coEvery { mockFileSystemOps.lookup(source, any()) } throws PathNotFoundException(source)
+
+        shouldThrow<PathNotFoundException> {
+            gateway.move(setOf(source), destination, onIssue = null, options = MoveAction.Options()).last()
+        }
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalPathCopyTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalPathCopyTest.kt
@@ -3,7 +3,7 @@ package eu.darken.butler.common.files.local
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.actions.CopyAction
-import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import io.kotest.assertions.throwables.shouldThrow
@@ -623,7 +623,7 @@ class LocalPathCopyTest : BaseTest() {
         val nonExistent = File(sourceFolder, "does-not-exist.txt")
 
         // When & Then
-        shouldThrow<ReadException> {
+        shouldThrow<PathNotFoundException> {
             LocalPath.build(nonExistent).copy(ops, LocalPath.build(destFolder)).last()
         }
     }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalPathMoveTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/LocalPathMoveTest.kt
@@ -3,7 +3,7 @@ package eu.darken.butler.common.files.local
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.actions.MoveAction
-import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.metadata.OwnershipResolver
 import io.kotest.assertions.throwables.shouldThrow
@@ -183,7 +183,7 @@ class LocalPathMoveTest : BaseTest() {
         val destFolder = File(tempDir, "dest").apply { mkdirs() }
         val nonExistentFile = File(sourceFolder, "does-not-exist.txt")
 
-        shouldThrow<ReadException> {
+        shouldThrow<PathNotFoundException> {
             LocalPath.build(nonExistentFile).move(ops, LocalPath.build(destFolder)).last()
         }
     }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
@@ -198,6 +198,13 @@ class PermissionErrorClassifierTest : BaseTest() {
     }
 
     @Test
+    fun `a gone error whose path contains permission is not a denial`() {
+        val gone = PathNotFoundException(LocalPath.build("/sdcard/permission-notes.txt"))
+
+        PermissionErrorClassifier.classify(gone) shouldBe null
+    }
+
+    @Test
     fun `an existing path is not a permission failure`() {
         val e = PathAlreadyExistsException(path = LocalPath.build("/sdcard/foo"))
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/ipc/ExceptionPropagationTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/ipc/ExceptionPropagationTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import eu.darken.butler.common.error.LocalizedErrorContext
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.PathPermissionDeniedException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.ServiceConnectionLostException as FileServiceConnectionLostException
@@ -44,6 +45,19 @@ class ExceptionPropagationTest : BaseTest(), IpcHostModule, IpcClientModule {
         val original = ReadException("Can't read from path.", filePath)
 
         original.propagate().shouldBeTypeOf<ReadException>().apply {
+            message shouldBe original.message
+            this.path!!.path shouldBe original.path!!.path
+        }
+    }
+
+    @Test
+    fun `round-trip - PATH_NOT_FOUND`() {
+        val original = PathNotFoundException(filePath)
+
+        // The subclass has to win over ReadException, which would drop the gone marker.
+        IpcErrorCodec.encode(original) shouldContain "\"code\":\"PATH_NOT_FOUND\""
+
+        original.propagate().shouldBeTypeOf<PathNotFoundException>().apply {
             message shouldBe original.message
             this.path!!.path shouldBe original.path!!.path
         }


### PR DESCRIPTION
## What changed

Copying or moving a file that no longer exists at its original location (for example, a clipboard copy task executed after the file was moved away) failed with "Permission denied: Cannot access … due to insufficient permissions". It now fails with "File is gone: "name" was deleted, renamed or moved somewhere else." This also holds when the lookup runs through root or ADB.

## Technical Context

- Root cause: the local lookup threw the same generic read error for a missing path and for an unreadable one, and its own catch-all wrapped it a second time. The permission classifier treats any path error that is not marked "gone" as an access denial, so an absence rendered as a denial.
- The lookup now consults the strict existence probe when type detection finds nothing: a definitive absence throws the existing gone-error type, a denied stat keeps the read error and its permission classification. The gone error is rethrown ahead of the catch-all because the classifier answers for the outermost matching chain link; review the ordering of those two catches closely.
- The gone error had no IPC carrier and would have decoded as a plain read error from a root or ADB host. A dedicated error code carries it; it is matched before the read-error branch in the encoder, which is the second spot worth a close look.
- The classifier now returns early for a top-level gone error before message matching: path errors render the path into their message, so a file called "permission-notes.txt" otherwise still read as a denial.
- Two commits add and then revert a short-circuit that skipped root/ADB escalation after a direct "gone". Android mounts /proc with hidepid=2, so that short-circuit made another UID's /proc entry read as gone for root users; escalation stays as before. Verified on an API 33 emulator: a copy whose source was deleted via adb shows the "File is gone" card.
