### PR TITLE
Workspace: Give the operation description the full sheet width

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
@@ -149,39 +149,42 @@ private fun OperationDetailsContent(
 private fun OperationDetailsHeader(
     operation: OperationDisplay,
 ) {
-    Row(
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            imageVector = operation.icon,
-            contentDescription = null,
-            modifier = Modifier.size(24.dp),
-            tint = MaterialTheme.colorScheme.primary,
-        )
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        Column(
-            modifier = Modifier.weight(1f)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
+            Icon(
+                imageVector = operation.icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
             Text(
+                modifier = Modifier.weight(1f),
                 text = operation.title.asComposable(),
                 style = MaterialTheme.typography.titleMedium,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
+        }
 
-            operation.description.let { description ->
-                Text(
-                    modifier = Modifier.padding(top = 2.dp),
-                    text = description.asComposable(),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
+        operation.description.let { description ->
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 2.dp),
+                text = description.asComposable(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }


### PR DESCRIPTION
## What changed

In the operation details sheet, the description under the operation title now runs the full width of the sheet instead of being indented behind the operation icon. Longer descriptions fit on fewer lines and truncate less often.

## Technical Context

- The header was `Row[Icon, Spacer, Column[Title, Description]]`, which cost the description 24dp of icon plus a 16dp spacer. It is now `Column[Row[Icon, Spacer, Title], Description]`, so only the title is offset.
- No test covers the header layout, so there was nothing to update.