### PR TITLE
History: Reset all filters at once and show chip selection clearly

### DIFF
--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryAddFilterSheet.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryAddFilterSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Add
+import androidx.compose.material.icons.twotone.Check
 import androidx.compose.material.icons.twotone.Folder
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,17 +30,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import eu.darken.butler.common.compose.ButlerChip
-import eu.darken.butler.common.compose.ButlerChipDefaults
 import eu.darken.butler.history.R
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryFilter
 import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
+import eu.darken.butler.common.R as CommonR
 
 /**
  * Add-filter sheet — three live-update sections (Outcome / Kind / Path scope), all chips visible.
  * Tapping a chip toggles the value in/out of the filter (parent VM updates immediately). Sheet
- * stays open until back/drag/tap-outside; no Done button.
+ * stays open until back/drag/tap-outside; no Done button. The header offers a reset that drops
+ * every dimension back to unfiltered.
  *
  * Path scope row offers an "+ Add path…" entry that closes the sheet and opens the existing
  * [PathScopeDialog] (we surface that dialog at the page level since stacking dialog over sheet is
@@ -52,6 +54,7 @@ fun HistoryAddFilterSheet(
     topInset: Dp = 0.dp,
     bottomInset: Dp = 0.dp,
     onDismiss: () -> Unit,
+    onResetFilter: () -> Unit,
     onToggleOutcome: (HistoryOutcome) -> Unit,
     onToggleKind: (Operation.Metadata.Kind) -> Unit,
     onRemovePathScope: (String) -> Unit,
@@ -69,19 +72,33 @@ fun HistoryAddFilterSheet(
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Text(
-                text = stringResource(R.string.history_add_filter_sheet_title),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = stringResource(R.string.history_add_filter_sheet_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                TextButton(
+                    onClick = onResetFilter,
+                    enabled = !filter.isUnfiltered,
+                ) {
+                    Text(stringResource(CommonR.string.general_reset_action))
+                }
+            }
 
             FilterSection(
                 title = stringResource(R.string.history_add_filter_section_outcome),
             ) {
                 HistoryOutcome.entries.forEach { outcome ->
+                    val selected = outcome in filter.outcomes
                     ButlerChip(
                         label = outcome.label(),
-                        selected = outcome in filter.outcomes,
+                        leadingIcon = if (selected) Icons.TwoTone.Check else null,
+                        selected = selected,
                         onClick = { onToggleOutcome(outcome) },
                     )
                 }
@@ -91,11 +108,12 @@ fun HistoryAddFilterSheet(
                 title = stringResource(R.string.history_add_filter_section_kind),
             ) {
                 Operation.Metadata.Kind.entries.forEach { kind ->
+                    val selected = kind in filter.kinds
                     ButlerChip(
                         label = kind.label(),
-                        selected = kind in filter.kinds,
+                        leadingIcon = if (selected) Icons.TwoTone.Check else null,
+                        selected = selected,
                         onClick = { onToggleKind(kind) },
-                        colors = ButlerChipDefaults.accentedColors(),
                     )
                 }
             }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlays.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlays.kt
@@ -40,6 +40,7 @@ fun HistoryWorkspaceOverlaysHost(
         filter = state?.filter,
         overlayState = overlayState,
         onDismissAddFilter = { vm.setAddFilterOpen(false) },
+        onResetFilter = { vm.clearFilter() },
         onToggleOutcome = { vm.toggleOutcome(it) },
         onToggleKind = { vm.toggleKind(it) },
         onRemovePathScope = { vm.removePathScope(it) },
@@ -66,6 +67,7 @@ fun HistoryWorkspaceOverlays(
     filter: HistoryFilter?,
     overlayState: HistoryWorkspaceViewModel.OverlayState,
     onDismissAddFilter: () -> Unit = {},
+    onResetFilter: () -> Unit = {},
     onToggleOutcome: (HistoryOutcome) -> Unit = {},
     onToggleKind: (Operation.Metadata.Kind) -> Unit = {},
     onRemovePathScope: (String) -> Unit = {},
@@ -88,6 +90,7 @@ fun HistoryWorkspaceOverlays(
             topInset = statusBarInset,
             bottomInset = navBarInset,
             onDismiss = onDismissAddFilter,
+            onResetFilter = onResetFilter,
             onToggleOutcome = onToggleOutcome,
             onToggleKind = onToggleKind,
             onRemovePathScope = onRemovePathScope,
@@ -129,6 +132,20 @@ fun HistoryWorkspaceOverlays(
 private fun HistoryWorkspaceOverlaysAddFilterPreview() {
     HistoryWorkspaceOverlays(
         filter = HistoryFilter(),
+        overlayState = HistoryWorkspaceViewModel.OverlayState(addFilterOpen = true),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryWorkspaceOverlaysAddFilterActivePreview() {
+    HistoryWorkspaceOverlays(
+        filter = HistoryFilter(
+            outcomes = setOf(HistoryOutcome.COMPLETED),
+            kinds = setOf(Operation.Metadata.Kind.DELETE),
+            pathScopes = setOf("/sdcard/ButlerQA"),
+        ),
         overlayState = HistoryWorkspaceViewModel.OverlayState(addFilterOpen = true),
     )
 }

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlaysTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlaysTest.kt
@@ -3,10 +3,16 @@ package eu.darken.butler.history.ui
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryFilter
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
 
@@ -27,6 +33,41 @@ class HistoryWorkspaceOverlaysTest : ComposeTest() {
         }
 
         composeTestRule.onNode(hasSetTextAction()).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the add-filter reset is disabled while the filter is empty`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    HistoryWorkspaceOverlays(
+                        filter = HistoryFilter(),
+                        overlayState = HistoryWorkspaceViewModel.OverlayState(addFilterOpen = true),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Reset").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `the add-filter reset fires once the filter has values`() {
+        var reset = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    HistoryWorkspaceOverlays(
+                        filter = HistoryFilter(kinds = setOf(Operation.Metadata.Kind.DELETE)),
+                        overlayState = HistoryWorkspaceViewModel.OverlayState(addFilterOpen = true),
+                        onResetFilter = { reset = true },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Reset").assertIsEnabled().performClick()
+        reset shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## What changed

The operation history's filter sheet now has a Reset button in its header that clears every filter at once. It stays greyed out while nothing is filtered, and the sheet stays open so you can watch the chips deselect.

Selecting a Kind is also easier to see. Selected and unselected Kind chips used to be two shades of green that were hard to tell apart at a glance. Unselected chips are now neutral grey, and every selected chip in the sheet carries a checkmark, so the state is readable without comparing colours.

## Technical Context

- The reset reuses the ViewModel's existing `clearFilter()`, which was previously only reachable from the "no results" empty state.
- The Kind section passed `ButlerChipDefaults.accentedColors()`, mapping unselected to `secondaryContainer` and selected to `primaryContainer`. In Butler's green palette those two read as near-identical. It now uses the default colors, matching the Outcome section that already worked.
- The equivalent `accentedColors()` call in the toolbar's filter chip row is deliberately left alone: every chip there is rendered selected, so it resolves to `primaryContainer` either way and was never visible.
- The checkmark is a leading icon, so a chip grows slightly when selected. That is standard Material filter-chip behaviour and the section reflows.
