### PR TITLE
Bugreport: Ask before deleting a report and space out its buttons

### DIFF
--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
@@ -65,6 +65,8 @@ fun BugReportWorkspaceOverlaysHost(
         },
         onConfirmDeleteAll = { vm.deleteAll() },
         onDismissDeleteAll = { vm.dismissDeleteAllConfirmation() },
+        onConfirmDelete = { vm.confirmDelete() },
+        onDismissDelete = { vm.dismissDeleteConfirmation() },
         onPrivacyPolicy = { openPrivacyPolicy(context) },
     )
 
@@ -82,6 +84,8 @@ fun BugReportWorkspaceOverlays(
     onStopRecordingAnyway: () -> Unit = {},
     onConfirmDeleteAll: () -> Unit = {},
     onDismissDeleteAll: () -> Unit = {},
+    onConfirmDelete: () -> Unit = {},
+    onDismissDelete: () -> Unit = {},
     onPrivacyPolicy: () -> Unit = {},
 ) {
     when (val dialog = overlayState.activeDialog) {
@@ -99,6 +103,11 @@ fun BugReportWorkspaceOverlays(
         ActiveDialog.DeleteAllConfirmation -> DeleteAllConfirmationDialog(
             onConfirm = onConfirmDeleteAll,
             onDismiss = onDismissDeleteAll,
+        )
+
+        is ActiveDialog.DeleteConfirmation -> DeleteReportConfirmationDialog(
+            onConfirm = onConfirmDelete,
+            onDismiss = onDismissDelete,
         )
 
         null -> Unit
@@ -129,5 +138,14 @@ private fun BugReportWorkspaceOverlaysShortRecordingPreview() {
 private fun BugReportWorkspaceOverlaysDeleteAllPreview() {
     BugReportWorkspaceOverlays(
         overlayState = BugReportWorkspaceViewModel.OverlayState(ActiveDialog.DeleteAllConfirmation),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun BugReportWorkspaceOverlaysDeletePreview() {
+    BugReportWorkspaceOverlays(
+        overlayState = BugReportWorkspaceViewModel.OverlayState(ActiveDialog.DeleteConfirmation("report-1")),
     )
 }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.BugReport
+import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material.icons.twotone.DeleteSweep
 import androidx.compose.material.icons.twotone.FiberManualRecord
 import androidx.compose.material.icons.twotone.ReportProblem
@@ -120,7 +121,7 @@ fun BugReportWorkspacePageHost(
             onBack = { vm.closeReport() },
             onToggleLog = { vm.setLogExpanded(it) },
             onShareReport = { report -> vm.requestShareConsent(report.id) },
-            onDeleteReport = { id -> vm.delete(id) },
+            onDeleteReport = { id -> vm.requestDeleteConfirmation(id) },
             onDeleteAll = { vm.requestDeleteAllConfirmation() },
             onStartRecording = { vm.startRecording() },
             onStopRecording = { vm.stopRecording() },
@@ -674,6 +675,43 @@ internal fun DeleteAllConfirmationDialog(
 @Composable
 private fun DeleteAllConfirmationDialogPreview() {
     DeleteAllConfirmationDialog(onConfirm = {}, onDismiss = {})
+}
+
+@Composable
+internal fun DeleteReportConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    PaneBoundAlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.TwoTone.Delete,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+        },
+        title = { Text(stringResource(R.string.bugreport_delete_confirm_title)) },
+        text = { Text(stringResource(R.string.bugreport_delete_confirm_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(R.string.bugreport_delete_action),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.bugreport_cancel_action)) }
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DeleteReportConfirmationDialogPreview() {
+    DeleteReportConfirmationDialog(onConfirm = {}, onDismiss = {})
 }
 
 @Composable

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
@@ -72,6 +73,12 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
 
     fun dismissDeleteAllConfirmation() = _overlayState.update {
         if (it.activeDialog is ActiveDialog.DeleteAllConfirmation) it.copy(activeDialog = null) else it
+    }
+
+    fun requestDeleteConfirmation(reportId: String) = requestDialog(ActiveDialog.DeleteConfirmation(reportId))
+
+    fun dismissDeleteConfirmation() = _overlayState.update {
+        if (it.activeDialog is ActiveDialog.DeleteConfirmation) it.copy(activeDialog = null) else it
     }
 
     // Loads the selected report's log tail once the user has asked for it — a requestId of 0 means
@@ -178,8 +185,16 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         bugReportRepo.markSeen(reportId)
     }
 
-    fun delete(reportId: String) = launch {
-        log(tag, INFO) { "delete($reportId)" }
+    /** Consumes the pending confirmation and deletes the report it named; a second call is a no-op. */
+    fun confirmDelete() {
+        val pending = _overlayState.getAndUpdate {
+            if (it.activeDialog is ActiveDialog.DeleteConfirmation) it.copy(activeDialog = null) else it
+        }.activeDialog as? ActiveDialog.DeleteConfirmation ?: return
+        log(tag, INFO) { "confirmDelete(${pending.reportId})" }
+        performDelete(pending.reportId)
+    }
+
+    private fun performDelete(reportId: String) = launch {
         bugReportRepo.delete(reportId)
         if (logSelection.value.reportId == reportId) selectReport(null)
     }
@@ -236,6 +251,7 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         data class ShareConsent(val reportId: String) : ActiveDialog
         data object ShortRecordingWarning : ActiveDialog
         data object DeleteAllConfirmation : ActiveDialog
+        data class DeleteConfirmation(val reportId: String) : ActiveDialog
     }
 
     /** The full-screen detail view's state: the report plus its (async) log tail. */

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailToolbarCard.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailToolbarCard.kt
@@ -81,6 +81,7 @@ fun BugReportDetailToolbarCard(
                 contentDescription = stringResource(R.string.bugreport_share_action),
                 onClick = onShare,
             )
+            Spacer(modifier = Modifier.width(8.dp))
             ToolbarControl(
                 icon = Icons.TwoTone.Delete,
                 contentDescription = stringResource(R.string.bugreport_delete_action),

--- a/app-workspace-bugreport/src/main/res/values/strings.xml
+++ b/app-workspace-bugreport/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="bugreport_delete_all_action">Delete all</string>
     <string name="bugreport_delete_all_confirm_title">Delete all debug logs?</string>
     <string name="bugreport_delete_all_confirm_message">This will permanently delete all recorded debug log sessions. Active recordings will not be affected.</string>
+    <string name="bugreport_delete_confirm_title">Delete this report?</string>
+    <string name="bugreport_delete_confirm_message">This will permanently delete this report and its log.</string>
     <string name="bugreport_cancel_action">Cancel</string>
 
     <string name="bugreport_share_chooser_title">Share bug report</string>

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportDeleteFlowTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportDeleteFlowTest.kt
@@ -1,0 +1,130 @@
+package eu.darken.butler.bugreport.ui
+
+import android.content.Context
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.bugreport.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.debug.bugreport.BugReport
+import eu.darken.butler.common.debug.bugreport.BugReportInfo
+import eu.darken.butler.common.debug.bugreport.BugReportRecorder
+import eu.darken.butler.common.debug.bugreport.BugReportRepo
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Instant
+
+/** The detail toolbar's Delete asks first: the report is only removed once the dialog is confirmed. */
+@Config(qualifiers = "w400dp-h800dp")
+class BugReportDeleteFlowTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val backLabel = context.getString(R.string.bugreport_detail_back_action)
+    private val deleteLabel = context.getString(R.string.bugreport_delete_action)
+    private val cancelLabel = context.getString(R.string.bugreport_cancel_action)
+    private val confirmTitle = context.getString(R.string.bugreport_delete_confirm_title)
+
+    private val report = BugReportInfo(
+        report = BugReport(
+            id = "report-1",
+            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+            type = BugReport.Type.CRASH,
+            errorClass = "java.lang.IllegalStateException",
+            errorMessage = "failure number 1",
+            stackTrace = "",
+            threadName = "main",
+            appVersion = "v0.0.0-beta1",
+            deviceFingerprint = "Pixel/foo",
+            apiLevel = "36",
+            flavor = "FOSS",
+            buildType = "RELEASE",
+            installId = "abc",
+            locale = "en-US",
+        ),
+        isSeen = true,
+    )
+
+    private val bugReportRepo = mockk<BugReportRepo>(relaxed = true).apply {
+        every { reports } returns flowOf(listOf(report))
+    }
+
+    private val workspaceId = Workspace.Id()
+
+    private val vm = BugReportWorkspaceViewModel(
+        id = workspaceId,
+        dispatchers = TestDispatcherProvider(),
+        bugReportRepo = bugReportRepo,
+        bugReportRecorder = mockk<BugReportRecorder>(relaxed = true).apply {
+            every { state } returns MutableStateFlow(BugReportRecorder.State())
+        },
+    )
+
+    /** Page and overlays are siblings sharing one ViewModel, the same way the pane hosts them. */
+    private fun setDetail() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    BugReportWorkspacePageHost(id = workspaceId, design = WorkspaceDesign(), vm = vm)
+                    BugReportWorkspaceOverlaysHost(id = workspaceId, vm = vm)
+                }
+            }
+        }
+        vm.openReport(report.id)
+        composeTestRule.waitForIdle()
+    }
+
+    // Via the semantics action, not performClick: in this fixed-size wrapper a laid-out but
+    // off-screen node swallows a click without reporting a failure.
+    private fun tapToolbarDelete() {
+        composeTestRule.onAllNodesWithContentDescription(deleteLabel)
+            .onFirst()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `the toolbar delete asks before deleting`() {
+        setDetail()
+
+        tapToolbarDelete()
+
+        composeTestRule.onNodeWithText(confirmTitle).assertIsDisplayed()
+        coVerify(exactly = 0) { bugReportRepo.delete(any()) }
+
+        composeTestRule.onNodeWithText(cancelLabel).performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(confirmTitle).assertDoesNotExist()
+        composeTestRule.onAllNodesWithContentDescription(backLabel).onFirst().assertExists()
+        coVerify(exactly = 0) { bugReportRepo.delete(any()) }
+    }
+
+    @Test
+    fun `confirming the toolbar delete removes the report`() {
+        setDetail()
+
+        tapToolbarDelete()
+
+        composeTestRule.onNodeWithText(deleteLabel).performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(confirmTitle).assertDoesNotExist()
+        coVerify(exactly = 1) { bugReportRepo.delete(report.id) }
+    }
+}

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
@@ -15,6 +15,7 @@ import eu.darken.butler.common.debug.bugreport.BugReportRepo
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,12 +30,14 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
+    private val bugReportRepo = mockk<BugReportRepo>(relaxed = true).apply {
+        every { reports } returns flowOf(emptyList())
+    }
+
     private fun createVM() = BugReportWorkspaceViewModel(
         id = Workspace.Id(),
         dispatchers = TestDispatcherProvider(),
-        bugReportRepo = mockk<BugReportRepo>(relaxed = true).apply {
-            every { reports } returns flowOf(emptyList())
-        },
+        bugReportRepo = bugReportRepo,
         bugReportRecorder = mockk<BugReportRecorder>(relaxed = true).apply {
             every { state } returns MutableStateFlow(BugReportRecorder.State())
         },
@@ -172,6 +175,69 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
 
         vm.dismissDeleteAllConfirmation()
         vm.overlayState.value.activeDialog shouldBe null
+    }
+
+    @Test
+    fun `the delete confirmation renders and reports both answers`() {
+        var confirmed = 0
+        var dismissed = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    BugReportWorkspaceOverlays(
+                        overlayState = BugReportWorkspaceViewModel.OverlayState(
+                            activeDialog = ActiveDialog.DeleteConfirmation("report-1"),
+                        ),
+                        onConfirmDelete = { confirmed++ },
+                        onDismissDelete = { dismissed++ },
+                    )
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.bugreport_delete_confirm_title))
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(context.getString(R.string.bugreport_cancel_action)).performClick()
+        composeTestRule.runOnIdle { dismissed shouldBe 1 }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.bugreport_delete_action)).performClick()
+        composeTestRule.runOnIdle { confirmed shouldBe 1 }
+    }
+
+    @Test
+    fun `the delete confirmation is requested and dismissed through the slot`() {
+        val vm = createVM()
+
+        vm.requestDeleteConfirmation("report-1")
+        vm.overlayState.value.activeDialog shouldBe ActiveDialog.DeleteConfirmation("report-1")
+
+        vm.dismissDeleteConfirmation()
+        vm.overlayState.value.activeDialog shouldBe null
+    }
+
+    @Test
+    fun `confirming consumes the dialog and deletes the named report`() {
+        val vm = createVM()
+
+        vm.requestDeleteConfirmation("report-1")
+        vm.confirmDelete()
+
+        vm.overlayState.value.activeDialog shouldBe null
+        coVerify(exactly = 1) { bugReportRepo.delete("report-1") }
+    }
+
+    @Test
+    fun `a second confirm after the dialog is consumed deletes nothing`() {
+        val vm = createVM()
+
+        vm.requestDeleteConfirmation("report-1")
+        vm.confirmDelete()
+        vm.confirmDelete()
+
+        coVerify(exactly = 1) { bugReportRepo.delete("report-1") }
     }
 
     @Test


### PR DESCRIPTION
## What changed

Deleting a single bug report from its detail screen now asks first. The Delete button in a report's toolbar used to delete it the moment you tapped it, with no confirmation and no way back — even though the "Delete all" action on the report list already asked. Confirming or cancelling now both do what you'd expect.

That Delete button also sat flush against the Share button, with no gap between the two tap targets, so a tap meant for Share could land on Delete. There is now space between them.

## Technical Context

- Root cause: the detail screen's delete callback went straight to the repository delete, while the list screen's delete-all routed through a confirmation dialog. Only the latter ever had one.
- The confirmation owns the report id rather than accepting one from the caller. Confirming consumes the pending dialog atomically and reads the id out of it, so two taps landing in the same frame delete once rather than twice, and no caller can pass an id the dialog never named. The previously public single-report delete entry point is now private.
- The new dialog is pane-scoped like the module's existing dialogs, so it stacks and dismisses with its pane rather than the window, and the page-level back handler needed no change.
- Worth a close look: `BugReportDeleteFlowTest` is the test that actually pins this fix. It drives the page and overlay hosts with one shared ViewModel and asserts the repository is untouched until the dialog is confirmed. The other new tests exercise the dialog in isolation and would still pass against the original wiring.
- The button spacing is checked on device rather than by a Robolectric bounds assertion, since `.claude/rules/testing.md` puts layout pixel precision outside what that harness is for.
