### PR TITLE
Developer: Generate test files at their advertised size

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,7 @@ Butler uses a workspace concept similar to browser tabs with 4 main workspace ty
 | Modal workspace pattern | `.claude/rules/architecture-modal-workspaces.md` |
 | Code style, composables | `.claude/rules/coding-standards.md` |
 | Testing | `.claude/rules/testing.md` |
+| Test data on device | `.claude/rules/test-data.md` |
 | UI, theming | `.claude/rules/ui-guidelines.md` |
 | Localization | `.claude/rules/localization.md` |
 | DI, logging, serialization | `.claude/rules/technical-patterns.md` |

--- a/.claude/rules/test-data.md
+++ b/.claude/rules/test-data.md
@@ -1,0 +1,69 @@
+# Generating Test Data
+
+Butler generates its own test files. Do NOT write a shell script that pushes files onto a device
+with `adb push`, `dd`, or a `for` loop. The Developer workspace already does nested trees, large
+files, high file counts, and fake operation history, and it does it through the gateway system so
+the result matches what a real user's storage looks like.
+
+## Reaching the generator
+
+Developer Tools is a normal workspace type: **Create tab, Developer Tools, then the "Test Data" tab**.
+
+The tile only appears while developer mode is unlocked. `DeveloperSettings.isDeveloperModeUnlocked`
+defaults to `BuildConfigWrap.DEBUG`, so on a debug build it is already unlocked and no gesture is
+needed. On a release build, unlock it with 7 long-presses on the changelog/version row in Settings.
+
+## Target paths
+
+The page pre-populates one entry per detected storage volume (`/storage/emulated/0`, SD cards).
+"Add path" opens the directory picker in multi-select mode, restricted to writable directories, so
+SAF trees and other gateway path types work as targets too. Every enabled generator runs once per
+listed path.
+
+## Grant all-files access first
+
+Without it every generator fails with `Permission denied: Cannot access "aButlerTextFiles" at
+"/storage/emulated/0" due to insufficient permissions.` On an emulator, skip the UI flow:
+
+```bash
+adb -s <serial> shell appops set --uid eu.darken.butler MANAGE_EXTERNAL_STORAGE allow
+```
+
+## What each option produces
+
+Each generator writes into its own folder under the target path, so the three are independent and
+re-running one overwrites only its own files.
+
+| Option | Folder | Actual result |
+|--------|--------|---------------|
+| Large files | `aButlerLargeFiles/` | 7 sparse files, `file_1MB.bin` to `file_8GB.bin`, 15.1 GiB of reported size in 64 KB of actual blocks |
+| Nested structure | `aButlerNestedData/` | 1092 folders, 6 levels deep, 3 folders per level; 1092 text files (1 KB to 50 KB each), ~41 MB |
+| Text files for Editor | `aButlerTextFiles/` | `text_10KB.txt` to `text_100MB.txt`, numbered lorem lines, ~117 MB |
+
+The `.bin` files are sparse: each reports its full nominal size but occupies almost no blocks, so
+the set generates in about a second on a device with nowhere near 15 GB free. Reading one back
+yields zeros, so use them for anything that goes by file size (listing, sorting, size warnings,
+copy estimates) and the `aButlerTextFiles/` set for anything that reads content.
+
+The nested tree's deepest level gets folders but no files, which is why the folder and file counts
+match.
+
+## While it runs
+
+Generators are regular `Operation`s: they show progress in the operations bar, run concurrently
+across the enabled options, are cancellable mid-run, and land in the History workspace on
+completion. That makes them useful as long-running operations to test progress and cancel UI, not
+just as a source of files.
+
+## Sample history entries
+
+The same tab has a "Generate sample history" button that inserts ~25 fake operation rows spanning
+the last 30 days with mixed kinds, outcomes and origins. Use it instead of performing 25 real file
+operations to populate the History workspace. It writes through the DAO directly, so the generator
+itself does not appear in the list.
+
+## Cleanup
+
+```bash
+adb -s <serial> shell rm -rf /storage/emulated/0/aButler{LargeFiles,NestedData,TextFiles}
+```

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateLargeFilesOperation.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateLargeFilesOperation.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.withContext
-import kotlin.random.Random
 
 class GenerateLargeFilesOperation @AssistedInject constructor(
     @Assisted private val workspaceId: Workspace.Id,
@@ -89,21 +88,7 @@ class GenerateLargeFilesOperation @AssistedInject constructor(
                     )
                 )
 
-                createLargeFile(filePath, size) { fileProgress ->
-                    send(
-                        State.Active(
-                            startedAt = operationContext.startedAt,
-                            primaryProgress = Progress.Data(
-                                primary = R.string.developer_operation_large_files_creating.toCaString(fileName),
-                                count = Progress.Count.Counter(index.toLong(), sizes.size.toLong()),
-                            ),
-                            secondaryProgress = Progress.Data(
-                                primary = fileName.toCaString(),
-                                count = Progress.Count.Size(bytesWritten + fileProgress, totalBytes),
-                            ),
-                        )
-                    )
-                }
+                createLargeFile(filePath, size)
 
                 bytesWritten += size
                 reportBuilder.addFile(filePath, size)
@@ -122,25 +107,15 @@ class GenerateLargeFilesOperation @AssistedInject constructor(
         }
     }
 
+    // Writing one byte past the end extends the file to its full size and leaves the skipped range
+    // as a hole, so an 8GB entry costs a single block. Reading it back yields zeros.
     private suspend fun createLargeFile(
         path: APath<*>,
         size: Long,
-        onProgress: suspend (Long) -> Unit,
     ) = withContext(dispatcherProvider.IO) {
         gatewaySwitch.createFile(path, createParents = false)
-        gatewaySwitch.openOutputStream(path, append = false).use { outputStream ->
-            val buffer = ByteArray(CHUNK_SIZE)
-            var position = 0L
-
-            while (position < size) {
-                currentCoroutineContext().ensureActive()
-
-                Random.nextBytes(buffer)
-                val writeSize = minOf(CHUNK_SIZE.toLong(), size - position).toInt()
-                outputStream.write(buffer, 0, writeSize)
-                position += SPARSE_INTERVAL
-                onProgress(minOf(position, size))
-            }
+        gatewaySwitch.file(path, readWrite = true).use { handle ->
+            handle.write(size - 1, ByteArray(1), 0, 1)
         }
     }
 
@@ -163,7 +138,5 @@ class GenerateLargeFilesOperation @AssistedInject constructor(
         private const val KB = 1024L
         private const val MB = 1024L * KB
         private const val GB = 1024L * MB
-        private const val CHUNK_SIZE = 1024 * 1024 // 1MB chunks
-        private const val SPARSE_INTERVAL = 10L * MB // Write every 10MB for sparse files
     }
 }

--- a/app-workspace-developer/src/main/res/values/strings.xml
+++ b/app-workspace-developer/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="developer_testdata_large_files">Large files</string>
     <string name="developer_testdata_large_files_desc">1MB, 10MB, 100MB, 1GB, 2GB, 4GB, 8GB</string>
     <string name="developer_testdata_nested_structure">Nested structure</string>
-    <string name="developer_testdata_nested_structure_desc">~1500 folders, ~3500 files</string>
+    <string name="developer_testdata_nested_structure_desc">~1100 folders, ~1100 files</string>
     <string name="developer_testdata_text_files">Text files for Editor</string>
     <string name="developer_testdata_text_files_desc">10KB, 100KB, 1MB, 10MB, 100MB</string>
     <string name="developer_testdata_generate_action">Generate</string>


### PR DESCRIPTION
## What changed

The Developer workspace's "Large files" test data option now produces files that are actually as
big as their names say. Previously every entry from `file_10MB.bin` upward came out at a tenth of
its advertised size, so the one labelled 8GB was really about 820MB, and generating the set cost
1.5GB of storage and several minutes. The files are now sparse: each reports its full size, the
whole set occupies 64KB of real storage, and generation finishes in about a second. Reading one
back yields zeros, so they are for exercising anything that goes by file size rather than content.

The "Nested structure" option's description also claimed roughly 1500 folders and 3500 files; a run
makes 1092 of each. The label now matches.

Also adds a rules file documenting the test data generator for contributors, so nobody writes their
own script to push test files onto a device.

## Technical Context

- The old writer advanced its position by 10MB for every 1MB chunk it wrote, which is where the
  tenth-size files came from. The fix seeks one byte past the intended end and writes there, so the
  skipped range stays a hole.
- okio's `FileHandle.resize()` looks like the natural call for this and is not usable: its JVM
  implementation grows a file by allocating a `ByteArray` of the delta, throwing `OutOfMemoryError`
  on the first 1GB entry. Worth knowing before someone simplifies the seek away.
- Per-file progress reporting inside a single large file is gone, since creating one is now a single
  operation. The per-file counter across the seven entries stays.
- The nested tree's deepest level gets folders but no files, which is why its folder and file counts
  are identical rather than off by the 3x files-per-folder factor.
