### PR TITLE
History: Make sharing and deleting history entries a Pro feature

### DIFF
--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryProUpgradeDialog.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryProUpgradeDialog.kt
@@ -1,0 +1,71 @@
+package eu.darken.butler.history.ui
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.WorkspacePremium
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.brandTitleText
+import eu.darken.butler.history.R
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
+import eu.darken.butler.common.R as CommonR
+
+@Composable
+fun HistoryProUpgradeDialog(
+    onDismiss: () -> Unit,
+    onUpgrade: () -> Unit,
+) {
+    PaneBoundAlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                modifier = Modifier.size(28.dp),
+                imageVector = Icons.TwoTone.WorkspacePremium,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+            )
+        },
+        title = {
+            Text(
+                text = brandTitleText(includeQualifier = true),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
+            Text(
+                text = stringResource(R.string.history_pro_dialog_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onUpgrade) {
+                Text(stringResource(CommonR.string.general_upgrade_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryProUpgradeDialogPreview() {
+    HistoryProUpgradeDialog(
+        onDismiss = {},
+        onUpgrade = {},
+    )
+}

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlays.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlays.kt
@@ -9,6 +9,7 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.error.ErrorEventHandler
+import eu.darken.butler.common.navigation.NavigationEventHandler
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.history.HistoryEntry
@@ -54,7 +55,11 @@ fun HistoryWorkspaceOverlaysHost(
             if (newScope != null) vm.addPathScope(newScope)
             vm.closePathScopePicker()
         },
+        onDismissProPrompt = { vm.dismissProPrompt() },
+        onProPromptUpgrade = { vm.onProPromptUpgrade() },
     )
+
+    NavigationEventHandler(vm)
 
     // Last on purpose: layers stack in composition order, so an error raised while one of
     // this page's own dialogs is up lands on top of it instead of underneath.
@@ -78,6 +83,8 @@ fun HistoryWorkspaceOverlays(
     onDismissDelete: () -> Unit = {},
     onDismissPathScope: () -> Unit = {},
     onApplyPathScope: (String?) -> Unit = {},
+    onDismissProPrompt: () -> Unit = {},
+    onProPromptUpgrade: () -> Unit = {},
 ) {
     val paneInsets = design.paneInsets()
     val navBarInset = paneInsets.bottom
@@ -124,6 +131,15 @@ fun HistoryWorkspaceOverlays(
             onApply = onApplyPathScope,
         )
     }
+
+    // Last of this page's own layers: the Pro gate can resolve while another overlay is up, and
+    // composition order is layer order.
+    if (overlayState.proPromptOpen) {
+        HistoryProUpgradeDialog(
+            onDismiss = onDismissProPrompt,
+            onUpgrade = onProPromptUpgrade,
+        )
+    }
 }
 
 @Preview2
@@ -157,6 +173,16 @@ private fun HistoryWorkspaceOverlaysPathScopePreview() {
     HistoryWorkspaceOverlays(
         filter = HistoryFilter(),
         overlayState = HistoryWorkspaceViewModel.OverlayState(pathScopeOpen = true),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun HistoryWorkspaceOverlaysProPromptPreview() {
+    HistoryWorkspaceOverlays(
+        filter = HistoryFilter(),
+        overlayState = HistoryWorkspaceViewModel.OverlayState(proPromptOpen = true),
     )
 }
 

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -196,6 +196,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
             is HistoryActionBarItem.DeselectAll -> clearSelection()
             is HistoryActionBarItem.Share -> {
                 if (!actionGateLock.tryLock()) return
+                val selectionAtTap = _selectedIds.value
                 launch {
                     try {
                         if (!upgradeRepo.isProForUi()) {
@@ -203,8 +204,10 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
                             return@launch
                         }
                         // The gate suspends, so the selection this action was taken on may have
-                        // changed by now - a single entry leaving it drops the whole action.
+                        // changed by now - an entry entering or leaving it drops the whole action,
+                        // as does an action item whose entries are not all selected.
                         val selectedIds = _selectedIds.value
+                        if (selectedIds != selectionAtTap) return@launch
                         if (item.entries.any { it.id !in selectedIds }) return@launch
                         shareEntries(item.entries, clearsSelection = true)
                     } finally {
@@ -214,6 +217,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
             }
             is HistoryActionBarItem.Delete -> {
                 if (!actionGateLock.tryLock()) return
+                val selectionAtTap = _selectedIds.value
                 launch {
                     try {
                         if (!upgradeRepo.isProForUi()) {
@@ -221,6 +225,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
                             return@launch
                         }
                         val selectedIds = _selectedIds.value
+                        if (selectedIds != selectionAtTap) return@launch
                         if (item.entries.any { it.id !in selectedIds }) return@launch
                         _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
                     } finally {

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -200,8 +200,10 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
                         showProPrompt()
                         return@launch
                     }
-                    // The gate suspends, so the selection this action was taken on may be gone by now.
-                    if (item.entries.none { it.id in _selectedIds.value }) return@launch
+                    // The gate suspends, so the selection this action was taken on may have changed
+                    // by now - a single entry leaving it drops the whole action.
+                    val selectedIds = _selectedIds.value
+                    if (item.entries.any { it.id !in selectedIds }) return@launch
                     shareEntries(item.entries, clearsSelection = true)
                 } finally {
                     actionGateLock.unlock()
@@ -214,7 +216,8 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
                         showProPrompt()
                         return@launch
                     }
-                    if (item.entries.none { it.id in _selectedIds.value }) return@launch
+                    val selectedIds = _selectedIds.value
+                    if (item.entries.any { it.id !in selectedIds }) return@launch
                     _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
                 } finally {
                     actionGateLock.unlock()

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -185,7 +185,8 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
 
     // One lock for BOTH gated action bar items, mirroring detailShareLock: while the gate is in
     // flight the buttons stay live, so without it a second tap - Share twice, or Share then Delete -
-    // queues a second action that fires when billing settles.
+    // queues a second action that fires when billing settles. Acquired synchronously, before the
+    // coroutine is launched, so two taps in the same frame cannot both dispatch.
     private val actionGateLock = Mutex()
 
     fun onActionClick(item: HistoryActionBarItem) {
@@ -193,34 +194,38 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         when (item) {
             is HistoryActionBarItem.SelectAll -> setSelection(item.ids)
             is HistoryActionBarItem.DeselectAll -> clearSelection()
-            is HistoryActionBarItem.Share -> launch {
-                if (!actionGateLock.tryLock()) return@launch
-                try {
-                    if (!upgradeRepo.isProForUi()) {
-                        showProPrompt()
-                        return@launch
+            is HistoryActionBarItem.Share -> {
+                if (!actionGateLock.tryLock()) return
+                launch {
+                    try {
+                        if (!upgradeRepo.isProForUi()) {
+                            showProPrompt()
+                            return@launch
+                        }
+                        // The gate suspends, so the selection this action was taken on may have
+                        // changed by now - a single entry leaving it drops the whole action.
+                        val selectedIds = _selectedIds.value
+                        if (item.entries.any { it.id !in selectedIds }) return@launch
+                        shareEntries(item.entries, clearsSelection = true)
+                    } finally {
+                        actionGateLock.unlock()
                     }
-                    // The gate suspends, so the selection this action was taken on may have changed
-                    // by now - a single entry leaving it drops the whole action.
-                    val selectedIds = _selectedIds.value
-                    if (item.entries.any { it.id !in selectedIds }) return@launch
-                    shareEntries(item.entries, clearsSelection = true)
-                } finally {
-                    actionGateLock.unlock()
                 }
             }
-            is HistoryActionBarItem.Delete -> launch {
-                if (!actionGateLock.tryLock()) return@launch
-                try {
-                    if (!upgradeRepo.isProForUi()) {
-                        showProPrompt()
-                        return@launch
+            is HistoryActionBarItem.Delete -> {
+                if (!actionGateLock.tryLock()) return
+                launch {
+                    try {
+                        if (!upgradeRepo.isProForUi()) {
+                            showProPrompt()
+                            return@launch
+                        }
+                        val selectedIds = _selectedIds.value
+                        if (item.entries.any { it.id !in selectedIds }) return@launch
+                        _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
+                    } finally {
+                        actionGateLock.unlock()
                     }
-                    val selectedIds = _selectedIds.value
-                    if (item.entries.any { it.id !in selectedIds }) return@launch
-                    _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
-                } finally {
-                    actionGateLock.unlock()
                 }
             }
         }

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspaceViewModel.kt
@@ -11,9 +11,13 @@ import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
-import eu.darken.butler.common.ui.ViewModel3
+import eu.darken.butler.common.navigation.Nav
+import eu.darken.butler.common.navigation.upgrade
+import eu.darken.butler.common.ui.ViewModel4
 import eu.darken.butler.history.core.HistoryWorkspace
 import eu.darken.butler.history.core.buildHistoryShareText
+import eu.darken.butler.upgrade.UpgradeRepo
+import eu.darken.butler.upgrade.isProForUi
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.operations.Operation
@@ -46,7 +50,8 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
     private val workspaceProvider: WorkspaceProvider,
     private val historyRepo: OperationHistoryRepo,
     private val historySettings: HistorySettings,
-) : ViewModel3(dispatchers, logTag("History", "Workspace", id.shortTag, "Page")) {
+    private val upgradeRepo: UpgradeRepo,
+) : ViewModel4(dispatchers, logTag("History", "Workspace", id.shortTag, "Page")) {
 
     private val workspaceSource = workspaceProvider.retrieve(id)
         .map { it as? HistoryWorkspace }
@@ -178,13 +183,43 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         _selectedIds.value = emptySet()
     }
 
+    // One lock for BOTH gated action bar items, mirroring detailShareLock: while the gate is in
+    // flight the buttons stay live, so without it a second tap - Share twice, or Share then Delete -
+    // queues a second action that fires when billing settles.
+    private val actionGateLock = Mutex()
+
     fun onActionClick(item: HistoryActionBarItem) {
         log(tag) { "onActionClick($item)" }
         when (item) {
             is HistoryActionBarItem.SelectAll -> setSelection(item.ids)
             is HistoryActionBarItem.DeselectAll -> clearSelection()
-            is HistoryActionBarItem.Share -> shareEntries(item.entries, clearsSelection = true)
-            is HistoryActionBarItem.Delete -> _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
+            is HistoryActionBarItem.Share -> launch {
+                if (!actionGateLock.tryLock()) return@launch
+                try {
+                    if (!upgradeRepo.isProForUi()) {
+                        showProPrompt()
+                        return@launch
+                    }
+                    // The gate suspends, so the selection this action was taken on may be gone by now.
+                    if (item.entries.none { it.id in _selectedIds.value }) return@launch
+                    shareEntries(item.entries, clearsSelection = true)
+                } finally {
+                    actionGateLock.unlock()
+                }
+            }
+            is HistoryActionBarItem.Delete -> launch {
+                if (!actionGateLock.tryLock()) return@launch
+                try {
+                    if (!upgradeRepo.isProForUi()) {
+                        showProPrompt()
+                        return@launch
+                    }
+                    if (item.entries.none { it.id in _selectedIds.value }) return@launch
+                    _overlayState.update { it.copy(deleteConfirmEntries = item.entries) }
+                } finally {
+                    actionGateLock.unlock()
+                }
+            }
         }
     }
 
@@ -202,6 +237,20 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         _overlayState.update { it.copy(deleteConfirmEntries = emptyList()) }
     }
 
+    private fun showProPrompt() {
+        log(tag, INFO) { "showProPrompt()" }
+        _overlayState.update { it.copy(proPromptOpen = true) }
+    }
+
+    fun dismissProPrompt() {
+        _overlayState.update { it.copy(proPromptOpen = false) }
+    }
+
+    fun onProPromptUpgrade() {
+        _overlayState.update { it.copy(proPromptOpen = false) }
+        navTo(Nav.Main.upgrade())
+    }
+
     // The sheet's Share button stays live while the query below is awaited, so a second tap starts
     // a second coroutine. Without this it would open its own chooser on top of the first one.
     private val detailShareLock = Mutex()
@@ -209,6 +258,14 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
     fun shareEntry(entry: HistoryEntry) = launch {
         if (!detailShareLock.tryLock()) return@launch
         try {
+            // Gated before the query below, so a denied share never runs it. The sheet may have been
+            // dismissed while the gate ran, and a prompt for a share nobody can see anymore is noise.
+            val allowed = upgradeRepo.isProForUi()
+            if (_overlayState.value.detailEntry?.id != entry.id) return@launch
+            if (!allowed) {
+                showProPrompt()
+                return@launch
+            }
             // An entry that reported no changes shares what the operation tried to touch instead. The
             // sheet's own load may still be in flight, and an empty list there is indistinguishable
             // from a finished one, so query rather than share a record that claims nothing happened.
@@ -285,6 +342,7 @@ class HistoryWorkspaceViewModel @AssistedInject constructor(
         val addFilterOpen: Boolean = false,
         val pathScopeOpen: Boolean = false,
         val deleteConfirmEntries: List<HistoryEntry> = emptyList(),
+        val proPromptOpen: Boolean = false,
     )
 
     data class DateGroup(

--- a/app-workspace-history/src/main/res/values/strings.xml
+++ b/app-workspace-history/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
         <item quantity="other">Delete %1$d entries</item>
     </plurals>
     <string name="history_delete_dialog_message">Only the history records are removed, the files themselves are not touched.</string>
+    <string name="history_pro_dialog_message">Sharing and deleting history entries is part of the upgrade. Clearing the whole history stays free in the history settings.</string>
 
     <!-- Shared text -->
     <string name="history_share_label_outcome">Outcome</string>

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
@@ -360,4 +360,42 @@ class HistoryProGateTest : BaseTest() {
         vm.overlayState.value.proPromptOpen shouldBe false
         startedChooser() shouldBe null
     }
+
+    /**
+     * The gate parks with only [entry] captured; adding [entry2] to the selection while it waits
+     * means the user is now looking at two selected rows, so the captured single-entry action is
+     * stale and must not fire.
+     */
+    @Test
+    fun `an entry added to the selection while the share gate waits drops the share`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Share(listOf(entry)))
+        // Billing has not settled, so the gate is parked while the action bar stays live.
+        runCurrent()
+
+        vm.toggleSelection(entry2.id)
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        startedChooser() shouldBe null
+    }
+
+    @Test
+    fun `an entry added to the selection while the delete gate waits drops the delete`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+        runCurrent()
+
+        vm.toggleSelection(entry2.id)
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        vm.overlayState.value.deleteConfirmEntries shouldBe emptyList()
+    }
 }

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
@@ -1,0 +1,311 @@
+package eu.darken.butler.history.ui
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.navigation.DestinationUpgrade
+import eu.darken.butler.common.navigation.NavEvent
+import eu.darken.butler.upgrade.UpgradeRepo
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.core.operations.history.HistoryEntry
+import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
+import eu.darken.butler.workspace.core.operations.history.HistorySettings
+import eu.darken.butler.workspace.core.operations.history.OperationHistoryRepo
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+
+/**
+ * Sharing and deleting history entries are Pro features. The gate suspends, so it also has to cope
+ * with the selection or the detail sheet moving on while it is in flight.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HistoryProGateTest : BaseTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val application = context as Application
+    private val completedAt = Instant.parse("2026-09-02T14:31:05Z")
+
+    private val workspaceProvider = mockk<WorkspaceProvider>().apply {
+        every { retrieve(any()) } returns flowOf(null)
+    }
+    private val historySettings = mockk<HistorySettings>(relaxed = true)
+    private val historyRepo = mockk<OperationHistoryRepo>(relaxed = true).apply {
+        every { observeCount() } returns flowOf(0)
+    }
+
+    private class FakeInfo(
+        override val isPro: Boolean,
+        override val isSettled: Boolean,
+        override val error: Throwable? = null,
+    ) : UpgradeRepo.Info {
+        override val type = UpgradeRepo.Type.FOSS
+        override val upgradedAt: Instant? = null
+    }
+
+    /**
+     * Backed by a MutableStateFlow, like the production repos. A cold single-element flow would end
+     * `isProForUi`'s wait in a NoSuchElementException, which its catch turns into an allow - every
+     * unsettled case would then pass through the fake instead of through the gate.
+     */
+    private class FakeUpgradeRepo(
+        pro: Boolean,
+        settled: Boolean = true,
+        error: Throwable? = null,
+    ) : UpgradeRepo {
+        private val infoFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro, settled, error))
+
+        override val storeSite = ""
+        override val upgradeSite = ""
+        override val betaSite = ""
+        override val upgradeInfo: Flow<UpgradeRepo.Info> = infoFlow
+
+        override suspend fun refresh() = Unit
+
+        fun settle(pro: Boolean) {
+            infoFlow.value = FakeInfo(pro, isSettled = true)
+        }
+    }
+
+    /** Reports no changes, so a share from the sheet falls back to the attempted paths query. */
+    private val entry = HistoryEntry(
+        id = "entry-1",
+        kind = Operation.Metadata.Kind.DELETE,
+        intent = null,
+        originType = HistoryEntry.OriginType.EXPLORER,
+        originWorkspaceId = "ws",
+        title = "Delete 2 items",
+        description = "2 items in /sdcard/ButlerQA",
+        summary = null,
+        startedAt = completedAt - 1200.milliseconds,
+        completedAt = completedAt,
+        duration = 1200.milliseconds,
+        outcome = HistoryOutcome.FAILED,
+        errorMessage = "Permission denied",
+        errorClass = null,
+        affectedPathsCount = 0,
+        partialErrorCount = 0,
+        pathsTruncated = false,
+        paths = emptyList(),
+    )
+
+    private val attempted = OperationHistoryRepo.AttemptedPaths(
+        paths = listOf("/sdcard/ButlerQA", "/sdcard/ButlerQA/notes.txt"),
+        totalCount = 2,
+    )
+
+    private fun createVM(
+        upgradeRepo: UpgradeRepo,
+        dispatchers: DispatcherProvider = TestDispatcherProvider(),
+    ) = HistoryWorkspaceViewModel(
+        id = Workspace.Id(),
+        context = context,
+        dispatchers = dispatchers,
+        workspaceProvider = workspaceProvider,
+        historyRepo = historyRepo,
+        historySettings = historySettings,
+        upgradeRepo = upgradeRepo,
+    )
+
+    private fun startedChooser(): Intent? = shadowOf(application).nextStartedActivity
+
+    @Test
+    fun `a free user gets the upgrade prompt instead of sharing the selection`() {
+        val vm = createVM(FakeUpgradeRepo(pro = false))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Share(listOf(entry)))
+
+        vm.overlayState.value.proPromptOpen shouldBe true
+        startedChooser() shouldBe null
+    }
+
+    @Test
+    fun `a free user gets the upgrade prompt instead of the delete confirmation`() {
+        val vm = createVM(FakeUpgradeRepo(pro = false))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+
+        vm.overlayState.value.proPromptOpen shouldBe true
+        vm.overlayState.value.deleteConfirmEntries shouldBe emptyList()
+    }
+
+    @Test
+    fun `the sheet's share is gated before the attempted paths are queried`() {
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } returns attempted
+        val vm = createVM(FakeUpgradeRepo(pro = false))
+
+        // Opening the sheet issues the one query this scenario expects; a gate placed after the
+        // query would add a second one.
+        vm.showEntryDetails(entry)
+        coVerify(exactly = 1) { historyRepo.getAttemptedPaths(entry.id) }
+
+        vm.shareEntry(entry)
+
+        vm.overlayState.value.proPromptOpen shouldBe true
+        coVerify(exactly = 1) { historyRepo.getAttemptedPaths(entry.id) }
+        startedChooser() shouldBe null
+    }
+
+    @Test
+    fun `a pro user shares the selection`() {
+        val vm = createVM(FakeUpgradeRepo(pro = true))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Share(listOf(entry)))
+
+        vm.overlayState.value.proPromptOpen shouldBe false
+        startedChooser()!!.action shouldBe Intent.ACTION_CHOOSER
+    }
+
+    @Test
+    fun `a pro user reaches the delete confirmation`() {
+        val vm = createVM(FakeUpgradeRepo(pro = true))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+
+        vm.overlayState.value.proPromptOpen shouldBe false
+        vm.overlayState.value.deleteConfirmEntries shouldBe listOf(entry)
+    }
+
+    @Test
+    fun `a pro user shares from the detail sheet`() {
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } returns attempted
+        val vm = createVM(FakeUpgradeRepo(pro = true))
+
+        vm.showEntryDetails(entry)
+        vm.shareEntry(entry)
+
+        vm.overlayState.value.proPromptOpen shouldBe false
+        startedChooser()!!.action shouldBe Intent.ACTION_CHOOSER
+    }
+
+    @Test
+    fun `dismissing the prompt closes it`() {
+        val vm = createVM(FakeUpgradeRepo(pro = false))
+        vm.setSelection(setOf(entry.id))
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+        vm.overlayState.value.proPromptOpen shouldBe true
+
+        vm.dismissProPrompt()
+
+        vm.overlayState.value.proPromptOpen shouldBe false
+    }
+
+    @Test
+    fun `upgrading from the prompt closes it and navigates to the upgrade screen`() {
+        val vm = createVM(FakeUpgradeRepo(pro = false))
+        vm.setSelection(setOf(entry.id))
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+
+        vm.onProPromptUpgrade()
+
+        vm.overlayState.value.proPromptOpen shouldBe false
+
+        val events = mutableListOf<NavEvent>()
+        val collector = CoroutineScope(Dispatchers.Unconfined).launch { vm.navEvents.toList(events) }
+        try {
+            events shouldBe listOf(NavEvent.GoTo(DestinationUpgrade))
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    /**
+     * Both shipped repos turn a failed entitlement read into a settled Info carrying the error
+     * rather than letting it escape the flow, so this - not an exception - is what a broken billing
+     * lookup looks like to the gate, and it denies.
+     */
+    @Test
+    fun `a settled state carrying a read error still denies`() {
+        val vm = createVM(FakeUpgradeRepo(pro = false, error = IllegalStateException("billing is down")))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+
+        vm.overlayState.value.proPromptOpen shouldBe true
+        vm.overlayState.value.deleteConfirmEntries shouldBe emptyList()
+    }
+
+    @Test
+    fun `a selection cleared while the delete gate waits drops the delete`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+        // Billing has not settled, so the gate is parked while the action bar stays live.
+        runCurrent()
+
+        vm.clearSelection()
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        vm.overlayState.value.deleteConfirmEntries shouldBe emptyList()
+        vm.overlayState.value.proPromptOpen shouldBe false
+    }
+
+    @Test
+    fun `a selection cleared while the share gate waits drops the share`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Share(listOf(entry)))
+        runCurrent()
+
+        vm.clearSelection()
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        startedChooser() shouldBe null
+        vm.overlayState.value.proPromptOpen shouldBe false
+    }
+
+    @Test
+    fun `a sheet dismissed while the share gate waits raises no prompt`() = runTest {
+        coEvery { historyRepo.getAttemptedPaths(entry.id) } returns attempted
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+
+        vm.showEntryDetails(entry)
+        vm.shareEntry(entry)
+        runCurrent()
+
+        vm.showEntryDetails(null)
+        upgradeRepo.settle(pro = false)
+        advanceUntilIdle()
+
+        vm.overlayState.value.proPromptOpen shouldBe false
+        startedChooser() shouldBe null
+    }
+}

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
@@ -328,6 +328,22 @@ class HistoryProGateTest : BaseTest() {
     }
 
     @Test
+    fun `a share tapped before the delete coroutine is scheduled is dropped`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry)))
+        vm.onActionClick(HistoryActionBarItem.Share(listOf(entry)))
+
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        vm.overlayState.value.deleteConfirmEntries shouldBe listOf(entry)
+        startedChooser() shouldBe null
+    }
+
+    @Test
     fun `a sheet dismissed while the share gate waits raises no prompt`() = runTest {
         coEvery { historyRepo.getAttemptedPaths(entry.id) } returns attempted
         val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryProGateTest.kt
@@ -116,6 +116,9 @@ class HistoryProGateTest : BaseTest() {
         paths = emptyList(),
     )
 
+    /** A second selected entry, so a partial deselection can be distinguished from a full one. */
+    private val entry2 = entry.copy(id = "entry-2", title = "Delete 1 item")
+
     private val attempted = OperationHistoryRepo.AttemptedPaths(
         paths = listOf("/sdcard/ButlerQA", "/sdcard/ButlerQA/notes.txt"),
         totalCount = 2,
@@ -289,6 +292,39 @@ class HistoryProGateTest : BaseTest() {
 
         startedChooser() shouldBe null
         vm.overlayState.value.proPromptOpen shouldBe false
+    }
+
+    @Test
+    fun `deselecting one of two entries while the share gate waits drops the share`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id, entry2.id))
+
+        vm.onActionClick(HistoryActionBarItem.Share(listOf(entry, entry2)))
+        // Billing has not settled, so the gate is parked while the action bar stays live.
+        runCurrent()
+
+        vm.toggleSelection(entry2.id)
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        startedChooser() shouldBe null
+    }
+
+    @Test
+    fun `deselecting one of two entries while the delete gate waits drops the delete`() = runTest {
+        val upgradeRepo = FakeUpgradeRepo(pro = false, settled = false)
+        val vm = createVM(upgradeRepo, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+        vm.setSelection(setOf(entry.id, entry2.id))
+
+        vm.onActionClick(HistoryActionBarItem.Delete(listOf(entry, entry2)))
+        runCurrent()
+
+        vm.toggleSelection(entry2.id)
+        upgradeRepo.settle(pro = true)
+        advanceUntilIdle()
+
+        vm.overlayState.value.deleteConfirmEntries shouldBe emptyList()
     }
 
     @Test

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlaysTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceOverlaysTest.kt
@@ -1,11 +1,15 @@
 package eu.darken.butler.history.ui
 
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -84,5 +88,98 @@ class HistoryWorkspaceOverlaysTest : ComposeTest() {
         }
 
         composeTestRule.onNode(hasSetTextAction()).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the upgrade prompt renders with both of its actions`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    HistoryWorkspaceOverlays(
+                        filter = HistoryFilter(),
+                        overlayState = HistoryWorkspaceViewModel.OverlayState(proPromptOpen = true),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText(PRO_PROMPT_MESSAGE).assertIsDisplayed()
+        composeTestRule.onNode(hasClickAction() and hasText(UPGRADE_ACTION)).assertIsDisplayed()
+        composeTestRule.onNode(hasClickAction() and hasText(CANCEL_ACTION)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the upgrade prompt's actions are wired to their own callbacks`() {
+        var upgrades = 0
+        var dismissals = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    HistoryWorkspaceOverlays(
+                        filter = HistoryFilter(),
+                        overlayState = HistoryWorkspaceViewModel.OverlayState(proPromptOpen = true),
+                        onDismissProPrompt = { dismissals++ },
+                        onProPromptUpgrade = { upgrades++ },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNode(hasClickAction() and hasText(UPGRADE_ACTION)).performClick()
+        composeTestRule.runOnIdle {
+            upgrades shouldBe 1
+            dismissals shouldBe 0
+        }
+
+        composeTestRule.onNode(hasClickAction() and hasText(CANCEL_ACTION)).performClick()
+        composeTestRule.runOnIdle {
+            upgrades shouldBe 1
+            dismissals shouldBe 1
+        }
+    }
+
+    /**
+     * The gate can resolve while another overlay is up. Bounds cannot tell the two dialogs apart -
+     * both scrims span the pane - so back ownership is the assertion: only the top layer takes it.
+     */
+    @Test
+    fun `the upgrade prompt sits above the path scope dialog`() {
+        var promptDismissals = 0
+        var pathScopeDismissals = 0
+        var dispatcher: OnBackPressedDispatcher? = null
+
+        composeTestRule.setContent {
+            dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    HistoryWorkspaceOverlays(
+                        filter = HistoryFilter(),
+                        overlayState = HistoryWorkspaceViewModel.OverlayState(
+                            pathScopeOpen = true,
+                            proPromptOpen = true,
+                        ),
+                        onDismissPathScope = { pathScopeDismissals++ },
+                        onDismissProPrompt = { promptDismissals++ },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText(PRO_PROMPT_MESSAGE).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { dispatcher!!.onBackPressed() }
+        composeTestRule.runOnIdle {
+            promptDismissals shouldBe 1
+            pathScopeDismissals shouldBe 0
+        }
+    }
+
+    companion object {
+        private const val PRO_PROMPT_MESSAGE =
+            "Sharing and deleting history entries is part of the upgrade. " +
+                "Clearing the whole history stays free in the history settings."
+        private const val UPGRADE_ACTION = "Upgrade"
+        private const val CANCEL_ACTION = "Cancel"
     }
 }

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryWorkspaceShareTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.history.core.HistoryWorkspace
+import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.operations.Operation
@@ -21,6 +22,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -82,6 +84,24 @@ class HistoryWorkspaceShareTest : BaseTest() {
         every { filter } returns flowOf(HistoryFilter())
     }
 
+    /** Settled and Pro, so the share gate resolves and these cases keep testing the share itself. */
+    private val upgradeRepo = object : UpgradeRepo {
+        override val storeSite = ""
+        override val upgradeSite = ""
+        override val betaSite = ""
+        override val upgradeInfo = MutableStateFlow<UpgradeRepo.Info>(
+            object : UpgradeRepo.Info {
+                override val type = UpgradeRepo.Type.FOSS
+                override val isPro = true
+                override val isSettled = true
+                override val upgradedAt: Instant? = null
+                override val error: Throwable? = null
+            }
+        )
+
+        override suspend fun refresh() = Unit
+    }
+
     private val attempted = OperationHistoryRepo.AttemptedPaths(
         paths = listOf("/sdcard/ButlerQA", "/sdcard/ButlerQA/notes.txt"),
         totalCount = 2,
@@ -94,6 +114,7 @@ class HistoryWorkspaceShareTest : BaseTest() {
         workspaceProvider = workspaceProvider,
         historyRepo = historyRepo,
         historySettings = historySettings,
+        upgradeRepo = upgradeRepo,
     )
 
     /**


### PR DESCRIPTION
## What changed

Sharing and deleting individual history entries now require the full version. Tapping Share or Delete on a history entry, either from the selection action bar or from an entry's details sheet, shows an upgrade prompt instead of performing the action. The prompt offers a way straight to the upgrade screen.

Clearing the whole history stays free in the history settings, as do turning history off entirely and the limit on how many entries are kept. A free user can still remove their own records.

## Technical Context

* The gate uses `UpgradeRepo.isProForUi()`, not `isProSettled()`. It resolves immediately once billing has settled and only waits out the GPlay cold-start window before denying, which is the same trade-off the tab-limit gate already accepts. `isProSettled()` is the backend safety-net variant and there is no backend boundary here.
* `onActionClick`'s Share and Delete branches were synchronous and now suspend, which opens two windows that did not exist before. A single mutex is acquired synchronously before `launch` so two taps in the same frame cannot both dispatch, and after the gate the selection is re-validated twice: an equality check against a snapshot taken at tap time, which catches the selection changing in either direction, and the pre-existing subset check, which catches an action item whose entries are not all selected even when the selection has not moved. Neither check subsumes the other.
* `shareEntry` runs the gate inside the existing share mutex and before the attempted-paths query, so a denied share never issues that query, and it re-checks the sheet's entry identity afterwards so a sheet dismissed during the wait raises no prompt.
* Settings, Clear history is deliberately left ungated. Paywalling the only bulk removal would leave a free user unable to delete records they already have.
* `HistoryWorkspaceViewModel` moved from `ViewModel3` to `ViewModel4` so the dialog's Upgrade button can navigate, which required adding `NavigationEventHandler` to the overlays host. That host is composed alongside the page at both pane call sites, so the nav event cannot be dropped. The upgrade dialog renders last in the overlay stack because composition order is layer order and the gate can resolve while another overlay is up.

The concurrency guards in `onActionClick` are the part worth reading closely. The three commits after the first each correct a defect in an earlier version of those guards, and every one of them carries a regression test that was confirmed to fail against the preceding commit.
