### PR TITLE
Workspace: Always show performance info, and explain when it's empty

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -61,39 +61,16 @@ private val TAG = logTag("PerformanceGraph")
 @Composable
 fun OperationPerformanceGraph(
     modifier: Modifier = Modifier,
-    performanceHistory: PerformanceHistory,
+    graphData: PerformanceGraphData,
 ) {
     val backgroundColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f)
-
-    val graphData = remember(performanceHistory) { PerformanceGraphData.from(performanceHistory) }
-
-    if (graphData == null) {
-        // Not enough data - show message
-        Box(
-            modifier = modifier
-                .fillMaxWidth()
-                .height(180.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .background(backgroundColor),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = stringResource(R.string.workspace_operation_performance_not_enough_data),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        return
-    }
 
     val byteSpeeds = graphData.byteSpeeds
     // Keyed by mode so a two series model can't be handed to a single layer chart
     val modelProducer = remember(byteSpeeds != null) { CartesianChartModelProducer() }
 
     LaunchedEffect(graphData) {
-        log(TAG, DEBUG) {
-            "Plotting ${graphData.progress.size} points from ${performanceHistory.samples.size} samples"
-        }
+        log(TAG, DEBUG) { "Plotting ${graphData.progress.size} points" }
         modelProducer.runTransaction {
             if (byteSpeeds != null) lineSeries { series(x = graphData.progress, y = byteSpeeds) }
             lineSeries { series(x = graphData.progress, y = graphData.itemSpeeds) }
@@ -216,7 +193,7 @@ fun OperationPerformanceGraph(
             // Recent average byte speed label (top-left, matches left Y-axis)
             if (byteSpeeds != null) {
                 SpeedChip(
-                    text = formatByteSpeed(performanceHistory.getRecentBytesPerSecond()),
+                    text = formatByteSpeed(graphData.recentBytesPerSecond),
                     color = bytesLineColor,
                     modifier = Modifier
                         .align(Alignment.TopStart)
@@ -226,7 +203,7 @@ fun OperationPerformanceGraph(
 
             // Recent average item speed label (top-right, matches right Y-axis)
             SpeedChip(
-                text = formatItemSpeed(performanceHistory.getRecentItemsPerSecond().toDouble()),
+                text = formatItemSpeed(graphData.recentItemsPerSecond.toDouble()),
                 color = itemsLineColor,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -287,33 +264,9 @@ private fun speedValueFormatter(maxY: Double) = CartesianValueFormatter { _, val
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun OperationPerformanceGraphNoDataPreview() {
-    // Not enough samples - should not render
-    val history = remember {
-        val now = kotlin.time.Clock.System.now()
-        PerformanceHistory(
-            samples = listOf(
-                PerformanceSample(
-                    timestamp = now,
-                    bytesPerSecond = 150_000_000,
-                    itemsPerSecond = 2.5f,
-                    totalBytesProcessed = 50_000_000,
-                    totalItemsProcessed = 5,
-                )
-            ),
-            startTime = now,
-            totalBytes = 1_000_000_000,
-        )
-    }
-    OperationPerformanceGraph(performanceHistory = history)
-}
-
-@Preview2
-@ComposePreviewWrapper(ButlerPreviewWrapper::class)
-@Composable
 private fun OperationPerformanceGraphHalfDataPreview() {
     // 50% completion with varying speeds (many small files scenario)
-    val history = remember {
+    val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
         val totalBytes = 1_000_000_000L
 
@@ -331,14 +284,15 @@ private fun OperationPerformanceGraphHalfDataPreview() {
             )
         }
 
-        PerformanceHistory(
+        val history = PerformanceHistory(
             samples = samples,
             startTime = baseTime,
             totalBytes = totalBytes,
             totalItems = 1000,
         )
-    }
-    OperationPerformanceGraph(performanceHistory = history)
+        PerformanceGraphData.from(history)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
 }
 
 @Preview2
@@ -346,7 +300,7 @@ private fun OperationPerformanceGraphHalfDataPreview() {
 @Composable
 private fun OperationPerformanceGraphFullDataPreview() {
     // 100% completion with varying speeds (mixed file sizes scenario)
-    val history = remember {
+    val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
         val totalBytes = 1_000_000_000L
 
@@ -368,14 +322,15 @@ private fun OperationPerformanceGraphFullDataPreview() {
             )
         }
 
-        PerformanceHistory(
+        val history = PerformanceHistory(
             samples = samples,
             startTime = baseTime,
             totalBytes = totalBytes,
             totalItems = 1000,
         )
-    }
-    OperationPerformanceGraph(performanceHistory = history)
+        PerformanceGraphData.from(history)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
 }
 
 @Preview2
@@ -383,7 +338,7 @@ private fun OperationPerformanceGraphFullDataPreview() {
 @Composable
 private fun OperationPerformanceGraphItemsOnlyPreview() {
     // Deleting 500 empty files: no bytes anywhere, only the items axis has data
-    val history = remember {
+    val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
         val totalItems = 500
 
@@ -398,13 +353,14 @@ private fun OperationPerformanceGraphItemsOnlyPreview() {
             )
         }
 
-        PerformanceHistory(
+        val history = PerformanceHistory(
             samples = samples,
             startTime = baseTime,
             totalItems = totalItems,
         )
-    }
-    OperationPerformanceGraph(performanceHistory = history)
+        PerformanceGraphData.from(history)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
 }
 
 @Preview2
@@ -412,7 +368,7 @@ private fun OperationPerformanceGraphItemsOnlyPreview() {
 @Composable
 private fun OperationPerformanceGraphSingleFilePreview() {
     // A single large file: the item count never moves, item speed stays below 1/s
-    val history = remember {
+    val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
         val totalBytes = 4_000_000_000L
 
@@ -428,12 +384,13 @@ private fun OperationPerformanceGraphSingleFilePreview() {
             )
         }
 
-        PerformanceHistory(
+        val history = PerformanceHistory(
             samples = samples,
             startTime = baseTime,
             totalBytes = totalBytes,
             totalItems = 1,
         )
-    }
-    OperationPerformanceGraph(performanceHistory = history)
+        PerformanceGraphData.from(history)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
@@ -1,33 +1,184 @@
 package eu.darken.butler.workspace.ui.operations.details
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ContentCopy
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.ProGate
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 internal fun OperationPerformanceGraphSection(
     operation: OperationDisplay,
-    graphContent: @Composable (PerformanceHistory) -> Unit = { OperationPerformanceGraph(performanceHistory = it) },
+    graphContent: @Composable (PerformanceGraphData) -> Unit = { OperationPerformanceGraph(graphData = it) },
 ) {
-    // Extract performance history from the operation state
-    val performanceHistory = when (val state = operation.state) {
+    OperationSection(
+        title = stringResource(R.string.workspace_operations_performance_graph_label),
+        initiallyExpanded = false,
+    ) {
+        // Inside the section: building the series walks the whole history, and a collapsed section
+        // never composes this lambda.
+        val graphState = remember(operation.state) { performanceGraphStateOf(operation) }
+        when (graphState) {
+            is PerformanceGraphState.Plottable -> ProGate { graphContent(graphState.data) }
+            is PerformanceGraphState.Unavailable -> PerformanceGraphUnavailableInfo(reason = graphState.reason)
+        }
+    }
+}
+
+internal sealed interface PerformanceGraphState {
+    data class Plottable(val data: PerformanceGraphData) : PerformanceGraphState
+    data class Unavailable(val reason: PerformanceGraphUnavailability) : PerformanceGraphState
+}
+
+internal enum class PerformanceGraphUnavailability {
+    NOT_STARTED,
+    COLLECTING,
+    INSUFFICIENT_DATA,
+    NOT_AVAILABLE,
+}
+
+/**
+ * Whether [operation] has something to plot, and if not, which explanation fits its state.
+ *
+ * A running operation is always [PerformanceGraphUnavailability.COLLECTING], whatever kept the
+ * series empty: no history yet, too few samples, or progress that hasn't moved. All three can still
+ * turn into a graph while it runs.
+ */
+internal fun performanceGraphStateOf(operation: OperationDisplay): PerformanceGraphState {
+    val history = when (val state = operation.state) {
         is OperationDisplay.State.Running -> state.performanceHistory
         is OperationDisplay.State.Completed -> state.performanceHistory
         else -> null
     }
 
-    // Return early if no data or insufficient samples
-    if (performanceHistory?.canShowGraph != true) return
+    val data = history?.let { PerformanceGraphData.from(it) }
+    if (data != null) return PerformanceGraphState.Plottable(data)
 
-    OperationSection(
-        title = stringResource(R.string.workspace_operations_performance_graph_label),
-        initiallyExpanded = false,
-    ) {
-        ProGate {
-            graphContent(performanceHistory)
+    val reason = when (operation.state) {
+        is OperationDisplay.State.Queued -> PerformanceGraphUnavailability.NOT_STARTED
+        is OperationDisplay.State.Running -> PerformanceGraphUnavailability.COLLECTING
+        is OperationDisplay.State.Completed -> when (history) {
+            null -> PerformanceGraphUnavailability.NOT_AVAILABLE
+            else -> PerformanceGraphUnavailability.INSUFFICIENT_DATA
         }
+        else -> PerformanceGraphUnavailability.NOT_AVAILABLE
     }
+    return PerformanceGraphState.Unavailable(reason)
+}
+
+@Composable
+private fun PerformanceGraphUnavailableInfo(
+    modifier: Modifier = Modifier,
+    reason: PerformanceGraphUnavailability,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            text = stringResource(reason.labelRes),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+private val PerformanceGraphUnavailability.labelRes: Int
+    get() = when (this) {
+        PerformanceGraphUnavailability.NOT_STARTED -> R.string.workspace_operation_performance_unavailable_not_started
+        PerformanceGraphUnavailability.COLLECTING -> R.string.workspace_operation_performance_unavailable_collecting
+        PerformanceGraphUnavailability.INSUFFICIENT_DATA -> R.string.workspace_operation_performance_unavailable_insufficient
+        PerformanceGraphUnavailability.NOT_AVAILABLE -> R.string.workspace_operation_performance_unavailable_not_available
+    }
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationPerformanceGraphSectionPreview() {
+    val now = remember { Clock.System.now() }
+    val history = remember {
+        PerformanceHistory(
+            samples = (0 until 20).map { i ->
+                PerformanceSample(
+                    timestamp = now + (i * 250).milliseconds,
+                    bytesPerSecond = 50_000_000L,
+                    itemsPerSecond = 5f,
+                    totalBytesProcessed = i * 50_000_000L,
+                    totalItemsProcessed = i,
+                )
+            },
+            startTime = now,
+            totalBytes = 1_000_000_000L,
+            totalItems = 20,
+        )
+    }
+    OperationPerformanceGraphSection(
+        operation = OperationDisplay(
+            id = Operation.Id(),
+            startedAt = now,
+            icon = Icons.TwoTone.ContentCopy,
+            title = "Copying files".toCaString(),
+            description = "3 of 10".toCaString(),
+            state = OperationDisplay.State.Running(performanceHistory = history),
+        ),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PerformanceGraphUnavailableInfoNotStartedPreview() {
+    PerformanceGraphUnavailableInfo(reason = PerformanceGraphUnavailability.NOT_STARTED)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PerformanceGraphUnavailableInfoCollectingPreview() {
+    PerformanceGraphUnavailableInfo(reason = PerformanceGraphUnavailability.COLLECTING)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PerformanceGraphUnavailableInfoInsufficientDataPreview() {
+    PerformanceGraphUnavailableInfo(reason = PerformanceGraphUnavailability.INSUFFICIENT_DATA)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PerformanceGraphUnavailableInfoNotAvailablePreview() {
+    PerformanceGraphUnavailableInfo(reason = PerformanceGraphUnavailability.NOT_AVAILABLE)
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -16,6 +16,9 @@ enum class ByteSpeedUnit(val divisor: Double) {
  * Plot-ready series for [OperationPerformanceGraph].
  *
  * All series share the [progress] x values, which are completion percentages rounded to 0.5 steps.
+ *
+ * [recentBytesPerSecond] and [recentItemsPerSecond] are averages over the raw history, not over the
+ * decimated and smoothed series, so they stay the speeds the operation actually reported last.
  */
 data class PerformanceGraphData(
     val progress: List<Float>,
@@ -24,6 +27,8 @@ data class PerformanceGraphData(
     val byteUnit: ByteSpeedUnit?,
     val maxByteSpeed: Double,
     val maxItemSpeed: Double,
+    val recentBytesPerSecond: Long,
+    val recentItemsPerSecond: Float,
 ) {
 
     companion object {
@@ -89,6 +94,8 @@ data class PerformanceGraphData(
                 byteUnit = byteUnit,
                 maxByteSpeed = byteSpeeds?.max()?.toDouble() ?: 0.0,
                 maxItemSpeed = itemSpeeds.max().toDouble(),
+                recentBytesPerSecond = history.getRecentBytesPerSecond(),
+                recentItemsPerSecond = history.getRecentItemsPerSecond(),
             )
         }
 

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -267,7 +267,10 @@
     <string name="workspace_file_info_total_size_label">Total size</string>
 
     <!-- Performance Graph -->
-    <string name="workspace_operation_performance_not_enough_data">Not enough data</string>
+    <string name="workspace_operation_performance_unavailable_not_started">This operation hasn\'t started yet.</string>
+    <string name="workspace_operation_performance_unavailable_collecting">Collecting performance data…</string>
+    <string name="workspace_operation_performance_unavailable_insufficient">There isn\'t enough performance data from this operation to plot a graph.</string>
+    <string name="workspace_operation_performance_unavailable_not_available">Performance data isn\'t available for this operation.</string>
     <string name="workspace_operation_performance_unit_bytes">B/s</string>
     <string name="workspace_operation_performance_unit_kilobytes">kB/s</string>
     <string name="workspace_operation_performance_unit_megabytes">MB/s</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ca.toCaString
@@ -21,7 +22,9 @@ import eu.darken.butler.workspace.ui.operations.OperationDisplay
 import org.junit.Test
 import testhelpers.ComposeTest
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
 class OperationPerformanceGraphSectionTest : ComposeTest() {
@@ -33,42 +36,78 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     private val collapseLabel = context.getString(R.string.operations_details_section_collapse, title)
     private val graphTag = "test-graph"
 
+    private val notStartedText = context.getString(R.string.workspace_operation_performance_unavailable_not_started)
+    private val collectingText = context.getString(R.string.workspace_operation_performance_unavailable_collecting)
+    private val insufficientText = context.getString(R.string.workspace_operation_performance_unavailable_insufficient)
+    private val notAvailableText = context.getString(R.string.workspace_operation_performance_unavailable_not_available)
+
     private val startTime = Instant.fromEpochMilliseconds(1000)
 
-    private fun history() = PerformanceHistory(
-        samples = (0 until 20).map { i ->
+    private fun history(
+        sampleCount: Int = 20,
+        totalBytes: Long = 1_000_000_000L,
+        totalItems: Int = 20,
+        spacing: Duration = 250.milliseconds,
+        advancing: Boolean = true,
+    ) = PerformanceHistory(
+        samples = (0 until sampleCount).map { i ->
             PerformanceSample(
-                timestamp = startTime + (i * 250).milliseconds,
+                timestamp = startTime + spacing * i,
                 bytesPerSecond = 50_000_000L,
                 itemsPerSecond = 5f,
-                totalBytesProcessed = i * 50_000_000L,
-                totalItemsProcessed = i,
+                totalBytesProcessed = if (advancing) i * 50_000_000L else 0L,
+                totalItemsProcessed = if (advancing) i else 0,
             )
         },
         startTime = startTime,
-        totalBytes = 1_000_000_000L,
-        totalItems = 20,
+        totalBytes = totalBytes,
+        totalItems = totalItems,
     )
 
-    private fun operation(history: PerformanceHistory) = OperationDisplay(
+    private fun operation(state: OperationDisplay.State) = OperationDisplay(
         id = Operation.Id(),
         startedAt = Clock.System.now(),
         icon = Icons.TwoTone.ContentCopy,
         title = "Copying files".toCaString(),
         description = "3 of 10".toCaString(),
-        state = OperationDisplay.State.Running(performanceHistory = history),
+        state = state,
     )
 
-    @Test
-    fun `toggling the section flips the expand affordance`() {
+    private fun running(history: PerformanceHistory?) = OperationDisplay.State.Running(
+        performanceHistory = history,
+    )
+
+    private fun completed(history: PerformanceHistory?) = OperationDisplay.State.Completed(
+        summary = "Copied 10 files".toCaString(),
+        completedAt = startTime,
+        report = null,
+        performanceHistory = history,
+    )
+
+    private fun waiting() = OperationDisplay.State.Waiting(reason = "Waiting for space".toCaString())
+
+    private fun failed() = OperationDisplay.State.Failed(
+        summary = "Copy failed".toCaString(),
+        completedAt = startTime,
+        report = null,
+    )
+
+    private fun cancelled() = OperationDisplay.State.Cancelled(completedAt = startTime, report = null)
+
+    private fun setSection(state: OperationDisplay.State) {
         composeTestRule.setContent {
             PreviewWrapper {
                 OperationPerformanceGraphSection(
-                    operation = operation(history()),
+                    operation = operation(state),
                     graphContent = { Text(text = "graph", modifier = Modifier.testTag(graphTag)) },
                 )
             }
         }
+    }
+
+    @Test
+    fun `toggling the section flips the expand affordance`() {
+        setSection(running(history()))
 
         composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
 
@@ -81,14 +120,7 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
 
     @Test
     fun `graph is only composed while expanded`() {
-        composeTestRule.setContent {
-            PreviewWrapper {
-                OperationPerformanceGraphSection(
-                    operation = operation(history()),
-                    graphContent = { Text(text = "graph", modifier = Modifier.testTag(graphTag)) },
-                )
-            }
-        }
+        setSection(running(history()))
 
         composeTestRule.onNodeWithTag(graphTag).assertDoesNotExist()
 
@@ -100,11 +132,154 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     fun `real graph renders for a byte and item history`() {
         composeTestRule.setContent {
             PreviewWrapper {
-                OperationPerformanceGraphSection(operation = operation(history()))
+                OperationPerformanceGraphSection(operation = operation(running(history())))
             }
         }
 
         composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
         composeTestRule.onNodeWithContentDescription(collapseLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a plottable history shows the graph without an explanation`() {
+        setSection(running(history()))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+        composeTestRule.onNodeWithText(notStartedText).assertDoesNotExist()
+        composeTestRule.onNodeWithText(collectingText).assertDoesNotExist()
+        composeTestRule.onNodeWithText(insufficientText).assertDoesNotExist()
+        composeTestRule.onNodeWithText(notAvailableText).assertDoesNotExist()
+    }
+
+    @Test
+    fun `queued operations get the section`() {
+        setSection(OperationDisplay.State.Queued)
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `waiting operations get the section`() {
+        setSection(waiting())
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `failed operations get the section`() {
+        setSection(failed())
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `cancelled operations get the section`() {
+        setSection(cancelled())
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `running operations without a history get the section`() {
+        setSection(running(null))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `completed operations without a history get the section`() {
+        setSection(completed(null))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a queued operation has not started yet`() {
+        setSection(OperationDisplay.State.Queued)
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(notStartedText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a running operation without a history is still collecting`() {
+        setSection(running(null))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(collectingText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a running operation with too few samples is still collecting`() {
+        setSection(running(history(sampleCount = 5)))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(collectingText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a running operation stuck on one progress step is still collecting`() {
+        setSection(running(history(totalItems = 0, advancing = false)))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(collectingText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a completed operation with too few samples has insufficient data`() {
+        setSection(completed(history(sampleCount = 5)))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(insufficientText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a completed operation without totals has insufficient data`() {
+        setSection(completed(history(totalBytes = 0L, totalItems = 0)))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(insufficientText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a long completed operation with few samples has insufficient data`() {
+        setSection(completed(history(sampleCount = 5, spacing = 2.minutes)))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(insufficientText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a completed operation without a history has no data available`() {
+        setSection(completed(null))
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(notAvailableText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a waiting operation has no data available`() {
+        setSection(waiting())
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(notAvailableText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a failed operation has no data available`() {
+        setSection(failed())
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(notAvailableText).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a cancelled operation has no data available`() {
+        setSection(cancelled())
+
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        composeTestRule.onNodeWithText(notAvailableText).assertIsDisplayed()
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
@@ -326,4 +326,61 @@ class PerformanceGraphDataTest : BaseTest() {
         data.itemSpeeds.last() shouldBe (10.5f plusOrMinus 0.001f)
         data.maxItemSpeed shouldBe (10.5 plusOrMinus 0.001)
     }
+
+    // ============ RECENT SPEEDS ============
+
+    @Test
+    fun `recent speeds average the raw samples`() {
+        val samples = (0 until 20).map { i ->
+            sample(
+                index = i,
+                bytesPerSecond = (i + 1) * 1_000_000L,
+                itemsPerSecond = (i + 1).toFloat(),
+                totalBytesProcessed = i * 1_000_000L,
+                totalItemsProcessed = i,
+            )
+        }
+
+        val data = PerformanceGraphData
+            .from(history(samples, totalBytes = 20_000_000L, totalItems = 20))
+            .shouldNotBeNull()
+
+        // (1 + 2 + … + 20) / 20 = 10.5
+        data.recentBytesPerSecond shouldBe 10_500_000L
+        data.recentItemsPerSecond shouldBe (10.5f plusOrMinus 0.001f)
+    }
+
+    @Test
+    fun `recent speeds only cover the last 30 samples`() {
+        val samples = (0 until 40).map { i ->
+            sample(
+                index = i,
+                bytesPerSecond = if (i < 10) 500_000_000L else 1_000_000L,
+                itemsPerSecond = if (i < 10) 100f else 2f,
+                totalBytesProcessed = i * 1_000_000L,
+                totalItemsProcessed = i,
+            )
+        }
+
+        val data = PerformanceGraphData
+            .from(history(samples, totalBytes = 40_000_000L, totalItems = 40))
+            .shouldNotBeNull()
+
+        data.recentBytesPerSecond shouldBe 1_000_000L
+        data.recentItemsPerSecond shouldBe (2f plusOrMinus 0.001f)
+    }
+
+    @Test
+    fun `recent speeds ignore the filtering and smoothing of the series`() {
+        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
+        val samples = (0 until 10).map { i ->
+            sample(index = i, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i + 1)
+        }
+
+        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
+
+        data.itemSpeeds shouldHaveSize 3
+        // (10 + 20 + … + 100) / 10, over every sample rather than the three plotted points
+        data.recentItemsPerSecond shouldBe (55f plusOrMinus 0.001f)
+    }
 }


### PR DESCRIPTION
## What changed

The operation details sheet now always shows its performance section. Before, the whole section
vanished whenever there was no graph to draw, which covers a lot of ordinary cases: an operation that
is still queued or waiting, one that failed or was cancelled, one that finished before enough data
was collected, and any operation whose type never records performance data at all. In all of those
the sheet simply had nothing where the section should be, with no indication that anything was
missing.

Expanding the section now tells you which of those applies instead of showing nothing.

The explanation itself is not part of the Pro feature. The upgrade prompt still covers the real
chart, but when there is no chart to show, the reason is plain readable text with no blur and no
upgrade button, since there is nothing there a subscription would unlock.

## Technical Context

- The section used to return early on `canShowGraph`, and a second "not enough data" message lived
  inside the Pro gate, where a free user saw it blurred on API 31+ and not drawn at all below that.
  Both are gone; one decision now yields either plottable data or a reason, and only the chart branch
  is gated.
- The four reason strings are worded so none asserts something the code cannot back. A running
  operation always reads as "collecting" whatever left its series empty, because all three causes can
  still become a graph. The completed-but-sparse wording avoids claiming the operation was short,
  since the sample count tracks progress reports rather than elapsed time. The unavailable wording
  avoids "not recorded", because a waiting or cancelled operation can have recorded samples that the
  display state then drops.
- `PerformanceGraphData` now carries the recent byte and item speeds. The chart's speed chips are raw
  30-sample averages over the unfiltered history, so deriving them from the decimated and smoothed
  plot series would have changed the numbers on screen.
- The decision is computed inside the section's expanded content rather than above it, so opening a
  details sheet on a collapsed section no longer walks up to 1000 samples.
- Worth close review: the reason mapping in `OperationPerformanceGraphSection` and the test table
  beside it. Each row is a distinct path through `PerformanceGraphData.from` and the display state
  model, and the mapping is the part most likely to drift if either changes.

Checked on an emulator rather than in unit tests: that the explanation renders ungated on a non-Pro
build. `ProGate` resolves entitlement through an entry point that is unavailable under Robolectric,
so a unit test there always sees a Pro user and cannot fail on this.
