### PR TITLE
General: Make clipboard configuration a Pro feature

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/settings/SettingsBaseItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/settings/SettingsBaseItem.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material3.Icon
@@ -15,10 +17,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -38,6 +42,7 @@ fun SettingsBaseItem(
     iconSize: Dp = 24.dp,
     subtitle: String? = null,
     enabled: Boolean = true,
+    requiresUpgrade: Boolean = false,
     onLongClick: (() -> Unit)? = null,
     trailingContent: @Composable (() -> Unit)? = null,
 ) {
@@ -81,12 +86,23 @@ fun SettingsBaseItem(
                 .weight(1f)
                 .padding(start = if (hasIcon) 16.dp else 0.dp)
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Normal,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha)
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Normal,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+                    // Only constrain the title when a badge has to sit beside it, ungated rows
+                    // keep their original wrap behavior.
+                    maxLines = if (requiresUpgrade) 1 else Int.MAX_VALUE,
+                    overflow = if (requiresUpgrade) TextOverflow.Ellipsis else TextOverflow.Clip,
+                    modifier = if (requiresUpgrade) Modifier.weight(1f, fill = false) else Modifier,
+                )
+                if (requiresUpgrade) {
+                    Spacer(Modifier.width(6.dp))
+                    UpgradeBadge(modifier = Modifier.alpha(contentAlpha))
+                }
+            }
             if (subtitle != null) {
                 Text(
                     text = subtitle,
@@ -125,4 +141,17 @@ private fun SettingsBaseItemPreview() {
             }
         )
     }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun SettingsBaseItemGatedPreview() {
+    SettingsBaseItem(
+        title = "Pro-gated item",
+        subtitle = "Shows the upgrade badge next to the title",
+        onClick = {},
+        icon = Icons.TwoTone.Settings,
+        requiresUpgrade = true,
+    )
 }

--- a/app-common/src/main/java/eu/darken/butler/common/settings/SettingsPreferenceItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/settings/SettingsPreferenceItem.kt
@@ -15,9 +15,9 @@ import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 
 /**
- * A non-null [onUpgrade] marks the row as requiring an upgrade: it gets the badge and every tap
- * goes to [onUpgrade] instead of [onClick]. A badged row without an upgrade action is therefore
- * unrepresentable.
+ * A non-null [onUpgrade] gates the row while it is enabled: it gets the badge and every tap goes
+ * to [onUpgrade] instead of [onClick]. A row with `enabled = false` shows no badge and keeps its
+ * normal inert behavior even with an upgrade action, because upgrading would not make it usable.
  */
 @Composable
 fun SettingsPreferenceItem(
@@ -30,16 +30,17 @@ fun SettingsPreferenceItem(
     enabled: Boolean = true,
     onUpgrade: (() -> Unit)? = null,
 ) {
+    val upgradeAction = onUpgrade?.takeIf { enabled }
     val contentAlpha = if (enabled) 1f else 0.5f
 
     SettingsBaseItem(
         icon = icon,
         title = title,
-        onClick = onUpgrade ?: onClick,
+        onClick = upgradeAction ?: onClick,
         modifier = modifier,
         subtitle = subtitle,
         enabled = enabled,
-        requiresUpgrade = onUpgrade != null,
+        requiresUpgrade = upgradeAction != null,
         trailingContent = if (value != null) {
             {
                 Text(

--- a/app-common/src/main/java/eu/darken/butler/common/settings/SettingsPreferenceItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/settings/SettingsPreferenceItem.kt
@@ -14,6 +14,11 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 
+/**
+ * A non-null [onUpgrade] marks the row as requiring an upgrade: it gets the badge and every tap
+ * goes to [onUpgrade] instead of [onClick]. A badged row without an upgrade action is therefore
+ * unrepresentable.
+ */
 @Composable
 fun SettingsPreferenceItem(
     icon: ImageVector,
@@ -23,16 +28,18 @@ fun SettingsPreferenceItem(
     subtitle: String? = null,
     value: String? = null,
     enabled: Boolean = true,
+    onUpgrade: (() -> Unit)? = null,
 ) {
     val contentAlpha = if (enabled) 1f else 0.5f
 
     SettingsBaseItem(
         icon = icon,
         title = title,
-        onClick = onClick,
+        onClick = onUpgrade ?: onClick,
         modifier = modifier,
         subtitle = subtitle,
         enabled = enabled,
+        requiresUpgrade = onUpgrade != null,
         trailingContent = if (value != null) {
             {
                 Text(
@@ -57,5 +64,20 @@ private fun SettingsPreferenceItemPreview() {
         onClick = {},
         modifier = Modifier,
         value = "Value"
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun SettingsPreferenceItemGatedPreview() {
+    SettingsPreferenceItem(
+        icon = Icons.TwoTone.Settings,
+        title = "Settings",
+        subtitle = "General settings",
+        onClick = {},
+        modifier = Modifier,
+        value = "Value",
+        onUpgrade = {},
     )
 }

--- a/app-common/src/main/java/eu/darken/butler/common/settings/SettingsSwitchItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/settings/SettingsSwitchItem.kt
@@ -13,6 +13,11 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 
+/**
+ * A non-null [onUpgrade] marks the row as requiring an upgrade: it gets the badge and every tap
+ * goes to [onUpgrade] instead of toggling. A badged row without an upgrade action is therefore
+ * unrepresentable.
+ */
 @Composable
 fun SettingsSwitchItem(
     icon: ImageVector,
@@ -22,19 +27,25 @@ fun SettingsSwitchItem(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    onUpgrade: (() -> Unit)? = null,
 ) {
     SettingsBaseItem(
         icon = icon,
         title = title,
-        onClick = { onCheckedChange(!checked) },
+        onClick = onUpgrade ?: { onCheckedChange(!checked) },
         modifier = modifier,
         subtitle = subtitle,
         enabled = enabled,
+        requiresUpgrade = onUpgrade != null,
         trailingContent = {
             Switch(
                 checked = checked,
-                onCheckedChange = onCheckedChange,
-                enabled = enabled,
+                // A null callback drops the Switch's own toggleable node, leaving the row's
+                // combinedClickable as the only place a tap can land. Pinned by the
+                // isToggleable() assertions in SettingsUpgradeBadgeTest.
+                onCheckedChange = if (onUpgrade != null) null else onCheckedChange,
+                // Appearance only, this does not affect pointer input.
+                enabled = enabled && onUpgrade == null,
                 modifier = Modifier.padding(start = 16.dp)
             )
         }
@@ -52,5 +63,20 @@ private fun SettingsSwitchItemPreview() {
         checked = true,
         onCheckedChange = {},
         modifier = Modifier,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun SettingsSwitchItemGatedPreview() {
+    SettingsSwitchItem(
+        icon = Icons.TwoTone.Settings,
+        title = "Settings",
+        subtitle = "General settings",
+        checked = true,
+        onCheckedChange = {},
+        modifier = Modifier,
+        onUpgrade = {},
     )
 }

--- a/app-common/src/main/java/eu/darken/butler/common/settings/SettingsSwitchItem.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/settings/SettingsSwitchItem.kt
@@ -14,9 +14,9 @@ import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 
 /**
- * A non-null [onUpgrade] marks the row as requiring an upgrade: it gets the badge and every tap
- * goes to [onUpgrade] instead of toggling. A badged row without an upgrade action is therefore
- * unrepresentable.
+ * A non-null [onUpgrade] gates the row while it is enabled: it gets the badge and every tap goes
+ * to [onUpgrade] instead of toggling. A row with `enabled = false` shows no badge and keeps its
+ * normal inert behavior even with an upgrade action, because upgrading would not make it usable.
  */
 @Composable
 fun SettingsSwitchItem(
@@ -29,23 +29,25 @@ fun SettingsSwitchItem(
     enabled: Boolean = true,
     onUpgrade: (() -> Unit)? = null,
 ) {
+    val upgradeAction = onUpgrade?.takeIf { enabled }
+
     SettingsBaseItem(
         icon = icon,
         title = title,
-        onClick = onUpgrade ?: { onCheckedChange(!checked) },
+        onClick = upgradeAction ?: { onCheckedChange(!checked) },
         modifier = modifier,
         subtitle = subtitle,
         enabled = enabled,
-        requiresUpgrade = onUpgrade != null,
+        requiresUpgrade = upgradeAction != null,
         trailingContent = {
             Switch(
                 checked = checked,
                 // A null callback drops the Switch's own toggleable node, leaving the row's
                 // combinedClickable as the only place a tap can land. Pinned by the
                 // isToggleable() assertions in SettingsUpgradeBadgeTest.
-                onCheckedChange = if (onUpgrade != null) null else onCheckedChange,
+                onCheckedChange = if (upgradeAction != null) null else onCheckedChange,
                 // Appearance only, this does not affect pointer input.
-                enabled = enabled && onUpgrade == null,
+                enabled = enabled && upgradeAction == null,
                 modifier = Modifier.padding(start = 16.dp)
             )
         }

--- a/app-common/src/main/java/eu/darken/butler/common/settings/UpgradeBadge.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/settings/UpgradeBadge.kt
@@ -1,0 +1,66 @@
+package eu.darken.butler.common.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.R
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+
+/**
+ * Inline "Pro"/"FOSS" chip rendered next to a settings row title when the feature requires an
+ * upgrade. Pure presentation, taps are handled by the hosting row.
+ *
+ * [label] exists so previews can show both flavor values, production callers use the default.
+ */
+@Composable
+fun UpgradeBadge(
+    modifier: Modifier = Modifier,
+    label: String = stringResource(R.string.app_name_upgrade_postfix),
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Decorative, the adjacent label is the accessible announcement.
+        Icon(
+            imageVector = Icons.TwoTone.Stars,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(Modifier.width(2.dp))
+        Text(
+            text = label,
+            color = MaterialTheme.colorScheme.primary,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun UpgradeBadgePreview() {
+    UpgradeBadge()
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun UpgradeBadgeFossPreview() {
+    UpgradeBadge(label = "FOSS")
+}

--- a/app-common/src/test/java/eu/darken/butler/common/settings/SettingsUpgradeBadgeTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/settings/SettingsUpgradeBadgeTest.kt
@@ -112,6 +112,51 @@ class SettingsUpgradeBadgeTest : ComposeTest() {
         toggles shouldBe 1
     }
 
+    @Test
+    fun `a disabled preference row drops the badge and the upgrade route`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.Settings,
+                    title = TITLE,
+                    subtitle = SUBTITLE,
+                    enabled = false,
+                    onClick = { clicks++ },
+                    onUpgrade = { upgrades++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(badgeLabel).assertDoesNotExist()
+
+        composeTestRule.onNodeWithText(TITLE).performClick()
+        upgrades shouldBe 0
+        clicks shouldBe 0
+    }
+
+    @Test
+    fun `a disabled switch row drops the badge and the upgrade route`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Settings,
+                    title = TITLE,
+                    subtitle = SUBTITLE,
+                    checked = false,
+                    enabled = false,
+                    onCheckedChange = { toggles++ },
+                    onUpgrade = { upgrades++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(badgeLabel).assertDoesNotExist()
+
+        composeTestRule.onNodeWithText(TITLE).performClick()
+        upgrades shouldBe 0
+        toggles shouldBe 0
+    }
+
     companion object {
         private const val TITLE = "Row title"
         private const val SUBTITLE = "Row subtitle"

--- a/app-common/src/test/java/eu/darken/butler/common/settings/SettingsUpgradeBadgeTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/settings/SettingsUpgradeBadgeTest.kt
@@ -1,0 +1,119 @@
+package eu.darken.butler.common.settings
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Settings
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+
+@Config(qualifiers = "w400dp-h800dp")
+class SettingsUpgradeBadgeTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val badgeLabel = context.getString(R.string.app_name_upgrade_postfix)
+
+    private var clicks = 0
+    private var upgrades = 0
+    private var toggles = 0
+
+    @Test
+    fun `an ungated preference row has no badge and runs its own action`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.Settings,
+                    title = TITLE,
+                    subtitle = SUBTITLE,
+                    onClick = { clicks++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(badgeLabel).assertDoesNotExist()
+
+        composeTestRule.onNodeWithText(TITLE).performClick()
+        clicks shouldBe 1
+        upgrades shouldBe 0
+    }
+
+    @Test
+    fun `a gated preference row shows the badge and routes to the upgrade`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.Settings,
+                    title = TITLE,
+                    subtitle = SUBTITLE,
+                    onClick = { clicks++ },
+                    onUpgrade = { upgrades++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(badgeLabel).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(TITLE).performClick()
+        upgrades shouldBe 1
+        clicks shouldBe 0
+    }
+
+    @Test
+    fun `a gated switch row has no toggle left to hit`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Settings,
+                    title = TITLE,
+                    subtitle = SUBTITLE,
+                    checked = false,
+                    onCheckedChange = { toggles++ },
+                    onUpgrade = { upgrades++ },
+                )
+            }
+        }
+
+        // A row tap lands in the title column, so it would miss the Switch either way. The absent
+        // toggleable node is what proves the Switch itself cannot be hit.
+        composeTestRule.onNode(isToggleable()).assertDoesNotExist()
+
+        composeTestRule.onNodeWithText(TITLE).performClick()
+        upgrades shouldBe 1
+        toggles shouldBe 0
+    }
+
+    @Test
+    fun `an ungated switch row keeps its toggle`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Settings,
+                    title = TITLE,
+                    subtitle = SUBTITLE,
+                    checked = false,
+                    onCheckedChange = { toggles++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(badgeLabel).assertDoesNotExist()
+
+        composeTestRule.onNode(isToggleable()).assertIsEnabled()
+        composeTestRule.onNode(isToggleable()).performClick()
+        toggles shouldBe 1
+    }
+
+    companion object {
+        private const val TITLE = "Row title"
+        private const val SUBTITLE = "Row subtitle"
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/clipboard/ClipboardSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/clipboard/ClipboardSettingsScreen.kt
@@ -48,6 +48,7 @@ fun ClipboardSettingsScreen(
     onNavigateUp: () -> Unit,
     onToggleRemoveOnPaste: () -> Unit,
     onSetMaxItems: (Int) -> Unit,
+    onUpgradeButler: () -> Unit,
 ) {
     var showMaxItemsDialog by remember { mutableStateOf(false) }
 
@@ -81,7 +82,8 @@ fun ClipboardSettingsScreen(
                     title = stringResource(R.string.clipboard_settings_remove_on_paste_title),
                     subtitle = stringResource(R.string.clipboard_settings_remove_on_paste_desc),
                     checked = state.removeOnPaste,
-                    onCheckedChange = { onToggleRemoveOnPaste() }
+                    onCheckedChange = { onToggleRemoveOnPaste() },
+                    onUpgrade = if (state.isUpgraded) null else onUpgradeButler,
                 )
             }
 
@@ -91,7 +93,8 @@ fun ClipboardSettingsScreen(
                     title = stringResource(R.string.clipboard_settings_max_items_title),
                     subtitle = stringResource(R.string.clipboard_settings_max_items_desc),
                     value = state.maxItems.toString(),
-                    onClick = { showMaxItemsDialog = true }
+                    onClick = { showMaxItemsDialog = true },
+                    onUpgrade = if (state.isUpgraded) null else onUpgradeButler,
                 )
             }
         }
@@ -159,10 +162,29 @@ private fun ClipboardSettingsScreenPreview() {
         state = ClipboardSettingsViewModel.State(
             removeOnPaste = false,
             maxItems = 3,
+            isUpgraded = true,
         ),
         onNavigateUp = {},
         onToggleRemoveOnPaste = {},
         onSetMaxItems = {},
+        onUpgradeButler = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ClipboardSettingsScreenLockedPreview() {
+    ClipboardSettingsScreen(
+        state = ClipboardSettingsViewModel.State(
+            removeOnPaste = false,
+            maxItems = 3,
+            isUpgraded = false,
+        ),
+        onNavigateUp = {},
+        onToggleRemoveOnPaste = {},
+        onSetMaxItems = {},
+        onUpgradeButler = {},
     )
 }
 
@@ -179,6 +201,7 @@ fun ClipboardSettingsScreenHost(vm: ClipboardSettingsViewModel = hiltViewModel()
             onNavigateUp = { vm.navUp() },
             onToggleRemoveOnPaste = { vm.toggleRemoveOnPaste() },
             onSetMaxItems = { vm.setMaxItems(it) },
+            onUpgradeButler = { vm.upgradeButler() },
         )
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/clipboard/ClipboardSettingsViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/clipboard/ClipboardSettingsViewModel.kt
@@ -4,8 +4,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.logging.logTag
-import kotlinx.coroutines.flow.combine
+import eu.darken.butler.common.flow.combine
+import eu.darken.butler.common.navigation.Nav
+import eu.darken.butler.common.navigation.upgrade
 import eu.darken.butler.common.ui.ViewModel4
+import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.core.clipboard.ClipboardSettings
 import javax.inject.Inject
 
@@ -13,15 +16,18 @@ import javax.inject.Inject
 class ClipboardSettingsViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val clipboardSettings: ClipboardSettings,
+    upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, logTag("Clipboard", "Settings", "Screen", "VM")) {
 
     val state = combine(
         clipboardSettings.removeOnPaste.flow,
         clipboardSettings.maxItems.flow,
-    ) { removeOnPaste, maxItems ->
+        upgradeRepo.upgradeInfo,
+    ) { removeOnPaste, maxItems, upgradeInfo ->
         State(
             removeOnPaste = removeOnPaste,
             maxItems = maxItems,
+            isUpgraded = upgradeInfo.isPro,
         )
     }.asStateFlow()
 
@@ -34,8 +40,13 @@ class ClipboardSettingsViewModel @Inject constructor(
         clipboardSettings.maxItems.value(count)
     }
 
+    fun upgradeButler() = launch {
+        navTo(Nav.Main.upgrade())
+    }
+
     data class State(
         val removeOnPaste: Boolean,
         val maxItems: Int,
+        val isUpgraded: Boolean,
     )
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/clipboard/ClipboardSettingsScreenTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/clipboard/ClipboardSettingsScreenTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.butler.workspace.ui.settings.clipboard
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.R
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import eu.darken.butler.common.R as CommonR
+
+@Config(qualifiers = "w400dp-h800dp")
+class ClipboardSettingsScreenTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val badgeLabel = context.getString(CommonR.string.app_name_upgrade_postfix)
+    private val removeOnPasteTitle = context.getString(R.string.clipboard_settings_remove_on_paste_title)
+    private val maxItemsTitle = context.getString(R.string.clipboard_settings_max_items_title)
+
+    private var toggles = 0
+    private var maxItems: Int? = null
+    private var upgrades = 0
+
+    private fun setScreen(isUpgraded: Boolean) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                ClipboardSettingsScreen(
+                    state = ClipboardSettingsViewModel.State(
+                        removeOnPaste = false,
+                        maxItems = 3,
+                        isUpgraded = isUpgraded,
+                    ),
+                    onNavigateUp = {},
+                    onToggleRemoveOnPaste = { toggles++ },
+                    onSetMaxItems = { maxItems = it },
+                    onUpgradeButler = { upgrades++ },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `both rows are badged for free users`() {
+        setScreen(isUpgraded = false)
+
+        composeTestRule.onAllNodesWithText(badgeLabel).assertCountEquals(2)
+    }
+
+    @Test
+    fun `the gated remove-on-paste row goes to the upgrade instead of toggling`() {
+        setScreen(isUpgraded = false)
+
+        composeTestRule.onNode(isToggleable()).assertDoesNotExist()
+
+        composeTestRule.onNodeWithText(removeOnPasteTitle).performClick()
+        upgrades shouldBe 1
+        toggles shouldBe 0
+    }
+
+    @Test
+    fun `the gated max-items row goes to the upgrade instead of opening the dialog`() {
+        setScreen(isUpgraded = false)
+
+        composeTestRule.onNodeWithText(maxItemsTitle).performClick()
+        upgrades shouldBe 1
+        composeTestRule.onNodeWithText(DIALOG_ONLY_OPTION).assertDoesNotExist()
+        maxItems shouldBe null
+    }
+
+    @Test
+    fun `pro users get no badge and working controls`() {
+        setScreen(isUpgraded = true)
+
+        composeTestRule.onAllNodesWithText(badgeLabel).assertCountEquals(0)
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        toggles shouldBe 1
+
+        composeTestRule.onNodeWithText(maxItemsTitle).performClick()
+        composeTestRule.onNodeWithText(DIALOG_ONLY_OPTION).assertIsDisplayed()
+
+        upgrades shouldBe 0
+    }
+
+    companion object {
+        /** Only the max-items dialog offers 10, the row itself shows the current value of 3. */
+        private const val DIALOG_ONLY_OPTION = "10"
+    }
+}

--- a/app/src/main/java/eu/darken/butler/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -119,21 +118,8 @@ fun GeneralSettingsScreen(
                     title = stringResource(R.string.ui_theme_mode_setting_label),
                     subtitle = stringResource(R.string.ui_theme_mode_setting_explanation),
                     value = state.themeState.mode.label.get(context),
-                    onClick = {
-                        if (state.isUpgraded) {
-                            showThemeModeDialog = true
-                        } else {
-                            scope.launch {
-                                val result = snackbarHostState.showSnackbar(
-                                    message = context.getString(R.string.upgrade_feature_requires_pro),
-                                    actionLabel = context.getString(R.string.upgrade_prompt_upgrade_action)
-                                )
-                                if (result == SnackbarResult.ActionPerformed) {
-                                    onUpgradeButler()
-                                }
-                            }
-                        }
-                    }
+                    onClick = { showThemeModeDialog = true },
+                    onUpgrade = if (state.isUpgraded) null else onUpgradeButler,
                 )
                 SettingsDivider()
             }
@@ -144,21 +130,8 @@ fun GeneralSettingsScreen(
                     title = stringResource(R.string.ui_theme_style_setting_label),
                     subtitle = stringResource(R.string.ui_theme_style_setting_explanation),
                     value = state.themeState.style.label.get(context),
-                    onClick = {
-                        if (state.isUpgraded) {
-                            showThemeStyleDialog = true
-                        } else {
-                            scope.launch {
-                                val result = snackbarHostState.showSnackbar(
-                                    message = context.getString(R.string.upgrade_feature_requires_pro),
-                                    actionLabel = context.getString(R.string.upgrade_prompt_upgrade_action)
-                                )
-                                if (result == SnackbarResult.ActionPerformed) {
-                                    onUpgradeButler()
-                                }
-                            }
-                        }
-                    }
+                    onClick = { showThemeStyleDialog = true },
+                    onUpgrade = if (state.isUpgraded) null else onUpgradeButler,
                 )
                 SettingsDivider()
             }
@@ -180,21 +153,10 @@ fun GeneralSettingsScreen(
                         state.themeState.color.label.get(context)
                     },
                     enabled = !isMaterialYouActive,
-                    onClick = {
-                        if (state.isUpgraded) {
-                            showThemeColorDialog = true
-                        } else {
-                            scope.launch {
-                                val result = snackbarHostState.showSnackbar(
-                                    message = context.getString(R.string.upgrade_feature_requires_pro),
-                                    actionLabel = context.getString(R.string.upgrade_prompt_upgrade_action)
-                                )
-                                if (result == SnackbarResult.ActionPerformed) {
-                                    onUpgradeButler()
-                                }
-                            }
-                        }
-                    }
+                    onClick = { if (!isMaterialYouActive) showThemeColorDialog = true },
+                    // Material You owning the color is not a tier problem, so no badge there:
+                    // upgrading would not unlock the row and the subtitle already explains it.
+                    onUpgrade = if (state.isUpgraded || isMaterialYouActive) null else onUpgradeButler,
                 )
                 SettingsDivider()
             }
@@ -362,6 +324,29 @@ fun GeneralSettingsScreen(
 private fun GeneralSettingsScreenPreview() {
     GeneralSettingsScreen(
         state = GeneralSettingsViewModel.State(),
+        onNavigateUp = {},
+        onLanguageSwitcher = {},
+        onThemeModeSelected = {},
+        onThemeStyleSelected = {},
+        onThemeColorSelected = {},
+        onUpdateCheckEnabledChange = {},
+        onMotdEnabledChange = {},
+        onConfirmExitEnabledChange = {},
+        onAvoidDisplayCutoutChange = {},
+        onDocumentsProviderEnabledChange = {},
+        onNavigateToPreviews = {},
+        onNavigateToShortcuts = {},
+        onResetGuidedTours = {},
+        onUpgradeButler = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun GeneralSettingsScreenUpgradedPreview() {
+    GeneralSettingsScreen(
+        state = GeneralSettingsViewModel.State(isUpgraded = true),
         onNavigateUp = {},
         onLanguageSwitcher = {},
         onThemeModeSelected = {},

--- a/app/src/test/java/eu/darken/butler/main/ui/settings/general/GeneralSettingsScreenGateTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/ui/settings/general/GeneralSettingsScreenGateTest.kt
@@ -1,0 +1,135 @@
+package eu.darken.butler.main.ui.settings.general
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.theming.ThemeState
+import eu.darken.butler.common.theming.ThemeStyle
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import eu.darken.butler.common.R as CommonR
+
+@Config(qualifiers = "w400dp-h800dp")
+class GeneralSettingsScreenGateTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val badgeLabel = context.getString(CommonR.string.app_name_upgrade_postfix)
+    private val modeTitle = context.getString(R.string.ui_theme_mode_setting_label)
+    private val styleTitle = context.getString(R.string.ui_theme_style_setting_label)
+    private val colorTitle = context.getString(R.string.ui_theme_color_setting_label)
+
+    /** Options that only ever appear inside the respective dialog, never as a row value here. */
+    private val modeDialogOption = context.getString(CommonR.string.ui_theme_mode_dark_label)
+    private val styleDialogOption = context.getString(CommonR.string.ui_theme_style_high_contrast_label)
+
+    private var upgrades = 0
+
+    private fun setScreen(
+        isUpgraded: Boolean,
+        style: ThemeStyle = ThemeStyle.DEFAULT,
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                GeneralSettingsScreen(
+                    state = GeneralSettingsViewModel.State(
+                        themeState = ThemeState(style = style),
+                        isUpgraded = isUpgraded,
+                    ),
+                    onNavigateUp = {},
+                    onLanguageSwitcher = null,
+                    onThemeModeSelected = {},
+                    onThemeStyleSelected = {},
+                    onThemeColorSelected = {},
+                    onUpgradeButler = { upgrades++ },
+                    onUpdateCheckEnabledChange = {},
+                    onMotdEnabledChange = {},
+                    onConfirmExitEnabledChange = {},
+                    onAvoidDisplayCutoutChange = {},
+                    onDocumentsProviderEnabledChange = {},
+                    onNavigateToPreviews = {},
+                    onNavigateToShortcuts = {},
+                    onResetGuidedTours = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the gated theme mode row goes to the upgrade instead of the dialog`() {
+        setScreen(isUpgraded = false)
+
+        composeTestRule.onNodeWithText(modeTitle).performClick()
+        upgrades shouldBe 1
+        composeTestRule.onNodeWithText(modeDialogOption).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the gated theme style row goes to the upgrade instead of the dialog`() {
+        setScreen(isUpgraded = false)
+
+        composeTestRule.onNodeWithText(styleTitle).performClick()
+        upgrades shouldBe 1
+        composeTestRule.onNodeWithText(styleDialogOption).assertDoesNotExist()
+    }
+
+    @Test
+    fun `pro users open the theme mode dialog`() {
+        setScreen(isUpgraded = true)
+
+        composeTestRule.onNodeWithText(modeTitle).performClick()
+        composeTestRule.onNodeWithText(modeDialogOption).assertIsDisplayed()
+        upgrades shouldBe 0
+    }
+
+    @Test
+    fun `pro users open the theme style dialog`() {
+        setScreen(isUpgraded = true)
+
+        composeTestRule.onNodeWithText(styleTitle).performClick()
+        composeTestRule.onNodeWithText(styleDialogOption).assertIsDisplayed()
+        upgrades shouldBe 0
+    }
+
+    @Test
+    fun `free users get a badge on all three theme rows`() {
+        setScreen(isUpgraded = false)
+
+        composeTestRule.onAllNodesWithText(badgeLabel).assertCountEquals(3)
+        composeTestRule.onNodeWithText(colorTitle).assertIsEnabled()
+    }
+
+    @Test
+    fun `material you takes the color row out of the gate`() {
+        setScreen(isUpgraded = false, style = ThemeStyle.MATERIAL_YOU)
+
+        // Mode and style only - upgrading would not unlock a row the theme style owns.
+        composeTestRule.onAllNodesWithText(badgeLabel).assertCountEquals(2)
+        composeTestRule.onNodeWithText(colorTitle).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `pro users get no badge at all`() {
+        setScreen(isUpgraded = true)
+
+        composeTestRule.onAllNodesWithText(badgeLabel).assertCountEquals(0)
+        composeTestRule.onNodeWithText(colorTitle).assertIsEnabled()
+    }
+
+    @Test
+    fun `material you disables the color row for pro users too`() {
+        setScreen(isUpgraded = true, style = ThemeStyle.MATERIAL_YOU)
+
+        composeTestRule.onAllNodesWithText(badgeLabel).assertCountEquals(0)
+        composeTestRule.onNodeWithText(colorTitle).assertIsNotEnabled()
+    }
+}


### PR DESCRIPTION
## What changed

The two clipboard options, "Remove on paste" and "Max items", now require an upgrade. Free users see the current values and a small badge on the row reading "Pro" or "FOSS" depending on the build, and tapping either row opens the upgrade screen instead of changing the setting. Whatever is already stored keeps working, so nobody loses a setting they had configured.

The same badge now also appears on the three theme rows in General settings, which have always required an upgrade but gave no sign of it until you tapped them and got a snackbar. Those rows now show the badge up front and go straight to the upgrade screen.

One row behaves differently on purpose: the theme colour row while Material You is active. Material You owns the colour there, so upgrading would not unlock the row. It stays disabled with no badge, exactly as before.

## Technical Context

- The badge and the gate live in `app-common`'s shared settings items, so any settings row in the app can opt in. Gating is carried by a nullable `onUpgrade` callback rather than a separate boolean flag, which makes a badged row with no upgrade action unrepresentable.
- A disabled row never shows the badge, even when an upgrade action is supplied. The row's click handling is disabled at that point, so a badge there would advertise a route that cannot be taken. This is the case the theme colour row hits under Material You, and it is covered by tests over all four combinations of Material You and upgrade state.
- The upgrade check reads `UpgradeRepo.Info.isPro` directly. `rendersAsPro()` was considered and rejected: it deliberately reports Pro for unsettled and errored billing states, which is right for blurring a chart but would leave the settings unlocked for free users during the Play billing handshake and indefinitely after a billing error.
- The pattern is ported from SD Maid SE's `UpgradeBadge`, with two deliberate differences. The badge reads its label straight from `app_name_upgrade_postfix` because that resource already lives in `app-common` here, so no CompositionLocal is needed. And the nullable-callback gate replaces the two-parameter `requiresUpgrade` + `onUpgrade` shape, so these files are no longer a byte-for-byte copy between the two apps.
- `upgrade_feature_requires_pro` and `upgrade_prompt_upgrade_action` are now unused in code but deliberately left in place, since they are translated across the full locale set on Crowdin. Removing them is a separate cleanup.
