### PR TITLE
Workspace: Open a new tab next to the one it came from

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
@@ -27,10 +27,15 @@ sealed interface WorkspaceAction {
          */
         val skipContentDedup: Boolean = false,
         /**
-         * Workspace this create was invoked from, if any. Purely a placement hint: the UI prefers a
-         * pane adjacent to it and never evicts the pane it occupies. Null (the default) means
-         * "no origin" - global entry points, the tab manager and session restore - and keeps
-         * today's first-empty-pane behaviour.
+         * Workspace this create was invoked from, if any. Placement in both senses:
+         * - tab order: the new tab is inserted directly right of the tab this id belongs to
+         *   (a modal anchors on the tab it is stacked on), keeping it next to what it came from.
+         * - pane placement: the UI prefers a pane adjacent to it and never evicts the pane it
+         *   occupies.
+         *
+         * Null (the default) means "no origin" - global entry points and session restore - and
+         * appends at the end of the tab list, into the first empty pane. A create that produces a
+         * sub-workspace or replaces a tab is never repositioned, whatever this says.
          */
         val sourceWorkspaceId: Workspace.Id? = null,
         /**
@@ -188,6 +193,15 @@ sealed interface WorkspaceAction {
         }
     }
 
+    /**
+     * @param sourceWorkspaceId workspace the batch was invoked from, with the same meaning as
+     * [Create.sourceWorkspaceId]. The tabs it opens land as one contiguous run in request order
+     * directly right of that tab: the first create anchors on it, and each further one on the tab
+     * just created. The anchor only advances onto a committed root tab, so a request that creates a
+     * sub-workspace cannot drag the run somewhere else. Neither can one that replaces some other
+     * tab; a request that replaces the run's own anchor does carry the run onto the replacement,
+     * which took over the anchor's slot.
+     */
     data class CreateBatch(
         val requests: List<Create>,
         val sourceWorkspaceId: Workspace.Id? = null,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceRemoteExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceRemoteExtensions.kt
@@ -99,7 +99,8 @@ suspend fun WorkspaceRemote.launchPicker(
  *
  * @param type The type of workspace to create
  * @param arguments Optional workspace-specific arguments
- * @param sourceWorkspaceId Workspace this was invoked from, used as a pane placement hint
+ * @param sourceWorkspaceId Workspace this was invoked from: the new tab is placed directly right of
+ *        it and the UI prefers a pane next to it; null appends at the end
  *        (see [WorkspaceAction.Create.sourceWorkspaceId]).
  * @param replace Workspace the new one takes the place of, inheriting its pane slot and focus
  *        (see [WorkspaceAction.Create.replace]). A replace occupies no additional slot, so the

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModel.kt
@@ -84,14 +84,33 @@ class WorkspaceButtonViewModel @Inject constructor(
         workspaceRemote.execute(action)
     }
 
-    override fun createWorkspace(item: QuickCreateItem) = launch {
-        log(tag) { "createWorkspace(${item.type})" }
-        workspaceRemote.createAndFocus(item.type, item.arguments)
+    /**
+     * Where a tab created from this button goes: right of whatever is focused right now.
+     *
+     * Sampled synchronously, before [launch] hands the block to a dispatcher - reading focus inside
+     * the coroutine would sample it at an arbitrary later moment and anchor the tab to wherever the
+     * user has navigated since the tap.
+     */
+    private fun focusedTabId(): Workspace.Id? = workspacePageManager.state.value.focusedWorkspaceId
+
+    override fun createWorkspace(item: QuickCreateItem) {
+        val sourceId = focusedTabId()
+        launch {
+            log(tag) { "createWorkspace(${item.type}), source=$sourceId" }
+            workspaceRemote.createAndFocus(item.type, item.arguments, sourceWorkspaceId = sourceId)
+        }
     }
 
-    override fun createTemplatesWorkspace() = launch {
-        log(tag) { "createTemplatesWorkspace()" }
-        workspaceRemote.createAndFocus(Workspace.Type.TEMPLATES, TemplatesArguments.Default())
+    override fun createTemplatesWorkspace() {
+        val sourceId = focusedTabId()
+        launch {
+            log(tag) { "createTemplatesWorkspace(), source=$sourceId" }
+            workspaceRemote.createAndFocus(
+                type = Workspace.Type.TEMPLATES,
+                arguments = TemplatesArguments.Default(),
+                sourceWorkspaceId = sourceId,
+            )
+        }
     }
 
     override fun navToWorkspaceManager() {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModelTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModelTest.kt
@@ -20,13 +20,17 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -37,7 +41,14 @@ class WorkspaceButtonViewModelTest : BaseTest() {
     private val workspaceRemote = mockk<WorkspaceRemote>(relaxed = true).apply {
         every { state } returns flowOf(WorkspaceRemote.State())
     }
-    private val pageManager = mockk<WorkspacePageManager>(relaxed = true)
+    private val pageManagerState = MutableStateFlow(WorkspacePageManager.State())
+    private val pageManager = mockk<WorkspacePageManager>(relaxed = true).apply {
+        every { state } returns pageManagerState
+    }
+
+    private fun focusOn(id: Workspace.Id) {
+        pageManagerState.value = WorkspacePageManager.State(focusedWorkspaceId = id)
+    }
 
     private class FakeTemplate(
         override val type: Workspace.Type,
@@ -54,8 +65,9 @@ class WorkspaceButtonViewModelTest : BaseTest() {
     private fun createVM(
         templates: Set<WorkspaceTemplate> = emptySet(),
         ranked: Flow<List<Workspace.Type>> = flowOf(emptyList()),
+        dispatcher: CoroutineDispatcher? = null,
     ) = WorkspaceButtonViewModel(
-        dispatchers = TestDispatcherProvider(),
+        dispatchers = TestDispatcherProvider(dispatcher),
         workspaceRemote = workspaceRemote,
         workspacePageManager = pageManager,
         workspaceTemplates = templates,
@@ -74,6 +86,8 @@ class WorkspaceButtonViewModelTest : BaseTest() {
     @Test
     fun `createWorkspace executes Create with the item type and args and requests selection`() {
         val newId = Workspace.Id()
+        val focused = Workspace.Id()
+        focusOn(focused)
         val action = slot<WorkspaceAction>()
         coEvery { workspaceRemote.execute(capture(action)) } returns WorkspaceAction.Create.Result.Success(newId)
         val item = explorerItem()
@@ -83,17 +97,41 @@ class WorkspaceButtonViewModelTest : BaseTest() {
         val created = action.captured as WorkspaceAction.Create
         created.type shouldBe Workspace.Type.EXPLORER
         created.arguments shouldBe item.arguments
-        coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(newId)) }
+        // The focused tab is the origin: the new tab is placed right of it
+        created.sourceWorkspaceId shouldBe focused
+        coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(newId, focused)) }
     }
 
     @Test
     fun `createWorkspace on AlreadyOpen requests selection of the existing workspace`() {
         val existingId = Workspace.Id()
+        val focused = Workspace.Id()
+        focusOn(focused)
         coEvery { workspaceRemote.execute(any()) } returns WorkspaceAction.Create.Result.AlreadyOpen(existingId)
 
         createVM().createWorkspace(explorerItem())
 
-        coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(existingId)) }
+        coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(existingId, focused)) }
+    }
+
+    /**
+     * Focus is read when the button is tapped, not when the queued create runs - anything else
+     * anchors the tab to wherever the user navigated in between.
+     */
+    @Test
+    fun `the origin is the tab focused at tap time, not when the create runs`() = runTest {
+        val focusedAtTap = Workspace.Id()
+        focusOn(focusedAtTap)
+        val action = slot<WorkspaceAction>()
+        coEvery { workspaceRemote.execute(capture(action)) } returns
+            WorkspaceAction.Create.Result.Success(Workspace.Id())
+        val vm = createVM(dispatcher = StandardTestDispatcher(testScheduler))
+
+        vm.createWorkspace(explorerItem())
+        focusOn(Workspace.Id())
+        runCurrent()
+
+        (action.captured as WorkspaceAction.Create).sourceWorkspaceId shouldBe focusedAtTap
     }
 
     @Test
@@ -108,13 +146,17 @@ class WorkspaceButtonViewModelTest : BaseTest() {
     @Test
     fun `createTemplatesWorkspace executes Create for the templates picker`() {
         val newId = Workspace.Id()
+        val focused = Workspace.Id()
+        focusOn(focused)
         val action = slot<WorkspaceAction>()
         coEvery { workspaceRemote.execute(capture(action)) } returns WorkspaceAction.Create.Result.Success(newId)
 
         createVM().createTemplatesWorkspace()
 
-        (action.captured as WorkspaceAction.Create).type shouldBe Workspace.Type.TEMPLATES
-        coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(newId)) }
+        val created = action.captured as WorkspaceAction.Create
+        created.type shouldBe Workspace.Type.TEMPLATES
+        created.sourceWorkspaceId shouldBe focused
+        coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(newId, focused)) }
     }
 
     private val allTemplates = setOf(

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -267,11 +267,13 @@ class WorkspaceRepo @Inject constructor(
         idToReplace: Workspace.Id? = null,
         existingId: Workspace.Id? = null,
         createdAt: Instant? = null,
+        anchorId: Workspace.Id? = null,
     ): Workspace.Id {
-        log(TAG) { "create($type, $arguments, $idToReplace, existingId=$existingId)" }
+        log(TAG) { "create($type, $arguments, $idToReplace, existingId=$existingId, anchorId=$anchorId)" }
         return commitWorkspace(
             newWorkspace = buildWorkspace(type, arguments, idToReplace, existingId),
             idToReplace = idToReplace,
+            anchorId = anchorId,
             createdAt = createdAt,
             returnsResult = arguments is Workspace.ArgumentsForResult,
         )
@@ -323,12 +325,18 @@ class WorkspaceRepo @Inject constructor(
     }
 
     /**
-     * Publishes an instance built by [buildWorkspace]: replace-or-append, creation timestamp, orphan
-     * cleanup. Must be called while holding [lock].
+     * Publishes an instance built by [buildWorkspace]: replace, insert beside [anchorId] or append,
+     * creation timestamp, orphan cleanup. Must be called while holding [lock].
+     *
+     * [anchorId] is the workspace the create was invoked from; the new tab lands directly right of
+     * the tab that anchor belongs to (see [tabInsertionIndexAfter]). It is ignored for a replace,
+     * which inherits its slot, and for a sub-workspace, whose position is stacking order rather than
+     * tab order.
      */
     private suspend fun commitWorkspace(
         newWorkspace: Workspace<out Workspace.Arguments>,
         idToReplace: Workspace.Id?,
+        anchorId: Workspace.Id?,
         createdAt: Instant?,
         returnsResult: Boolean,
     ): Workspace.Id {
@@ -358,7 +366,10 @@ class WorkspaceRepo @Inject constructor(
                 }
             }
         } else {
-            wip.add(newWorkspace)
+            val insertAt = anchorId
+                ?.takeIf { !newWorkspace.info.value.isSubWorkspace }
+                ?.let { tabInsertionIndexAfter(it) }
+            if (insertAt != null) wip.add(insertAt, newWorkspace) else wip.add(newWorkspace)
         }
 
         // Before the publish: create() returns to its caller only after the list was published, so a
@@ -571,6 +582,7 @@ class WorkspaceRepo @Inject constructor(
                     idToReplace = action.replace,
                     existingId = action.id,
                     createdAt = action.createdAt,
+                    anchorId = action.sourceWorkspaceId,
                 )
                 trackUsage(action, Clock.System.now())
                 log(TAG) { "New workspace created with ID $newId, emitting event" }
@@ -1495,6 +1507,7 @@ class WorkspaceRepo @Inject constructor(
             val newId = commitWorkspace(
                 newWorkspace = built,
                 idToReplace = action.replace,
+                anchorId = action.sourceWorkspaceId,
                 createdAt = action.createdAt,
                 returnsResult = action.arguments is Workspace.ArgumentsForResult,
             )
@@ -1603,6 +1616,10 @@ class WorkspaceRepo @Inject constructor(
             results[req] = WorkspaceAction.CreateBatch.CreationResult.AlreadyOpen(existingId)
         }
 
+        // Walks along the tabs this batch opens, so they land as one contiguous run in request order
+        // directly after the source tab instead of all stacking onto the same anchor in reverse.
+        var anchorId = sourceWorkspaceId?.let { peekStacks().ownerOf(it) }
+
         requests.forEach { createRequest ->
             // Catches the case where two requests in the same batch target the same singleton type
             // or content path: first iteration creates the instance, subsequent iterations see it
@@ -1615,13 +1632,25 @@ class WorkspaceRepo @Inject constructor(
 
             try {
                 log(TAG) { "Creating workspace: ${createRequest.type}" }
+                val replacedAnchor = createRequest.replace != null && createRequest.replace == anchorId
                 val newId = create(
                     type = createRequest.type,
                     arguments = createRequest.arguments,
                     idToReplace = createRequest.replace,
                     existingId = createRequest.id,
                     createdAt = createRequest.createdAt,
+                    anchorId = anchorId,
                 )
+                // Advanced right here, not at the Success assignment below: a cancellation between
+                // the publish and that assignment would leave the tab in the list while the anchor
+                // still pointed behind it, and the rest of the batch would interleave with it.
+                // Only onto a committed root tab - a replace took somebody else's slot, and a
+                // sub-workspace is not a tab, so anchoring on either would break the run. The one
+                // replace that does advance it is the one that took the anchor's own slot: it sits
+                // where the anchor sat, and the anchor id is gone from the list to insert after.
+                if ((createRequest.replace == null || replacedAnchor) && peek(newId)?.info?.value?.isSubWorkspace == false) {
+                    anchorId = newId
+                }
                 // Captured before the emit below can suspend, matching the single-create path
                 val usedAt = Clock.System.now()
                 _events.emit(
@@ -2211,6 +2240,24 @@ class WorkspaceRepo @Inject constructor(
         if (snapshot.unitOrderIndex >= owners.size) return current.size
         val ownerAtIndex = owners[snapshot.unitOrderIndex].id
         return current.indexOfFirst { it.id == ownerAtIndex }.takeIf { it >= 0 } ?: current.size
+    }
+
+    /**
+     * Where a tab created from [anchorId] goes: directly before the next TAB following the one the
+     * anchor belongs to, or null when it should just be appended - the anchor is the last tab, or it
+     * is not open any more (limit recovery can have closed it). Must be called while holding [lock].
+     *
+     * The anchor is resolved to its ownership root first, so a create invoked from a modal stacked
+     * on a tab anchors on that tab. And the scan skips forward instead of taking `ownerIdx + 1`:
+     * the anchor's own sub-workspaces sit directly behind it in list order and belong on its side of
+     * the boundary, never between it and the new tab.
+     */
+    private fun tabInsertionIndexAfter(anchorId: Workspace.Id): Int? {
+        val current = _workspaces.value
+        val ownerId = peekStacks().ownerOf(anchorId)
+        val ownerIdx = current.indexOfFirst { it.id == ownerId }
+        if (ownerIdx < 0) return null
+        return (ownerIdx + 1 until current.size).firstOrNull { !current[it].info.value.isSubWorkspace }
     }
 
     /**

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -675,8 +675,14 @@ class WorkspaceRepoTest : BaseTest() {
     private suspend fun WorkspaceRepo.createRecoverable(
         type: Workspace.Type = Workspace.Type.EXPLORER,
         arguments: Workspace.Arguments = FakeArguments(type),
+        source: Workspace.Id? = null,
     ): WorkspaceAction.Create.Result = execute(
-        WorkspaceAction.Create(type = type, arguments = arguments, allowLimitRecovery = true)
+        WorkspaceAction.Create(
+            type = type,
+            arguments = arguments,
+            allowLimitRecovery = true,
+            sourceWorkspaceId = source,
+        )
     ) as WorkspaceAction.Create.Result
 
     private suspend fun WorkspaceRepo.createReadyTabAt(
@@ -1426,6 +1432,260 @@ class WorkspaceRepoTest : BaseTest() {
         repo.retrieve(ids[0]).first() shouldBe null
         createdWorkspaces.count { it.type == Workspace.Type.SEARCHER } shouldBe 1
         repo.countedTabs() shouldBe WorkspaceRepo.FREE_TIER_WORKSPACE_LIMIT
+    }
+
+    // ==================== Anchored tab placement ====================
+
+    private suspend fun WorkspaceRepo.createTabAnchoredOn(
+        anchor: Workspace.Id?,
+        type: Workspace.Type = Workspace.Type.EXPLORER,
+    ): Workspace.Id {
+        val result = execute(
+            WorkspaceAction.Create(
+                type = type,
+                arguments = FakeArguments(type),
+                sourceWorkspaceId = anchor,
+            )
+        )
+        return (result as WorkspaceAction.Create.Result.Success).newId
+    }
+
+    private suspend fun WorkspaceRepo.createBatchFrom(
+        source: Workspace.Id?,
+        vararg requests: WorkspaceAction.Create,
+    ): WorkspaceAction.CreateBatch.Result.Success = execute(
+        WorkspaceAction.CreateBatch(requests = requests.toList(), sourceWorkspaceId = source)
+    ) as WorkspaceAction.CreateBatch.Result.Success
+
+    private fun WorkspaceAction.CreateBatch.Result.Success.idOf(request: WorkspaceAction.Create): Workspace.Id =
+        (results.getValue(request) as WorkspaceAction.CreateBatch.CreationResult.Success).workspaceId
+
+    /** Only the rows the tab strip shows, i.e. the list without anything stacked on a tab. */
+    private suspend fun WorkspaceRepo.tabIds(): List<Workspace.Id> =
+        state.first().infos.filter { !it.isSubWorkspace }.map { it.id }
+
+    @Test
+    fun `a tab created from another one lands directly right of it`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = true)
+        val first = repo.createTab()
+        val anchor = repo.createTab()
+        val last = repo.createTab()
+
+        val created = repo.createTabAnchoredOn(anchor)
+
+        repo.workspaceIds() shouldBe listOf(first, anchor, created, last)
+    }
+
+    @Test
+    fun `a tab created from the last tab is appended`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = true)
+        val first = repo.createTab()
+        val anchor = repo.createTab()
+
+        val created = repo.createTabAnchoredOn(anchor)
+
+        repo.workspaceIds() shouldBe listOf(first, anchor, created)
+    }
+
+    @Test
+    fun `a create without an origin is appended`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = true)
+        val first = repo.createTab()
+        val second = repo.createTab()
+
+        val created = repo.createTabAnchoredOn(null)
+
+        repo.workspaceIds() shouldBe listOf(first, second, created)
+    }
+
+    /** Limit recovery can close the very tab the create came from - that must not fail the create. */
+    @Test
+    fun `an anchor that is no longer open falls back to appending`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = true)
+        val first = repo.createTab()
+        val gone = repo.createTab()
+        val last = repo.createTab()
+        repo.execute(WorkspaceAction.Close(gone))
+
+        val created = repo.createTabAnchoredOn(gone)
+
+        repo.workspaceIds() shouldBe listOf(first, last, created)
+    }
+
+    @Test
+    fun `a create from a stacked sub-workspace anchors on the tab it sits on`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo(isPro = true)
+            val anchor = repo.createTab()
+            val last = repo.createTab()
+            val picker = repo.createSubWorkspace(caller = anchor)
+
+            val created = repo.createTabAnchoredOn(picker)
+
+            repo.tabIds() shouldBe listOf(anchor, created, last)
+        }
+
+    @Test
+    fun `the new tab goes behind the anchor's stacked children, not between them`() =
+        runTest(UnconfinedTestDispatcher()) {
+            listOf(true, false).forEach { anchorOnChild ->
+                val repo = createRepo(isPro = true)
+                val anchor = repo.createTab()
+                val child = repo.createSubWorkspace(caller = anchor)
+                val last = repo.createTab()
+
+                val created = repo.createTabAnchoredOn(if (anchorOnChild) child else anchor)
+
+                // Raw list order: the child sits directly behind its tab, so an anchorIndex + 1
+                // insert would wedge the new tab into the middle of the stack.
+                repo.workspaceIds() shouldBe listOf(anchor, child, created, last)
+            }
+        }
+
+    @Test
+    fun `a create that produces a sub-workspace is appended even with an origin`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo(isPro = true)
+            val anchor = repo.createTab()
+            val last = repo.createTab()
+
+            val result = repo.execute(
+                WorkspaceAction.Create(
+                    type = Workspace.Type.EXPLORER,
+                    arguments = FakePickerArguments(Workspace.Type.EXPLORER, anchor),
+                    sourceWorkspaceId = anchor,
+                )
+            )
+            val picker = (result as WorkspaceAction.Create.Result.Success).newId
+
+            repo.workspaceIds() shouldBe listOf(anchor, last, picker)
+        }
+
+    @Test
+    fun `a batch opens its tabs as one run in request order after the source`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo(isPro = true)
+            val first = repo.createTab()
+            val source = repo.createTab()
+            val last = repo.createTab()
+            val requests = listOf(
+                createReq(Workspace.Type.EXPLORER),
+                createReq(Workspace.Type.SEARCHER),
+                createReq(Workspace.Type.EDITOR),
+            )
+
+            val result = repo.createBatchFrom(source, *requests.toTypedArray())
+
+            repo.workspaceIds() shouldBe listOf(first, source) + requests.map { result.idOf(it) } + listOf(last)
+        }
+
+    @Test
+    fun `already-open and failing requests do not break up the run`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = true)
+        val source = repo.createTab()
+        val singleton = repo.createTab(type = Workspace.Type.DEVELOPER)
+        val last = repo.createTab()
+        val failingId = Workspace.Id()
+        createFailures[failingId] = IllegalStateException("Factory exploded")
+        val firstReq = createReq(Workspace.Type.EXPLORER)
+        val secondReq = createReq(Workspace.Type.SEARCHER)
+        val thirdReq = createReq(Workspace.Type.EDITOR)
+
+        val result = repo.createBatchFrom(
+            source,
+            firstReq,
+            // Resolves to the open DEVELOPER tab, so it creates nothing to anchor on
+            createReq(Workspace.Type.DEVELOPER),
+            secondReq,
+            createReq(Workspace.Type.APPS, id = failingId),
+            thirdReq,
+        )
+
+        repo.workspaceIds() shouldBe listOf(
+            source,
+            result.idOf(firstReq),
+            result.idOf(secondReq),
+            result.idOf(thirdReq),
+            singleton,
+            last,
+        )
+    }
+
+    @Test
+    fun `a sub-workspace or replace in the batch never takes the anchor`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = true)
+        val source = repo.createTab()
+        val replaced = repo.createTab()
+        val last = repo.createTab()
+        val firstReq = createReq(Workspace.Type.EXPLORER)
+        val secondReq = createReq(Workspace.Type.SEARCHER)
+        val pickerReq = WorkspaceAction.Create(
+            type = Workspace.Type.EXPLORER,
+            arguments = FakePickerArguments(Workspace.Type.EXPLORER, source),
+        )
+        val replaceReq = WorkspaceAction.Create(
+            type = Workspace.Type.EDITOR,
+            arguments = FakeArguments(Workspace.Type.EDITOR),
+            replace = replaced,
+        )
+
+        // secondReq trails both odd requests: where it lands is what proves neither took the anchor
+        val result = repo.createBatchFrom(source, firstReq, pickerReq, replaceReq, secondReq)
+
+        repo.workspaceIds() shouldBe listOf(
+            source,
+            result.idOf(firstReq),
+            result.idOf(secondReq),
+            // The morph keeps the slot of the tab it replaced, the picker stacks at the end
+            result.idOf(replaceReq),
+            last,
+            result.idOf(pickerReq),
+        )
+    }
+
+    @Test
+    fun `a batch that replaces its own source continues the run at the replacement`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo(isPro = true)
+            val source = repo.createTab()
+            val following = repo.createTab()
+            val replaceReq = WorkspaceAction.Create(
+                type = Workspace.Type.SEARCHER,
+                arguments = FakeArguments(Workspace.Type.SEARCHER),
+                replace = source,
+            )
+            val secondReq = createReq(Workspace.Type.EDITOR)
+
+            val result = repo.createBatchFrom(source, replaceReq, secondReq)
+
+            // The morph keeps the source's slot, so the rest of the batch has to follow the
+            // replacement - the source id it took over is no longer in the list to anchor on.
+            repo.workspaceIds() shouldBe listOf(result.idOf(replaceReq), result.idOf(secondReq), following)
+        }
+
+    @Test
+    fun `a tab recovered from the limit dialog lands next to the tab it came from`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo(isPro = false)
+            val ids = repo.fillWithReadyTabs()
+
+            repo.createRecoverable(type = Workspace.Type.SEARCHER, source = ids[1])
+            repo.resolveLimit(ids[0]).await()
+
+            val recovered = createdWorkspaces.single { it.type == Workspace.Type.SEARCHER }.id
+            repo.workspaceIds() shouldBe listOf(ids[1], recovered) + ids.drop(2)
+        }
+
+    @Test
+    fun `a tab recovered by closing its own origin is appended`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo(isPro = false)
+        val ids = repo.fillWithReadyTabs()
+
+        repo.createRecoverable(type = Workspace.Type.SEARCHER, source = ids[0])
+        repo.resolveLimit(ids[0]).await()
+
+        val recovered = createdWorkspaces.single { it.type == Workspace.Type.SEARCHER }.id
+        repo.workspaceIds() shouldBe ids.drop(1) + recovered
     }
 
     // ==================== Creation timestamps ====================

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceUndoCloseTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceUndoCloseTest.kt
@@ -177,8 +177,13 @@ class WorkspaceUndoCloseTest : BaseTest() {
     /** Lets the event collectors run without advancing virtual time past the undo window. */
     private fun settle() = scope.testScheduler.runCurrent()
 
-    private suspend fun createTab(type: Workspace.Type = Workspace.Type.EXPLORER): Workspace.Id {
-        val result = repo.execute(WorkspaceAction.Create(type = type, arguments = FakeArguments(type)))
+    private suspend fun createTab(
+        type: Workspace.Type = Workspace.Type.EXPLORER,
+        source: Workspace.Id? = null,
+    ): Workspace.Id {
+        val result = repo.execute(
+            WorkspaceAction.Create(type = type, arguments = FakeArguments(type), sourceWorkspaceId = source)
+        )
         settle()
         return (result as WorkspaceAction.Create.Result.Success).newId
     }
@@ -222,6 +227,25 @@ class WorkspaceUndoCloseTest : BaseTest() {
         openIds() shouldBe listOf(first, closed, last)
         stash.feedback.value shouldBe null
     }
+
+    /**
+     * Undo keeps deciding placement from the neighbours it captured, not from where a create would
+     * have put the tab. The order has to be built by anchored creates up front: any create after the
+     * close is a foreign mutation that drops the entry, so "close, create, undo" can never test this.
+     */
+    @Test
+    fun `an undone close ignores where a create would have placed the tab`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val first = createTab()
+            val closed = createTab(source = first)
+            val last = createTab(source = closed)
+            openIds() shouldBe listOf(first, closed, last)
+
+            closeUndoable(closed)
+            undo().shouldBeInstanceOf<WorkspaceAction.UndoClose.Result.Success>()
+
+            openIds() shouldBe listOf(first, closed, last)
+        }
 
     @Test
     fun `the restored tab holds the arguments it was closed with`() = runTest(UnconfinedTestDispatcher()) {


### PR DESCRIPTION
## What changed

New tabs were always added to the end of the tab list, however far that was from whatever you were working on. They now open directly to the right of the tab they came from, so a tab you open while reading another one stays next to it.

This covers the Butler button, which anchors on the tab you currently have open, and every other place that opens a tab from somewhere: opening a file in the editor, drilling into a folder, and the equivalents in Searcher, Viewer and Apps. Selecting several files and choosing "Open in new tabs" keeps them together as one run in selection order, right after the folder they came from.

Places with no origin are unchanged and still add at the end: restoring a session, and the tab manager's "Add tab".

On multi-pane layouts the Butler button's new tab now also prefers a pane next to the one you are in, rather than the first empty pane. That is the rule every other origin-carrying tab already followed.

## Technical Context

- `WorkspaceAction.Create.sourceWorkspaceId` already existed as a pane placement hint and is now the tab-order anchor too. Its KDoc carries the full contract. Nothing new was added to the action surface.
- Insertion goes before the next *tab* following the anchor, not at `anchorIndex + 1`. Sub-workspaces are appended when created, so an ownership unit's members are not contiguous in the list, and the anchor's own stacked children sit directly behind it. `tabInsertionIndexAfter` also resolves the anchor to its ownership root, so a create invoked from a modal anchors on the tab that modal sits on.
- Only tabs are repositioned. A create producing a sub-workspace still appends (its position is stacking order, not tab order) and a replace still inherits the slot it took over, so undo-close keeps deciding placement from the neighbours it captured rather than from where a create would have put the tab.
- `CreateBatch` walks the anchor along the tabs it opens. It advances only onto a committed root tab and only immediately after `create()` returns rather than at the `Success` assignment, so a cancellation in between cannot strand it behind a tab already in the list. The one replace that does move it is the one that took the anchor's own slot, since the replaced id is then gone from the list.
- The Butler button samples the focused id synchronously at the tap. `ViewModel2.launch` dispatches onto `Default`, so reading it inside the coroutine would anchor the tab to wherever the user had navigated by the time it ran. `WorkspaceButtonViewModelTest` pins this with a queued-dispatcher test.
- Worth a close look: the batch anchor walk in `executeBatchCreation` across its `AlreadyOpen`, factory-failure and free-tier-filter branches, and `tabInsertionIndexAfter`'s behaviour when the anchor is the last tab or no longer open (both append).
