### PR TITLE
General: Show how many items a drag is carrying

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/ExplorerItemRenderer.kt
@@ -64,7 +64,14 @@ fun ExplorerItemRenderer(
 
     // The long press arms the drag while the pointer is still down, which is what the platform needs
     // to pick up the drag. A null payload means no drag.
-    val dragSource = dragPayloadFactory?.let { factory -> rememberWorkspaceDragSource { factory(item) } }
+    val dragSource = dragPayloadFactory?.let { factory ->
+        rememberWorkspaceDragSource(
+            cornerRadius = when (viewStyle) {
+                is ExplorerViewStyle.List -> 8.dp
+                is ExplorerViewStyle.Grid -> 4.dp
+            },
+        ) { factory(item) }
+    }
 
     Box(
         modifier = focusModifier

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -381,7 +381,7 @@ fun SearcherWorkspacePage(
                                 when (item) {
                                     is SearchListItem.Result -> {
                                         val dragSource = if (dragsToOtherPanes) {
-                                            rememberWorkspaceDragSource {
+                                            rememberWorkspaceDragSource(cornerRadius = 8.dp) {
                                                 SearcherDragPayloadFactory.build(
                                                     currentState,
                                                     workspaceId,
@@ -514,7 +514,7 @@ fun SearcherWorkspacePage(
                                 contentType = { "result" },
                             ) { item ->
                                 val dragSource = if (dragsToOtherPanes) {
-                                    rememberWorkspaceDragSource {
+                                    rememberWorkspaceDragSource(cornerRadius = 4.dp) {
                                         SearcherDragPayloadFactory.build(
                                             currentState,
                                             workspaceId,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.workspace.ui.dnd
 
 import android.content.ClipData
+import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -43,11 +44,13 @@ import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
 
 /**
  * The payload rides along as [DragAndDropTransferData.localState], the ClipData only carries a
- * label plus an item count so a drag leaving the app can't expose any path.
+ * label plus an item count so a drag leaving the app can't expose any path. The transfer asks for an
+ * opaque shadow so nothing behind the drag decoration shows through it.
  */
 fun WorkspaceDragPayload.toTransferData(): DragAndDropTransferData = DragAndDropTransferData(
     clipData = ClipData.newPlainText(WorkspaceDragPayload.CLIP_LABEL, "${items.size}"),
     localState = this,
+    flags = View.DRAG_FLAG_OPAQUE,
 )
 
 fun DragAndDropEvent.workspaceDragPayload(): WorkspaceDragPayload? =

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.draw.DrawResult
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
@@ -33,6 +32,7 @@ import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
@@ -69,6 +69,8 @@ fun DragAndDropEvent.positionInRoot(): Offset = toAndroidDragEvent().let { Offse
  * [startDrag] from its long-click callback.
  */
 class WorkspaceDragSource internal constructor(
+    internal val decorationProvider: () -> WorkspaceDragDecoration? = { null },
+    internal val cornerRadius: Dp = CARD_CORNER_DEFAULT,
     internal val payloadProvider: () -> WorkspaceDragPayload?,
 ) {
 
@@ -88,11 +90,24 @@ class WorkspaceDragSource internal constructor(
 /**
  * Remembers a [WorkspaceDragSource] whose payload is resolved when the drag actually starts, so it
  * always reflects the latest state the caller has collected.
+ *
+ * [cornerRadius] is the radius of the composable the drag starts from, so the shadow's card matches
+ * the shape the user long-pressed.
  */
 @Composable
-fun rememberWorkspaceDragSource(payloadProvider: () -> WorkspaceDragPayload?): WorkspaceDragSource {
+fun rememberWorkspaceDragSource(
+    cornerRadius: Dp = CARD_CORNER_DEFAULT,
+    payloadProvider: () -> WorkspaceDragPayload?,
+): WorkspaceDragSource {
     val currentProvider by rememberUpdatedState(payloadProvider)
-    return remember { WorkspaceDragSource { currentProvider() } }
+    val currentDecoration by rememberUpdatedState(rememberWorkspaceDragDecoration())
+    return remember(cornerRadius) {
+        WorkspaceDragSource(
+            decorationProvider = { currentDecoration },
+            cornerRadius = cornerRadius,
+            payloadProvider = { currentProvider() },
+        )
+    }
 }
 
 private class WorkspaceDragSourceElement(
@@ -121,14 +136,21 @@ internal class WorkspaceDragSourceNode(
 
     private val dragAndDropNode = delegate(
         DragAndDropSourceModifierNode {
-            val payload = source.payloadProvider()
-            if (payload != null) {
-                startDragAndDropTransfer(
-                    transferData = payload.toTransferData(),
-                    decorationSize = size.toSize(),
-                    drawDragDecoration = { dragShadow.drawDragShadow(this) },
-                )
-            }
+            val payload = source.payloadProvider() ?: return@DragAndDropSourceModifierNode
+            val spec = dragDecorationSpec(payload.items) ?: return@DragAndDropSourceModifierNode
+            val decoration = source.decorationProvider()
+            val cornerRadius = source.cornerRadius
+            startDragAndDropTransfer(
+                transferData = payload.toTransferData(),
+                decorationSize = decoration?.decorationSize(spec, size.toSize(), cornerRadius) ?: size.toSize(),
+                drawDragDecoration = {
+                    if (decoration != null) {
+                        decoration.draw(this, spec, cornerRadius, dragShadow.layer)
+                    } else {
+                        dragShadow.layer?.let { drawLayer(it) }
+                    }
+                },
+            )
         }
     )
 
@@ -173,12 +195,8 @@ internal class WorkspaceDragSourceNode(
  */
 private class DragShadowCallback {
 
-    private var layer: GraphicsLayer? = null
-
-    fun drawDragShadow(scope: DrawScope) {
-        val recorded = layer ?: return
-        with(scope) { drawLayer(recorded) }
-    }
+    internal var layer: GraphicsLayer? = null
+        private set
 
     fun cachePicture(scope: CacheDrawScope): DrawResult = with(scope) {
         val recorded = obtainGraphicsLayer().apply { record { drawContent() } }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragAndDrop.kt
@@ -140,12 +140,13 @@ internal class WorkspaceDragSourceNode(
             val spec = dragDecorationSpec(payload.items) ?: return@DragAndDropSourceModifierNode
             val decoration = source.decorationProvider()
             val cornerRadius = source.cornerRadius
+            val prepared = decoration?.prepare(spec, size.toSize(), cornerRadius)
             startDragAndDropTransfer(
                 transferData = payload.toTransferData(),
-                decorationSize = decoration?.decorationSize(spec, size.toSize(), cornerRadius) ?: size.toSize(),
+                decorationSize = prepared?.layout?.size ?: size.toSize(),
                 drawDragDecoration = {
-                    if (decoration != null) {
-                        decoration.draw(this, spec, cornerRadius, dragShadow.layer)
+                    if (decoration != null && prepared != null) {
+                        decoration.draw(this, prepared, cornerRadius, dragShadow.layer)
                     } else {
                         dragShadow.layer?.let { drawLayer(it) }
                     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragDecoration.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragDecoration.kt
@@ -1,0 +1,370 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import android.content.res.Resources
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Layers
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.common.R as CommonR
+
+internal val STACK_OFFSET = 6.dp
+internal val CARD_CORNER_DEFAULT = 8.dp
+internal val SUMMARY_MAX_WIDTH = 280.dp
+internal val SUMMARY_PADDING = 16.dp
+internal val SUMMARY_PADDING_VERTICAL = 12.dp
+internal val SUMMARY_ICON = 24.dp
+internal val SUMMARY_GAP = 12.dp
+
+private val PLATE_BORDER = 1.dp
+private const val STACK_MAX_ITEMS = 3
+
+/** What the drag shadow shows: the dragged item itself, a stack of cards, or a counted summary. */
+internal sealed interface DragDecorationSpec {
+    data object Single : DragDecorationSpec
+    data class Stack(val depth: Int) : DragDecorationSpec
+    data class Summary(val total: Int, val folders: Int, val files: Int) : DragDecorationSpec
+}
+
+internal fun dragDecorationSpec(items: List<WorkspaceDragPayload.Item>): DragDecorationSpec? = when {
+    items.isEmpty() -> null
+    items.size == 1 -> DragDecorationSpec.Single
+    items.size <= STACK_MAX_ITEMS -> DragDecorationSpec.Stack(items.size)
+    else -> {
+        val folders = items.count { it.kind == WorkspaceDragPayload.Kind.DIRECTORY }
+        DragDecorationSpec.Summary(
+            total = items.size,
+            folders = folders,
+            files = items.size - folders,
+        )
+    }
+}
+
+internal data class DecorationLayout(
+    val size: Size,
+    /** Back to front, so the last one is the card the dragged content goes on. */
+    val plates: List<Rect>,
+    val iconBounds: Rect?,
+    val countOffset: Offset?,
+    val breakdownOffset: Offset?,
+)
+
+internal fun decorationLayout(
+    spec: DragDecorationSpec,
+    sourceSize: Size,
+    density: Density,
+    layoutDirection: LayoutDirection,
+    countSize: IntSize,
+    breakdownSize: IntSize?,
+): DecorationLayout {
+    val isRtl = layoutDirection == LayoutDirection.Rtl
+    return when (spec) {
+        is DragDecorationSpec.Single -> DecorationLayout(
+            size = sourceSize,
+            plates = listOf(Rect(Offset.Zero, sourceSize)),
+            iconBounds = null,
+            countOffset = null,
+            breakdownOffset = null,
+        )
+
+        is DragDecorationSpec.Stack -> {
+            val step = with(density) { STACK_OFFSET.toPx() }
+            val span = step * (spec.depth - 1)
+            val size = Size(sourceSize.width + span, sourceSize.height + span)
+            // The front card sits at the top, the ones behind it fan out toward the end edge.
+            val plates = (spec.depth - 1 downTo 0).map { depth ->
+                val left = if (isRtl) span - depth * step else depth * step
+                Rect(Offset(left, depth * step), sourceSize)
+            }
+            DecorationLayout(
+                size = size,
+                plates = plates,
+                iconBounds = null,
+                countOffset = null,
+                breakdownOffset = null,
+            )
+        }
+
+        is DragDecorationSpec.Summary -> {
+            val padding = with(density) { SUMMARY_PADDING.toPx() }
+            val paddingVertical = with(density) { SUMMARY_PADDING_VERTICAL.toPx() }
+            val icon = with(density) { SUMMARY_ICON.toPx() }
+            val gap = with(density) { SUMMARY_GAP.toPx() }
+            val maxWidth = with(density) { SUMMARY_MAX_WIDTH.toPx() }
+            val textWidth = maxOf(countSize.width, breakdownSize?.width ?: 0).toFloat()
+            val textHeight = (countSize.height + (breakdownSize?.height ?: 0)).toFloat()
+            val width = (padding * 2 + icon + gap + textWidth).coerceAtMost(maxWidth)
+            val height = paddingVertical * 2 + maxOf(icon, textHeight)
+            val iconLeft = if (isRtl) width - padding - icon else padding
+            val textEdge = if (isRtl) width - padding - icon - gap else padding + icon + gap
+            val countLeft = if (isRtl) textEdge - countSize.width else textEdge
+            val breakdownLeft = if (isRtl) textEdge - (breakdownSize?.width ?: 0) else textEdge
+            val textTop = (height - textHeight) / 2
+            DecorationLayout(
+                size = Size(width, height),
+                plates = listOf(Rect(Offset.Zero, Size(width, height))),
+                iconBounds = Rect(Offset(iconLeft, (height - icon) / 2), Size(icon, icon)),
+                countOffset = Offset(countLeft, textTop),
+                breakdownOffset = breakdownSize?.let { Offset(breakdownLeft, textTop + countSize.height) },
+            )
+        }
+    }
+}
+
+internal data class SummaryLabels(val count: String, val breakdown: String)
+
+/**
+ * Draws the drag shadow. Built in composition so theme, density and resources are available, but
+ * invoked later from the drag source's modifier node, on a canvas the platform owns.
+ */
+internal class WorkspaceDragDecoration(
+    private val textMeasurer: TextMeasurer,
+    private val density: Density,
+    private val layoutDirection: LayoutDirection,
+    private val countStyle: TextStyle,
+    private val breakdownStyle: TextStyle,
+    private val containerColor: Color,
+    private val outlineColor: Color,
+    private val icon: Painter,
+    private val iconTint: Color,
+    private val labels: (DragDecorationSpec.Summary) -> SummaryLabels,
+) {
+
+    private class SummaryText(val count: TextLayoutResult, val breakdown: TextLayoutResult)
+
+    fun decorationSize(spec: DragDecorationSpec, sourceSize: Size, cornerRadius: Dp): Size =
+        layout(spec, sourceSize, summaryText(spec)).size
+
+    fun draw(scope: DrawScope, spec: DragDecorationSpec, cornerRadius: Dp, recorded: GraphicsLayer?) = with(scope) {
+        val text = summaryText(spec)
+        val layout = layout(spec, sourceSize(spec, size), text)
+        val radius = CornerRadius(with(density) { cornerRadius.toPx() })
+        val border = Stroke(width = with(density) { PLATE_BORDER.toPx() })
+        val content = recorded?.takeIf { spec !is DragDecorationSpec.Summary }
+
+        layout.plates.forEachIndexed { index, plate ->
+            drawRoundRect(
+                color = containerColor,
+                topLeft = plate.topLeft,
+                size = plate.size,
+                cornerRadius = radius,
+            )
+            if (content != null && index == layout.plates.lastIndex) {
+                val clip = Path().apply { addRoundRect(RoundRect(plate, radius)) }
+                clipPath(clip) {
+                    translate(plate.left, plate.top) { drawLayer(content) }
+                }
+            }
+            drawRoundRect(
+                color = outlineColor,
+                topLeft = plate.topLeft,
+                size = plate.size,
+                cornerRadius = radius,
+                style = border,
+            )
+        }
+
+        if (text != null) {
+            layout.iconBounds?.let { bounds ->
+                translate(bounds.left, bounds.top) {
+                    with(icon) { draw(size = bounds.size, colorFilter = ColorFilter.tint(iconTint)) }
+                }
+            }
+            layout.countOffset?.let { drawText(text.count, topLeft = it) }
+            layout.breakdownOffset?.let { drawText(text.breakdown, topLeft = it) }
+        }
+    }
+
+    private fun layout(spec: DragDecorationSpec, sourceSize: Size, text: SummaryText?) = decorationLayout(
+        spec = spec,
+        sourceSize = sourceSize,
+        density = density,
+        layoutDirection = layoutDirection,
+        countSize = text?.count?.size ?: IntSize.Zero,
+        breakdownSize = text?.breakdown?.size,
+    )
+
+    /** The canvas is sized for the whole decoration, so the stack fan has to be taken back off. */
+    private fun sourceSize(spec: DragDecorationSpec, decorationSize: Size): Size {
+        if (spec !is DragDecorationSpec.Stack) return decorationSize
+        val span = with(density) { STACK_OFFSET.toPx() } * (spec.depth - 1)
+        return Size(decorationSize.width - span, decorationSize.height - span)
+    }
+
+    private fun summaryText(spec: DragDecorationSpec): SummaryText? {
+        if (spec !is DragDecorationSpec.Summary) return null
+        val labels = labels(spec)
+        return SummaryText(
+            count = measureLine(labels.count, countStyle),
+            breakdown = measureLine(labels.breakdown, breakdownStyle),
+        )
+    }
+
+    /** Measured against the same budget it is drawn in, so an overlong line ellipsises instead of clipping. */
+    private fun measureLine(text: String, style: TextStyle): TextLayoutResult = textMeasurer.measure(
+        text = text,
+        style = style,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        constraints = Constraints(maxWidth = textBudget),
+        layoutDirection = layoutDirection,
+        density = density,
+    )
+
+    private val textBudget: Int
+        get() = with(density) {
+            (SUMMARY_MAX_WIDTH - SUMMARY_PADDING * 2 - SUMMARY_ICON - SUMMARY_GAP).roundToPx()
+        }
+}
+
+@Composable
+internal fun rememberWorkspaceDragDecoration(): WorkspaceDragDecoration {
+    val textMeasurer = rememberTextMeasurer()
+    val icon = rememberVectorPainter(Icons.TwoTone.Layers)
+    val colorScheme = MaterialTheme.colorScheme
+    val typography = MaterialTheme.typography
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val configuration = LocalConfiguration.current
+    val resources = LocalContext.current.resources
+    return remember(colorScheme, typography, density, layoutDirection, configuration) {
+        WorkspaceDragDecoration(
+            textMeasurer = textMeasurer,
+            density = density,
+            layoutDirection = layoutDirection,
+            countStyle = typography.titleSmall.copy(color = colorScheme.onSurface),
+            breakdownStyle = typography.bodySmall.copy(color = colorScheme.onSurfaceVariant),
+            containerColor = colorScheme.surfaceContainerHighest,
+            outlineColor = colorScheme.outlineVariant,
+            icon = icon,
+            iconTint = colorScheme.primary,
+            labels = { spec -> summaryLabels(resources, spec) },
+        )
+    }
+}
+
+private fun summaryLabels(resources: Resources, spec: DragDecorationSpec.Summary): SummaryLabels {
+    val folders = resources.getQuantityString(CommonR.plurals.common_folders_count, spec.folders, spec.folders)
+    val files = resources.getQuantityString(CommonR.plurals.common_files_count, spec.files, spec.files)
+    return SummaryLabels(
+        count = resources.getQuantityString(R.plurals.workspace_drag_decoration_items, spec.total, spec.total),
+        breakdown = when {
+            spec.folders > 0 && spec.files > 0 -> {
+                resources.getString(R.string.workspace_drag_decoration_breakdown, folders, files)
+            }
+            spec.files > 0 -> files
+            else -> folders
+        },
+    )
+}
+
+@Composable
+private fun DragDecorationCanvas(
+    modifier: Modifier = Modifier,
+    spec: DragDecorationSpec,
+    sourceSize: DpSize = DpSize(220.dp, 56.dp),
+    cornerRadius: Dp = CARD_CORNER_DEFAULT,
+) {
+    val decoration = rememberWorkspaceDragDecoration()
+    val density = LocalDensity.current
+    val size = with(density) {
+        decoration.decorationSize(spec, sourceSize.toSize(), cornerRadius).toDpSize()
+    }
+    Canvas(modifier = modifier.size(size)) {
+        decoration.draw(this, spec, cornerRadius, null)
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DragDecorationStackPreview() {
+    PreviewWrapper {
+        DragDecorationCanvas(
+            modifier = Modifier.padding(16.dp),
+            spec = DragDecorationSpec.Stack(depth = 3),
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DragDecorationSummaryMixedPreview() {
+    PreviewWrapper {
+        DragDecorationCanvas(
+            modifier = Modifier.padding(16.dp),
+            spec = DragDecorationSpec.Summary(total = 12, folders = 4, files = 8),
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DragDecorationSummaryFoldersPreview() {
+    PreviewWrapper {
+        DragDecorationCanvas(
+            modifier = Modifier.padding(16.dp),
+            spec = DragDecorationSpec.Summary(total = 5, folders = 5, files = 0),
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DragDecorationSummaryRtlPreview() {
+    PreviewWrapper {
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+            DragDecorationCanvas(
+                modifier = Modifier.padding(16.dp),
+                spec = DragDecorationSpec.Summary(total = 12, folders = 4, files = 8),
+            )
+        }
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragDecoration.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragDecoration.kt
@@ -157,6 +157,15 @@ internal fun decorationLayout(
 
 internal data class SummaryLabels(val count: String, val breakdown: String)
 
+internal class SummaryText(val count: TextLayoutResult, val breakdown: TextLayoutResult)
+
+/** A decoration measured for one drag: what the shadow shows, where it goes, and the text it carries. */
+internal class PreparedDragDecoration(
+    val spec: DragDecorationSpec,
+    val layout: DecorationLayout,
+    val text: SummaryText?,
+)
+
 /**
  * Draws the drag shadow. Built in composition so theme, density and resources are available, but
  * invoked later from the drag source's modifier node, on a canvas the platform owns.
@@ -174,17 +183,34 @@ internal class WorkspaceDragDecoration(
     private val labels: (DragDecorationSpec.Summary) -> SummaryLabels,
 ) {
 
-    private class SummaryText(val count: TextLayoutResult, val breakdown: TextLayoutResult)
-
-    fun decorationSize(spec: DragDecorationSpec, sourceSize: Size, cornerRadius: Dp): Size =
-        layout(spec, sourceSize, summaryText(spec)).size
-
-    fun draw(scope: DrawScope, spec: DragDecorationSpec, cornerRadius: Dp, recorded: GraphicsLayer?) = with(scope) {
+    /** Measures the decoration once, so the size the platform is told matches what [draw] puts on the canvas. */
+    fun prepare(spec: DragDecorationSpec, sourceSize: Size, cornerRadius: Dp): PreparedDragDecoration {
         val text = summaryText(spec)
-        val layout = layout(spec, sourceSize(spec, size), text)
+        return PreparedDragDecoration(
+            spec = spec,
+            layout = decorationLayout(
+                spec = spec,
+                sourceSize = sourceSize,
+                density = density,
+                layoutDirection = layoutDirection,
+                countSize = text?.count?.size ?: IntSize.Zero,
+                breakdownSize = text?.breakdown?.size,
+            ),
+            text = text,
+        )
+    }
+
+    fun draw(
+        scope: DrawScope,
+        prepared: PreparedDragDecoration,
+        cornerRadius: Dp,
+        recorded: GraphicsLayer?,
+    ) = with(scope) {
+        val text = prepared.text
+        val layout = prepared.layout
         val radius = CornerRadius(with(density) { cornerRadius.toPx() })
         val border = Stroke(width = with(density) { PLATE_BORDER.toPx() })
-        val content = recorded?.takeIf { spec !is DragDecorationSpec.Summary }
+        val content = recorded?.takeIf { prepared.spec !is DragDecorationSpec.Summary }
 
         layout.plates.forEachIndexed { index, plate ->
             drawRoundRect(
@@ -217,22 +243,6 @@ internal class WorkspaceDragDecoration(
             layout.countOffset?.let { drawText(text.count, topLeft = it) }
             layout.breakdownOffset?.let { drawText(text.breakdown, topLeft = it) }
         }
-    }
-
-    private fun layout(spec: DragDecorationSpec, sourceSize: Size, text: SummaryText?) = decorationLayout(
-        spec = spec,
-        sourceSize = sourceSize,
-        density = density,
-        layoutDirection = layoutDirection,
-        countSize = text?.count?.size ?: IntSize.Zero,
-        breakdownSize = text?.breakdown?.size,
-    )
-
-    /** The canvas is sized for the whole decoration, so the stack fan has to be taken back off. */
-    private fun sourceSize(spec: DragDecorationSpec, decorationSize: Size): Size {
-        if (spec !is DragDecorationSpec.Stack) return decorationSize
-        val span = with(density) { STACK_OFFSET.toPx() } * (spec.depth - 1)
-        return Size(decorationSize.width - span, decorationSize.height - span)
     }
 
     private fun summaryText(spec: DragDecorationSpec): SummaryText? {
@@ -311,11 +321,10 @@ private fun DragDecorationCanvas(
 ) {
     val decoration = rememberWorkspaceDragDecoration()
     val density = LocalDensity.current
-    val size = with(density) {
-        decoration.decorationSize(spec, sourceSize.toSize(), cornerRadius).toDpSize()
-    }
+    val prepared = with(density) { decoration.prepare(spec, sourceSize.toSize(), cornerRadius) }
+    val size = with(density) { prepared.layout.size.toDpSize() }
     Canvas(modifier = modifier.size(size)) {
-        decoration.draw(this, spec, cornerRadius, null)
+        decoration.draw(this, prepared, cornerRadius, null)
     }
 }
 

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -418,6 +418,13 @@
     <string name="workspace_limit_stacked_content_desc">Closing this tab also closes what is stacked on it</string>
     <string name="workspace_limit_pro_description">Open as many tabs as you like.</string>
 
+    <!-- Drag and drop -->
+    <plurals name="workspace_drag_decoration_items">
+        <item quantity="one">%1$d item</item>
+        <item quantity="other">%1$d items</item>
+    </plurals>
+    <string name="workspace_drag_decoration_breakdown">%1$s, %2$s</string>
+
     <!-- Restore operation -->
     <string name="workspace_operation_restore_title">Trash restore</string>
     <plurals name="workspace_operation_restore_description">

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DragTransferFlagsTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/DragTransferFlagsTest.kt
@@ -1,0 +1,35 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import android.view.View
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+// Robolectric: DragAndDropTransferData wraps a ClipData, which needs the Android runtime.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class, sdk = [34])
+class DragTransferFlagsTest : BaseTest() {
+
+    @Test
+    fun `the transfer asks for an opaque drag shadow`() {
+        val payload = WorkspaceDragPayload(
+            sourceWorkspaceId = Workspace.Id(),
+            items = listOf(
+                WorkspaceDragPayload.Item(
+                    path = LocalPath.build("/storage/emulated/0/one.txt"),
+                    kind = WorkspaceDragPayload.Kind.FILE_OTHER,
+                ),
+            ),
+            allowMove = true,
+        )
+
+        (payload.toTransferData().flags and View.DRAG_FLAG_OPAQUE) shouldBe View.DRAG_FLAG_OPAQUE
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragDecorationTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragDecorationTest.kt
@@ -1,0 +1,170 @@
+package eu.darken.butler.workspace.ui.dnd
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class WorkspaceDragDecorationTest : BaseTest() {
+
+    private val density = Density(density = 2f, fontScale = 1f)
+    private val sourceSize = Size(400f, 120f)
+
+    private fun dir(path: String) = WorkspaceDragPayload.Item(
+        path = LocalPath.build(path),
+        kind = WorkspaceDragPayload.Kind.DIRECTORY,
+    )
+
+    private fun file(path: String) = WorkspaceDragPayload.Item(
+        path = LocalPath.build(path),
+        kind = WorkspaceDragPayload.Kind.FILE_OTHER,
+    )
+
+    private fun textFile(path: String) = WorkspaceDragPayload.Item(
+        path = LocalPath.build(path),
+        kind = WorkspaceDragPayload.Kind.FILE_TEXT,
+    )
+
+    private fun items(count: Int) = (1..count).map { file("/storage/emulated/0/file-$it") }
+
+    private fun layout(
+        spec: DragDecorationSpec,
+        density: Density = this.density,
+        layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+        countSize: IntSize = IntSize(120, 40),
+        breakdownSize: IntSize? = IntSize(90, 32),
+    ) = decorationLayout(
+        spec = spec,
+        sourceSize = sourceSize,
+        density = density,
+        layoutDirection = layoutDirection,
+        countSize = countSize,
+        breakdownSize = breakdownSize,
+    )
+
+    @Test
+    fun `an empty selection has nothing to draw`() {
+        dragDecorationSpec(emptyList()) shouldBe null
+    }
+
+    @Test
+    fun `a single item drags as itself`() {
+        dragDecorationSpec(items(1)) shouldBe DragDecorationSpec.Single
+    }
+
+    @Test
+    fun `two or three items drag as a stack`() {
+        dragDecorationSpec(items(2)) shouldBe DragDecorationSpec.Stack(2)
+        dragDecorationSpec(items(3)) shouldBe DragDecorationSpec.Stack(3)
+    }
+
+    @Test
+    fun `four or more items drag as a summary`() {
+        dragDecorationSpec(items(4)) shouldBe DragDecorationSpec.Summary(total = 4, folders = 0, files = 4)
+        dragDecorationSpec(items(5)) shouldBe DragDecorationSpec.Summary(total = 5, folders = 0, files = 5)
+        dragDecorationSpec(items(20)) shouldBe DragDecorationSpec.Summary(total = 20, folders = 0, files = 20)
+    }
+
+    @Test
+    fun `the summary counts folders apart from files`() {
+        dragDecorationSpec(
+            listOf(dir("/a"), dir("/b"), dir("/c"), dir("/d")),
+        ) shouldBe DragDecorationSpec.Summary(total = 4, folders = 4, files = 0)
+
+        dragDecorationSpec(
+            listOf(dir("/a"), dir("/b"), file("/c.jpg"), textFile("/d.txt")),
+        ) shouldBe DragDecorationSpec.Summary(total = 4, folders = 2, files = 2)
+    }
+
+    @Test
+    fun `both file kinds count as files`() {
+        dragDecorationSpec(
+            listOf(textFile("/a.txt"), textFile("/b.txt"), file("/c.jpg"), file("/d.jpg")),
+        ) shouldBe DragDecorationSpec.Summary(total = 4, folders = 0, files = 4)
+    }
+
+    @Test
+    fun `a single item decoration is the size of the dragged item`() {
+        val layout = layout(DragDecorationSpec.Single)
+        layout.size shouldBe sourceSize
+        layout.plates.size shouldBe 1
+    }
+
+    @Test
+    fun `the stack grows by one offset per extra card`() {
+        val step = with(density) { STACK_OFFSET.toPx() }
+
+        val two = layout(DragDecorationSpec.Stack(2))
+        two.plates.size shouldBe 2
+        two.size shouldBe Size(sourceSize.width + step, sourceSize.height + step)
+
+        val three = layout(DragDecorationSpec.Stack(3))
+        three.plates.size shouldBe 3
+        three.size shouldBe Size(sourceSize.width + step * 2, sourceSize.height + step * 2)
+    }
+
+    @Test
+    fun `the summary width is capped`() {
+        val capped = layout(
+            spec = DragDecorationSpec.Summary(total = 12, folders = 4, files = 8),
+            countSize = IntSize(4000, 40),
+        )
+        capped.size.width shouldBe with(density) { SUMMARY_MAX_WIDTH.toPx() }
+    }
+
+    @Test
+    fun `the summary grows with the font scale`() {
+        val spec = DragDecorationSpec.Summary(total = 12, folders = 4, files = 8)
+        val normal = Density(density = 2f, fontScale = 1f)
+        val scaled = Density(density = 2f, fontScale = 2f)
+
+        fun heightAt(density: Density): Float {
+            val line = IntSize(
+                width = with(density) { 100.dp.roundToPx() },
+                height = with(density) { 20.sp.roundToPx() },
+            )
+            return layout(spec, density = density, countSize = line, breakdownSize = line).size.height
+        }
+
+        heightAt(scaled) shouldBeGreaterThan heightAt(normal)
+    }
+
+    @Test
+    fun `right to left mirrors the summary icon to the end edge`() {
+        val spec = DragDecorationSpec.Summary(total = 12, folders = 4, files = 8)
+        val padding = with(density) { SUMMARY_PADDING.toPx() }
+        val icon = with(density) { SUMMARY_ICON.toPx() }
+        val gap = with(density) { SUMMARY_GAP.toPx() }
+        val countSize = IntSize(120, 40)
+
+        val ltr = layout(spec, countSize = countSize)
+        ltr.iconBounds!!.left shouldBe padding
+        ltr.countOffset!!.x shouldBe padding + icon + gap
+
+        val rtl = layout(spec, layoutDirection = LayoutDirection.Rtl, countSize = countSize)
+        rtl.iconBounds!!.left shouldBe rtl.size.width - padding - icon
+        rtl.countOffset!!.x shouldBe rtl.size.width - padding - icon - gap - countSize.width
+    }
+
+    @Test
+    fun `right to left fans the stack toward the start edge`() {
+        val step = with(density) { STACK_OFFSET.toPx() }
+        val spec = DragDecorationSpec.Stack(3)
+
+        val ltr = layout(spec)
+        ltr.plates.first().left shouldBe step * 2
+        ltr.plates.last().left shouldBe 0f
+
+        val rtl = layout(spec, layoutDirection = LayoutDirection.Rtl)
+        rtl.plates.first().left shouldBe 0f
+        rtl.plates.last().left shouldBe step * 2
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragSourceTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/dnd/WorkspaceDragSourceTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
+import eu.darken.butler.workspace.core.Workspace
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
@@ -57,6 +59,40 @@ class WorkspaceDragSourceTest : ComposeTest() {
         source.startDrag()
 
         payloadRequests shouldBe 0
+    }
+
+    @Test
+    fun `starting a drag with an empty payload is a no-op`() {
+        var decorationRequests = 0
+        val source = WorkspaceDragSource(
+            decorationProvider = {
+                decorationRequests++
+                null
+            },
+        ) {
+            WorkspaceDragPayload(
+                sourceWorkspaceId = Workspace.Id(),
+                items = emptyList(),
+                allowMove = true,
+            )
+        }
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .testTag(TAG)
+                        .then(source.modifier),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(TAG).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { source.startDrag() }
+
+        composeTestRule.runOnIdle { decorationRequests shouldBe 0 }
     }
 
     companion object {


### PR DESCRIPTION
## What changed

Dragging several selected files used to look exactly like dragging one: only the row you long-pressed followed your finger, so there was no way to tell a 12-file drag from a 1-file drag while it was in flight.

Now the drag shadow shows what it is carrying:

- One item drags as a single card showing that row.
- Two or three items drag as a small fanned stack of cards.
- Four or more drag as a summary card with a count and a breakdown, for example "12 items" over "4 folders, 8 files". A selection that is all one kind just reads "5 folders" rather than padding out a zero.

The shadow is also solid now instead of translucent, so whatever it passes over no longer shows through it. This applies to all four places a drag can start: the Explorer's list and grid, and the Searcher's list and grid, with the card matching the shape of the item you pressed.

## Technical Context

- A stack is offset copies of the pressed row, not one thumbnail per selected item. Selected rows scrolled out of view are not composed in a lazy list, so no recorded layer exists for them; per-item thumbnails are not obtainable for an arbitrary selection. The thresholds were chosen with that constraint in mind.
- The transfer now sets `View.DRAG_FLAG_OPAQUE`. Without it the platform composites the drag shadow surface translucently, which defeats the card's opaque plate. This is invisible against the light-theme file list, where a light plate blends into a light background, and obvious over the dark grid tiles. It was measured rather than eyeballed: inside a fixed summary-card region, the brightness difference between pixels sitting over dark background and over light text was +41 without the flag and roughly zero with it.
- Each call site passes its own corner radius (8dp for rows, 4dp for grid tiles) so the shadow's card matches the shape that was long-pressed. A single hardcoded radius misfits the grid.
- The decoration is built in composition but drawn later from a modifier node on a platform-owned canvas. It is reached through a provider read at drag time rather than captured once, because `rememberWorkspaceDragSource` uses an unkeyed `remember` and would otherwise freeze the theme, density, font scale and locale that were current when the row was first composed.
- Compose hardcodes the drag shadow's draw scope to LTR, so nothing mirrors for RTL on its own. Mirroring of the icon, the text and the stack fan direction is explicit, and is asserted by unit tests over the extracted pure layout function, along with the width cap and font-scale growth.
