### PR TITLE
Searcher: Install APKs and app bundles straight from search results

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -44,9 +44,6 @@ import eu.darken.butler.common.flow.combine as combineMany
 import eu.darken.butler.common.issue.Issue
 import eu.darken.butler.common.navigation.Nav
 import eu.darken.butler.common.navigation.destSetup
-import eu.darken.butler.common.pkgs.installer.AppInstallEvent
-import eu.darken.butler.common.pkgs.installer.AppInstallInspector
-import eu.darken.butler.common.pkgs.installer.AppInstaller
 import eu.darken.butler.common.trash.TrashManager
 import eu.darken.butler.common.trash.TrashRepo
 import eu.darken.butler.common.ui.ViewModel4
@@ -121,18 +118,16 @@ import eu.darken.butler.workspace.core.createAndFocus
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.core.clipboard.ClipboardRepo
 import eu.darken.butler.workspace.core.clipboard.ClipboardSettings
-import eu.darken.butler.workspace.core.operations.AppInstallOperation
+import eu.darken.butler.workspace.core.operations.AppInstallLauncher
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationPathPlan
 import eu.darken.butler.workspace.core.operations.OperationFocusRequest
-import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
 import eu.darken.butler.workspace.core.returnResult
 import eu.darken.butler.workspace.ui.operations.OperationsDisplayState
 import eu.darken.butler.workspace.ui.operations.details.OperationDialogState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -195,10 +190,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
     private val folderSortRules: FolderSortRulesRepo,
     private val tabSortStore: ExplorerTabSortStore,
     private val tabViewStore: ExplorerTabViewStore,
-    private val appInstallInspector: AppInstallInspector,
-    private val appInstaller: AppInstaller,
-    private val appInstallOperationFactory: AppInstallOperation.Factory,
-    private val operationsManager: OperationsManager,
+    private val appInstallLauncher: AppInstallLauncher,
     private val json: Json,
     private val errorIncidentStore: ErrorIncidentStore,
     chromeFactory: WorkspacePageChrome.Factory,
@@ -1269,42 +1261,20 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
-    /**
-     * Installs an APK or app bundle.
-     *
-     * Inspection runs here rather than inside the operation so an unreadable, protected or
-     * unsupported container is answered right away instead of behind a progress bar. The
-     * unknown-sources check is a preflight for the same reason: without elevated access the platform
-     * installer is the only route, and it refuses to run until Butler is an authorized install
-     * source, so the user goes to the settings page and no operation is created.
-     */
+    /** Installs an APK or app bundle. */
     private suspend fun installPackage(path: APath<*>) {
         try {
-            val plan = appInstallInspector.inspect(path)
-            if (!appInstaller.hasElevation() && !appInstaller.canUseSystemInstaller()) {
-                log(tag, INFO) { "installPackage($path): Butler is not an authorized install source yet" }
-                context.startActivity(appInstaller.unknownSourcesSettings())
-                toastEvents.emit(WorkspaceR.string.workspace_install_unknown_sources_required.toCaString())
-                return
-            }
-
-            val events = MutableSharedFlow<AppInstallEvent>(extraBufferCapacity = 16)
-            // Subscribed before submitting, so an event emitted right at the start is not missed.
-            events
-                .filterIsInstance<AppInstallEvent.ObbFailed>()
-                .onEach { toastEvents.emit(WorkspaceR.string.workspace_install_obb_failed.toCaString(it.reason)) }
-                .launchInViewModel()
-
-            // Closing this tab cancels the operation outright, which abandons the install session.
-            // If the system's confirm dialog is already on screen the platform owns it from there
-            // and may still complete the install on its own.
-            operationsManager.submit(
-                appInstallOperationFactory.create(
-                    installOrigin = Operation.Metadata.Origin.Explorer(id),
-                    plan = plan,
-                    events = events,
-                )
+            val result = appInstallLauncher.launch(
+                path = path,
+                origin = Operation.Metadata.Origin.Explorer(id),
+                collectorScope = vmScope,
+                onObbFailed = { reason ->
+                    toastEvents.emit(WorkspaceR.string.workspace_install_obb_failed.toCaString(reason))
+                },
             )
+            if (result is AppInstallLauncher.Result.UnknownSourcesRequired) {
+                toastEvents.emit(WorkspaceR.string.workspace_install_unknown_sources_required.toCaString())
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/actions/DirectoryActionProvider.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/actions/DirectoryActionProvider.kt
@@ -1,7 +1,6 @@
 package eu.darken.butler.explorer.ui.explorer.actions
 
 import eu.darken.butler.common.files.ArchivePath
-import eu.darken.butler.common.files.SmbPath
 import eu.darken.butler.common.files.archive.ArchiveFormat
 import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.ExplorerItem
@@ -9,6 +8,7 @@ import eu.darken.butler.explorer.core.engine.ExplorerLocation
 import eu.darken.butler.explorer.core.favorites.ExplorerFavoritesRepo
 import eu.darken.butler.explorer.core.toggled
 import eu.darken.butler.explorer.ui.explorer.util.ExplorerSelectionState
+import eu.darken.butler.workspace.ui.actions.FileActionCapabilities
 import javax.inject.Inject
 
 class DirectoryActionProvider @Inject constructor(
@@ -66,12 +66,13 @@ class DirectoryActionProvider @Inject constructor(
                 )
             }
 
-            // Handing a file to another app needs a file:// or content:// URI, which a file on a
-            // server does not have, so a selection holding one is not offered for sharing.
-            val selectionHasNetworkEntry = selectionState.selectedItems.any {
-                it is ExplorerItem.Lookup && it.path is SmbPath
+            // Handing a file to another app needs a URI the system can resolve, which is what
+            // FileActionCapabilities answers, so a selection holding anything else - or a folder -
+            // is not offered for sharing.
+            val selectionIsShareable = selectionState.selectedItems.all {
+                it is ExplorerItem.File && FileActionCapabilities.canHandOffToOtherApps(it.path)
             }
-            if (!selectionHasNetworkEntry && selectionState.selectedItems.all { it is ExplorerItem.File }) {
+            if (selectionIsShareable) {
                 actions.add(ExplorerActionBarItem.Directory.Share())
             }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheet.kt
@@ -50,15 +50,11 @@ import coil3.request.ImageRequest
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
-import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MimeInfo
-import eu.darken.butler.common.files.SmbPath
-import eu.darken.butler.common.files.archive.ArchiveFormat
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.files.toCaString
-import eu.darken.butler.common.pkgs.installer.AppInstallFormat
 import eu.darken.butler.common.DateTimeStyle
 import eu.darken.butler.common.formatDateTime
 import eu.darken.butler.common.formatFileSize
@@ -68,6 +64,7 @@ import eu.darken.butler.explorer.ui.explorer.actions.ExplorerActionBarItem
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.icon
 import eu.darken.butler.workspace.core.operations.partitionByTrashSupport
+import eu.darken.butler.workspace.ui.actions.FileActionCapabilities
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 
 @Composable
@@ -222,29 +219,16 @@ private fun FileOptionsContent(
             fontWeight = FontWeight.Medium,
         )
 
-        // Determine if file is text-editable
-        val isTextFile = remember(item.mimeType) {
-            item.mimeType.isText
-        }
+        val caps = remember(item.lookup) { FileActionCapabilities.of(item.lookup) }
         // Archive entries are structurally read-only (checked directly so it holds even before the
         // async writability pass sets canWrite). Otherwise canWrite==false gates writes; null (still
         // loading) stays permissive.
-        val isArchiveEntry = item.lookup.lookedUp is ArchivePath
-        val isWritable = !isArchiveEntry && item.canWrite != false
-        // Handing a file to another app needs a file:// or content:// URI, which a file on a server
-        // does not have, so those entries are not offered for it.
-        val isNetworkFile = item.lookup.lookedUp is SmbPath
-        // Offer Extract only for real archive files. An entry that is itself inside an archive (a nested
-        // archive) can't be opened as a container, so extraction would fail.
-        val isArchiveFile = remember(item.lookup.name, isArchiveEntry) {
-            !isArchiveEntry && ArchiveFormat.fromFileName(item.lookup.name) != null
-        }
-        val installFormat = remember(item.lookup.name) { AppInstallFormat.fromFileName(item.lookup.name) }
+        val isWritable = !caps.isArchiveEntry && item.canWrite != false
 
         // Above "Extract" and "Open": an app bundle is also an archive, but installing it is what
         // the user came for. Suppressed inside a picker like every other action that would spawn a
         // workspace while the caller is still blocked waiting for a result.
-        if (openActionsEnabled && installFormat != null) {
+        if (openActionsEnabled && caps.isInstallable) {
             FileActionRow(
                 icon = Icons.TwoTone.InstallMobile,
                 title = stringResource(R.string.explorer_file_action_install),
@@ -253,7 +237,7 @@ private fun FileOptionsContent(
             )
         }
 
-        if (isArchiveFile) {
+        if (caps.isArchiveFile) {
             FileActionRow(
                 icon = Icons.TwoTone.Unarchive,
                 title = stringResource(R.string.explorer_file_action_extract),
@@ -265,7 +249,7 @@ private fun FileOptionsContent(
         // Inside a picker these would spawn a workspace while the caller is still blocked waiting
         // for a result, so the picker suppresses them here just like on the action bar.
         if (openActionsEnabled) {
-            if (isTextFile) {
+            if (caps.isText) {
                 FileActionRow(
                     icon = Workspace.Type.EDITOR.icon,
                     title = stringResource(R.string.explorer_file_action_open_in_editor),
@@ -288,7 +272,7 @@ private fun FileOptionsContent(
                 onClick = { onAction(ExplorerActionBarItem.File.OpenInTab(item)) },
             )
 
-            if (!isNetworkFile) {
+            if (caps.canHandOffToOtherApps) {
                 FileActionRow(
                     icon = Icons.TwoTone.OpenInBrowser,
                     title = stringResource(R.string.explorer_file_action_open_with),
@@ -298,7 +282,7 @@ private fun FileOptionsContent(
             }
         }
 
-        if (!isNetworkFile) {
+        if (caps.canHandOffToOtherApps) {
             FileActionRow(
                 icon = Icons.TwoTone.Share,
                 title = stringResource(R.string.explorer_file_action_share),

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/actions/DirectoryActionProviderTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/actions/DirectoryActionProviderTest.kt
@@ -3,9 +3,11 @@ package eu.darken.butler.explorer.ui.explorer.actions
 import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.SmbPath
 import eu.darken.butler.common.files.archive.ArchivePathLookup
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.saf.SAFPathLookup
 import eu.darken.butler.common.files.smb.SmbPathLookup
 import eu.darken.butler.explorer.core.ExplorerViewStyle
 import eu.darken.butler.explorer.core.engine.ExplorerItem
@@ -165,6 +167,26 @@ class DirectoryActionProviderTest : BaseTest() {
         actions.any { it is ExplorerActionBarItem.Directory.Share } shouldBe false
     }
 
+    private fun safFile(name: String) = ExplorerItem.RegularFile(
+        lookup = SAFPathLookup(
+            lookedUp = SAFPath.build(TREE_URI, "Documents", name),
+            fileType = FileType.FILE,
+            size = 10L,
+            modifiedAt = null,
+        ),
+        mimeType = MimeInfo("text/plain"),
+    )
+
+    @Test
+    fun `a selection holding a SAF file does not offer Share`() {
+        val actions = selectionActions(
+            directory(null),
+            setOf(MockDataProvider.createMockRegularFile(), safFile("notes.txt")),
+        )
+
+        actions.any { it is ExplorerActionBarItem.Directory.Share } shouldBe false
+    }
+
     @Test
     fun `a purely local selection offers Share`() {
         val actions = selectionActions(directory(null), setOf(MockDataProvider.createMockRegularFile()))
@@ -194,5 +216,6 @@ class DirectoryActionProviderTest : BaseTest() {
 
     companion object {
         private val LOCATION_ID = Uuid.parse("11111111-2222-3333-4444-555555555555")
+        private const val TREE_URI = "content://com.android.externalstorage.documents/tree/primary%3A"
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheetTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/FileOptionsBottomSheetTest.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.test.performScrollTo
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.SmbPath
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.saf.SAFPathLookup
 import eu.darken.butler.common.files.smb.SmbPathLookup
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.ui.explorer.actions.ExplorerActionBarItem
@@ -50,6 +52,20 @@ class FileOptionsBottomSheetTest : ComposeTest() {
     private val networkFile = ExplorerItem.RegularFile(
         lookup = SmbPathLookup(
             lookedUp = SmbPath(Uuid.parse("11111111-2222-3333-4444-555555555555"), listOf("notes.txt")),
+            fileType = FileType.FILE,
+            size = 128L,
+            modifiedAt = null,
+        ),
+        mimeType = MimeInfo("text/plain"),
+    )
+
+    private val safFile = ExplorerItem.RegularFile(
+        lookup = SAFPathLookup(
+            lookedUp = SAFPath.build(
+                "content://com.android.externalstorage.documents/tree/primary%3A",
+                "Documents",
+                "notes.txt",
+            ),
             fileType = FileType.FILE,
             size = 128L,
             modifiedAt = null,
@@ -113,6 +129,16 @@ class FileOptionsBottomSheetTest : ComposeTest() {
         countOf("Open with") shouldBe 0
         countOf("Share") shouldBe 0
         // The actions that work on it are untouched
+        countOf("Copy") shouldBe 1
+    }
+
+    /** A SAF grant we were given cannot be passed on, so neither hand-off can work on one. */
+    @Test
+    fun `a file behind a storage grant offers neither sharing nor opening with another app`() {
+        setSheetContent(safFile)
+
+        countOf("Open with") shouldBe 0
+        countOf("Share") shouldBe 0
         countOf("Copy") shouldBe 1
     }
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.searcher.ui.search
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -634,6 +635,13 @@ fun SearcherWorkspacePageHost(
     LaunchedEffect(vm) {
         vm.shareIntentEvent.collect { intent ->
             context.startActivity(intent)
+        }
+    }
+
+    // Handle one-shot toast confirmations (e.g. an install that needs permission first)
+    LaunchedEffect(vm) {
+        vm.toastEvents.collect { message ->
+            Toast.makeText(context, message.get(context), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
@@ -76,6 +76,7 @@ import eu.darken.butler.workspace.core.handleResult
 import eu.darken.butler.workspace.core.launchPicker
 import eu.darken.butler.workspace.core.operations.AppInstallLauncher
 import eu.darken.butler.workspace.core.operations.Operation
+import eu.darken.butler.workspace.ui.actions.FileActionCapabilities
 import eu.darken.butler.workspace.ui.operations.details.OperationDialogState
 import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
 import kotlinx.coroutines.flow.Flow
@@ -439,9 +440,14 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
                 // Cut
                 add(SearcherActionBarItem.Cut(updatedSelectionState.selectedResults))
 
-                // Share (if reasonable number of items)
+                // Share (if reasonable number of items). Handing a file to another app needs a URI
+                // the system can resolve, which is what FileActionCapabilities answers, so a
+                // selection holding anything else - or a folder - is not offered for sharing.
                 val shareAction = SearcherActionBarItem.Share(updatedSelectionState.selectedResults)
-                if (shareAction.isVisible) {
+                val selectionIsShareable = updatedSelectionState.selectedResults.all {
+                    it.fileType != FileType.DIRECTORY && FileActionCapabilities.canHandOffToOtherApps(it.path)
+                }
+                if (shareAction.isVisible && selectionIsShareable) {
                     add(shareAction)
                 }
 

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspaceViewModel.kt
@@ -8,6 +8,8 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.ApiLevel
+import eu.darken.butler.common.ca.CaString
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.searcher.core.resultKey
 import eu.darken.butler.common.datastore.value
@@ -72,6 +74,7 @@ import eu.darken.butler.workspace.core.clipboard.ClipboardRepo
 import eu.darken.butler.workspace.core.createAndFocus
 import eu.darken.butler.workspace.core.handleResult
 import eu.darken.butler.workspace.core.launchPicker
+import eu.darken.butler.workspace.core.operations.AppInstallLauncher
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.details.OperationDialogState
 import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
@@ -96,7 +99,9 @@ import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import eu.darken.butler.workspace.R as WorkspaceR
 
 @HiltViewModel(assistedFactory = SearcherWorkspaceViewModel.Factory::class)
 class SearcherWorkspaceViewModel @AssistedInject constructor(
@@ -113,6 +118,7 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
     private val openWithIntentUseCase: OpenWithIntentUseCase,
     private val trashSettings: TrashSettings,
     private val folderPreviewResolver: FolderPreviewResolver,
+    private val appInstallLauncher: AppInstallLauncher,
     private val apiLevel: ApiLevel,
     private val errorIncidentStore: ErrorIncidentStore,
     itemSorterFactory: SearchItemSorter.Factory,
@@ -164,6 +170,9 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
     val issueState = conflicts.issueState
 
     val dialogEvents = SingleEventFlow<SearcherDialogEvent>()
+
+    /** One-shot confirmations, e.g. what an install could not finish. */
+    val toastEvents = SingleEventFlow<CaString>()
 
     val shareIntentEvent = chrome.shareIntentEvent
 
@@ -858,6 +867,9 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
                     }
                 }
             }
+            is SearcherActionBarItem.Install -> {
+                launch { installPackage(action.result.path) }
+            }
             is SearcherActionBarItem.OpenInEditor -> {
                 launch {
                     workspaceRemote.createAndFocus(
@@ -956,6 +968,28 @@ class SearcherWorkspaceViewModel @AssistedInject constructor(
             arguments = request.arguments,
             sourceWorkspaceId = id,
         )
+    }
+
+    /** Installs an APK or app bundle found by the search. */
+    private suspend fun installPackage(path: APath<*>) {
+        try {
+            val result = appInstallLauncher.launch(
+                path = path,
+                origin = Operation.Metadata.Origin.Searcher(id),
+                collectorScope = vmScope,
+                onObbFailed = { reason ->
+                    toastEvents.emit(WorkspaceR.string.workspace_install_obb_failed.toCaString(reason))
+                },
+            )
+            if (result is AppInstallLauncher.Result.UnknownSourcesRequired) {
+                toastEvents.emit(WorkspaceR.string.workspace_install_unknown_sources_required.toCaString())
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "installPackage($path) failed: ${e.asLog()}" }
+            errorEvents.emit(e)
+        }
     }
 
     private suspend fun executeOpenInNewTabs(analysis: OpenInNewTabsUseCase.AnalysisResult) {

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchResultItemDetails.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchResultItemDetails.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -30,7 +31,6 @@ import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.TintedAsyncImage
 import eu.darken.butler.common.files.LocalPath
-import eu.darken.butler.common.files.TextFileDetector
 import eu.darken.butler.common.files.local.LocalPathLookup
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.DateTimeStyle
@@ -40,6 +40,7 @@ import eu.darken.butler.searcher.R
 import eu.darken.butler.searcher.core.SearchItem
 import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
 import eu.darken.butler.searcher.ui.search.util.getEllipsizedMatchLine
+import eu.darken.butler.workspace.ui.actions.FileActionCapabilities
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
 import kotlin.time.Clock
 
@@ -54,6 +55,8 @@ fun SearchResultItemDetails(
     topInset: Dp = 0.dp,
     bottomInset: Dp = 0.dp,
 ) {
+    val caps = remember(result.lookup) { FileActionCapabilities.of(result.lookup) }
+
     PaneScopedBottomSheet(
         visible = true,
         onDismiss = onDismiss,
@@ -193,6 +196,16 @@ fun SearchResultItemDetails(
             Column(
                 modifier = Modifier.padding(top = 4.dp)
             ) {
+                // Above "Open": an app bundle is also an archive, but installing it is what the user
+                // came for.
+                if (caps.isInstallable) {
+                    QuickActionItem(
+                        action = SearcherActionBarItem.Install(result),
+                        onClick = onAction,
+                        isPrimary = true
+                    )
+                }
+
                 // Primary actions
                 if (result.fileType != FileType.DIRECTORY) {
                     QuickActionItem(
@@ -208,7 +221,7 @@ fun SearchResultItemDetails(
                     )
                 }
 
-                if (isTextFile(result)) {
+                if (caps.isText) {
                     QuickActionItem(
                         action = SearcherActionBarItem.OpenInEditor(result),
                         onClick = onAction,
@@ -216,7 +229,7 @@ fun SearchResultItemDetails(
                     )
                 }
 
-                if (result.fileType != FileType.DIRECTORY) {
+                if (result.fileType != FileType.DIRECTORY && caps.canHandOffToOtherApps) {
                     QuickActionItem(
                         action = SearcherActionBarItem.OpenWith(result),
                         onClick = onAction,
@@ -252,10 +265,12 @@ fun SearchResultItemDetails(
                 )
 
                 // Additional actions
-                QuickActionItem(
-                    action = SearcherActionBarItem.Share(listOf(result)),
-                    onClick = onAction
-                )
+                if (caps.canHandOffToOtherApps) {
+                    QuickActionItem(
+                        action = SearcherActionBarItem.Share(listOf(result)),
+                        onClick = onAction
+                    )
+                }
 
                 QuickActionItem(
                     action = SearcherActionBarItem.CopyPath(result),
@@ -324,8 +339,6 @@ private fun QuickActionItem(
         )
     }
 }
-
-private fun isTextFile(result: SearchItem): Boolean = TextFileDetector.isTextFile(result.path)
 
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherActionBarItem.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/util/SearcherActionBarItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.twotone.DeleteForever
 import androidx.compose.material.icons.twotone.Deselect
 import androidx.compose.material.icons.twotone.GridView
 import androidx.compose.material.icons.twotone.Info
+import androidx.compose.material.icons.twotone.InstallMobile
 import androidx.compose.material.icons.twotone.Link
 import androidx.compose.material.icons.twotone.OpenInBrowser
 import androidx.compose.material.icons.twotone.SelectAll
@@ -92,6 +93,13 @@ sealed interface SearcherActionBarItem : WorkspaceActionBarItem {
     ) : SearcherActionBarItem {
         override val icon = Icons.TwoTone.OpenInBrowser
         override val label = R.string.searcher_action_open_with.toCaString()
+    }
+
+    data class Install(
+        val result: SearchItem,
+    ) : SearcherActionBarItem {
+        override val icon = Icons.TwoTone.InstallMobile
+        override val label = R.string.searcher_action_install.toCaString()
     }
 
     data class OpenInEditor(

--- a/app-workspace-searcher/src/main/res/values/strings.xml
+++ b/app-workspace-searcher/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="searcher_action_open_with">Open with</string>
     <string name="searcher_action_open_in_editor">Open in editor</string>
     <string name="searcher_action_open_in_explorer">Open in explorer</string>
+    <string name="searcher_action_install">Install</string>
     <string name="searcher_action_copy">Copy</string>
     <string name="searcher_action_cut">Cut</string>
     <string name="searcher_action_delete">Delete</string>

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherInstallActionTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherInstallActionTest.kt
@@ -1,17 +1,23 @@
 package eu.darken.butler.searcher.ui.search
 
-import eu.darken.butler.common.error.ErrorIncident
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.flow.SingleEventFlow
+import eu.darken.butler.searcher.core.SearchItem
 import eu.darken.butler.searcher.core.SearchSortSettings
 import eu.darken.butler.searcher.core.SearcherSettings
 import eu.darken.butler.searcher.core.SearcherViewStyle
 import eu.darken.butler.searcher.core.SearcherWorkspace
+import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
 import eu.darken.butler.searcher.ui.search.util.SearcherPageAction
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.operations.AppInstallLauncher
+import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
-import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -32,27 +38,29 @@ import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
 import testhelpers.error.recordingIncidentStore
 
-/**
- * Sharing a failure hands over the incident it was already frozen into, so the report carries the
- * log trail from around the failure rather than from whenever the user tapped Share. The search
- * state's failure is frozen by the workspace, a target failure by the page that shows it.
- */
+/** A package found by a search installs from the search, the same way it does in the Explorer. */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
-class SearcherErrorShareTest {
+class SearcherInstallActionTest {
 
     private val workspaceId = Workspace.Id()
-    private val searchState = MutableStateFlow(SearcherWorkspace.State())
-    private val incidentStore = recordingIncidentStore()
+    private val appInstallLauncher = mockk<AppInstallLauncher>(relaxed = true)
 
-    /** What the share action handed to the chrome. */
-    private val shared = mutableListOf<ErrorIncident>()
+    private val apkPath = LocalPath.build("/storage/emulated/0/Download/app.apk")
+    private val apkResult: SearchItem = SearchItem.fromLookup(
+        lookup = LocalPathLookup(
+            lookedUp = apkPath,
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = null,
+        ),
+        matchedQuery = "app",
+    )
 
     @Before
     fun setup() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
-        shared.clear()
     }
 
     @After
@@ -62,7 +70,7 @@ class SearcherErrorShareTest {
 
     private fun makeViewModel(): SearcherWorkspaceViewModel {
         val workspace = mockk<SearcherWorkspace>(relaxed = true).apply {
-            every { state } returns searchState
+            every { state } returns MutableStateFlow(SearcherWorkspace.State())
         }
         return SearcherWorkspaceViewModel(
             id = workspaceId,
@@ -85,58 +93,37 @@ class SearcherErrorShareTest {
             openWithIntentUseCase = mockk(relaxed = true),
             trashSettings = mockk(relaxed = true),
             folderPreviewResolver = mockk(relaxed = true),
-            appInstallLauncher = mockk(relaxed = true),
+            appInstallLauncher = appInstallLauncher,
             apiLevel = mockk(relaxed = true),
-            errorIncidentStore = incidentStore,
+            errorIncidentStore = recordingIncidentStore(),
             itemSorterFactory = mockk {
                 every { create(any()) } returns mockk(relaxed = true)
             },
             chromeFactory = mockk<WorkspacePageChrome.Factory>().apply {
-                every { create(any(), any()) } returns mockk<WorkspacePageChrome>().apply {
+                every { create(any(), any()) } returns mockk<WorkspacePageChrome>(relaxed = true).apply {
                     every { shareIntentEvent } returns SingleEventFlow()
                     every { pendingErrorShare } returns MutableStateFlow(null)
                     every { pendingConflicts } returns flowOf(emptyMap())
                     every { clipboard } returns emptyFlow()
                     every { operations } returns emptyFlow()
-                    every { shareWorkspaceError(any(), any()) } answers { shared += firstArg<ErrorIncident>() }
                 }
             },
         )
     }
 
     @Test
-    fun `sharing a search failure hands over the incident it was frozen into`() = runTest2 {
+    fun `installing a result submits it as an install from this search`() = runTest2 {
         val vm = makeViewModel()
 
-        val sentinel = IllegalStateException("search blew up")
-        // What the workspace does when it publishes the failure into the state the page renders
-        incidentStore.remember(sentinel, mapOf("search.targets" to ""))
-        searchState.value = SearcherWorkspace.State(
-            searchStatus = SearcherWorkspace.State.SearchStatus.ERROR,
-            error = sentinel,
-        )
+        vm.onPageAction(SearcherPageAction.WorkspaceAction(SearcherActionBarItem.Install(apkResult)))
 
-        vm.onPageAction(SearcherPageAction.Error.Share(sentinel))
-
-        val incident = shared.single()
-        (incident.error === sentinel) shouldBe true
-        incident.occurredAtIsApproximate shouldBe false
-        incident.context.containsKey("incident.frozenAtShare") shouldBe false
-    }
-
-    @Test
-    fun `sharing a target failure hands over the incident the dialog was opened with`() = runTest2 {
-        val vm = makeViewModel()
-
-        val sentinel = IllegalStateException("target unreadable")
-        vm.onPageAction(SearcherPageAction.Overlays.ShowTargetError("/sdcard/Android/data", sentinel))
-
-        vm.onPageAction(SearcherPageAction.Error.Share(sentinel, "/sdcard/Android/data"))
-
-        val incident = shared.single()
-        (incident.error === sentinel) shouldBe true
-        incident.context["search.targetPath"] shouldBe "/sdcard/Android/data"
-        incident.occurredAtIsApproximate shouldBe false
-        incident.context.containsKey("incident.frozenAtShare") shouldBe false
+        coVerify {
+            appInstallLauncher.launch(
+                path = apkPath,
+                origin = Operation.Metadata.Origin.Searcher(workspaceId),
+                collectorScope = any(),
+                onObbFailed = any(),
+            )
+        }
     }
 }

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherSelectionShareTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/SearcherSelectionShareTest.kt
@@ -1,0 +1,166 @@
+package eu.darken.butler.searcher.ui.search
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.SAFPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.saf.SAFPathLookup
+import eu.darken.butler.common.flow.SingleEventFlow
+import eu.darken.butler.searcher.core.SearchItem
+import eu.darken.butler.searcher.core.SearchSortSettings
+import eu.darken.butler.searcher.core.SearcherSettings
+import eu.darken.butler.searcher.core.SearcherViewStyle
+import eu.darken.butler.searcher.core.SearcherWorkspace
+import eu.darken.butler.searcher.core.history.SearchHistory
+import eu.darken.butler.searcher.core.sorting.SearchItemSorter
+import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
+import eu.darken.butler.searcher.ui.search.util.SearcherPageAction
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import testhelpers.error.recordingIncidentStore
+
+/**
+ * Sharing a selection needs a URI the system can resolve for every single result, so the action bar
+ * only offers it when the whole selection is made of local files. A mixed selection is the one that
+ * would fail quietly: only the local part of it would ever reach the other app.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SearcherSelectionShareTest {
+
+    private val workspaceId = Workspace.Id()
+
+    private fun localResult(name: String): SearchItem = SearchItem.fromLookup(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath.build("/storage/emulated/0/Download/$name"),
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = null,
+        ),
+        matchedQuery = "config",
+    )
+
+    private fun safResult(name: String): SearchItem = SearchItem.fromLookup(
+        lookup = SAFPathLookup(
+            lookedUp = SAFPath.build(
+                "content://com.android.externalstorage.documents/tree/primary%3A",
+                "Download",
+                name,
+            ),
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = null,
+        ),
+        matchedQuery = "config",
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun makeViewModel(results: List<SearchItem>): SearcherWorkspaceViewModel {
+        val workspace = mockk<SearcherWorkspace>(relaxed = true).apply {
+            every { state } returns MutableStateFlow(SearcherWorkspace.State(results = results))
+        }
+        return SearcherWorkspaceViewModel(
+            id = workspaceId,
+            appContext = mockk(relaxed = true),
+            dispatchers = TestDispatcherProvider(),
+            searchHistory = mockk<SearchHistory>(relaxed = true).apply {
+                every { getSearches(any()) } returns flowOf(emptyList())
+            },
+            searcherSettings = mockk<SearcherSettings>(relaxed = true).apply {
+                every { defaultSort.flow } returns flowOf(SearchSortSettings())
+                every { defaultViewStyle.flow } returns flowOf(SearcherViewStyle.default())
+                every { maxHistoryItems.flow } returns flowOf(50)
+            },
+            clipboardRepo = mockk(relaxed = true),
+            workspaceRemote = mockk<WorkspaceRemote>(relaxed = true).apply {
+                every { events } returns emptyFlow()
+            },
+            workspaceProvider = mockk<WorkspaceProvider>().apply {
+                every { retrieve(workspaceId) } returns MutableStateFlow(workspace)
+            },
+            openInNewTabsUseCase = mockk(relaxed = true),
+            shareIntentUseCase = mockk(relaxed = true),
+            openWithIntentUseCase = mockk(relaxed = true),
+            trashSettings = mockk(relaxed = true) {
+                every { enabled.flow } returns flowOf(true)
+            },
+            folderPreviewResolver = mockk(relaxed = true),
+            appInstallLauncher = mockk(relaxed = true),
+            apiLevel = mockk(relaxed = true),
+            errorIncidentStore = recordingIncidentStore(),
+            itemSorterFactory = mockk {
+                every { create(any()) } returns mockk<SearchItemSorter> {
+                    every { sortItems(any(), any()) } answers { firstArg() }
+                }
+            },
+            chromeFactory = mockk<WorkspacePageChrome.Factory>().apply {
+                every { create(any(), any()) } returns mockk<WorkspacePageChrome>(relaxed = true).apply {
+                    every { shareIntentEvent } returns SingleEventFlow()
+                    every { pendingErrorShare } returns MutableStateFlow(null)
+                    every { pendingConflicts } returns flowOf(emptyMap())
+                    every { clipboard } returns emptyFlow()
+                    every { operations } returns emptyFlow()
+                }
+            },
+        )
+    }
+
+    private fun sharesOffered(results: List<SearchItem>, selection: List<SearchItem>): Boolean {
+        val vm = makeViewModel(results)
+        selection.forEach { vm.onPageAction(SearcherPageAction.Results.ToggleSelection(it)) }
+        val ready = vm.state.value as SearcherWorkspaceViewModel.State.Ready
+        return ready.availableActions.any { it is SearcherActionBarItem.Share }
+    }
+
+    @Test
+    fun `a selection of local files can be shared`() = runTest2 {
+        val results = listOf(localResult("config-a.txt"), localResult("config-b.txt"))
+
+        sharesOffered(results, results) shouldBe true
+    }
+
+    @Test
+    fun `a selection reached through SAF is not offered for sharing`() = runTest2 {
+        val results = listOf(safResult("config-a.txt"), safResult("config-b.txt"))
+
+        sharesOffered(results, results) shouldBe false
+    }
+
+    @Test
+    fun `a selection mixing local and SAF results is not offered for sharing`() = runTest2 {
+        val results = listOf(localResult("config-a.txt"), safResult("config-b.txt"))
+
+        sharesOffered(results, results) shouldBe false
+    }
+}

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/elements/SearchResultItemDetailsTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/elements/SearchResultItemDetailsTest.kt
@@ -1,0 +1,169 @@
+package eu.darken.butler.searcher.ui.search.elements
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.SAFPath
+import eu.darken.butler.common.files.SmbPath
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.saf.SAFPathLookup
+import eu.darken.butler.common.files.smb.SmbPathLookup
+import eu.darken.butler.searcher.core.SearchItem
+import eu.darken.butler.searcher.ui.search.util.SearcherActionBarItem
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.TestApplication
+import kotlin.uuid.Uuid
+
+/**
+ * The sheet anchors to the bottom of its pane, so the root has to be tall enough to hold every row -
+ * a touch below the root lands on nothing while still reporting success.
+ */
+@Config(application = TestApplication::class, sdk = [34], qualifiers = "w400dp-h1600dp")
+class SearchResultItemDetailsTest : ComposeTest() {
+
+    private fun localResult(name: String, fileType: FileType = FileType.FILE): SearchItem =
+        SearchItem.fromLookup(
+            lookup = LocalPathLookup(
+                lookedUp = LocalPath.build("/storage/emulated/0/Download/$name"),
+                fileType = fileType,
+                size = 1024L,
+                modifiedAt = null,
+            ),
+            matchedQuery = name,
+        )
+
+    private val networkResult: SearchItem = SearchItem.fromLookup(
+        lookup = SmbPathLookup(
+            lookedUp = SmbPath(Uuid.parse("11111111-2222-3333-4444-555555555555"), listOf("notes.txt")),
+            fileType = FileType.FILE,
+            size = 128L,
+            modifiedAt = null,
+        ),
+        matchedQuery = "notes",
+    )
+
+    private val safResult: SearchItem = SearchItem.fromLookup(
+        lookup = SAFPathLookup(
+            lookedUp = SAFPath.build(
+                "content://com.android.externalstorage.documents/tree/primary%3A",
+                "Download",
+                "notes.txt",
+            ),
+            fileType = FileType.FILE,
+            size = 128L,
+            modifiedAt = null,
+        ),
+        matchedQuery = "notes",
+    )
+
+    private var lastAction: SearcherActionBarItem? = null
+
+    /** Swapping this restages the sheet without a second `setContent` call. */
+    private var currentResult by mutableStateOf<SearchItem>(localResult("notes.txt"))
+
+    private fun setSheetContent(result: SearchItem) {
+        currentResult = result
+        lastAction = null
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    SearchResultItemDetails(
+                        result = currentResult,
+                        trashEnabled = false,
+                        onAction = { lastAction = it },
+                        onLongPress = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+    }
+
+    private fun countOf(text: String): Int =
+        composeTestRule.onAllNodes(hasText(text)).fetchSemanticsNodes().size
+
+    @Test
+    fun `install is offered for every installable format`() {
+        setSheetContent(localResult("app.apk"))
+
+        listOf("app.apk", "app.apks", "app.xapk", "app.apkm").forEach { name ->
+            lastAction = null
+            currentResult = localResult(name)
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithText("Install").performScrollTo().assertIsDisplayed()
+            composeTestRule.onNodeWithText("Install").performClick()
+
+            lastAction.shouldBeInstanceOf<SearcherActionBarItem.Install>()
+        }
+    }
+
+    @Test
+    fun `install is not offered for other files`() {
+        setSheetContent(localResult("notes.txt"))
+
+        countOf("Install") shouldBe 0
+    }
+
+    /** A folder named like a package is still a folder, and inspecting it would only throw. */
+    @Test
+    fun `install is not offered for a folder that is named like a package`() {
+        setSheetContent(localResult("app.apk", fileType = FileType.DIRECTORY))
+
+        countOf("Install") shouldBe 0
+    }
+
+    @Test
+    fun `install sits above open`() {
+        setSheetContent(localResult("app.apk"))
+
+        val install = composeTestRule.onNodeWithText("Install").performScrollTo().getUnclippedBoundsInRoot()
+        val open = composeTestRule.onNodeWithText("Open").performScrollTo().getUnclippedBoundsInRoot()
+
+        (install.top.value < open.top.value) shouldBe true
+    }
+
+    @Test
+    fun `a local file can be shared and opened with another app`() {
+        setSheetContent(localResult("notes.txt"))
+
+        countOf("Open with") shouldBe 1
+        countOf("Share") shouldBe 1
+    }
+
+    /** Both hand a URI to another app, which a file on a server has none of. */
+    @Test
+    fun `a file on network storage offers neither sharing nor opening with another app`() {
+        setSheetContent(networkResult)
+
+        countOf("Open with") shouldBe 0
+        countOf("Share") shouldBe 0
+        countOf("Copy") shouldBe 1
+    }
+
+    /** A SAF grant we were given cannot be passed on, so neither hand-off can work on one. */
+    @Test
+    fun `a file behind a storage grant offers neither sharing nor opening with another app`() {
+        setSheetContent(safResult)
+
+        countOf("Open with") shouldBe 0
+        countOf("Share") shouldBe 0
+        countOf("Copy") shouldBe 1
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
@@ -19,15 +19,11 @@ import eu.darken.butler.common.error.ErrorIncidentStore
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.MimeInfo
-import eu.darken.butler.common.files.SmbPath
 import eu.darken.butler.common.files.actions.PathActionIssue
 import eu.darken.butler.common.files.validation.FilenameValidator
 import eu.darken.butler.common.flow.SingleEventFlow
 import eu.darken.butler.common.flow.combine as combineMany
 import eu.darken.butler.common.issue.Issue
-import eu.darken.butler.common.pkgs.installer.AppInstallEvent
-import eu.darken.butler.common.pkgs.installer.AppInstallInspector
-import eu.darken.butler.common.pkgs.installer.AppInstaller
 import eu.darken.butler.common.trash.TrashSettings
 import eu.darken.butler.common.ui.ViewModel3
 import eu.darken.butler.viewer.R
@@ -59,7 +55,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.clipboard.ClipboardClip
 import eu.darken.butler.workspace.core.clipboard.ClipboardRepo
 import eu.darken.butler.workspace.core.createAndFocus
-import eu.darken.butler.workspace.core.operations.AppInstallOperation
+import eu.darken.butler.workspace.core.operations.AppInstallLauncher
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.core.operations.partitionByTrashSupport
@@ -69,6 +65,7 @@ import eu.darken.butler.workspace.core.WorkspaceProvider
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.handleResult
 import eu.darken.butler.workspace.core.launchPicker
+import eu.darken.butler.workspace.ui.actions.FileActionCapabilities
 import eu.darken.butler.workspace.ui.page.WorkspacePageChrome
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -77,7 +74,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -114,9 +110,7 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
     private val clipboardRepo: ClipboardRepo,
     private val trashSettings: TrashSettings,
     private val operationsManager: OperationsManager,
-    private val appInstallInspector: AppInstallInspector,
-    private val appInstaller: AppInstaller,
-    private val appInstallOperationFactory: AppInstallOperation.Factory,
+    private val appInstallLauncher: AppInstallLauncher,
     private val apkIconExporter: ApkIconExporter,
     private val filenameValidator: FilenameValidator,
     private val errorIncidentStore: ErrorIncidentStore,
@@ -818,44 +812,22 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
         )
     }
 
-    /**
-     * Installs the APK or app bundle this tab is showing.
-     *
-     * Inspection runs here rather than inside the operation so an unreadable, protected or
-     * unsupported container is answered right away instead of behind a progress bar. The
-     * unknown-sources check is a preflight for the same reason: without elevated access the platform
-     * installer is the only route, and it refuses to run until Butler is an authorized install
-     * source, so the user goes to the settings page and no operation is created.
-     */
+    /** Installs the APK or app bundle this tab is showing. */
     fun install() = launch {
         val path = workspaceSource.first().storedPath ?: return@launch
         log(tag, INFO) { "install($path)" }
         try {
-            val plan = appInstallInspector.inspect(path)
-            if (!appInstaller.hasElevation() && !appInstaller.canUseSystemInstaller()) {
-                log(tag, INFO) { "install($path): Butler is not an authorized install source yet" }
-                context.startActivity(appInstaller.unknownSourcesSettings())
-                toastEvents.emit(WorkspaceR.string.workspace_install_unknown_sources_required.toCaString())
-                return@launch
-            }
-
-            val events = MutableSharedFlow<AppInstallEvent>(extraBufferCapacity = 16)
-            // Subscribed before submitting, so an event emitted right at the start is not missed.
-            events
-                .filterIsInstance<AppInstallEvent.ObbFailed>()
-                .onEach { toastEvents.emit(WorkspaceR.string.workspace_install_obb_failed.toCaString(it.reason)) }
-                .launchInViewModel()
-
-            // Closing this tab cancels the operation outright, which abandons the install session.
-            // If the system's confirm dialog is already on screen the platform owns it from there
-            // and may still complete the install on its own.
-            operationsManager.submit(
-                appInstallOperationFactory.create(
-                    installOrigin = Operation.Metadata.Origin.Viewer(id),
-                    plan = plan,
-                    events = events,
-                )
+            val result = appInstallLauncher.launch(
+                path = path,
+                origin = Operation.Metadata.Origin.Viewer(id),
+                collectorScope = vmScope,
+                onObbFailed = { reason ->
+                    toastEvents.emit(WorkspaceR.string.workspace_install_obb_failed.toCaString(reason))
+                },
             )
+            if (result is AppInstallLauncher.Result.UnknownSourcesRequired) {
+                toastEvents.emit(WorkspaceR.string.workspace_install_unknown_sources_required.toCaString())
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -1261,9 +1233,9 @@ internal fun viewerActions(
             if (content is ViewerContent.Text) {
                 add(ViewerActionBarItem.OpenInEditor)
             }
-            // Handing a file to another app needs a file:// or content:// URI, which a file on a
-            // server does not have, so those two are not offered for it.
-            if (source.path !is SmbPath) {
+            // Handing a file to another app needs a URI Butler can pass on, which is what
+            // [FileActionCapabilities.canHandOffToOtherApps] answers.
+            if (FileActionCapabilities.canHandOffToOtherApps(source.path)) {
                 add(ViewerActionBarItem.OpenWith)
                 add(ViewerActionBarItem.Share)
             }

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileStepTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerFileStepTest.kt
@@ -163,9 +163,7 @@ class ViewerFileStepTest : BaseTest() {
                 every { enabled.flow } returns flowOf(false)
             },
             operationsManager = mockk(relaxed = true),
-            appInstallInspector = mockk(relaxed = true),
-            appInstaller = mockk(relaxed = true),
-            appInstallOperationFactory = mockk(relaxed = true),
+            appInstallLauncher = mockk(relaxed = true),
             apkIconExporter = mockk(relaxed = true),
             filenameValidator = FilenameValidator(),
             errorIncidentStore = incidentStore,

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerRenderFailureTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerRenderFailureTest.kt
@@ -146,9 +146,7 @@ class ViewerRenderFailureTest : BaseTest() {
                 every { enabled.flow } returns trashEnabled
             },
             operationsManager = mockk(relaxed = true),
-            appInstallInspector = mockk(relaxed = true),
-            appInstaller = mockk(relaxed = true),
-            appInstallOperationFactory = mockk(relaxed = true),
+            appInstallLauncher = mockk(relaxed = true),
             apkIconExporter = mockk(relaxed = true),
             filenameValidator = FilenameValidator(),
             errorIncidentStore = incidentStore,

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerSaveCopyTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerSaveCopyTest.kt
@@ -128,9 +128,7 @@ class ViewerSaveCopyTest : BaseTest() {
                 every { enabled.flow } returns flowOf(false)
             },
             operationsManager = mockk(relaxed = true),
-            appInstallInspector = mockk(relaxed = true),
-            appInstaller = mockk(relaxed = true),
-            appInstallOperationFactory = mockk(relaxed = true),
+            appInstallLauncher = mockk(relaxed = true),
             apkIconExporter = mockk(relaxed = true),
             filenameValidator = FilenameValidator(),
             errorIncidentStore = incidentStore,

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePageTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspacePageTest.kt
@@ -186,6 +186,20 @@ class ViewerWorkspacePageTest : ComposeTest() {
         localActions.contains(ViewerActionBarItem.Share) shouldBe true
     }
 
+    @Test
+    fun `a file behind a storage grant is not offered to other apps`() {
+        // A grant Butler was given cannot be passed on, so both would fail on every tap.
+        val safPath = SAFPath.build(
+            "content://com.android.externalstorage.documents/tree/primary%3ADownload",
+            "notes.txt",
+        )
+
+        val actions = viewerActions(ViewerSource.Stored(safPath), trashEnabled = false)
+        actions.contains(ViewerActionBarItem.OpenWith) shouldBe false
+        actions.contains(ViewerActionBarItem.Share) shouldBe false
+        actions.contains(ViewerActionBarItem.Copy) shouldBe true
+    }
+
     private fun unsupportedState(content: ViewerContent) = ViewerWorkspaceViewModel.State.Ready(
         content = content,
         fileInfo = ViewerFileInfo(size = 1024L),

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelExternalChangeTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelExternalChangeTest.kt
@@ -118,9 +118,7 @@ class ViewerWorkspaceViewModelExternalChangeTest : BaseTest() {
                 every { enabled.flow } returns flowOf(false)
             },
             operationsManager = mockk(relaxed = true),
-            appInstallInspector = mockk(relaxed = true),
-            appInstaller = mockk(relaxed = true),
-            appInstallOperationFactory = mockk(relaxed = true),
+            appInstallLauncher = mockk(relaxed = true),
             apkIconExporter = mockk(relaxed = true),
             filenameValidator = FilenameValidator(),
             errorIncidentStore = incidentStore,

--- a/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
+++ b/app-workspace-viewer/src/test/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModelPagingTest.kt
@@ -141,9 +141,7 @@ class ViewerWorkspaceViewModelPagingTest : BaseTest() {
                 every { enabled.flow } returns flowOf(false)
             },
             operationsManager = mockk(relaxed = true),
-            appInstallInspector = mockk(relaxed = true),
-            appInstaller = mockk(relaxed = true),
-            appInstallOperationFactory = mockk(relaxed = true),
+            appInstallLauncher = mockk(relaxed = true),
             // Unused by the paging cases, but the ViewModel now owns the APK icon export too.
             apkIconExporter = mockk(relaxed = true),
             filenameValidator = FilenameValidator(),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallLauncher.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallLauncher.kt
@@ -3,18 +3,20 @@ package eu.darken.butler.workspace.core.operations
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.installer.AppInstallEvent
 import eu.darken.butler.common.pkgs.installer.AppInstallInspector
 import eu.darken.butler.common.pkgs.installer.AppInstaller
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -40,7 +42,8 @@ class AppInstallLauncher @Inject constructor(
      * source, so the user goes to the settings page and no operation is created.
      *
      * Failures propagate - the caller owns how it reports them. [onObbFailed] runs in
-     * [collectorScope] and is unsubscribed once the install is done.
+     * [collectorScope], the first time inline before this returns, and is unsubscribed once the
+     * install is done.
      */
     suspend fun launch(
         path: APath<*>,
@@ -55,14 +58,32 @@ class AppInstallLauncher @Inject constructor(
             return Result.UnknownSourcesRequired
         }
 
-        // Replayed, not just buffered: launchIn schedules the collector rather than starting it, and
-        // a SharedFlow drops what it emits while nobody is subscribed. The flow is created per
-        // install and carries only this install's events, so there is nothing stale to replay.
+        // Replayed, not just buffered: a SharedFlow drops what it emits while nobody is subscribed.
+        // The flow is created per install and carries only this install's events, so there is nothing
+        // stale to replay.
         val events = MutableSharedFlow<AppInstallEvent>(replay = 16, extraBufferCapacity = 16)
-        val collector = events
-            .filterIsInstance<AppInstallEvent.ObbFailed>()
-            .onEach { onObbFailed(it.reason) }
-            .launchIn(collectorScope)
+
+        val submittedId = CompletableDeferred<Operation.Id>()
+        val installFinished = CompletableDeferred<Unit>()
+
+        // Subscribed before the operation exists, hence the id arriving through a Deferred:
+        // completedOperations has no replay, so an install that finishes while submit() is still
+        // running would go unnoticed and leave the collector subscribed for the rest of
+        // collectorScope's life. Undispatched so that subscribing happens here rather than whenever
+        // collectorScope next runs.
+        collectorScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                operationsManager.completedOperations.first { it.id == submittedId.await() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // collectorScope is the caller's, letting this out would take down whatever else runs
+                // in it over a watcher that only decides when to unsubscribe.
+                log(TAG, ERROR) { "launch($path): waiting for the end of the install failed - ${e.asLog()}" }
+            } finally {
+                installFinished.complete(Unit)
+            }
+        }
 
         // Closing the calling tab cancels the operation outright, which abandons the install session.
         // If the system's confirm dialog is already on screen the platform owns it from there and may
@@ -75,11 +96,18 @@ class AppInstallLauncher @Inject constructor(
             )
         )
         log(TAG, INFO) { "launch($path): submitted as $operationId" }
+        submittedId.complete(operationId)
 
-        collectorScope.launch {
-            operationsManager.completedOperations.first { it.id == operationId }
-            collector.cancel()
+        // Undispatched: a scheduled collector only starts once collectorScope next runs, and the
+        // operation starts inside submit(), so an ObbFailed it already reported would reach the
+        // caller late or, if the scope ends first, never. Starting here drains the replay cache
+        // before this returns.
+        val collector = collectorScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            events
+                .filterIsInstance<AppInstallEvent.ObbFailed>()
+                .collect { onObbFailed(it.reason) }
         }
+        installFinished.invokeOnCompletion { collector.cancel() }
 
         return Result.Submitted(operationId)
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallLauncher.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallLauncher.kt
@@ -3,20 +3,17 @@ package eu.darken.butler.workspace.core.operations
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
-import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.pkgs.installer.AppInstallEvent
 import eu.darken.butler.common.pkgs.installer.AppInstallInspector
 import eu.darken.butler.common.pkgs.installer.AppInstaller
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -42,8 +39,7 @@ class AppInstallLauncher @Inject constructor(
      * source, so the user goes to the settings page and no operation is created.
      *
      * Failures propagate - the caller owns how it reports them. [onObbFailed] runs in
-     * [collectorScope], the first time inline before this returns, and is unsubscribed once the
-     * install is done.
+     * [collectorScope] until the install is done.
      */
     suspend fun launch(
         path: APath<*>,
@@ -58,56 +54,37 @@ class AppInstallLauncher @Inject constructor(
             return Result.UnknownSourcesRequired
         }
 
-        // Replayed, not just buffered: a SharedFlow drops what it emits while nobody is subscribed.
-        // The flow is created per install and carries only this install's events, so there is nothing
-        // stale to replay.
-        val events = MutableSharedFlow<AppInstallEvent>(replay = 16, extraBufferCapacity = 16)
+        // A channel rather than a flow: it buffers what nobody is receiving yet, and the operation
+        // closing it on its way out both drains what is queued and ends the collector, so a listener
+        // never outlives its install and nothing depends on which coroutine is scheduled first.
+        val events = Channel<AppInstallEvent>(capacity = Channel.BUFFERED)
 
-        val submittedId = CompletableDeferred<Operation.Id>()
-        val installFinished = CompletableDeferred<Unit>()
-
-        // Subscribed before the operation exists, hence the id arriving through a Deferred:
-        // completedOperations has no replay, so an install that finishes while submit() is still
-        // running would go unnoticed and leave the collector subscribed for the rest of
-        // collectorScope's life. Undispatched so that subscribing happens here rather than whenever
-        // collectorScope next runs.
+        // Receiving starts before the operation exists because the operation starts inside submit().
+        // Undispatched so that happens here rather than whenever collectorScope next runs.
         collectorScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            try {
-                operationsManager.completedOperations.first { it.id == submittedId.await() }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // collectorScope is the caller's, letting this out would take down whatever else runs
-                // in it over a watcher that only decides when to unsubscribe.
-                log(TAG, ERROR) { "launch($path): waiting for the end of the install failed - ${e.asLog()}" }
-            } finally {
-                installFinished.complete(Unit)
-            }
+            events.receiveAsFlow()
+                .filterIsInstance<AppInstallEvent.ObbFailed>()
+                .collect { onObbFailed(it.reason) }
         }
 
         // Closing the calling tab cancels the operation outright, which abandons the install session.
         // If the system's confirm dialog is already on screen the platform owns it from there and may
         // still complete the install on its own.
-        val operationId = operationsManager.submit(
-            appInstallOperationFactory.create(
-                installOrigin = origin,
-                plan = plan,
-                events = events,
+        val operationId = try {
+            operationsManager.submit(
+                appInstallOperationFactory.create(
+                    installOrigin = origin,
+                    plan = plan,
+                    events = events,
+                )
             )
-        )
-        log(TAG, INFO) { "launch($path): submitted as $operationId" }
-        submittedId.complete(operationId)
-
-        // Undispatched: a scheduled collector only starts once collectorScope next runs, and the
-        // operation starts inside submit(), so an ObbFailed it already reported would reach the
-        // caller late or, if the scope ends first, never. Starting here drains the replay cache
-        // before this returns.
-        val collector = collectorScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            events
-                .filterIsInstance<AppInstallEvent.ObbFailed>()
-                .collect { onObbFailed(it.reason) }
+        } catch (e: Throwable) {
+            // No operation owns the channel, so nothing else would ever close it and the collector
+            // would sit in collectorScope for the rest of its life.
+            events.close()
+            throw e
         }
-        installFinished.invokeOnCompletion { collector.cancel() }
+        log(TAG, INFO) { "launch($path): submitted as $operationId" }
 
         return Result.Submitted(operationId)
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallLauncher.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallLauncher.kt
@@ -1,0 +1,97 @@
+package eu.darken.butler.workspace.core.operations
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
+import eu.darken.butler.common.debug.logging.log
+import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.pkgs.installer.AppInstallEvent
+import eu.darken.butler.common.pkgs.installer.AppInstallInspector
+import eu.darken.butler.common.pkgs.installer.AppInstaller
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Turns "install this file" into a submitted [AppInstallOperation], for every workspace that offers
+ * it. Only [Operation.Metadata.Origin] and the messages shown differ between them.
+ */
+@Singleton
+class AppInstallLauncher @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val appInstallInspector: AppInstallInspector,
+    private val appInstaller: AppInstaller,
+    private val operationsManager: OperationsManager,
+    private val appInstallOperationFactory: AppInstallOperation.Factory,
+) {
+
+    /**
+     * Inspection runs here rather than inside the operation so an unreadable, protected or
+     * unsupported container is answered right away instead of behind a progress bar. The
+     * unknown-sources check is a preflight for the same reason: without elevated access the platform
+     * installer is the only route, and it refuses to run until Butler is an authorized install
+     * source, so the user goes to the settings page and no operation is created.
+     *
+     * Failures propagate - the caller owns how it reports them. [onObbFailed] runs in
+     * [collectorScope] and is unsubscribed once the install is done.
+     */
+    suspend fun launch(
+        path: APath<*>,
+        origin: Operation.Metadata.Origin,
+        collectorScope: CoroutineScope,
+        onObbFailed: suspend (reason: String) -> Unit,
+    ): Result {
+        val plan = appInstallInspector.inspect(path)
+        if (!appInstaller.hasElevation() && !appInstaller.canUseSystemInstaller()) {
+            log(TAG, INFO) { "launch($path): Butler is not an authorized install source yet" }
+            context.startActivity(appInstaller.unknownSourcesSettings())
+            return Result.UnknownSourcesRequired
+        }
+
+        // Replayed, not just buffered: launchIn schedules the collector rather than starting it, and
+        // a SharedFlow drops what it emits while nobody is subscribed. The flow is created per
+        // install and carries only this install's events, so there is nothing stale to replay.
+        val events = MutableSharedFlow<AppInstallEvent>(replay = 16, extraBufferCapacity = 16)
+        val collector = events
+            .filterIsInstance<AppInstallEvent.ObbFailed>()
+            .onEach { onObbFailed(it.reason) }
+            .launchIn(collectorScope)
+
+        // Closing the calling tab cancels the operation outright, which abandons the install session.
+        // If the system's confirm dialog is already on screen the platform owns it from there and may
+        // still complete the install on its own.
+        val operationId = operationsManager.submit(
+            appInstallOperationFactory.create(
+                installOrigin = origin,
+                plan = plan,
+                events = events,
+            )
+        )
+        log(TAG, INFO) { "launch($path): submitted as $operationId" }
+
+        collectorScope.launch {
+            operationsManager.completedOperations.first { it.id == operationId }
+            collector.cancel()
+        }
+
+        return Result.Submitted(operationId)
+    }
+
+    sealed interface Result {
+        data class Submitted(val operationId: Operation.Id) : Result
+
+        /** Butler is not an authorized install source yet, the settings page was opened instead. */
+        data object UnknownSourcesRequired : Result
+    }
+
+    companion object {
+        private val TAG = logTag("Workspace", "Operation", "AppInstall", "Launcher")
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallOperation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/AppInstallOperation.kt
@@ -19,8 +19,8 @@ import eu.darken.butler.common.pkgs.installer.AppInstaller
 import eu.darken.butler.common.progress.Progress
 import eu.darken.butler.workspace.R
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -30,12 +30,13 @@ import kotlin.time.Instant
  *
  * [events] is how anything that is not progress reaches the caller: [OperationsManager.submit]
  * hands back an id and [ManagedOperation] relays nothing but [Operation.State], so there is no
- * framework channel for the rest. The submitting ViewModel subscribes to it before submitting.
+ * framework channel for the rest. [AppInstallLauncher] receives from it and closes with this
+ * operation.
  */
 class AppInstallOperation @AssistedInject constructor(
     @Assisted private val installOrigin: Operation.Metadata.Origin,
     @Assisted private val plan: AppInstallPlan,
-    @Assisted private val events: MutableSharedFlow<AppInstallEvent>,
+    @Assisted private val events: SendChannel<AppInstallEvent>,
     private val appInstaller: AppInstaller,
 ) : Operation {
 
@@ -70,7 +71,7 @@ class AppInstallOperation @AssistedInject constructor(
                     )
                 )
 
-                is AppInstallEvent.ObbFailed -> events.emit(event)
+                is AppInstallEvent.ObbFailed -> events.send(event)
                 // Waiting rather than a bespoke notification: it is what the operations framework
                 // already alerts about, and its issue is what offers the dialog again.
                 is AppInstallEvent.ConfirmationRequired -> send(
@@ -111,6 +112,11 @@ class AppInstallOperation @AssistedInject constructor(
             is AppInstallEvent.Failure -> throw result.error
             else -> throw IllegalStateException("The install ended without a result")
         }
+    }
+
+    /** Ends [AppInstallLauncher]'s collector, after it has drained what is still queued. */
+    override fun onDiscarded() {
+        events.close()
     }
 
     private fun AppInstallEvent.Progress.toProgressData() = Progress.Data(
@@ -160,7 +166,7 @@ class AppInstallOperation @AssistedInject constructor(
         fun create(
             installOrigin: Operation.Metadata.Origin,
             plan: AppInstallPlan,
-            events: MutableSharedFlow<AppInstallEvent>,
+            events: SendChannel<AppInstallEvent>,
         ): AppInstallOperation
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilities.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilities.kt
@@ -1,0 +1,54 @@
+package eu.darken.butler.workspace.ui.actions
+
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.APathLookup
+import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.archive.ArchiveFormat
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.pkgs.installer.AppInstallFormat
+
+/**
+ * What a single file can be offered, shared by every surface that lists per-file actions, so the
+ * same file is offered the same things in the Explorer, the Searcher and the Viewer.
+ */
+data class FileActionCapabilities(
+    val installFormat: AppInstallFormat?,
+    val archiveFormat: ArchiveFormat?,
+    val isArchiveEntry: Boolean,
+    val isText: Boolean,
+    /** A file the system can be handed a `file://`/`content://` URI for. */
+    val canHandOffToOtherApps: Boolean,
+) {
+
+    val isInstallable: Boolean get() = installFormat != null
+
+    val isArchiveFile: Boolean get() = archiveFormat != null
+
+    companion object {
+        fun of(lookup: APathLookup<*>): FileActionCapabilities {
+            val path = lookup.lookedUp
+            val isArchiveEntry = path is ArchivePath
+            // Every name-derived answer below is meaningless for a folder, and each one ends with an
+            // executor being handed a directory: a folder named "app.apk" is not an install container.
+            val isFile = lookup.fileType != FileType.DIRECTORY
+            return FileActionCapabilities(
+                installFormat = if (isFile) AppInstallFormat.fromFileName(path.name) else null,
+                // An entry inside an archive is a nested archive at best, and cannot be opened as a
+                // container where it lies.
+                archiveFormat = if (isFile && !isArchiveEntry) ArchiveFormat.fromFileName(path.name) else null,
+                isArchiveEntry = isArchiveEntry,
+                isText = isFile && MimeInfo.fromFileName(path.name).isText,
+                canHandOffToOtherApps = canHandOffToOtherApps(path),
+            )
+        }
+
+        /**
+         * The single definition of [FileActionCapabilities.canHandOffToOtherApps], for the surfaces
+         * that only hold a path. It is the constraint OpenWithIntentUseCase and ShareIntentUseCase
+         * impose: they resolve a URI for nothing else, and every other path type fails the hand-off.
+         */
+        fun canHandOffToOtherApps(path: APath<*>): Boolean = path is LocalPath
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilities.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilities.kt
@@ -40,7 +40,7 @@ data class FileActionCapabilities(
                 archiveFormat = if (isFile && !isArchiveEntry) ArchiveFormat.fromFileName(path.name) else null,
                 isArchiveEntry = isArchiveEntry,
                 isText = isFile && MimeInfo.fromFileName(path.name).isText,
-                canHandOffToOtherApps = canHandOffToOtherApps(path),
+                canHandOffToOtherApps = isFile && canHandOffToOtherApps(path),
             )
         }
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.job
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -156,28 +158,44 @@ class AppInstallLauncherTest : BaseTest() {
     }
 
     /**
-     * The normal case for a real install: the expansion file fails after launch() has returned, and
-     * the install finishes right behind it.
+     * The normal case for a real install, driven through the real lifecycle: the expansion file
+     * fails while the install runs, the install finishes right behind it, and the operation being
+     * discarded is what closes the channel. Nothing stands in for the operation here, so a reason
+     * lost at completion and a listener that outlives its install both surface as a failure.
      */
     @Test
     fun `a failed expansion file survives the install completing right after it`() = runTest2 {
         val launcher = create()
-        val events = slot<SendChannel<AppInstallEvent>>()
-        every { operationFactory.create(any(), any(), capture(events)) } returns mockk(relaxed = true)
+        every { installer.install(any(), any()) } returns flowOf(
+            AppInstallEvent.ObbFailed("No space left"),
+            AppInstallEvent.Success(pkgId = plan.pkgId, viaMode = AppInstaller.Mode.ROOT, obbPlaced = false),
+        )
+        every { operationFactory.create(any(), any(), any()) } answers {
+            AppInstallOperation(
+                installOrigin = firstArg<Operation.Metadata.Origin>(),
+                plan = secondArg<AppInstallPlan>(),
+                events = thirdArg<SendChannel<AppInstallEvent>>(),
+                appInstaller = installer,
+            )
+        }
+        coEvery { operationsManager.submit(any()) } coAnswers {
+            ManagedOperation(operationId, firstArg<Operation>(), backgroundScope).start()
+            operationId
+        }
 
         val dispatcher = ReorderingDispatcher()
         val collectorScope = CoroutineScope(dispatcher + Job())
         val reasons = mutableListOf<String>()
 
         launcher.launch(source, origin, collectorScope) { reasons.add(it) }
+        val collector = collectorScope.coroutineContext.job.children.single()
 
-        events.captured.send(AppInstallEvent.ObbFailed("No space left"))
-
-        dispatcher.runQueuedNewestFirst()
+        advanceUntilIdle()
         dispatcher.runQueued()
-        collectorScope.cancel()
 
         reasons shouldBe listOf("No space left")
+        collector.isCompleted shouldBe true
+        collectorScope.cancel()
     }
 
     /**
@@ -209,7 +227,7 @@ class AppInstallLauncherTest : BaseTest() {
 
     /**
      * Stands in for a multi-threaded dispatcher: it queues resumptions instead of running them, so a
-     * test can pick when and in which order ready coroutines run.
+     * test can pick when ready coroutines run.
      */
     private class ReorderingDispatcher : CoroutineDispatcher() {
 
@@ -217,11 +235,6 @@ class AppInstallLauncherTest : BaseTest() {
 
         override fun dispatch(context: CoroutineContext, block: Runnable) {
             synchronized(tasks) { tasks.add(block) }
-        }
-
-        fun runQueuedNewestFirst() {
-            val pending = synchronized(tasks) { tasks.toList().also { tasks.clear() } }
-            pending.asReversed().forEach { it.run() }
         }
 
         fun runQueued() {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.job
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import testhelpers.BaseTest
@@ -178,8 +179,11 @@ class AppInstallLauncherTest : BaseTest() {
                 appInstaller = installer,
             )
         }
+        // Not backgroundScope: advanceUntilIdle() ignores background work, so the operation would
+        // never run at all and the test would pass an empty channel off as a delivered event.
+        val operationScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
         coEvery { operationsManager.submit(any()) } coAnswers {
-            ManagedOperation(operationId, firstArg<Operation>(), backgroundScope).start()
+            ManagedOperation(operationId, firstArg<Operation>(), operationScope).start()
             operationId
         }
 
@@ -196,6 +200,7 @@ class AppInstallLauncherTest : BaseTest() {
         reasons shouldBe listOf("No space left")
         collector.isCompleted shouldBe true
         collectorScope.cancel()
+        operationScope.cancel()
     }
 
     /**

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
@@ -18,11 +18,17 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.job
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import kotlin.coroutines.CoroutineContext
 
 class AppInstallLauncherTest : BaseTest() {
 
@@ -59,7 +65,6 @@ class AppInstallLauncherTest : BaseTest() {
         every { installer.unknownSourcesSettings() } returns mockk<Intent>(relaxed = true)
         every { operationFactory.create(any(), any(), any()) } returns mockk(relaxed = true)
         coEvery { operationsManager.submit(any()) } returns operationId
-        every { operationsManager.completedOperations } returns MutableSharedFlow()
         return AppInstallLauncher(
             context = context,
             appInstallInspector = inspector,
@@ -129,15 +134,15 @@ class AppInstallLauncherTest : BaseTest() {
     }
 
     /**
-     * The operation may report a failed expansion file before the collector is running, which is
+     * The operation may report a failed expansion file while it is still being submitted, which is
      * the one window in which the toast used to be lost.
      */
     @Test
-    fun `a failed expansion file reported before the collector starts still reaches the caller`() = runTest2 {
+    fun `a failed expansion file reported during submission still reaches the caller`() = runTest2 {
         val launcher = create()
         val reasons = mutableListOf<String>()
         every { operationFactory.create(any(), any(), any()) } answers {
-            thirdArg<MutableSharedFlow<AppInstallEvent>>().tryEmit(AppInstallEvent.ObbFailed("No space left"))
+            thirdArg<SendChannel<AppInstallEvent>>().trySend(AppInstallEvent.ObbFailed("No space left"))
             mockk(relaxed = true)
         }
 
@@ -145,5 +150,82 @@ class AppInstallLauncherTest : BaseTest() {
         advanceUntilIdle()
 
         reasons shouldBe listOf("No space left")
+    }
+
+    /**
+     * The normal case for a real install: the expansion file fails after launch() has returned, and
+     * the install finishes right behind it.
+     */
+    @Test
+    fun `a failed expansion file survives the install completing right after it`() = runTest2 {
+        val launcher = create()
+        val events = slot<SendChannel<AppInstallEvent>>()
+        every { operationFactory.create(any(), any(), capture(events)) } returns mockk(relaxed = true)
+
+        val dispatcher = ReorderingDispatcher()
+        val collectorScope = CoroutineScope(dispatcher + Job())
+        val reasons = mutableListOf<String>()
+
+        launcher.launch(source, origin, collectorScope) { reasons.add(it) }
+
+        events.captured.send(AppInstallEvent.ObbFailed("No space left"))
+
+        dispatcher.runQueuedNewestFirst()
+        dispatcher.runQueued()
+        collectorScope.cancel()
+
+        reasons shouldBe listOf("No space left")
+    }
+
+    /**
+     * The operation closes the channel when it is discarded, and that is the only thing that ends
+     * the collector: an event the channel still holds has to reach the caller anyway, and the
+     * collector has to be gone afterwards so no listener outlives its install.
+     */
+    @Test
+    fun `closing the events channel delivers what it still holds and then ends the collector`() = runTest2 {
+        val launcher = create()
+        val events = slot<SendChannel<AppInstallEvent>>()
+        every { operationFactory.create(any(), any(), capture(events)) } returns mockk(relaxed = true)
+
+        val dispatcher = ReorderingDispatcher()
+        val collectorScope = CoroutineScope(dispatcher + Job())
+        val reasons = mutableListOf<String>()
+
+        launcher.launch(source, origin, collectorScope) { reasons.add(it) }
+        val collector = collectorScope.coroutineContext.job.children.single()
+
+        events.captured.send(AppInstallEvent.ObbFailed("No space left"))
+        events.captured.close()
+        dispatcher.runQueued()
+
+        reasons shouldBe listOf("No space left")
+        collector.isCompleted shouldBe true
+        collectorScope.cancel()
+    }
+
+    /**
+     * Stands in for a multi-threaded dispatcher: it queues resumptions instead of running them, so a
+     * test can pick when and in which order ready coroutines run.
+     */
+    private class ReorderingDispatcher : CoroutineDispatcher() {
+
+        private val tasks = mutableListOf<Runnable>()
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            synchronized(tasks) { tasks.add(block) }
+        }
+
+        fun runQueuedNewestFirst() {
+            val pending = synchronized(tasks) { tasks.toList().also { tasks.clear() } }
+            pending.asReversed().forEach { it.run() }
+        }
+
+        fun runQueued() {
+            while (true) {
+                val next = synchronized(tasks) { tasks.firstOrNull()?.also { tasks.removeAt(0) } } ?: return
+                next.run()
+            }
+        }
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.job
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -146,10 +145,14 @@ class AppInstallLauncherTest : BaseTest() {
             mockk(relaxed = true)
         }
 
-        launcher.launch(source, origin, backgroundScope) { reasons.add(it) }
-        advanceUntilIdle()
+        val dispatcher = ReorderingDispatcher()
+        val collectorScope = CoroutineScope(dispatcher + Job())
+
+        launcher.launch(source, origin, collectorScope) { reasons.add(it) }
+        dispatcher.runQueued()
 
         reasons shouldBe listOf("No space left")
+        collectorScope.cancel()
     }
 
     /**

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallLauncherTest.kt
@@ -1,0 +1,149 @@
+package eu.darken.butler.workspace.core.operations
+
+import android.content.Context
+import android.content.Intent
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.pkgs.installer.AppInstallEvent
+import eu.darken.butler.common.pkgs.installer.AppInstallFormat
+import eu.darken.butler.common.pkgs.installer.AppInstallInspector
+import eu.darken.butler.common.pkgs.installer.AppInstallPlan
+import eu.darken.butler.common.pkgs.installer.AppInstaller
+import eu.darken.butler.common.pkgs.toPkgId
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class AppInstallLauncherTest : BaseTest() {
+
+    private val source = LocalPath.build("/sdcard/Download/example.apk")
+
+    private val plan = AppInstallPlan(
+        source = source,
+        format = AppInstallFormat.APK,
+        pkgId = "com.example.app".toPkgId(),
+        baseInfo = null,
+        splits = listOf(
+            AppInstallPlan.Split(entryPath = "example.apk", stagedName = "base.apk", size = 1024L),
+        ),
+        obbEntries = emptyList(),
+        warnings = emptyList(),
+    )
+
+    private val origin = Operation.Metadata.Origin.Searcher(Workspace.Id())
+    private val operationId = Operation.Id()
+
+    private val context = mockk<Context>(relaxed = true)
+    private val inspector = mockk<AppInstallInspector>()
+    private val installer = mockk<AppInstaller>()
+    private val operationsManager = mockk<OperationsManager>()
+    private val operationFactory = mockk<AppInstallOperation.Factory>()
+
+    private fun create(
+        hasElevation: Boolean = true,
+        canUseSystemInstaller: Boolean = false,
+    ): AppInstallLauncher {
+        coEvery { inspector.inspect(source) } returns plan
+        coEvery { installer.hasElevation() } returns hasElevation
+        every { installer.canUseSystemInstaller() } returns canUseSystemInstaller
+        every { installer.unknownSourcesSettings() } returns mockk<Intent>(relaxed = true)
+        every { operationFactory.create(any(), any(), any()) } returns mockk(relaxed = true)
+        coEvery { operationsManager.submit(any()) } returns operationId
+        every { operationsManager.completedOperations } returns MutableSharedFlow()
+        return AppInstallLauncher(
+            context = context,
+            appInstallInspector = inspector,
+            appInstaller = installer,
+            operationsManager = operationsManager,
+            appInstallOperationFactory = operationFactory,
+        )
+    }
+
+    @Test
+    fun `a container that cannot be inspected never becomes an operation`() = runTest2 {
+        val launcher = create()
+        coEvery { inspector.inspect(source) } throws IllegalStateException("Unreadable")
+
+        shouldThrow<IllegalStateException> {
+            launcher.launch(source, origin, backgroundScope) {}
+        }
+
+        coVerify(exactly = 0) { operationsManager.submit(any()) }
+    }
+
+    @Test
+    fun `elevated access installs without asking about unknown sources`() = runTest2 {
+        val launcher = create(hasElevation = true, canUseSystemInstaller = false)
+
+        val result = launcher.launch(source, origin, backgroundScope) {}
+
+        result shouldBe AppInstallLauncher.Result.Submitted(operationId)
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `an authorized install source installs without elevated access`() = runTest2 {
+        val launcher = create(hasElevation = false, canUseSystemInstaller = true)
+
+        val result = launcher.launch(source, origin, backgroundScope) {}
+
+        result shouldBe AppInstallLauncher.Result.Submitted(operationId)
+        coVerify { operationsManager.submit(any()) }
+    }
+
+    /** Without either route the install would only fail later, so the settings page comes first. */
+    @Test
+    fun `an unauthorized install source is sent to the settings page instead`() = runTest2 {
+        val launcher = create(hasElevation = false, canUseSystemInstaller = false)
+
+        val result = launcher.launch(source, origin, backgroundScope) {}
+
+        result shouldBe AppInstallLauncher.Result.UnknownSourcesRequired
+        verify { context.startActivity(any()) }
+        coVerify(exactly = 0) { operationsManager.submit(any()) }
+    }
+
+    @Test
+    fun `the inspected plan and the calling workspace reach the operation`() = runTest2 {
+        val launcher = create()
+        val planSlot = slot<AppInstallPlan>()
+        val originSlot = slot<Operation.Metadata.Origin>()
+        every {
+            operationFactory.create(capture(originSlot), capture(planSlot), any())
+        } returns mockk(relaxed = true)
+
+        launcher.launch(source, origin, backgroundScope) {}
+
+        planSlot.captured shouldBe plan
+        originSlot.captured shouldBe origin
+    }
+
+    /**
+     * The operation may report a failed expansion file before the collector is running, which is
+     * the one window in which the toast used to be lost.
+     */
+    @Test
+    fun `a failed expansion file reported before the collector starts still reaches the caller`() = runTest2 {
+        val launcher = create()
+        val reasons = mutableListOf<String>()
+        every { operationFactory.create(any(), any(), any()) } answers {
+            thirdArg<MutableSharedFlow<AppInstallEvent>>().tryEmit(AppInstallEvent.ObbFailed("No space left"))
+            mockk(relaxed = true)
+        }
+
+        launcher.launch(source, origin, backgroundScope) { reasons.add(it) }
+        advanceUntilIdle()
+
+        reasons shouldBe listOf("No space left")
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallOperationTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/AppInstallOperationTest.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import org.junit.Test
@@ -44,7 +44,7 @@ class AppInstallOperationTest : BaseTest() {
     private fun operation(appInstaller: AppInstaller = mockk()) = AppInstallOperation(
         installOrigin = Operation.Metadata.Origin.Explorer(Workspace.Id()),
         plan = plan,
-        events = MutableSharedFlow(),
+        events = Channel(),
         appInstaller = appInstaller,
     )
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilitiesTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilitiesTest.kt
@@ -1,0 +1,105 @@
+package eu.darken.butler.workspace.ui.actions
+
+import eu.darken.butler.common.files.ArchivePath
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.SAFPath
+import eu.darken.butler.common.files.SmbPath
+import eu.darken.butler.common.files.archive.ArchivePathLookup
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.saf.SAFPathLookup
+import eu.darken.butler.common.files.smb.SmbPathLookup
+import eu.darken.butler.common.pkgs.installer.AppInstallFormat
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import kotlin.uuid.Uuid
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class FileActionCapabilitiesTest : BaseTest() {
+
+    private val treeUri = "content://com.android.externalstorage.documents/tree/primary%3A"
+
+    private fun localFile(name: String, fileType: FileType = FileType.FILE) = LocalPathLookup(
+        lookedUp = LocalPath.build("/storage/emulated/0/Download/$name"),
+        fileType = fileType,
+        size = 1024L,
+        modifiedAt = null,
+    )
+
+    @Test
+    fun `every app install container is installable`() {
+        listOf("app.apk", "app.apks", "app.xapk", "app.apkm").forEach { name ->
+            FileActionCapabilities.of(localFile(name)).isInstallable shouldBe true
+        }
+    }
+
+    @Test
+    fun `the extension is matched regardless of case`() {
+        FileActionCapabilities.of(localFile("APP.APK")).installFormat shouldBe AppInstallFormat.APK
+    }
+
+    @Test
+    fun `an archive is not an app install container`() {
+        val caps = FileActionCapabilities.of(localFile("stuff.zip"))
+
+        caps.isArchiveFile shouldBe true
+        caps.isInstallable shouldBe false
+    }
+
+    @Test
+    fun `an entry inside an archive cannot be extracted as a container of its own`() {
+        val caps = FileActionCapabilities.of(
+            ArchivePathLookup(
+                lookedUp = ArchivePath(
+                    container = LocalPath.build("/storage/emulated/0/Download/outer.zip"),
+                    segments = listOf("inner.zip"),
+                ),
+                fileType = FileType.FILE,
+                size = 512L,
+                modifiedAt = null,
+            )
+        )
+
+        caps.isArchiveEntry shouldBe true
+        caps.archiveFormat shouldBe null
+    }
+
+    @Test
+    fun `text files are recognized by name`() {
+        FileActionCapabilities.of(localFile("notes.txt")).isText shouldBe true
+        FileActionCapabilities.of(localFile("app.apk")).isText shouldBe false
+    }
+
+    @Test
+    fun `a folder is never treated as the file its name looks like`() {
+        FileActionCapabilities.of(localFile("app.apk", FileType.DIRECTORY)).isInstallable shouldBe false
+        FileActionCapabilities.of(localFile("notes.txt", FileType.DIRECTORY)).isText shouldBe false
+        FileActionCapabilities.of(localFile("stuff.zip", FileType.DIRECTORY)).isArchiveFile shouldBe false
+    }
+
+    @Test
+    fun `only a local file can be handed to another app`() {
+        FileActionCapabilities.of(localFile("notes.txt")).canHandOffToOtherApps shouldBe true
+
+        val onServer = SmbPathLookup(
+            lookedUp = SmbPath(Uuid.parse("11111111-2222-3333-4444-555555555555"), listOf("notes.txt")),
+            fileType = FileType.FILE,
+            size = 128L,
+            modifiedAt = null,
+        )
+        FileActionCapabilities.of(onServer).canHandOffToOtherApps shouldBe false
+
+        val viaSaf = SAFPathLookup(
+            lookedUp = SAFPath.build(treeUri, "Download", "notes.txt"),
+            fileType = FileType.FILE,
+            size = 128L,
+            modifiedAt = null,
+        )
+        FileActionCapabilities.of(viaSaf).canHandOffToOtherApps shouldBe false
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilitiesTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/actions/FileActionCapabilitiesTest.kt
@@ -86,6 +86,9 @@ class FileActionCapabilitiesTest : BaseTest() {
     fun `only a local file can be handed to another app`() {
         FileActionCapabilities.of(localFile("notes.txt")).canHandOffToOtherApps shouldBe true
 
+        // A folder has no stream a receiver could open, so it is not something to hand off either.
+        FileActionCapabilities.of(localFile("Pictures", FileType.DIRECTORY)).canHandOffToOtherApps shouldBe false
+
         val onServer = SmbPathLookup(
             lookedUp = SmbPath(Uuid.parse("11111111-2222-3333-4444-555555555555"), listOf("notes.txt")),
             fileType = FileType.FILE,


### PR DESCRIPTION
## What changed

Finding an APK, APKS, XAPK or APKM file through search and opening its actions now offers **Install**, the same as browsing to it in the file list does. Until now the only way to install a package you had found by searching was to open its folder first.

Two actions also stopped being offered where they could never work:

- **Share** and **Open with** no longer appear for files the system cannot hand to another app: files on a network share, and files reached through a storage grant, which is how `/Android/data` is reached on Android 11 and newer. They used to appear and fail every time they were tapped. This affects the file list, the search results and the viewer alike. Selecting several files at once is covered too, where sharing a mixed selection previously handed over only some of the files without saying so.
- **Install** and **Share** no longer appear for folders. A folder named something like `app.apk` was previously offered Install.

## Technical Context

- Root cause of the missing action: every workspace decided for itself which actions a file supports, from its own private predicates. The file list checked whether a name looked installable; search never asked. The same divergence had produced three separate copies of a "can this be handed to another app" check, and each copy had to be found and corrected by a different reviewer.
- The fix introduces one shared resolver (`FileActionCapabilities`) that every surface asks, and one shared executor (`AppInstallLauncher`) replacing an install code path that had been duplicated between two view models. Adding a third copy is what fixing the reported bug would otherwise have cost.
- The hand-off rule is now the constraint the intent code actually imposes — the path is a plain local file — instead of the previous "not a network path". That is a deliberate behaviour change: SAF-backed files lose two menu entries in the file list and viewer, entries that returned an error 100% of the time.
- `AppInstallOperation` now receives a channel rather than a shared flow, and closes it when discarded. This is the part worth close review: the previous arrangement could drop the "expansion files couldn't be placed" warning, first because nothing was subscribed when it was emitted, then because a completion watcher could cancel the subscriber before it drained. The channel removes both windows, and the lifecycle test drives a real operation to completion rather than a mock.
- Search results now carry the same directory handling as the file list, so name-derived answers (installable, archive, text) are not applied to folders.
