### PR TITLE
Workspace: Grow the tab manager out of the button that opens it

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/compose/CircularReveal.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/compose/CircularReveal.kt
@@ -1,0 +1,82 @@
+package eu.darken.butler.common.compose
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.hypot
+import kotlin.math.max
+
+/** Material's emphasized decelerate curve, for content entering the screen. */
+val EmphasizedDecelerate = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1.0f)
+
+/** Material's emphasized accelerate curve, for content leaving the screen. */
+val EmphasizedAccelerate = CubicBezierEasing(0.3f, 0.0f, 0.8f, 0.15f)
+
+/**
+ * Distance from [origin] to the farthest corner of a rect of [size] — the radius at which a circle
+ * around [origin] covers that rect completely.
+ */
+fun maxRevealRadius(origin: Offset, size: Size): Float {
+    val left = origin.x
+    val top = origin.y
+    val right = size.width - origin.x
+    val bottom = size.height - origin.y
+    return max(
+        max(hypot(left, top), hypot(right, top)),
+        max(hypot(left, bottom), hypot(right, bottom)),
+    )
+}
+
+/**
+ * Circle around [origin] that grows from nothing at [progress] `0` to the whole layer at `1`.
+ * A null [origin] centres the circle.
+ *
+ * A uniform round rect whose corner radius is half its side is a circle and stays on the outline
+ * fast path, which an [Outline.Generic] path would not.
+ */
+@Immutable
+class CircularRevealShape(
+    private val progress: Float,
+    private val origin: Offset?,
+) : Shape {
+
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+        if (progress >= 1f) return Outline.Rectangle(size.toRect())
+        val centre = origin ?: size.center
+        val radius = maxRevealRadius(centre, size) * progress
+        return Outline.Rounded(
+            RoundRect(
+                left = centre.x - radius,
+                top = centre.y - radius,
+                right = centre.x + radius,
+                bottom = centre.y + radius,
+                cornerRadius = CornerRadius(radius),
+            ),
+        )
+    }
+}
+
+/**
+ * Clips the content to a [CircularRevealShape]. Both parameters are lambdas and the layer block is
+ * deferred, so an animated progress stays in the draw phase instead of recomposing the content.
+ *
+ * [origin] is in the coordinates of the node this is applied to.
+ */
+fun Modifier.circularReveal(
+    progress: () -> Float,
+    origin: () -> Offset?,
+): Modifier = graphicsLayer {
+    clip = true
+    shape = CircularRevealShape(progress(), origin())
+}

--- a/app-common/src/test/java/eu/darken/butler/common/compose/CircularRevealTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/compose/CircularRevealTest.kt
@@ -1,0 +1,77 @@
+package eu.darken.butler.common.compose
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CircularRevealTest : BaseTest() {
+
+    private val size = Size(300f, 400f)
+
+    private fun outlineAt(progress: Float, origin: Offset?) = CircularRevealShape(progress, origin)
+        .createOutline(size, LayoutDirection.Ltr, Density(1f))
+
+    @Test
+    fun `a corner reaches across the diagonal`() {
+        val diagonal = 500f
+        maxRevealRadius(Offset(0f, 0f), size) shouldBe (diagonal plusOrMinus 0.01f)
+        maxRevealRadius(Offset(300f, 0f), size) shouldBe (diagonal plusOrMinus 0.01f)
+        maxRevealRadius(Offset(0f, 400f), size) shouldBe (diagonal plusOrMinus 0.01f)
+        maxRevealRadius(Offset(300f, 400f), size) shouldBe (diagonal plusOrMinus 0.01f)
+    }
+
+    @Test
+    fun `the centre reaches half the diagonal`() {
+        maxRevealRadius(Offset(150f, 200f), size) shouldBe (250f plusOrMinus 0.01f)
+    }
+
+    @Test
+    fun `an off-centre origin measures to the farthest corner`() {
+        // Near the top-left, so the bottom-right corner is the one that decides: hypot(290, 390).
+        maxRevealRadius(Offset(10f, 10f), size) shouldBe (486.0f plusOrMinus 0.1f)
+    }
+
+    @Test
+    fun `a finished reveal is the plain rect`() {
+        val outline = outlineAt(progress = 1f, origin = Offset(10f, 10f))
+            .shouldBeInstanceOf<Outline.Rectangle>()
+        outline.rect.left shouldBe 0f
+        outline.rect.top shouldBe 0f
+        outline.rect.right shouldBe 300f
+        outline.rect.bottom shouldBe 400f
+    }
+
+    @Test
+    fun `a running reveal is a circle around the origin`() {
+        val origin = Offset(10f, 10f)
+        val outline = outlineAt(progress = 0.5f, origin = origin)
+            .shouldBeInstanceOf<Outline.Rounded>()
+
+        val radius = 486.0f / 2f
+        outline.roundRect.left shouldBe ((origin.x - radius) plusOrMinus 0.1f)
+        outline.roundRect.top shouldBe ((origin.y - radius) plusOrMinus 0.1f)
+        outline.roundRect.right shouldBe ((origin.x + radius) plusOrMinus 0.1f)
+        outline.roundRect.bottom shouldBe ((origin.y + radius) plusOrMinus 0.1f)
+        outline.roundRect.topLeftCornerRadius.x shouldBe (radius plusOrMinus 0.1f)
+        outline.roundRect.topLeftCornerRadius.y shouldBe (radius plusOrMinus 0.1f)
+    }
+
+    @Test
+    fun `no origin reveals from the centre`() {
+        val outline = outlineAt(progress = 0.5f, origin = null)
+            .shouldBeInstanceOf<Outline.Rounded>()
+
+        val radius = 250f / 2f
+        outline.roundRect.left shouldBe ((150f - radius) plusOrMinus 0.1f)
+        outline.roundRect.top shouldBe ((200f - radius) plusOrMinus 0.1f)
+        outline.roundRect.right shouldBe ((150f + radius) plusOrMinus 0.1f)
+        outline.roundRect.bottom shouldBe ((200f + radius) plusOrMinus 0.1f)
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
@@ -27,7 +27,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -55,10 +58,19 @@ fun WorkspaceButton(
     mascotVariant: ButlerMascotMode = ButlerMascotMode.Animated.RandomCycling(),
 ) {
     val provider = LocalWorkspaceButtonProvider.current
+    val revealOrigin = LocalWorkspaceRevealOrigin.current
     val state = provider?.state?.collectAsState(initial = null)?.value
 
     var expanded by remember { mutableStateOf(false) }
     var showCloseAllDialog by remember { mutableStateOf(false) }
+    // The button, not the surrounding box: the badges overflow that box, so its centre is offset
+    // from the mascot the manager should appear to grow out of.
+    var buttonBounds by remember { mutableStateOf(Rect.Zero) }
+
+    val openManager: () -> Unit = {
+        revealOrigin?.offset = buttonBounds.center
+        provider?.navToWorkspaceManager()
+    }
 
     Box(modifier = modifier) {
         @Suppress("COMPOSE_APPLIER_CALL_MISMATCH")
@@ -66,13 +78,12 @@ fun WorkspaceButton(
             modifier = Modifier
                 .size(buttonSize)
                 .testTag(WorkspaceButtonDefaults.TEST_TAG)
+                .onGloballyPositioned { buttonBounds = it.boundsInRoot() }
                 .clip(RoundedCornerShape(8.dp))
                 .background(containerColor ?: MaterialTheme.colorScheme.tertiaryContainer)
                 .combinedClickable(
                     onClick = { expanded = true },
-                    onLongClick = {
-                        provider?.navToWorkspaceManager()
-                    }
+                    onLongClick = openManager
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -91,6 +102,7 @@ fun WorkspaceButton(
             currentWorkspaceId = currentWorkspaceId,
             provider = provider,
             onCloseAllRequested = { showCloseAllDialog = true },
+            onOpenManager = openManager,
         )
 
         // Close all confirmation dialog

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
@@ -43,6 +43,7 @@ fun WorkspaceButtonMenu(
     currentWorkspaceId: Workspace.Id? = null,
     provider: WorkspaceButtonProvider?,
     onCloseAllRequested: () -> Unit,
+    onOpenManager: () -> Unit,
 ) {
     DismissWhenPaneUnfocused(expanded = expanded, onDismiss = onDismissRequest)
     DropdownMenu(
@@ -100,7 +101,7 @@ fun WorkspaceButtonMenu(
             text = { Text(stringResource(R.string.workspace_button_menu_manager_action)) },
             onClick = {
                 onDismissRequest()
-                provider?.navToWorkspaceManager()
+                onOpenManager()
             },
             leadingIcon = {
                 Icon(
@@ -216,6 +217,7 @@ private fun WorkspaceButtonMenuPreview() {
         currentWorkspaceId = Workspace.Id(),
         provider = FakeWorkspaceButtonProvider(),
         onCloseAllRequested = {},
+        onOpenManager = {},
     )
 }
 
@@ -236,6 +238,7 @@ private fun WorkspaceButtonMenuFreshInstallPreview() {
         currentWorkspaceId = null,
         provider = FakeWorkspaceButtonProvider(),
         onCloseAllRequested = {},
+        onOpenManager = {},
     )
 }
 
@@ -250,5 +253,6 @@ private fun WorkspaceButtonMenuNoRecentsPreview() {
         currentWorkspaceId = Workspace.Id(),
         provider = FakeWorkspaceButtonProvider(),
         onCloseAllRequested = {},
+        onOpenManager = {},
     )
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceRevealOrigin.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceRevealOrigin.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.workspace.ui.manager
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.geometry.Offset
+
+/**
+ * Where the tab manager should grow from, in root coordinates.
+ *
+ * The slot is written at the moment a button asks to open the manager, never continuously from
+ * layout, and it is never cleared. Many buttons exist at once, so a slot fed from layout would hold
+ * whichever of them laid out last instead of the one the user pressed.
+ */
+@Stable
+class WorkspaceRevealOrigin {
+    var offset: Offset? by mutableStateOf(null)
+}
+
+val LocalWorkspaceRevealOrigin = staticCompositionLocalOf<WorkspaceRevealOrigin?> { null }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlay.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlay.kt
@@ -108,17 +108,11 @@ internal fun ManagerRevealOverlay(
             // The origin is recorded in root coordinates while the clip shape is built in this
             // Box's own ones, so subtract wherever the Box landed.
             .onGloballyPositioned { boxOriginInRoot = it.positionInRoot() }
-            // Before the scaling layer on purpose: the clip stays the outer layer, so the circle
-            // keeps its anchor in unscaled coordinates while the content scales inside it.
-            .circularReveal(
-                progress = { state.progress.value },
-                origin = { revealOrigin.offset?.minus(boxOriginInRoot) },
-            )
-            // The manager is laid out and hit-testable from progress 0, so without this a tap lands
-            // on a card the clip has not uncovered yet, and a tap during the exit acts on an
-            // overlay the user already dismissed. The Initial pass is required: Compose dispatches
-            // it parent-to-child, while a barrier on the default Main pass would only see a card's
-            // down/up after that card's `clickable` had already fired.
+            // Outside the clip, so it swallows pointer events across the whole Box while the reveal
+            // runs: neither the cards above nor the workspace below react until it settles. The
+            // Initial pass is required: Compose dispatches it parent-to-child, while a barrier on
+            // the default Main pass would only see a card's down/up after that card's `clickable`
+            // had already fired.
             .then(
                 if (state.revealSettled) {
                     Modifier
@@ -131,6 +125,12 @@ internal fun ManagerRevealOverlay(
                         }
                     }
                 },
+            )
+            // Before the scaling layer on purpose: the clip stays the outer layer, so the circle
+            // keeps its anchor in unscaled coordinates while the content scales inside it.
+            .circularReveal(
+                progress = { state.progress.value },
+                origin = { revealOrigin.offset?.minus(boxOriginInRoot) },
             )
             .graphicsLayer {
                 alpha = (state.progress.value / 0.4f).coerceIn(0f, 1f)

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlay.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlay.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
@@ -31,6 +32,7 @@ import eu.darken.butler.common.compose.EmphasizedAccelerate
 import eu.darken.butler.common.compose.EmphasizedDecelerate
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.circularReveal
+import eu.darken.butler.workspace.ui.manager.LocalWorkspaceRevealOrigin
 import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
 
 /**
@@ -145,7 +147,12 @@ internal fun ManagerRevealOverlay(
                 }
             },
     ) {
-        content()
+        // The origin slot belongs to the buttons outside the manager. The manager's own content
+        // hosts a WorkspaceButton as an illustration, and pressing it would otherwise re-aim the
+        // exit animation at the middle of the grid.
+        CompositionLocalProvider(LocalWorkspaceRevealOrigin provides null) {
+            content()
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlay.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlay.kt
@@ -1,0 +1,166 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.EmphasizedAccelerate
+import eu.darken.butler.common.compose.EmphasizedDecelerate
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.circularReveal
+import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
+
+/**
+ * Transition state of the tab manager overlay, hoisted out of [ManagerRevealOverlay] because the
+ * back handler and the pane focus suppression have to follow [layerPresent] too.
+ */
+@Stable
+internal class ManagerRevealState internal constructor(
+    /** Composition lifetime of the overlay: true from the frame `visible` flips true until the exit settles. */
+    val layerPresent: Boolean,
+    internal val progress: State<Float>,
+    internal val contentScale: State<Float>,
+    private val settled: State<Boolean>,
+) {
+    val revealSettled: Boolean get() = settled.value
+}
+
+@Composable
+internal fun rememberManagerRevealState(visible: Boolean): ManagerRevealState {
+    // `currentState` is seeded from the initial `visible`, so a process restore with the manager
+    // already open snaps instead of replaying the reveal.
+    val transition = updateTransition(targetState = visible, label = "ManagerReveal")
+    // Kept as the State object rather than `by`-delegated: the layer blocks below read it in the
+    // draw phase, so nothing recomposes per frame.
+    val progress = transition.animateFloat(
+        transitionSpec = {
+            if (targetState) {
+                tween(320, easing = EmphasizedDecelerate)
+            } else {
+                tween(220, easing = EmphasizedAccelerate)
+            }
+        },
+        label = "reveal",
+    ) { if (it) 1f else 0f }
+    val contentScale = transition.animateFloat(
+        transitionSpec = {
+            if (targetState) {
+                spring(dampingRatio = 0.68f, stiffness = Spring.StiffnessMediumLow)
+            } else {
+                tween(220, easing = EmphasizedAccelerate)
+            }
+        },
+        label = "revealScale",
+    ) { if (it) 1f else 0.85f }
+    // Derived, not a plain getter: a reader in composition wakes up when the boolean flips instead
+    // of on every animation frame.
+    val settled = remember(progress) { derivedStateOf { progress.value >= 1f } }
+    return ManagerRevealState(
+        layerPresent = transition.currentState || transition.targetState,
+        progress = progress,
+        contentScale = contentScale,
+        settled = settled,
+    )
+}
+
+/**
+ * Grows [content] out of the button recorded in [revealOrigin] and shrinks it back into it.
+ */
+@Composable
+internal fun ManagerRevealOverlay(
+    modifier: Modifier = Modifier,
+    state: ManagerRevealState,
+    revealOrigin: WorkspaceRevealOrigin,
+    content: @Composable () -> Unit,
+) {
+    if (!state.layerPresent) return
+
+    var boxOriginInRoot by remember { mutableStateOf(Offset.Zero) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            // The origin is recorded in root coordinates while the clip shape is built in this
+            // Box's own ones, so subtract wherever the Box landed.
+            .onGloballyPositioned { boxOriginInRoot = it.positionInRoot() }
+            // Before the scaling layer on purpose: the clip stays the outer layer, so the circle
+            // keeps its anchor in unscaled coordinates while the content scales inside it.
+            .circularReveal(
+                progress = { state.progress.value },
+                origin = { revealOrigin.offset?.minus(boxOriginInRoot) },
+            )
+            // The manager is laid out and hit-testable from progress 0, so without this a tap lands
+            // on a card the clip has not uncovered yet, and a tap during the exit acts on an
+            // overlay the user already dismissed. The Initial pass is required: Compose dispatches
+            // it parent-to-child, while a barrier on the default Main pass would only see a card's
+            // down/up after that card's `clickable` had already fired.
+            .then(
+                if (state.revealSettled) {
+                    Modifier
+                } else {
+                    Modifier.pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                            }
+                        }
+                    }
+                },
+            )
+            .graphicsLayer {
+                alpha = (state.progress.value / 0.4f).coerceIn(0f, 1f)
+                scaleX = state.contentScale.value
+                scaleY = state.contentScale.value
+                val local = revealOrigin.offset?.minus(boxOriginInRoot)
+                transformOrigin = if (local != null && size.width > 0f && size.height > 0f) {
+                    TransformOrigin(
+                        pivotFractionX = (local.x / size.width).coerceIn(0f, 1f),
+                        pivotFractionY = (local.y / size.height).coerceIn(0f, 1f),
+                    )
+                } else {
+                    TransformOrigin.Center
+                }
+            },
+    ) {
+        content()
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ManagerRevealOverlayPreview() {
+    ManagerRevealOverlay(
+        state = rememberManagerRevealState(visible = true),
+        revealOrigin = remember { WorkspaceRevealOrigin() },
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -60,11 +60,13 @@ import eu.darken.butler.workspace.ui.dialogs.WorkspaceRenameDialog
 import eu.darken.butler.workspace.ui.error.ErrorShareConsentDialog
 import eu.darken.butler.workspace.ui.feedback.BannerState
 import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
+import eu.darken.butler.workspace.ui.manager.LocalWorkspaceRevealOrigin
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonViewModel
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerScreen
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerGridDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceManagerViewModel
+import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
 import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
@@ -404,10 +406,16 @@ fun WorkspacesScreenHost(
         tourController.tryStart(managerTourDefinition)
     }
 
+    val revealOrigin = remember { WorkspaceRevealOrigin() }
+    val revealState = rememberManagerRevealState(visible = pageManagerState.isManagerOverlayVisible)
+
     // Selection mode is a state inside the overlay, so back leaves it first; dismissing the manager
     // outright would drop a selection the user is still assembling.
+    // Gated on the layer rather than the logical flag, same as the pane suppression below: both
+    // switch off together, so back during the exit cannot reach a pane handler underneath an
+    // overlay that is still drawn.
     ManagerOverlayBackHandler(
-        isOverlayVisible = pageManagerState.isManagerOverlayVisible,
+        isOverlayVisible = revealState.layerPresent,
         onDismiss = {
             // Asks the ViewModel rather than the collected state: a long-press reaches selectionFlow
             // a frame before managerState reflects it, and back in that window must not dismiss the
@@ -426,6 +434,7 @@ fun WorkspacesScreenHost(
 
     CompositionLocalProvider(
         LocalWorkspaceButtonProvider provides workspaceButtonVm,
+        LocalWorkspaceRevealOrigin provides revealOrigin,
         LocalWorkspacePageHosts provides vm.pageHosts,
         LocalWorkspaceScrollPositions provides vm.scrollPositions,
         LocalWorkspaceBarCollapseStates provides vm.barCollapseStates,
@@ -441,7 +450,7 @@ fun WorkspacesScreenHost(
                 managerDialogStates = managerDialogStates,
                 managerDialogs = managerDialogs,
                 modalDialogState = dialogRouting.modalHosted,
-                isOverlayVisible = pageManagerState.isManagerOverlayVisible,
+                isOverlayVisible = revealState.layerPresent,
                 reviewActivity = activity,
                 onScreenAction = { vm.executeScreenAction(it) },
                 onHideMotd = { vm.hideMotd(it) },
@@ -455,12 +464,15 @@ fun WorkspacesScreenHost(
         }
 
         // Manager overlay
-        if (pageManagerState.isManagerOverlayVisible) {
+        ManagerRevealOverlay(state = revealState, revealOrigin = revealOrigin) {
             managerState?.let { currentManagerState ->
                 WorkspaceManagerScreen(
                     state = currentManagerState,
                     lazyGridState = managerGridState,
-                    closeConfirmation = managerCloseConfirmation,
+                    // The manager sits outside every pane, where its dialogs are platform windows
+                    // rather than descendants of the reveal layer - a confirmation already pending
+                    // when the manager opens would show up full-size over a growing circle.
+                    closeConfirmation = managerCloseConfirmation.takeIf { revealState.revealSettled },
                     onCloseConfirmationResolve = { confirmed ->
                         managerCloseConfirmation?.let {
                             vm.executeScreenAction(

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealBarrierCoverageTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealBarrierCoverageTest.kt
@@ -1,0 +1,114 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.maxRevealRadius
+import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
+import io.kotest.assertions.withClue
+import io.kotest.matchers.floats.shouldBeGreaterThan
+import io.kotest.matchers.floats.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.math.hypot
+
+private const val BENEATH_TAG = "reveal.beneath"
+
+/**
+ * The overlay covers the whole screen from the first frame, but the reveal only uncovers a circle
+ * around the button that opened it. The screen behind is still there, still hit-testable, and a tap
+ * on the part the circle has not reached yet must not reach it.
+ */
+class ManagerRevealBarrierCoverageTest : ComposeTest() {
+
+    private fun ComposeContentTestRule.applyAndAdvanceBy(millis: Long) {
+        waitForIdle()
+        mainClock.advanceTimeBy(millis)
+    }
+
+    @Test
+    fun `a tap outside the growing circle does not reach the screen behind`() {
+        var visible by mutableStateOf(false)
+        var beneathClicks = 0
+        var state: ManagerRevealState? = null
+        val origin = WorkspaceRevealOrigin()
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(BENEATH_TAG)
+                            .clickable { beneathClicks++ },
+                    )
+                    val revealState = rememberManagerRevealState(visible = visible)
+                    state = revealState
+                    ManagerRevealOverlay(state = revealState, revealOrigin = origin) {
+                        Box(modifier = Modifier.fillMaxSize())
+                    }
+                }
+            }
+        }
+
+        composeTestRule.applyAndAdvanceBy(1_000)
+
+        val bounds = composeTestRule.onNodeWithTag(BENEATH_TAG).fetchSemanticsNode().boundsInRoot
+        val size = Size(bounds.width, bounds.height)
+        // Aim the reveal at the top left corner, so the opposite corner is the point that stays
+        // outside the circle for the longest.
+        composeTestRule.runOnIdle { origin.offset = Offset(bounds.left, bounds.top) }
+
+        composeTestRule.runOnIdle { visible = true }
+        composeTestRule.applyAndAdvanceBy(50)
+
+        val progress = composeTestRule.runOnIdle { state!!.progress.value }
+        val radius = maxRevealRadius(Offset.Zero, size) * progress
+        // Node-local, and the node fills the same area as the overlay, so this is also the distance
+        // from the circle's centre.
+        val farCorner = Offset(size.width * 0.97f, size.height * 0.97f)
+        val distance = hypot(farCorner.x, farCorner.y)
+
+        withClue("the reveal has to be part-way through, otherwise nothing is being covered up") {
+            progress shouldBeGreaterThan 0f
+            progress shouldBeLessThan 1f
+        }
+        withClue("the tap has to land outside the circle for this to test anything") {
+            distance shouldBeGreaterThan radius
+        }
+
+        composeTestRule.onNodeWithTag(BENEATH_TAG).performTouchInput { click(farCorner) }
+        composeTestRule.waitForIdle()
+
+        withClue(
+            "A tap on the part of the screen the reveal has not uncovered yet went through the " +
+                "tab manager and hit the workspace behind it. The reveal was $progress of the way " +
+                "in, so the circle had a radius of $radius and the tap landed $distance out."
+        ) {
+            beneathClicks shouldBe 0
+        }
+
+        // Guards the assertion above against passing for the wrong reason: once the reveal settles
+        // and the barrier goes away, the very same coordinate does reach the node underneath.
+        composeTestRule.applyAndAdvanceBy(1_000)
+        composeTestRule.onNodeWithTag(BENEATH_TAG).performTouchInput { click(farCorner) }
+        composeTestRule.waitForIdle()
+        withClue("the tap has to be able to reach the node underneath at all") {
+            beneathClicks shouldBe 1
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOriginScopeTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOriginScopeTest.kt
@@ -1,0 +1,87 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.butler.common.compose.LocalUserActivity
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.compose.UserActivitySignal
+import eu.darken.butler.workspace.ui.manager.LocalWorkspaceRevealOrigin
+import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
+import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
+import eu.darken.butler.workspace.ui.manager.rows.WorkspaceBadgeExplanationCard
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Duration
+
+/**
+ * The reveal origin records which button the user pressed to open the manager, and the exit
+ * animation shrinks back into it. The manager's own content contains a WorkspaceButton that is
+ * there to be looked at, not pressed, so nothing the overlay hosts may reach that slot.
+ */
+class ManagerRevealOriginScopeTest : ComposeTest() {
+
+    /** Where the rail button that opened the manager sat, in root coordinates. */
+    private val pressedButton = Offset(80f, 112f)
+
+    /**
+     * The illustrative mascot animates on a loop the card gives no way to override, and the
+     * composition-local default reports the user as permanently active, so the loop would keep the
+     * Robolectric clock from ever reaching idle. Reporting no activity parks it instead.
+     */
+    private object NeverActive : UserActivitySignal {
+        override fun isActive(idleAfter: Duration): Flow<Boolean> = MutableStateFlow(false)
+    }
+
+    @Composable
+    private fun OverlayHarness(origin: WorkspaceRevealOrigin) {
+        PreviewWrapper {
+            CompositionLocalProvider(
+                LocalUserActivity provides NeverActive,
+                LocalWorkspaceRevealOrigin provides origin,
+            ) {
+                ManagerRevealOverlay(
+                    // Already open on the first frame, so the reveal snaps and the overlay's
+                    // pre-settle input barrier is never in the way of the gesture below.
+                    state = rememberManagerRevealState(visible = true),
+                    revealOrigin = origin,
+                ) {
+                    WorkspaceBadgeExplanationCard(onDismiss = {})
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the manager's own content cannot move the reveal origin`() {
+        val origin = WorkspaceRevealOrigin().apply { offset = pressedButton }
+
+        composeTestRule.setContent { OverlayHarness(origin) }
+
+        composeTestRule.onNodeWithTag(WorkspaceButtonDefaults.TEST_TAG).assertExists()
+        composeTestRule.onNodeWithTag(WorkspaceButtonDefaults.TEST_TAG)
+            .performTouchInput { longClick() }
+
+        withClue(
+            "The illustrative WorkspaceButton in WorkspaceBadgeExplanationCard overwrote the reveal " +
+                "origin with its own centre. The manager would then shrink back into that card " +
+                "instead of into the button the user opened it from."
+        ) {
+            origin.offset shouldBe pressedButton
+        }
+
+        // Guards the assertion above against a false pass: had the overlay swallowed the gesture,
+        // the origin would survive for the wrong reason. The same node still takes a tap.
+        composeTestRule.onNodeWithTag(WorkspaceButtonDefaults.TEST_TAG).performClick()
+        composeTestRule.onNodeWithText("Tab manager").assertExists()
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlayTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlayTest.kt
@@ -1,0 +1,179 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+private const val CONTENT_TAG = "reveal.content"
+
+@Composable
+private fun RevealHarness(
+    visible: Boolean,
+    onState: (ManagerRevealState) -> Unit = {},
+    onContentClick: () -> Unit = {},
+) {
+    val state = rememberManagerRevealState(visible = visible)
+    onState(state)
+    ManagerRevealOverlay(
+        state = state,
+        revealOrigin = remember { WorkspaceRevealOrigin() },
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(CONTENT_TAG)
+                .clickable(onClick = onContentClick),
+        )
+    }
+}
+
+/**
+ * Robolectric cannot draw, so the clip itself is not asserted here - `CircularRevealTest` covers the
+ * geometry. What this pins is the overlay's lifetime, which is what keeps the manager's back handler
+ * and the pane focus suppression alive after the flag that opens it has already gone.
+ */
+class ManagerRevealOverlayTest : ComposeTest() {
+
+    @Test
+    fun `content composes on the frame the manager opens`() {
+        var visible by mutableStateOf(false)
+        var layerPresent: Boolean? = null
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RevealHarness(visible = visible, onState = { layerPresent = it.layerPresent })
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertDoesNotExist()
+        layerPresent shouldBe false
+
+        composeTestRule.runOnIdle { visible = true }
+        composeTestRule.mainClock.advanceTimeByFrame()
+
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+        layerPresent shouldBe true
+    }
+
+    @Test
+    fun `content stays composed through the exit`() {
+        var visible by mutableStateOf(true)
+        var layerPresent: Boolean? = null
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RevealHarness(visible = visible, onState = { layerPresent = it.layerPresent })
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+
+        composeTestRule.runOnIdle { visible = false }
+        composeTestRule.mainClock.advanceTimeBy(100)
+
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+        layerPresent shouldBe true
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertDoesNotExist()
+        layerPresent shouldBe false
+    }
+
+    @Test
+    fun `reopening mid-enter reverses instead of restarting`() {
+        var visible by mutableStateOf(false)
+        var layerPresent: Boolean? = null
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RevealHarness(visible = visible, onState = { layerPresent = it.layerPresent })
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.runOnIdle { visible = true }
+        composeTestRule.mainClock.advanceTimeBy(100)
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+
+        composeTestRule.runOnIdle { visible = false }
+        composeTestRule.mainClock.advanceTimeBy(50)
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+        layerPresent shouldBe true
+
+        composeTestRule.runOnIdle { visible = true }
+        composeTestRule.mainClock.advanceTimeBy(50)
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+        layerPresent shouldBe true
+    }
+
+    @Test
+    fun `revealSettled only reports once the enter has finished`() {
+        var visible by mutableStateOf(false)
+        var settled: Boolean? = null
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RevealHarness(visible = visible, onState = { settled = it.revealSettled })
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.runOnIdle { visible = true }
+        composeTestRule.mainClock.advanceTimeBy(100)
+
+        composeTestRule.runOnIdle { settled shouldBe false }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+
+        composeTestRule.runOnIdle { settled shouldBe true }
+    }
+
+    @Test
+    fun `input is blocked until the reveal settles`() {
+        var visible by mutableStateOf(false)
+        var clicks = 0
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RevealHarness(visible = visible, onContentClick = { clicks++ })
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.runOnIdle { visible = true }
+        composeTestRule.mainClock.advanceTimeBy(100)
+
+        composeTestRule.onNodeWithTag(CONTENT_TAG).performClick()
+        composeTestRule.runOnIdle { clicks shouldBe 0 }
+
+        composeTestRule.mainClock.advanceTimeBy(1_000)
+
+        composeTestRule.onNodeWithTag(CONTENT_TAG).performClick()
+        composeTestRule.runOnIdle { clicks shouldBe 1 }
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlayTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlayTest.kt
@@ -15,6 +15,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.ui.manager.WorkspaceRevealOrigin
+import io.kotest.assertions.withClue
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.floats.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
@@ -118,11 +121,18 @@ class ManagerRevealOverlayTest : ComposeTest() {
     fun `reopening mid-enter reverses instead of restarting`() {
         var visible by mutableStateOf(false)
         var layerPresent: Boolean? = null
+        var state: ManagerRevealState? = null
 
         composeTestRule.mainClock.autoAdvance = false
         composeTestRule.setContent {
             PreviewWrapper {
-                RevealHarness(visible = visible, onState = { layerPresent = it.layerPresent })
+                RevealHarness(
+                    visible = visible,
+                    onState = {
+                        state = it
+                        layerPresent = it.layerPresent
+                    },
+                )
             }
         }
 
@@ -136,13 +146,36 @@ class ManagerRevealOverlayTest : ComposeTest() {
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
         layerPresent shouldBe true
 
+        val midExit = composeTestRule.runOnIdle { state!!.progress.value }
+        withClue("The exit has to be part-way through for the reversal to have somewhere to come back from") {
+            midExit shouldBeGreaterThan 0.1f
+        }
+
         composeTestRule.runOnIdle { visible = true }
-        composeTestRule.applyAndAdvanceBy(50)
+        // No clock movement here on purpose: a restart snaps the reveal to 0 on the frame it begins,
+        // a reversal keeps whatever the exit had left.
+        composeTestRule.waitForIdle()
+        withClue("Reopening restarted the reveal from zero instead of reversing the exit") {
+            composeTestRule.runOnIdle { state!!.progress.value } shouldBe (midExit plusOrMinus 0.01f)
+        }
+
+        // Sampled per frame, not just at the end: a restart also arrives at 1f eventually, it just
+        // travels up from zero to get there. The reopen still costs the one exit frame already in
+        // flight, so the low-water mark sits a little below where the exit was interrupted.
+        var lowest = midExit
+        repeat(40) {
+            composeTestRule.applyAndAdvanceFrame()
+            lowest = minOf(lowest, composeTestRule.runOnIdle { state!!.progress.value })
+        }
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
+        withClue("The reveal fell back towards zero instead of growing on from where the exit stopped") {
+            lowest shouldBeGreaterThan midExit / 2f
+        }
 
         composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
         layerPresent shouldBe true
+        composeTestRule.runOnIdle { state!!.progress.value } shouldBe (1f plusOrMinus 0.001f)
     }
 
     @Test

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlayTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerRevealOverlayTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -42,6 +43,21 @@ private fun RevealHarness(
 }
 
 /**
+ * With `autoAdvance = false` nothing applies the global snapshot between a `runOnIdle` write and the
+ * next frame, so the recomposer would spend those frames on the old value. `waitForIdle` applies the
+ * write without moving the clock, so it has to come first.
+ */
+private fun ComposeContentTestRule.applyAndAdvanceBy(millis: Long) {
+    waitForIdle()
+    mainClock.advanceTimeBy(millis)
+}
+
+private fun ComposeContentTestRule.applyAndAdvanceFrame() {
+    waitForIdle()
+    mainClock.advanceTimeByFrame()
+}
+
+/**
  * Robolectric cannot draw, so the clip itself is not asserted here - `CircularRevealTest` covers the
  * geometry. What this pins is the overlay's lifetime, which is what keeps the manager's back handler
  * and the pane focus suppression alive after the flag that opens it has already gone.
@@ -60,12 +76,12 @@ class ManagerRevealOverlayTest : ComposeTest() {
             }
         }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertDoesNotExist()
         layerPresent shouldBe false
 
         composeTestRule.runOnIdle { visible = true }
-        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.applyAndAdvanceFrame()
 
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
         layerPresent shouldBe true
@@ -83,16 +99,16 @@ class ManagerRevealOverlayTest : ComposeTest() {
             }
         }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
 
         composeTestRule.runOnIdle { visible = false }
-        composeTestRule.mainClock.advanceTimeBy(100)
+        composeTestRule.applyAndAdvanceBy(100)
 
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
         layerPresent shouldBe true
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
 
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertDoesNotExist()
         layerPresent shouldBe false
@@ -110,21 +126,21 @@ class ManagerRevealOverlayTest : ComposeTest() {
             }
         }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.runOnIdle { visible = true }
-        composeTestRule.mainClock.advanceTimeBy(100)
+        composeTestRule.applyAndAdvanceBy(100)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
 
         composeTestRule.runOnIdle { visible = false }
-        composeTestRule.mainClock.advanceTimeBy(50)
+        composeTestRule.applyAndAdvanceBy(50)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
         layerPresent shouldBe true
 
         composeTestRule.runOnIdle { visible = true }
-        composeTestRule.mainClock.advanceTimeBy(50)
+        composeTestRule.applyAndAdvanceBy(50)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.onNodeWithTag(CONTENT_TAG).assertExists()
         layerPresent shouldBe true
     }
@@ -141,13 +157,13 @@ class ManagerRevealOverlayTest : ComposeTest() {
             }
         }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.runOnIdle { visible = true }
-        composeTestRule.mainClock.advanceTimeBy(100)
+        composeTestRule.applyAndAdvanceBy(100)
 
         composeTestRule.runOnIdle { settled shouldBe false }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
 
         composeTestRule.runOnIdle { settled shouldBe true }
     }
@@ -164,14 +180,14 @@ class ManagerRevealOverlayTest : ComposeTest() {
             }
         }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
         composeTestRule.runOnIdle { visible = true }
-        composeTestRule.mainClock.advanceTimeBy(100)
+        composeTestRule.applyAndAdvanceBy(100)
 
         composeTestRule.onNodeWithTag(CONTENT_TAG).performClick()
         composeTestRule.runOnIdle { clicks shouldBe 0 }
 
-        composeTestRule.mainClock.advanceTimeBy(1_000)
+        composeTestRule.applyAndAdvanceBy(1_000)
 
         composeTestRule.onNodeWithTag(CONTENT_TAG).performClick()
         composeTestRule.runOnIdle { clicks shouldBe 1 }


### PR DESCRIPTION
## What changed

The tab manager used to appear and disappear instantly. It now opens with a circular reveal that grows out of the Butler button you pressed, and closes back into that same button. The content fades in as the circle expands and settles with a slight spring. Opening takes about a third of a second and closing a little over a fifth, short enough to stay out of the way.

The button that opens the manager sits in different places depending on the layout — the navigation rail in multi-pane, the top corner of the Templates page on a phone — and the animation follows whichever one was actually pressed, by either route (long-press, or the "Tab manager" item in its dropdown).

## Technical Context

- The reveal origin is recorded at the moment a button *asks* to open the manager, never from layout. There are 17 `WorkspaceButton` call sites, including a purely decorative one inside the manager's own badge-explanation card, so a layout-fed slot would hold whichever of them laid out last. The manager's content is additionally composed under a null origin local, so nothing the overlay hosts can reach the slot at all.
- The overlay's composition lifetime is hoisted out of the animation into `WorkspacesScreenHost` and feeds both `ManagerOverlayBackHandler` and `WorkspaceScreen(isOverlayVisible = …)`. Both previously read the logical flag and switched off in the frame the exit began, so a second Back inside the exit window reached a pane handler and could close the focused tab while the manager was still drawn. `ManagerOverlayBackHandler` deliberately does not move: `RawBackHandlerBanTest` pins it to `WorkspacesScreen.kt`, and its exemption rests on registering above the workspace content.
- The pre-settle input barrier sits *before* the reveal's clip in the modifier chain. Compose's hit testing respects layer clipping (`NodeCoordinator.hitTest` treats a pointer outside the layer outline as a complete miss), so a barrier placed after the clip only covers the circle and taps outside it fall through to the panes.
- A tab-close confirmation already pending when the manager opens is withheld until the reveal settles. The manager sits outside every pane, where `LocalAlertDialogRenderer` falls back to a platform window dialog — not a descendant of either graphics layer, so nothing clips it.
- Worth a close look: the modifier order in `ManagerRevealOverlay` is load-bearing in two independent ways — barrier before clip (hit testing), clip before scale (so the circle keeps its anchor in unscaled coordinates while the content scales inside it).
