### PR TITLE
Bugreport: Name your bug reports so you can tell them apart

### DIFF
--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReport.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReport.kt
@@ -29,6 +29,8 @@ data class BugReport(
     val buildType: String,
     val installId: String,
     val locale: String,
+    /** User-set name. Purely cosmetic: [id] stays the storage key and is never derived from this. */
+    val label: String? = null,
 ) {
     enum class Type {
         /** Automatic, captured synchronously from the uncaught-exception handler. */
@@ -40,6 +42,50 @@ data class BugReport(
         /** Manual, continuous file capture started/stopped by the user. */
         RECORDING,
     }
+
+    companion object {
+        /**
+         * Longest [label] that survives [normalizeLabel]. The UI caps input at the same value to give
+         * immediate feedback while typing; [normalizeLabel] stays authoritative.
+         */
+        const val MAX_LABEL_LENGTH = 128
+
+        /**
+         * Normalized [label], or null when the input clears it: whitespace runs (including NBSP and
+         * line separators) collapse to a single space, control characters are dropped, the result is
+         * trimmed, capped at [MAX_LABEL_LENGTH] and blank == clear.
+         */
+        fun normalizeLabel(raw: String?): String? = raw
+            ?.collapseWhitespace()
+            ?.takeCodePoints(MAX_LABEL_LENGTH)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    }
+}
+
+/**
+ * Whitespace runs become a single space, ISO control characters are dropped, and the result carries
+ * no leading or trailing space. `" a \n b "` becomes `"a b"`.
+ */
+private fun String.collapseWhitespace(): String = buildString(length) {
+    var pendingSpace = false
+    this@collapseWhitespace.forEach { char ->
+        when {
+            char.isWhitespace() -> pendingSpace = isNotEmpty()
+            char.isISOControl() -> Unit
+            else -> {
+                if (pendingSpace) append(' ')
+                pendingSpace = false
+                append(char)
+            }
+        }
+    }
+}
+
+/** [String.take] on code points, so a cap can never cut a surrogate pair in half. */
+internal fun String.takeCodePoints(max: Int): String {
+    if (codePointCount(0, length) <= max) return this
+    return substring(0, offsetByCodePoints(0, max))
 }
 
 /**

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -61,6 +63,17 @@ class BugReportRepo @Inject constructor(
 
     private val shareDir = BugReportStorage.shareDir(context)
     private val refreshTrigger = MutableStateFlow(0)
+
+    /**
+     * Guards everything that reads or writes a report's metadata together with its share zip. Without
+     * it a rename landing mid-compression produces a zip named after the old label whose sealed
+     * `meta.json` carries the new one.
+     *
+     * Not reentrant, so: the recorder mutex is always taken first ([requireNotRecording]), never the
+     * reverse, and each call path takes this exactly once — [buildShareZip] locks in the private
+     * overload only, and the public one delegates to it without locking.
+     */
+    private val mutex = Mutex()
 
     // Re-scans on manual triggers AND on recording start/stop transitions. We key on recordingId
     // (distinct) rather than the whole recorder state so the periodic live-size ticks do NOT trigger a
@@ -134,12 +147,39 @@ class BugReportRepo @Inject constructor(
         refresh()
     }
 
+    /**
+     * Sets or clears the user-set name of a report. Nothing moves on disk — the id stays the storage
+     * key — so this is safe to do while the report is being recorded ([BugReportRecorder] writes
+     * `meta.json` only when the recording starts).
+     */
+    suspend fun setLabel(id: String, rawLabel: String?) = withContext(dispatcherProvider.IO) {
+        val label = BugReport.normalizeLabel(rawLabel)
+        log(TAG, INFO) { "setLabel($id, $label)" }
+        val written = mutex.withLock {
+            // Gone (deleted or pruned meanwhile) or already named that way.
+            val current = resolveReportEntry(id)?.second ?: return@withLock false
+            if (current.label == label) return@withLock false
+            // Every copy, like delete(): updating only the resolved one would let a shadowed copy
+            // resurface later still carrying the previous name.
+            storageLayout.allReportDirs(id).forEach { dir ->
+                val report = readReport(dir) ?: return@forEach
+                writeMeta(dir, report.copy(label = label))
+            }
+            true
+        }
+        // No share-zip sweep: buildShareZip always re-zips and drops the other names afterwards, and a
+        // sweep here would delete the .tmp an in-flight zip build is still writing.
+        if (written) refresh()
+    }
+
     suspend fun delete(id: String) = withContext(dispatcherProvider.IO) {
         require(!bugReportRecorder.isActiveOrStarting(id)) { "Cannot delete an active recording" }
-        // Every copy, not just the one scan() lists: dropping only the listed copy would let the
-        // shadowed one take its place in the very next scan.
-        storageLayout.allReportDirs(id).forEach { it.deleteRecursively() }
-        File(shareDir, "$id.zip").delete()
+        mutex.withLock {
+            // Every copy, not just the one scan() lists: dropping only the listed copy would let the
+            // shadowed one take its place in the very next scan.
+            storageLayout.allReportDirs(id).forEach { it.deleteRecursively() }
+            deleteShareZips(id)
+        }
         refresh()
     }
 
@@ -149,16 +189,18 @@ class BugReportRepo @Inject constructor(
         // before publishing the id to recorder state, so the sentinel check also covers a recording
         // that is mid-start when delete-all fires.
         val activeId = bugReportRecorder.state.value.recordingId
-        storageLayout.roots.forEach { root ->
-            root.listFiles()?.forEach { entry ->
-                if (entry.name == activeId) return@forEach
-                if (entry.isDirectory && File(entry, BugReportStorage.RECORDING_SENTINEL).exists()) return@forEach
-                if (entry.isDirectory) entry.deleteRecursively() else entry.delete()
+        mutex.withLock {
+            storageLayout.roots.forEach { root ->
+                root.listFiles()?.forEach { entry ->
+                    if (entry.name == activeId) return@forEach
+                    if (entry.isDirectory && File(entry, BugReportStorage.RECORDING_SENTINEL).exists()) return@forEach
+                    if (entry.isDirectory) entry.deleteRecursively() else entry.delete()
+                }
             }
-        }
-        shareDir.listFiles()?.forEach { zip ->
-            if (activeId != null && zip.name == "$activeId.zip") return@forEach
-            zip.delete()
+            shareDir.listFiles()?.forEach { zip ->
+                if (activeId != null && BugReportStorage.isShareZipFor(zip.name, activeId)) return@forEach
+                zip.delete()
+            }
         }
         refresh()
     }
@@ -218,37 +260,54 @@ class BugReportRepo @Inject constructor(
      */
     suspend fun buildShareZip(id: String): File {
         requireNotRecording(id)
-        val dir = withContext(dispatcherProvider.IO) { resolveReportDir(id) }
-        return buildShareZip(dir, id)
+        val entry = withContext(dispatcherProvider.IO) { resolveReportEntry(id) }
+        return buildShareZip(entry?.first, entry?.second, id)
     }
 
-    private suspend fun buildShareZip(dir: File?, id: String): File = withContext(dispatcherProvider.IO) {
-        // Kept even though every caller here already guarded: this overload takes an
-        // already-resolved dir, so it must not be shareable past the guard on its own.
-        requireNotRecording(id)
-        val files = dir?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
-        require(files.isNotEmpty()) { "No report files for $id" }
+    /**
+     * [report] comes from the same resolve as [dir], so the file name and the packaged payload can
+     * never describe different copies of [id].
+     */
+    private suspend fun buildShareZip(dir: File?, report: BugReport?, id: String): File =
+        withContext(dispatcherProvider.IO) {
+            // Kept even though every caller here already guarded: this overload takes an
+            // already-resolved dir, so it must not be shareable past the guard on its own.
+            requireNotRecording(id)
+            mutex.withLock {
+                val files = dir?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
+                require(files.isNotEmpty()) { "No report files for $id" }
 
-        if (!shareDir.exists()) shareDir.mkdirs()
-        val payloadSize = files.sumOf { it.length() }
-        val usableSpace = shareDir.usableSpace
-        // A recording can be tens of MB and the zip is a second copy of it. Failing here is a message
-        // the user can act on; filling the cache volume instead breaks unrelated features.
-        check(usableSpace > payloadSize) {
-            "Not enough space for the share zip of $id: needs up to $payloadSize bytes, $usableSpace available"
+                if (!shareDir.exists()) shareDir.mkdirs()
+                val payloadSize = files.sumOf { it.length() }
+                val usableSpace = shareDir.usableSpace
+                // A recording can be tens of MB and the zip is a second copy of it. Failing here is a
+                // message the user can act on; filling the cache volume instead breaks unrelated features.
+                check(usableSpace > payloadSize) {
+                    "Not enough space for the share zip of $id: needs up to $payloadSize bytes, $usableSpace available"
+                }
+
+                val zipName = BugReportStorage.shareZipName(id, report?.label)
+                val zip = File(shareDir, zipName)
+                val tmpZip = File(shareDir, "$zipName${BugReportStorage.TMP_SUFFIX}")
+                try {
+                    Zipper().zip(files.map { it.path }, tmpZip.path)
+                    zip.delete()
+                    if (!tmpZip.renameTo(zip)) throw IOException("Could not finalize the share zip for $id")
+                } catch (t: Throwable) {
+                    runCatching { tmpZip.delete() }
+                    throw t
+                }
+                // Whatever the report was called before this build.
+                deleteShareZips(id, keep = zip.name)
+                zip
+            }
         }
 
-        val zip = File(shareDir, "$id.zip")
-        val tmpZip = File(shareDir, "$id.zip${BugReportStorage.TMP_SUFFIX}")
-        try {
-            Zipper().zip(files.map { it.path }, tmpZip.path)
-            zip.delete()
-            if (!tmpZip.renameTo(zip)) throw IOException("Could not finalize the share zip for $id")
-        } catch (t: Throwable) {
-            runCatching { tmpZip.delete() }
-            throw t
+    /** Every share zip of [id], under any label it carried, plus the leftovers of a crashed build. */
+    private fun deleteShareZips(id: String, keep: String? = null) {
+        shareDir.listFiles()?.forEach { file ->
+            if (file.name != keep && BugReportStorage.isShareZipFor(file.name, id)) file.delete()
         }
-        zip
     }
 
     /**
@@ -260,17 +319,28 @@ class BugReportRepo @Inject constructor(
         // One resolve for both the zip and the body: the same id can exist under two storage roots,
         // and resolving twice could attach one copy while describing the other.
         val entry = withContext(dispatcherProvider.IO) { resolveReportEntry(id) }
-        val zip = buildShareZip(entry?.first, id)
+        val zip = buildShareZip(entry?.first, entry?.second, id)
         val uri = FileProvider.getUriForFile(context, "${BuildConfigWrap.APPLICATION_ID}.provider", zip)
+        val label = entry?.second?.label
         return Intent(Intent.ACTION_SEND).apply {
             type = "application/zip"
             putExtra(
                 Intent.EXTRA_SUBJECT,
-                context.getString(
-                    R.string.general_bug_report_subject,
-                    context.getString(R.string.app_name),
-                    id,
-                ),
+                // The id stays in the subject either way: it is what a reply can be matched against.
+                if (label != null) {
+                    context.getString(
+                        R.string.general_bug_report_subject_labeled,
+                        context.getString(R.string.app_name),
+                        label,
+                        id,
+                    )
+                } else {
+                    context.getString(
+                        R.string.general_bug_report_subject,
+                        context.getString(R.string.app_name),
+                        id,
+                    )
+                },
             )
             putExtra(Intent.EXTRA_TEXT, buildShareBody(id, entry?.second))
             putExtra(Intent.EXTRA_STREAM, uri)
@@ -310,6 +380,7 @@ class BugReportRepo @Inject constructor(
             }
             if (error.isNotBlank()) appendLine("Error: $error")
         }
+        report?.label?.let { appendLine("Name: $it") }
         appendLine("Report: $id")
         appendLine()
         append("Details are in the attached zip.")
@@ -368,6 +439,24 @@ class BugReportRepo @Inject constructor(
             runCatching { tmpDir.deleteRecursively() }
             // Best-effort; never propagate (the crash path must still delegate to the old handler).
             log(TAG, ERROR) { "writeReport failed for ${report.id}: ${t.asLog()}" }
+        }
+    }
+
+    /**
+     * Replaces a report's `meta.json` atomically or not at all: a truncated overwrite makes
+     * [readReport] reject the report, so the whole report — logs included — would drop out of the
+     * list. A failed replace leaves the original in place and surfaces.
+     */
+    private fun writeMeta(dir: File, report: BugReport) {
+        val meta = File(dir, BugReportStorage.META_FILE)
+        val tmpMeta = File(dir, "${BugReportStorage.META_FILE}${BugReportStorage.TMP_SUFFIX}")
+        try {
+            tmpMeta.writeText(json.encodeToString(BugReport.serializer(), report))
+            if (!tmpMeta.renameTo(meta)) throw IOException("Could not replace ${meta.path}")
+        } catch (t: Throwable) {
+            runCatching { tmpMeta.delete() }
+            log(TAG, ERROR) { "writeMeta failed for ${dir.path}: ${t.asLog()}" }
+            throw t
         }
     }
 
@@ -453,7 +542,7 @@ class BugReportRepo @Inject constructor(
         }
     }
 
-    private fun prune() {
+    private suspend fun prune() = mutex.withLock {
         // Never prune the active recording, even if it would otherwise be the oldest. Guarded by the
         // on-disk sentinel, not just recorder state: this also runs in the :isolated process, where
         // recorder state is empty for a recording the main process owns.
@@ -461,10 +550,10 @@ class BugReportRepo @Inject constructor(
             !info.isOngoingRecording && storageLayout.allReportDirs(info.id)
                 .none { File(it, BugReportStorage.RECORDING_SENTINEL).exists() }
         }
-        if (valid.size <= MAX_REPORTS) return
+        if (valid.size <= MAX_REPORTS) return@withLock
         valid.drop(MAX_REPORTS).forEach { stale ->
             storageLayout.allReportDirs(stale.id).forEach { it.deleteRecursively() }
-            File(shareDir, "${stale.id}.zip").delete()
+            deleteShareZips(stale.id)
             log(TAG) { "Pruned old report: ${stale.id}" }
         }
     }

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportRepo.kt
@@ -65,13 +65,14 @@ class BugReportRepo @Inject constructor(
     private val refreshTrigger = MutableStateFlow(0)
 
     /**
-     * Guards everything that reads or writes a report's metadata together with its share zip. Without
-     * it a rename landing mid-compression produces a zip named after the old label whose sealed
-     * `meta.json` carries the new one.
+     * Guards everything that reads or writes a report's metadata together with its share zip, the
+     * resolve the zip name is taken from included. A rename landing between an unlocked resolve and
+     * the compression produces a zip named after the old label whose sealed `meta.json` carries the
+     * new one.
      *
      * Not reentrant, so: the recorder mutex is always taken first ([requireNotRecording]), never the
-     * reverse, and each call path takes this exactly once — [buildShareZip] locks in the private
-     * overload only, and the public one delegates to it without locking.
+     * reverse, and each call path takes this exactly once — the share paths lock in
+     * [buildShareZipLocked] only, and [buildShareZip] and [buildShareIntent] delegate to it.
      */
     private val mutex = Mutex()
 
@@ -258,23 +259,21 @@ class BugReportRepo @Inject constructor(
      * Built under a temporary name and renamed on success, because [Zipper] leaves its output behind
      * when compression throws — a half-written `<id>.zip` would then be shared as if it were whole.
      */
-    suspend fun buildShareZip(id: String): File {
-        requireNotRecording(id)
-        val entry = withContext(dispatcherProvider.IO) { resolveReportEntry(id) }
-        return buildShareZip(entry?.first, entry?.second, id)
-    }
+    suspend fun buildShareZip(id: String): File = buildShareZipLocked(id).first
 
     /**
-     * [report] comes from the same resolve as [dir], so the file name and the packaged payload can
-     * never describe different copies of [id].
+     * The zip plus the report it was named after, resolved under [mutex] rather than before it so the
+     * file name and the sealed `meta.json` always describe the same state. Handing that snapshot back
+     * lets [buildShareIntent] describe the very copy that was packaged without resolving again — the
+     * same id can exist under two storage roots.
      */
-    private suspend fun buildShareZip(dir: File?, report: BugReport?, id: String): File =
+    private suspend fun buildShareZipLocked(id: String): Pair<File, BugReport?> =
         withContext(dispatcherProvider.IO) {
-            // Kept even though every caller here already guarded: this overload takes an
-            // already-resolved dir, so it must not be shareable past the guard on its own.
             requireNotRecording(id)
             mutex.withLock {
-                val files = dir?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
+                val entry = resolveReportEntry(id)
+                val report = entry?.second
+                val files = entry?.first?.let { BugReportStorage.payloadFiles(it) } ?: emptyList()
                 require(files.isNotEmpty()) { "No report files for $id" }
 
                 if (!shareDir.exists()) shareDir.mkdirs()
@@ -299,7 +298,7 @@ class BugReportRepo @Inject constructor(
                 }
                 // Whatever the report was called before this build.
                 deleteShareZips(id, keep = zip.name)
-                zip
+                zip to report
             }
         }
 
@@ -315,13 +314,9 @@ class BugReportRepo @Inject constructor(
      * chooser. [FLAG_GRANT_READ_URI_PERMISSION] + clipData grant the receiving app read access.
      */
     suspend fun buildShareIntent(id: String): Intent {
-        requireNotRecording(id)
-        // One resolve for both the zip and the body: the same id can exist under two storage roots,
-        // and resolving twice could attach one copy while describing the other.
-        val entry = withContext(dispatcherProvider.IO) { resolveReportEntry(id) }
-        val zip = buildShareZip(entry?.first, entry?.second, id)
+        val (zip, report) = buildShareZipLocked(id)
         val uri = FileProvider.getUriForFile(context, "${BuildConfigWrap.APPLICATION_ID}.provider", zip)
-        val label = entry?.second?.label
+        val label = report?.label
         return Intent(Intent.ACTION_SEND).apply {
             type = "application/zip"
             putExtra(
@@ -342,7 +337,7 @@ class BugReportRepo @Inject constructor(
                     )
                 },
             )
-            putExtra(Intent.EXTRA_TEXT, buildShareBody(id, entry?.second))
+            putExtra(Intent.EXTRA_TEXT, buildShareBody(id, report))
             putExtra(Intent.EXTRA_STREAM, uri)
             clipData = ClipData.newRawUri("", uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
@@ -62,7 +62,7 @@ object BugReportStorage {
      * keeps it unique and lets [isShareZipFor] find it again.
      */
     fun shareZipName(id: String, label: String?): String {
-        val sanitized = label?.let { sanitizeForFileName(it) }?.takeIf { it.isNotEmpty() }
+        val sanitized = label?.takeUnless { it.isBlank() }?.let { sanitizeForFileName(it) }?.takeIf { it.isNotEmpty() }
         return if (sanitized == null) "$id.zip" else "${sanitized}_$id.zip"
     }
 

--- a/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
+++ b/app-common/src/main/java/eu/darken/butler/common/debug/bugreport/BugReportStorage.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.common.debug.bugreport
 import android.content.Context
 import java.io.File
 import java.nio.file.Files
+import java.text.Normalizer
 
 /**
  * Shared on-disk layout for the unified bug-report store, used by both [BugReportRepo] (crashes +
@@ -11,7 +12,7 @@ import java.nio.file.Files
  * ```
  * <root>/bugreports/<id>/   meta.json | report.log | root.log? | adb.log? | .seen? | .recording (while live)
  * <root>/bugreports/.tmp-<id>/   snapshot two-phase writes
- * cacheDir/bugreports_share/<id>.zip
+ * cacheDir/bugreports_share/[<label>_]<id>.zip
  * ```
  *
  * `<root>` is resolved by [BugReportStorageLayout], which owns the order of the two report roots.
@@ -55,4 +56,44 @@ object BugReportStorage {
     fun payloadFiles(reportDir: File): List<File> = listOf(META_FILE, LOG_FILE, ROOT_LOG_FILE, ADB_LOG_FILE)
         .map { File(reportDir, it) }
         .filter { it.isFile && !Files.isSymbolicLink(it.toPath()) }
+
+    /**
+     * File name of a report's share zip: the label makes it recognizable in a mail client, the id
+     * keeps it unique and lets [isShareZipFor] find it again.
+     */
+    fun shareZipName(id: String, label: String?): String {
+        val sanitized = label?.let { sanitizeForFileName(it) }?.takeIf { it.isNotEmpty() }
+        return if (sanitized == null) "$id.zip" else "${sanitized}_$id.zip"
+    }
+
+    /**
+     * Whether [fileName] is a share zip of [id], under any label it has ever carried, including the
+     * [TMP_SUFFIX] form a crashed zip build leaves behind. Ids have a fixed `type_millis_uuid8`
+     * shape, so no id is a suffix of another one.
+     */
+    fun isShareZipFor(fileName: String, id: String): Boolean {
+        val name = fileName.removeSuffix(TMP_SUFFIX)
+        return name == "$id.zip" || name.endsWith("_$id.zip")
+    }
+
+    /**
+     * Unicode letters and digits are kept — an ASCII-only filter would sanitize `厨房` to nothing and
+     * `Küche` to `K_che`, which is exactly the recognizability the label exists for. Only what a file
+     * system reads as structure is replaced.
+     */
+    private fun sanitizeForFileName(label: String): String = Normalizer
+        .normalize(label, Normalizer.Form.NFC)
+        .map { if (it in RESERVED_NAME_CHARS || it.isISOControl()) '_' else it }
+        .joinToString("")
+        .replace(UNDERSCORE_RUN, "_")
+        // A leading dot would make the zip a hidden file.
+        .trimStart('.')
+        .trim('_')
+        .takeCodePoints(MAX_ZIP_LABEL_LENGTH)
+
+    private val RESERVED_NAME_CHARS = setOf('/', '\\', ':', '*', '?', '"', '<', '>', '|')
+    private val UNDERSCORE_RUN = Regex("_+")
+
+    /** The label is a hint in a file listing, not the whole name — the id still has to fit next to it. */
+    private const val MAX_ZIP_LABEL_LENGTH = 48
 }

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="general_error_report_consent_confirm">Share report</string>
     <string name="general_privacy_policy_action">Privacy policy</string>
     <string name="general_bug_report_subject">%1$s Bug Report (%2$s)</string>
+    <string name="general_bug_report_subject_labeled">%1$s Bug Report: %2$s (%3$s)</string>
     <string name="general_bug_report_body_what_happened_prompt">(Describe what happened here.)</string>
     <string name="general_bug_report_body_expected_prompt">(Describe what you expected instead.)</string>
     <string name="general_duration_input_label">Duration</string>

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportRepoTest.kt
@@ -80,6 +80,7 @@ class BugReportRepoTest : BaseTest() {
         createdAt: Instant = kotlin.time.Clock.System.now(),
         errorClass: String? = null,
         errorMessage: String? = null,
+        label: String? = null,
     ): BugReport {
         val dir = File(root, id).apply { mkdirs() }
         val report = BugReport(
@@ -95,6 +96,7 @@ class BugReportRepoTest : BaseTest() {
             buildType = "DEBUG",
             installId = "iid",
             locale = "en",
+            label = label,
         )
         File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
         File(dir, "report.log").writeText(logText)
@@ -425,6 +427,137 @@ class BugReportRepoTest : BaseTest() {
         createRepo()
 
         stale.exists() shouldBe false
+    }
+
+    private fun storedReport(id: String, root: File = reportsDir): BugReport = json.decodeFromString(
+        BugReport.serializer(),
+        File(File(root, id), "meta.json").readText(),
+    )
+
+    @Test
+    fun `setLabel round-trips through meta json`() = runTest {
+        val repo = createRepo()
+        writeReportDir("label_1")
+
+        repo.setLabel("label_1", "Copy stalls on SD card")
+
+        storedReport("label_1").label shouldBe "Copy stalls on SD card"
+        repo.reports.first().single { it.id == "label_1" }.report.label shouldBe "Copy stalls on SD card"
+    }
+
+    @Test
+    fun `setLabel clears the name again`() = runTest {
+        val repo = createRepo()
+        writeReportDir("label_2", label = "Named")
+
+        repo.setLabel("label_2", "   ")
+
+        storedReport("label_2").label shouldBe null
+    }
+
+    @Test
+    fun `a label is normalized before it is stored`() = runTest {
+        val repo = createRepo()
+        writeReportDir("label_3")
+
+        repo.setLabel("label_3", "  Copy\u00A0\n stalls\u0000 ")
+
+        storedReport("label_3").label shouldBe "Copy stalls"
+    }
+
+    @Test
+    fun `normalization collapses whitespace runs and drops control characters`() {
+        BugReport.normalizeLabel("a\u00A0\u00A0b") shouldBe "a b"
+        BugReport.normalizeLabel("a\u2028b") shouldBe "a b"
+        BugReport.normalizeLabel("a\tb\nc") shouldBe "a b c"
+        BugReport.normalizeLabel("a\u0007b") shouldBe "ab"
+        BugReport.normalizeLabel("  spaced  out  ") shouldBe "spaced out"
+    }
+
+    @Test
+    fun `normalization treats a blank label as a clear`() {
+        BugReport.normalizeLabel(null) shouldBe null
+        BugReport.normalizeLabel("") shouldBe null
+        BugReport.normalizeLabel("   ") shouldBe null
+        BugReport.normalizeLabel("\u0000\u0001") shouldBe null
+    }
+
+    @Test
+    fun `an over-length label is capped without a trailing space`() {
+        val label = BugReport.normalizeLabel("a".repeat(BugReport.MAX_LABEL_LENGTH - 1) + " b")
+
+        label shouldBe "a".repeat(BugReport.MAX_LABEL_LENGTH - 1)
+    }
+
+    // Cutting at char 128 would land inside the pair and leave a lone surrogate behind.
+    @Test
+    fun `an emoji straddling the cap is dropped whole`() {
+        val label = BugReport.normalizeLabel("a".repeat(BugReport.MAX_LABEL_LENGTH - 1) + "\uD83D\uDC1B" + "b")!!
+
+        label shouldBe "a".repeat(BugReport.MAX_LABEL_LENGTH - 1) + "\uD83D\uDC1B"
+        label.count { it.isSurrogate() } shouldBe 2
+    }
+
+    @Test
+    fun `a meta json without a label key still parses`() = runTest {
+        val repo = createRepo()
+        val dir = File(reportsDir, "label_4").apply { mkdirs() }
+        File(dir, "meta.json").writeText(
+            """{"id":"label_4","createdAt":"2026-06-15T10:00:00Z","type":"REPORTED","appVersion":"1.0",""" +
+                """"deviceFingerprint":"fp","apiLevel":"29","flavor":"FOSS","buildType":"DEBUG",""" +
+                """"installId":"iid","locale":"en"}""",
+        )
+        File(dir, "report.log").writeText("log")
+
+        repo.reports.first().single { it.id == "label_4" }.report.label shouldBe null
+    }
+
+    @Test
+    fun `setLabel on a report that is gone does nothing`() = runTest {
+        val repo = createRepo()
+
+        repo.setLabel("label_gone", "Name")
+
+        File(reportsDir, "label_gone").exists() shouldBe false
+    }
+
+    @Test
+    fun `setLabel updates every physical copy of an id`() = runTest {
+        val repo = createRepo()
+        writeReportDir("label_5")
+        writeReportDir("label_5", root = privateReportsDir)
+
+        repo.setLabel("label_5", "Named")
+
+        storedReport("label_5").label shouldBe "Named"
+        storedReport("label_5", root = privateReportsDir).label shouldBe "Named"
+    }
+
+    @Test
+    fun `a failed metadata write leaves the report readable under its old name`() = runTest {
+        val repo = createRepo()
+        writeReportDir("label_6", label = "Before")
+        // The new metadata is staged under this name before replacing meta.json; an (empty) directory
+        // sitting there makes the staging write fail.
+        File(File(reportsDir, "label_6"), "meta.json.tmp").mkdirs()
+
+        shouldThrow<Exception> { repo.setLabel("label_6", "After") }
+
+        storedReport("label_6").label shouldBe "Before"
+        repo.reports.first().single { it.id == "label_6" }.report.label shouldBe "Before"
+    }
+
+    // The recorder writes meta.json only when a recording starts, so a rename mid-recording sticks.
+    @Test
+    fun `a recording can be renamed while it is running`() = runTest {
+        val repo = createRepo()
+        writeReportDir("recording_10_jjjj", BugReport.Type.RECORDING, ongoing = true)
+        recorderState.value = BugReportRecorder.State(isRecording = true, recordingId = "recording_10_jjjj")
+        startingRecordingIds += "recording_10_jjjj"
+
+        repo.setLabel("recording_10_jjjj", "Stalling copy")
+
+        storedReport("recording_10_jjjj").label shouldBe "Stalling copy"
     }
 
     private val whatPrompt: String

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
@@ -1,0 +1,239 @@
+package eu.darken.butler.common.debug.bugreport
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.debug.logging.RingLogBuffer
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import java.util.zip.ZipFile
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+/** How a report's name reaches its share zip, and what happens to zips named after an older one. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class BugReportShareNamingTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val storageLayout by lazy { BugReportStorageLayout(context) }
+    private val reportsDir get() = storageLayout.writeRoot
+    private val shareDir get() = File(context.cacheDir, BugReportStorage.SHARE_DIRNAME)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val recorderState = MutableStateFlow(BugReportRecorder.State())
+
+    private fun createRepo(): BugReportRepo {
+        val recorder = mockk<BugReportRecorder>(relaxed = true) {
+            every { state } returns recorderState
+            coEvery { isActiveOrStarting(any()) } answers {
+                firstArg<String>() == recorderState.value.recordingId
+            }
+        }
+        return BugReportRepo(
+            context = context,
+            appScope = CoroutineScope(Dispatchers.Unconfined),
+            dispatcherProvider = TestDispatcherProvider(),
+            ringLogBuffer = RingLogBuffer(),
+            bugReportRecorder = recorder,
+            butlerId = ButlerId(context),
+            json = json,
+            storageLayout = storageLayout,
+        )
+    }
+
+    private fun writeReportDir(
+        id: String,
+        label: String? = null,
+        ongoing: Boolean = false,
+        logText: String = "log line",
+        createdAt: Instant = kotlin.time.Clock.System.now(),
+    ): BugReport {
+        val dir = File(reportsDir, id).apply { mkdirs() }
+        val report = BugReport(
+            id = id,
+            createdAt = createdAt,
+            type = BugReport.Type.REPORTED,
+            appVersion = "1.0",
+            deviceFingerprint = "fp",
+            apiLevel = "29",
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            installId = "iid",
+            locale = "en",
+            label = label,
+        )
+        File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
+        File(dir, "report.log").writeText(logText)
+        if (ongoing) File(dir, ".recording").createNewFile()
+        return report
+    }
+
+    private fun writeShareZip(name: String) {
+        shareDir.mkdirs()
+        File(shareDir, name).writeText("zip")
+    }
+
+    private fun shareZipNames(): List<String> = (shareDir.listFiles() ?: emptyArray())
+        .map { it.name }
+        .sorted()
+
+    @Test
+    fun `an unnamed report keeps the bare id as its zip name`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_plain")
+
+        repo.buildShareZip("share_plain").name shouldBe "share_plain.zip"
+    }
+
+    @Test
+    fun `a named report carries its name in the zip name`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_named", label = "Copy stalls on SD card")
+
+        repo.buildShareZip("share_named").name shouldBe "Copy stalls on SD card_share_named.zip"
+    }
+
+    @Test
+    fun `a non-ASCII name survives into the zip name`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_de", label = "Küche")
+        writeReportDir("share_zh", label = "厨房")
+
+        repo.buildShareZip("share_de").name shouldBe "Küche_share_de.zip"
+        repo.buildShareZip("share_zh").name shouldBe "厨房_share_zh.zip"
+    }
+
+    @Test
+    fun `a name made of separators falls back to the bare id`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_seps", label = "/\\:*")
+
+        repo.buildShareZip("share_seps").name shouldBe "share_seps.zip"
+    }
+
+    @Test
+    fun `a name starting with a dot does not produce a hidden file`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_dot", label = ".hidden")
+
+        repo.buildShareZip("share_dot").name shouldBe "hidden_share_dot.zip"
+    }
+
+    @Test
+    fun `rebuilding after a rename leaves only the zip under the current name`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_rebuilt", label = "Before")
+        repo.buildShareZip("share_rebuilt")
+
+        repo.setLabel("share_rebuilt", "After")
+        repo.buildShareZip("share_rebuilt")
+
+        shareZipNames() shouldContainExactly listOf("After_share_rebuilt.zip")
+    }
+
+    @Test
+    fun `delete removes a named zip and the leftovers of a crashed build`() = runTest {
+        val repo = createRepo()
+        writeReportDir("share_del", label = "Named")
+        writeShareZip("Named_share_del.zip")
+        writeShareZip("Older_share_del.zip.tmp")
+        writeShareZip("keep_me_share_other.zip")
+
+        repo.delete("share_del")
+
+        shareZipNames() shouldContainExactly listOf("keep_me_share_other.zip")
+    }
+
+    @Test
+    fun `deleteAll removes named zips but keeps the active recording's`() = runTest {
+        val repo = createRepo()
+        writeReportDir("recording_live", label = "Live", ongoing = true)
+        recorderState.value = BugReportRecorder.State(isRecording = true, recordingId = "recording_live")
+        writeReportDir("share_old", label = "Old")
+        writeShareZip("Live_recording_live.zip")
+        writeShareZip("Old_share_old.zip")
+        writeShareZip("Old_share_old.zip.tmp")
+
+        repo.deleteAll()
+
+        shareZipNames() shouldContainExactly listOf("Live_recording_live.zip")
+    }
+
+    @Test
+    fun `retention removes the named zip of a pruned report`() = runTest {
+        val repo = createRepo()
+        val base = kotlin.time.Clock.System.now()
+        repeat(30) { index ->
+            writeReportDir("prune_$index", label = "Name$index", createdAt = base - (30 - index).seconds)
+        }
+        writeShareZip("Name0_prune_0.zip")
+        writeShareZip("Name29_prune_29.zip")
+
+        // captureReport writes a fresh report and prunes afterwards.
+        repo.captureReport(IllegalStateException("boom"))
+
+        shareZipNames() shouldContainExactly listOf("Name29_prune_29.zip")
+    }
+
+    @Test
+    fun `the share body names the report only when it has a name`() {
+        val repo = createRepo()
+        val named = writeReportDir("body_named", label = "Copy stalls")
+        val plain = writeReportDir("body_plain")
+
+        repo.buildShareBody("body_named", named) shouldContain "Name: Copy stalls"
+        repo.buildShareBody("body_plain", plain) shouldNotContain "Name:"
+    }
+
+    /**
+     * A rename that lands while the zip is being compressed must not produce a zip named after the
+     * old name whose sealed `meta.json` carries the new one. The build runs on a real thread and the
+     * rename is fired once the compression has started, so the two genuinely overlap.
+     */
+    @Test
+    fun `a rename cannot interleave with a zip build`() = runBlocking<Unit> {
+        val repo = createRepo()
+        val bulkyLog = (1..200_000).joinToString("\n") { "line $it ${it * 7919}" }
+        writeReportDir("race_1", label = "Before", logText = bulkyLog)
+
+        val zipJob = launch(Dispatchers.IO) { repo.buildShareZip("race_1") }
+        val deadline = System.currentTimeMillis() + 10_000
+        while (
+            shareDir.listFiles()?.none { it.name.endsWith(BugReportStorage.TMP_SUFFIX) } != false &&
+            System.currentTimeMillis() < deadline
+        ) {
+            Thread.sleep(1)
+        }
+
+        repo.setLabel("race_1", "After")
+        zipJob.join()
+
+        val zip = shareDir.listFiles()!!.single()
+        val sealed = ZipFile(zip).use { file ->
+            json.decodeFromString(
+                BugReport.serializer(),
+                file.getInputStream(file.getEntry("meta.json")).readBytes().decodeToString(),
+            )
+        }
+        zip.name shouldBe BugReportStorage.shareZipName("race_1", sealed.label)
+    }
+}

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
@@ -3,7 +3,9 @@ package eu.darken.butler.common.debug.bugreport
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.RingLogBuffer
+import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -11,6 +13,7 @@ import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,7 +28,10 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -41,7 +47,7 @@ class BugReportShareNamingTest : BaseTest() {
     private val json = Json { ignoreUnknownKeys = true }
     private val recorderState = MutableStateFlow(BugReportRecorder.State())
 
-    private fun createRepo(): BugReportRepo {
+    private fun createRepo(dispatcherProvider: DispatcherProvider = TestDispatcherProvider()): BugReportRepo {
         val recorder = mockk<BugReportRecorder>(relaxed = true) {
             every { state } returns recorderState
             coEvery { isActiveOrStarting(any()) } answers {
@@ -51,7 +57,7 @@ class BugReportShareNamingTest : BaseTest() {
         return BugReportRepo(
             context = context,
             appScope = CoroutineScope(Dispatchers.Unconfined),
-            dispatcherProvider = TestDispatcherProvider(),
+            dispatcherProvider = dispatcherProvider,
             ringLogBuffer = RingLogBuffer(),
             bugReportRecorder = recorder,
             butlerId = ButlerId(context),
@@ -205,9 +211,9 @@ class BugReportShareNamingTest : BaseTest() {
     }
 
     /**
-     * A rename that lands while the zip is being compressed must not produce a zip named after the
-     * old name whose sealed `meta.json` carries the new one. The build runs on a real thread and the
-     * rename is fired once the compression has started, so the two genuinely overlap.
+     * The rename waits for the `.tmp` zip, which only exists once the lock is already held, so it
+     * queues behind the build instead of overlapping it. What this covers is that the lock spans the
+     * whole build: the zip name and the `meta.json` sealed inside it describe the same name.
      */
     @Test
     fun `a rename cannot interleave with a zip build`() = runBlocking<Unit> {
@@ -235,5 +241,52 @@ class BugReportShareNamingTest : BaseTest() {
             )
         }
         zip.name shouldBe BugReportStorage.shareZipName("race_1", sealed.label)
+    }
+
+    /**
+     * The rename lands in the gap between the resolve and the lock: the caller runs on a dispatcher
+     * this test pumps by hand, so the build is held right after `resolveReportEntry` returned and
+     * before it can take the mutex. The zip name and the `meta.json` sealed inside it must still
+     * describe the same name.
+     */
+    @Test
+    fun `a rename between the resolve and the lock cannot split name from metadata`() {
+        val caller = QueueDispatcher()
+        val repo = createRepo(TestDispatcherProvider(Dispatchers.IO))
+        writeReportDir("race_gap", label = "Before")
+
+        val job = CoroutineScope(caller).launch { repo.buildShareZip("race_gap") }
+        // Runs the build up to its first hop off this dispatcher.
+        caller.awaitNext()!!.run()
+        // Queued only once that hop came back, i.e. the entry is resolved and the lock is not held.
+        val afterResolve = caller.awaitNext()!!
+
+        runBlocking { repo.setLabel("race_gap", "After") }
+
+        afterResolve.run()
+        while (job.isActive) caller.awaitNext(1_000)?.run()
+        runBlocking { job.join() }
+
+        val zip = shareDir.listFiles()!!.single()
+        val sealed = ZipFile(zip).use { file ->
+            json.decodeFromString(
+                BugReport.serializer(),
+                file.getInputStream(file.getEntry("meta.json")).readBytes().decodeToString(),
+            )
+        }
+        withClue("zip file is named \"${zip.name}\" but seals the name \"${sealed.label}\"") {
+            zip.name shouldBe BugReportStorage.shareZipName("race_gap", sealed.label)
+        }
+    }
+
+    /** A dispatcher whose queue the test drains by hand, one task at a time. */
+    private class QueueDispatcher : CoroutineDispatcher() {
+        private val queue = LinkedBlockingQueue<Runnable>()
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            queue.put(block)
+        }
+
+        fun awaitNext(timeoutMs: Long = 10_000): Runnable? = queue.poll(timeoutMs, TimeUnit.MILLISECONDS)
     }
 }

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
@@ -137,6 +137,15 @@ class BugReportShareNamingTest : BaseTest() {
     }
 
     @Test
+    fun `a name of nothing but whitespace falls back to the bare id`() = runTest {
+        val repo = createRepo()
+        // setLabel cannot store this, but a meta.json written elsewhere can carry it.
+        writeReportDir("share_blank", label = "   ")
+
+        repo.buildShareZip("share_blank").name shouldBe "share_blank.zip"
+    }
+
+    @Test
     fun `a name starting with a dot does not produce a hidden file`() = runTest {
         val repo = createRepo()
         writeReportDir("share_dot", label = ".hidden")

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.common.debug.bugreport
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ButlerId
+import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.RingLogBuffer
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContainExactly
@@ -13,6 +14,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -43,7 +45,7 @@ class BugReportShareNamingTest : BaseTest() {
     private val json = Json { ignoreUnknownKeys = true }
     private val recorderState = MutableStateFlow(BugReportRecorder.State())
 
-    private fun createRepo(): BugReportRepo {
+    private fun createRepo(dispatcherProvider: DispatcherProvider = TestDispatcherProvider()): BugReportRepo {
         val recorder = mockk<BugReportRecorder>(relaxed = true) {
             every { state } returns recorderState
             coEvery { isActiveOrStarting(any()) } answers {
@@ -53,7 +55,7 @@ class BugReportShareNamingTest : BaseTest() {
         return BugReportRepo(
             context = context,
             appScope = CoroutineScope(Dispatchers.Unconfined),
-            dispatcherProvider = TestDispatcherProvider(),
+            dispatcherProvider = dispatcherProvider,
             ringLogBuffer = RingLogBuffer(),
             bugReportRecorder = recorder,
             butlerId = ButlerId(context),
@@ -226,20 +228,31 @@ class BugReportShareNamingTest : BaseTest() {
     @Test
     fun `a rename can neither land inside a zip build nor name a queued build from a stale resolve`() =
         runBlocking<Unit> {
-            val repo = createRepo()
+            // The proof below needs IO to run in place: an explicit Unconfined keeps a later change
+            // to TestDispatcherProvider's default from silently weakening it.
+            val repo = createRepo(TestDispatcherProvider(Dispatchers.Unconfined))
             writeBulkyReportDir("race_lock", label = "Before")
 
             val firstBuild = launch(Dispatchers.IO) { repo.buildShareZip("race_lock") }
             awaitTmpZip()
 
-            val rename = launch(Dispatchers.IO) { repo.setLabel("race_lock", "After") }
-            Thread.sleep(RENAME_GRACE_MS)
+            // Unconfined + UNDISPATCHED: the body runs on this thread until it either finishes or
+            // suspends, so launch() returning with the job still active means the rename is parked
+            // on the mutex - not merely that it has yet to be scheduled.
+            val rename = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+                repo.setLabel("race_lock", "After")
+            }
             withClue("setLabel finished while a share zip was still being written") {
                 rename.isActive shouldBe true
             }
 
-            // The rename is still blocked, so it is queued ahead of this build.
-            val secondBuild = launch(Dispatchers.IO) { runCatching { repo.buildShareZip("race_lock") } }
+            // Started the same way, so it parks behind the rename in the mutex's queue.
+            val secondBuild = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+                runCatching { repo.buildShareZip("race_lock") }
+            }
+            withClue("the second build did not queue behind the rename") {
+                secondBuild.isActive shouldBe true
+            }
 
             firstBuild.join()
             rename.join()
@@ -273,11 +286,9 @@ class BugReportShareNamingTest : BaseTest() {
 
     /** Returns once a build has opened its `.tmp`, i.e. once it holds the report. */
     private fun awaitTmpZip() {
-        val deadline = System.currentTimeMillis() + 10_000
-        while (
-            shareDir.listFiles()?.none { it.name.endsWith(BugReportStorage.TMP_SUFFIX) } != false &&
-            System.currentTimeMillis() < deadline
-        ) {
+        val deadline = System.currentTimeMillis() + TMP_WAIT_MS
+        while (shareDir.listFiles()?.none { it.name.endsWith(BugReportStorage.TMP_SUFFIX) } != false) {
+            check(System.currentTimeMillis() < deadline) { "No build opened a share zip within ${TMP_WAIT_MS}ms" }
             Thread.sleep(1)
         }
     }
@@ -292,6 +303,6 @@ class BugReportShareNamingTest : BaseTest() {
     companion object {
         /** ~48MB hard-linked into three payload entries: ~1.4s of compression to act inside. */
         private const val BULK_LOG_LINES = 800_000
-        private const val RENAME_GRACE_MS = 100L
+        private const val TMP_WAIT_MS = 10_000L
     }
 }

--- a/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
+++ b/app-common/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareNamingTest.kt
@@ -3,7 +3,6 @@ package eu.darken.butler.common.debug.bugreport
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.ButlerId
-import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.debug.logging.RingLogBuffer
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContainExactly
@@ -13,7 +12,6 @@ import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,10 +26,8 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
+import java.nio.file.Files
 import java.util.zip.ZipFile
-import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -47,7 +43,7 @@ class BugReportShareNamingTest : BaseTest() {
     private val json = Json { ignoreUnknownKeys = true }
     private val recorderState = MutableStateFlow(BugReportRecorder.State())
 
-    private fun createRepo(dispatcherProvider: DispatcherProvider = TestDispatcherProvider()): BugReportRepo {
+    private fun createRepo(): BugReportRepo {
         val recorder = mockk<BugReportRecorder>(relaxed = true) {
             every { state } returns recorderState
             coEvery { isActiveOrStarting(any()) } answers {
@@ -57,7 +53,7 @@ class BugReportShareNamingTest : BaseTest() {
         return BugReportRepo(
             context = context,
             appScope = CoroutineScope(Dispatchers.Unconfined),
-            dispatcherProvider = dispatcherProvider,
+            dispatcherProvider = TestDispatcherProvider(),
             ringLogBuffer = RingLogBuffer(),
             bugReportRecorder = recorder,
             butlerId = ButlerId(context),
@@ -220,17 +216,63 @@ class BugReportShareNamingTest : BaseTest() {
     }
 
     /**
-     * The rename waits for the `.tmp` zip, which only exists once the lock is already held, so it
-     * queues behind the build instead of overlapping it. What this covers is that the lock spans the
-     * whole build: the zip name and the `meta.json` sealed inside it describe the same name.
+     * Both halves of what the lock buys, in one run.
+     *
+     * The rename is fired while the first build is compressing, so it must not be able to finish
+     * before that build has released. The second build is started while the rename is queued ahead
+     * of it, so it must take its name from the report as the rename leaves it - a resolve taken
+     * before the lock names the zip "Before" while sealing "After" inside it.
      */
     @Test
-    fun `a rename cannot interleave with a zip build`() = runBlocking<Unit> {
-        val repo = createRepo()
-        val bulkyLog = (1..200_000).joinToString("\n") { "line $it ${it * 7919}" }
-        writeReportDir("race_1", label = "Before", logText = bulkyLog)
+    fun `a rename can neither land inside a zip build nor name a queued build from a stale resolve`() =
+        runBlocking<Unit> {
+            val repo = createRepo()
+            writeBulkyReportDir("race_lock", label = "Before")
 
-        val zipJob = launch(Dispatchers.IO) { repo.buildShareZip("race_1") }
+            val firstBuild = launch(Dispatchers.IO) { repo.buildShareZip("race_lock") }
+            awaitTmpZip()
+
+            val rename = launch(Dispatchers.IO) { repo.setLabel("race_lock", "After") }
+            Thread.sleep(RENAME_GRACE_MS)
+            withClue("setLabel finished while a share zip was still being written") {
+                rename.isActive shouldBe true
+            }
+
+            // The rename is still blocked, so it is queued ahead of this build.
+            val secondBuild = launch(Dispatchers.IO) { runCatching { repo.buildShareZip("race_lock") } }
+
+            firstBuild.join()
+            rename.join()
+            secondBuild.join()
+
+            val zip = shareDir.listFiles()!!.single()
+            val sealed = readSealedReport(zip)
+            // The surviving zip is the one built after the rename; without this a second build that
+            // died early would leave the first build's (self-consistent) zip and pass the check below.
+            sealed.label shouldBe "After"
+            withClue("zip file is named \"${zip.name}\" but seals the name \"${sealed.label}\"") {
+                zip.name shouldBe BugReportStorage.shareZipName("race_lock", sealed.label)
+            }
+        }
+
+    /**
+     * A report whose payload takes long enough to compress that the test can act while a build holds
+     * it. `root.log`/`adb.log` are hard links rather than copies: three payload entries worth of
+     * compression for one file worth of disk.
+     */
+    private fun writeBulkyReportDir(id: String, label: String) {
+        writeReportDir(id, label = label)
+        val dir = File(reportsDir, id)
+        val log = File(dir, BugReportStorage.LOG_FILE)
+        log.bufferedWriter().use { writer ->
+            repeat(BULK_LOG_LINES) { writer.write("line $it ${it * 7919} filler that keeps the compressor busy\n") }
+        }
+        Files.createLink(File(dir, BugReportStorage.ROOT_LOG_FILE).toPath(), log.toPath())
+        Files.createLink(File(dir, BugReportStorage.ADB_LOG_FILE).toPath(), log.toPath())
+    }
+
+    /** Returns once a build has opened its `.tmp`, i.e. once it holds the report. */
+    private fun awaitTmpZip() {
         val deadline = System.currentTimeMillis() + 10_000
         while (
             shareDir.listFiles()?.none { it.name.endsWith(BugReportStorage.TMP_SUFFIX) } != false &&
@@ -238,64 +280,18 @@ class BugReportShareNamingTest : BaseTest() {
         ) {
             Thread.sleep(1)
         }
-
-        repo.setLabel("race_1", "After")
-        zipJob.join()
-
-        val zip = shareDir.listFiles()!!.single()
-        val sealed = ZipFile(zip).use { file ->
-            json.decodeFromString(
-                BugReport.serializer(),
-                file.getInputStream(file.getEntry("meta.json")).readBytes().decodeToString(),
-            )
-        }
-        zip.name shouldBe BugReportStorage.shareZipName("race_1", sealed.label)
     }
 
-    /**
-     * The rename lands in the gap between the resolve and the lock: the caller runs on a dispatcher
-     * this test pumps by hand, so the build is held right after `resolveReportEntry` returned and
-     * before it can take the mutex. The zip name and the `meta.json` sealed inside it must still
-     * describe the same name.
-     */
-    @Test
-    fun `a rename between the resolve and the lock cannot split name from metadata`() {
-        val caller = QueueDispatcher()
-        val repo = createRepo(TestDispatcherProvider(Dispatchers.IO))
-        writeReportDir("race_gap", label = "Before")
-
-        val job = CoroutineScope(caller).launch { repo.buildShareZip("race_gap") }
-        // Runs the build up to its first hop off this dispatcher.
-        caller.awaitNext()!!.run()
-        // Queued only once that hop came back, i.e. the entry is resolved and the lock is not held.
-        val afterResolve = caller.awaitNext()!!
-
-        runBlocking { repo.setLabel("race_gap", "After") }
-
-        afterResolve.run()
-        while (job.isActive) caller.awaitNext(1_000)?.run()
-        runBlocking { job.join() }
-
-        val zip = shareDir.listFiles()!!.single()
-        val sealed = ZipFile(zip).use { file ->
-            json.decodeFromString(
-                BugReport.serializer(),
-                file.getInputStream(file.getEntry("meta.json")).readBytes().decodeToString(),
-            )
-        }
-        withClue("zip file is named \"${zip.name}\" but seals the name \"${sealed.label}\"") {
-            zip.name shouldBe BugReportStorage.shareZipName("race_gap", sealed.label)
-        }
+    private fun readSealedReport(zip: File): BugReport = ZipFile(zip).use { file ->
+        json.decodeFromString(
+            BugReport.serializer(),
+            file.getInputStream(file.getEntry(BugReportStorage.META_FILE)).readBytes().decodeToString(),
+        )
     }
 
-    /** A dispatcher whose queue the test drains by hand, one task at a time. */
-    private class QueueDispatcher : CoroutineDispatcher() {
-        private val queue = LinkedBlockingQueue<Runnable>()
-
-        override fun dispatch(context: CoroutineContext, block: Runnable) {
-            queue.put(block)
-        }
-
-        fun awaitNext(timeoutMs: Long = 10_000): Runnable? = queue.poll(timeoutMs, TimeUnit.MILLISECONDS)
+    companion object {
+        /** ~48MB hard-linked into three payload entries: ~1.4s of compression to act inside. */
+        private const val BULK_LOG_LINES = 800_000
+        private const val RENAME_GRACE_MS = 100L
     }
 }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.bugreport.R
@@ -13,6 +14,7 @@ import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel.ActiveDialog
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.debug.bugreport.BugReport
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
@@ -20,6 +22,7 @@ import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.error.ErrorEventHandler
 import eu.darken.butler.common.openPrivacyPolicy
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.dialogs.CustomNameDialog
 import kotlinx.coroutines.launch
 
 private val TAG = logTag("BugReport", "Workspace", "Overlays")
@@ -67,6 +70,8 @@ fun BugReportWorkspaceOverlaysHost(
         onDismissDeleteAll = { vm.dismissDeleteAllConfirmation() },
         onConfirmDelete = { vm.confirmDelete() },
         onDismissDelete = { vm.dismissDeleteConfirmation() },
+        onRename = { reportId, label -> vm.rename(reportId, label) },
+        onDismissRename = { vm.dismissRename() },
         onPrivacyPolicy = { openPrivacyPolicy(context) },
     )
 
@@ -86,6 +91,8 @@ fun BugReportWorkspaceOverlays(
     onDismissDeleteAll: () -> Unit = {},
     onConfirmDelete: () -> Unit = {},
     onDismissDelete: () -> Unit = {},
+    onRename: (String, String?) -> Unit = { _, _ -> },
+    onDismissRename: () -> Unit = {},
     onPrivacyPolicy: () -> Unit = {},
 ) {
     when (val dialog = overlayState.activeDialog) {
@@ -110,8 +117,35 @@ fun BugReportWorkspaceOverlays(
             onDismiss = onDismissDelete,
         )
 
+        is ActiveDialog.Rename -> BugReportRenameDialog(
+            currentLabel = dialog.currentLabel,
+            autoTitle = dialog.autoTitle,
+            onConfirm = { onRename(dialog.reportId, it) },
+            onDismiss = onDismissRename,
+        )
+
         null -> Unit
     }
+}
+
+/** Names a report so it can be told apart in the list and in the shared file name. */
+@Composable
+private fun BugReportRenameDialog(
+    currentLabel: String?,
+    autoTitle: String,
+    onConfirm: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    CustomNameDialog(
+        currentName = currentLabel,
+        autoName = autoTitle,
+        dialogTitle = stringResource(R.string.bugreport_rename_dialog_title),
+        fieldLabel = stringResource(R.string.bugreport_rename_name_label),
+        fieldHint = stringResource(R.string.bugreport_rename_name_hint),
+        maxLength = BugReport.MAX_LABEL_LENGTH,
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
 }
 
 @Preview2
@@ -147,5 +181,20 @@ private fun BugReportWorkspaceOverlaysDeleteAllPreview() {
 private fun BugReportWorkspaceOverlaysDeletePreview() {
     BugReportWorkspaceOverlays(
         overlayState = BugReportWorkspaceViewModel.OverlayState(ActiveDialog.DeleteConfirmation("report-1")),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun BugReportWorkspaceOverlaysRenamePreview() {
+    BugReportWorkspaceOverlays(
+        overlayState = BugReportWorkspaceViewModel.OverlayState(
+            ActiveDialog.Rename(
+                reportId = "crash_1",
+                currentLabel = "Crash while copying",
+                autoTitle = "NullPointerException",
+            ),
+        ),
     )
 }

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlays.kt
@@ -193,7 +193,7 @@ private fun BugReportWorkspaceOverlaysRenamePreview() {
             ActiveDialog.Rename(
                 reportId = "crash_1",
                 currentLabel = "Crash while copying",
-                autoTitle = "NullPointerException",
+                autoTitle = "Crash — NullPointerException",
             ),
         ),
     )

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -473,19 +473,16 @@ private fun ReportCard(
         onClick = onClick,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            val typeLabel = report.type.label()
             val prefix = if (!info.isSeen) "• " else ""
-            val detail = report.errorClass?.substringAfterLast('.')
-            val autoTitle = typeLabel + if (!detail.isNullOrBlank()) " — $detail" else ""
             Text(
-                text = prefix + (report.label ?: autoTitle),
+                text = prefix + (report.label ?: report.autoTitle()),
                 style = MaterialTheme.typography.titleSmall,
             )
             // The automatic identification stays visible under a user-set name: it is what the report
             // is actually about.
             if (report.label != null) {
                 Text(
-                    text = autoTitle,
+                    text = report.autoTitle(),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -692,10 +689,12 @@ private fun DeleteAllConfirmationDialogPreview() {
     DeleteAllConfirmationDialog(onConfirm = {}, onDismiss = {})
 }
 
-/** What a report is called without a user-set [BugReport.label]. */
+/** What a report is called without a user-set [BugReport.label]: its type, plus what went wrong. */
 @Composable
-internal fun BugReport.autoTitle(): String =
-    errorClass?.substringAfterLast('.')?.takeIf { it.isNotBlank() } ?: type.label()
+internal fun BugReport.autoTitle(): String {
+    val detail = errorClass?.substringAfterLast('.')?.takeIf { it.isNotBlank() }
+    return type.label() + if (detail != null) " — $detail" else ""
+}
 
 @Composable
 internal fun DeleteReportConfirmationDialog(

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -121,6 +121,7 @@ fun BugReportWorkspacePageHost(
             onBack = { vm.closeReport() },
             onToggleLog = { vm.setLogExpanded(it) },
             onShareReport = { report -> vm.requestShareConsent(report.id) },
+            onRenameReport = { report, autoTitle -> vm.requestRename(report.id, report.label, autoTitle) },
             onDeleteReport = { id -> vm.requestDeleteConfirmation(id) },
             onDeleteAll = { vm.requestDeleteAllConfirmation() },
             onStartRecording = { vm.startRecording() },
@@ -137,6 +138,7 @@ fun BugReportWorkspacePage(
     onReportClick: (BugReportInfo) -> Unit = {},
     onBack: () -> Unit = {},
     onShareReport: (BugReport) -> Unit = {},
+    onRenameReport: (BugReport, String) -> Unit = { _, _ -> },
     onDeleteReport: (String) -> Unit = {},
     onDeleteAll: () -> Unit = {},
     onStartRecording: () -> Unit = {},
@@ -145,11 +147,14 @@ fun BugReportWorkspacePage(
 ) {
     val detail = state.detail
     if (detail != null) {
+        val report = detail.info.report
+        val autoTitle = report.autoTitle()
         BugReportDetailContent(
             modifier = modifier,
             design = design,
             detail = detail,
             onBack = onBack,
+            onRename = { onRenameReport(report, autoTitle) },
             onShare = { onShareReport(detail.info.report) },
             onDelete = { onDeleteReport(detail.info.id) },
             onToggleLog = onToggleLog,
@@ -471,10 +476,20 @@ private fun ReportCard(
             val typeLabel = report.type.label()
             val prefix = if (!info.isSeen) "• " else ""
             val detail = report.errorClass?.substringAfterLast('.')
+            val autoTitle = typeLabel + if (!detail.isNullOrBlank()) " — $detail" else ""
             Text(
-                text = prefix + typeLabel + if (!detail.isNullOrBlank()) " — $detail" else "",
+                text = prefix + (report.label ?: autoTitle),
                 style = MaterialTheme.typography.titleSmall,
             )
+            // The automatic identification stays visible under a user-set name: it is what the report
+            // is actually about.
+            if (report.label != null) {
+                Text(
+                    text = autoTitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             report.errorMessage?.takeIf { it.isNotBlank() }?.let {
                 Text(
                     text = it,
@@ -677,6 +692,11 @@ private fun DeleteAllConfirmationDialogPreview() {
     DeleteAllConfirmationDialog(onConfirm = {}, onDismiss = {})
 }
 
+/** What a report is called without a user-set [BugReport.label]. */
+@Composable
+internal fun BugReport.autoTitle(): String =
+    errorClass?.substringAfterLast('.')?.takeIf { it.isNotBlank() } ?: type.label()
+
 @Composable
 internal fun DeleteReportConfirmationDialog(
     onConfirm: () -> Unit,
@@ -749,22 +769,7 @@ private fun BugReportWorkspacePagePreview() {
                 recordingLogSize = 24_000L,
                 reports = listOf(
                     BugReportInfo(
-                        report = BugReport(
-                            id = "crash_1",
-                            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
-                            type = BugReport.Type.CRASH,
-                            errorClass = "java.lang.NullPointerException",
-                            errorMessage = "Attempt to read from null array",
-                            stackTrace = "",
-                            threadName = "main",
-                            appVersion = "v0.0.0-beta1",
-                            deviceFingerprint = "Pixel/foo",
-                            apiLevel = "36",
-                            flavor = "FOSS",
-                            buildType = "RELEASE",
-                            installId = "abc",
-                            locale = "en-US",
-                        ),
+                        report = previewReport(),
                         isSeen = false,
                     ),
                 ),
@@ -772,3 +777,39 @@ private fun BugReportWorkspacePagePreview() {
         )
     }
 }
+
+@Preview2
+@Composable
+private fun BugReportWorkspacePageLabeledPreview() {
+    PreviewWrapper {
+        BugReportWorkspacePage(
+            state = BugReportWorkspaceViewModel.State(
+                id = Workspace.Id(),
+                reports = listOf(
+                    BugReportInfo(
+                        report = previewReport(label = "Crash while copying"),
+                        isSeen = true,
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+private fun previewReport(label: String? = null) = BugReport(
+    id = "crash_1",
+    createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+    type = BugReport.Type.CRASH,
+    errorClass = "java.lang.NullPointerException",
+    errorMessage = "Attempt to read from null array",
+    stackTrace = "",
+    threadName = "main",
+    appVersion = "v0.0.0-beta1",
+    deviceFingerprint = "Pixel/foo",
+    apiLevel = "36",
+    flavor = "FOSS",
+    buildType = "RELEASE",
+    installId = "abc",
+    locale = "en-US",
+    label = label,
+)

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceViewModel.kt
@@ -69,6 +69,13 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         if (it.activeDialog is ActiveDialog.ShortRecordingWarning) it.copy(activeDialog = null) else it
     }
 
+    fun requestRename(reportId: String, currentLabel: String?, autoTitle: String) =
+        requestDialog(ActiveDialog.Rename(reportId, currentLabel, autoTitle))
+
+    fun dismissRename() = _overlayState.update {
+        if (it.activeDialog is ActiveDialog.Rename) it.copy(activeDialog = null) else it
+    }
+
     fun requestDeleteAllConfirmation() = requestDialog(ActiveDialog.DeleteAllConfirmation)
 
     fun dismissDeleteAllConfirmation() = _overlayState.update {
@@ -210,6 +217,13 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
+    fun rename(reportId: String, label: String?) {
+        log(tag, INFO) { "rename($reportId)" }
+        // Dismiss before the IO, like deleteAll(): a throw inside setLabel would strand the dialog open.
+        dismissRename()
+        launch { bugReportRepo.setLabel(reportId, label) }
+    }
+
     fun startRecording() = launch {
         log(tag, INFO) { "startRecording()" }
         bugReportRecorder.start()
@@ -252,6 +266,13 @@ class BugReportWorkspaceViewModel @AssistedInject constructor(
         data object ShortRecordingWarning : ActiveDialog
         data object DeleteAllConfirmation : ActiveDialog
         data class DeleteConfirmation(val reportId: String) : ActiveDialog
+
+        /** [autoTitle] is what the report is called without a name, shown as the field's placeholder. */
+        data class Rename(
+            val reportId: String,
+            val currentLabel: String?,
+            val autoTitle: String,
+        ) : ActiveDialog
     }
 
     /** The full-screen detail view's state: the report plus its (async) log tail. */

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import eu.darken.butler.bugreport.R
 import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel
+import eu.darken.butler.bugreport.ui.autoTitle
 import eu.darken.butler.bugreport.ui.label
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -73,6 +74,7 @@ fun BugReportDetailContent(
     design: WorkspaceDesign,
     detail: BugReportWorkspaceViewModel.Detail,
     onBack: () -> Unit,
+    onRename: () -> Unit,
     onShare: () -> Unit,
     onDelete: () -> Unit,
     onToggleLog: (Boolean) -> Unit,
@@ -89,8 +91,7 @@ fun BugReportDetailContent(
     )
 
     val report = detail.info.report
-    val errorShort = report.errorClass?.substringAfterLast('.')?.takeIf { it.isNotBlank() }
-    val title = errorShort ?: report.type.label()
+    val title = report.label ?: report.autoTitle()
     val hasError = !report.errorClass.isNullOrBlank() ||
         !report.errorMessage.isNullOrBlank() ||
         !report.stackTrace.isNullOrBlank()
@@ -138,6 +139,7 @@ fun BugReportDetailContent(
                     BugReportDetailToolbarCard(
                         title = title,
                         onBack = onBack,
+                        onRename = onRename,
                         onShare = onShare,
                         onDelete = onDelete,
                     )
@@ -407,6 +409,7 @@ private fun BugReportDetailContentCrashPreview() {
                 isLogExpanded = true,
             ),
             onBack = {},
+            onRename = {},
             onShare = {},
             onDelete = {},
             onToggleLog = {},
@@ -431,6 +434,7 @@ private fun BugReportDetailContentRecordingPreview() {
                 isLogExpanded = true,
             ),
             onBack = {},
+            onRename = {},
             onShare = {},
             onDelete = {},
             onToggleLog = {},
@@ -450,6 +454,7 @@ private fun BugReportDetailContentLoadingPreview() {
                 isLogExpanded = true,
             ),
             onBack = {},
+            onRename = {},
             onShare = {},
             onDelete = {},
             onToggleLog = {},
@@ -469,6 +474,7 @@ private fun BugReportDetailContentLogCollapsedPreview() {
                 isLogExpanded = false,
             ),
             onBack = {},
+            onRename = {},
             onShare = {},
             onDelete = {},
             onToggleLog = {},

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailToolbarCard.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailToolbarCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.Edit
 import androidx.compose.material.icons.twotone.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -37,7 +38,8 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 
 /**
- * Static, compact toolbar for the bug-report detail view: back arrow + title + Share + Delete.
+ * Static, compact toolbar for the bug-report detail view: back arrow + title + Rename + Share +
+ * Delete.
  * It stays at the compact workspace-button size (no expand/collapse) — the larger form just wasted
  * vertical space here. Controls are plain clickable boxes (not IconButton) so the bar height isn't
  * pinned to the 48dp minimum interactive size.
@@ -47,6 +49,7 @@ fun BugReportDetailToolbarCard(
     modifier: Modifier = Modifier,
     title: String,
     onBack: () -> Unit,
+    onRename: () -> Unit,
     onShare: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -75,6 +78,11 @@ fun BugReportDetailToolbarCard(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
+            )
+            ToolbarControl(
+                icon = Icons.TwoTone.Edit,
+                contentDescription = stringResource(R.string.bugreport_rename_action),
+                onClick = onRename,
             )
             ToolbarControl(
                 icon = Icons.TwoTone.Share,
@@ -124,6 +132,7 @@ private fun BugReportDetailToolbarCardPreview() {
         BugReportDetailToolbarCard(
             title = "NullPointerException",
             onBack = {},
+            onRename = {},
             onShare = {},
             onDelete = {},
             modifier = Modifier.padding(16.dp),

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailToolbarCard.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailToolbarCard.kt
@@ -130,7 +130,7 @@ private fun ToolbarControl(
 private fun BugReportDetailToolbarCardPreview() {
     PreviewWrapper {
         BugReportDetailToolbarCard(
-            title = "NullPointerException",
+            title = "Crash — NullPointerException",
             onBack = {},
             onRename = {},
             onShare = {},

--- a/app-workspace-bugreport/src/main/res/values/strings.xml
+++ b/app-workspace-bugreport/src/main/res/values/strings.xml
@@ -20,6 +20,11 @@
     <string name="bugreport_recording_short_message">This recording is only a few seconds long and may not contain useful information. Stop it anyway?</string>
     <string name="bugreport_recording_short_keep_action">Keep recording</string>
 
+    <string name="bugreport_rename_action">Rename</string>
+    <string name="bugreport_rename_dialog_title">Name this report</string>
+    <string name="bugreport_rename_name_label">Name</string>
+    <string name="bugreport_rename_name_hint">Shown in the list and in the shared file name</string>
+
     <string name="bugreport_share_action">Share</string>
     <string name="bugreport_delete_action">Delete</string>
     <string name="bugreport_delete_all_action">Delete all</string>

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspaceOverlaysTest.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.bugreport.R
 import eu.darken.butler.bugreport.ui.BugReportWorkspaceViewModel.ActiveDialog
@@ -15,6 +17,7 @@ import eu.darken.butler.common.debug.bugreport.BugReportRepo
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -248,5 +251,89 @@ class BugReportWorkspaceOverlaysTest : ComposeTest() {
         vm.requestShareConsent("report-1")
 
         vm.overlayState.value.activeDialog shouldBe ActiveDialog.DeleteAllConfirmation
+    }
+
+    @Test
+    fun `the rename dialog confirms, clears and dismisses`() {
+        var renamedTo: String? = "unset"
+        var renamedId: String? = null
+        var dismissed = 0
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    BugReportWorkspaceOverlays(
+                        overlayState = BugReportWorkspaceViewModel.OverlayState(
+                            activeDialog = ActiveDialog.Rename(
+                                reportId = "report-1",
+                                currentLabel = "Copy stalls",
+                                autoTitle = "IllegalStateException",
+                            ),
+                        ),
+                        onRename = { id, label ->
+                            renamedId = id
+                            renamedTo = label
+                        },
+                        onDismissRename = { dismissed++ },
+                    )
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.bugreport_rename_dialog_title))
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(context.getString(CommonR.string.general_cancel_action)).performClick()
+        composeTestRule.runOnIdle { dismissed shouldBe 1 }
+
+        composeTestRule.onNodeWithText(context.getString(CommonR.string.general_clear_action)).performClick()
+        composeTestRule.runOnIdle {
+            renamedId shouldBe "report-1"
+            renamedTo shouldBe null
+        }
+
+        composeTestRule.onNode(hasSetTextAction()).performTextReplacement("  Renamed  ")
+        composeTestRule.onNodeWithText(context.getString(CommonR.string.general_rename_action)).performClick()
+        composeTestRule.runOnIdle { renamedTo shouldBe "Renamed" }
+    }
+
+    @Test
+    fun `a rename request while another dialog is showing is dropped`() {
+        val vm = createVM()
+
+        vm.requestDeleteAllConfirmation()
+        vm.requestRename("report-1", "Copy stalls", "IllegalStateException")
+
+        vm.overlayState.value.activeDialog shouldBe ActiveDialog.DeleteAllConfirmation
+    }
+
+    @Test
+    fun `the rename dialog is requested and dismissed through the slot`() {
+        val vm = createVM()
+
+        vm.requestRename("report-1", "Copy stalls", "IllegalStateException")
+        vm.overlayState.value.activeDialog shouldBe
+            ActiveDialog.Rename("report-1", "Copy stalls", "IllegalStateException")
+
+        vm.dismissRename()
+        vm.overlayState.value.activeDialog shouldBe null
+    }
+
+    /** The dialog is closed before the IO, so a failure inside setLabel cannot strand it open. */
+    @Test
+    fun `renaming dismisses the dialog before writing`() {
+        val vm = createVM()
+        var dialogWhileWriting: ActiveDialog? = ActiveDialog.DeleteAllConfirmation
+        coEvery { bugReportRepo.setLabel(any(), any()) } answers {
+            dialogWhileWriting = vm.overlayState.value.activeDialog
+        }
+
+        vm.requestRename("report-1", null, "IllegalStateException")
+        vm.rename("report-1", "Named")
+
+        dialogWhileWriting shouldBe null
+        vm.overlayState.value.activeDialog shouldBe null
+        coVerify { bugReportRepo.setLabel("report-1", "Named") }
     }
 }

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePageTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePageTest.kt
@@ -34,7 +34,7 @@ class BugReportWorkspacePageTest : ComposeTest() {
     private val stopLabel = context.getString(R.string.bugreport_stop_action)
     private val deleteAllLabel = context.getString(R.string.bugreport_delete_all_action)
 
-    private fun report(index: Int) = BugReportInfo(
+    private fun report(index: Int, label: String? = null) = BugReportInfo(
         report = BugReport(
             id = "report-$index",
             createdAt = Instant.parse("2026-06-15T10:00:00Z"),
@@ -50,6 +50,7 @@ class BugReportWorkspacePageTest : ComposeTest() {
             buildType = "RELEASE",
             installId = "abc",
             locale = "en-US",
+            label = label,
         ),
         isSeen = true,
     )
@@ -135,5 +136,23 @@ class BugReportWorkspacePageTest : ComposeTest() {
             .performSemanticsAction(SemanticsActions.OnClick)
 
         composeTestRule.runOnIdle { deleteAlls shouldBe 1 }
+    }
+
+    @Test
+    fun `a named report shows its name above the automatic one`() {
+        setPage(reports = listOf(report(1, label = "Copy stalls on SD card")))
+
+        composeTestRule.onNodeWithText("Copy stalls on SD card").assertExists()
+        // The type and error class stay visible: they are what the report is actually about.
+        val autoTitle = context.getString(R.string.bugreport_type_crash) + " — IllegalStateException"
+        composeTestRule.onNodeWithText(autoTitle).assertExists()
+    }
+
+    @Test
+    fun `an unnamed report shows only the automatic title`() {
+        setPage(reports = listOf(report(2)))
+
+        val autoTitle = context.getString(R.string.bugreport_type_crash) + " — IllegalStateException"
+        composeTestRule.onNodeWithText(autoTitle).assertExists()
     }
 }

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContentTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContentTest.kt
@@ -29,6 +29,7 @@ class BugReportDetailContentTest : ComposeTest() {
     private val expandLabel = context.getString(eu.darken.butler.common.R.string.general_expand_action)
     private val collapseLabel = context.getString(eu.darken.butler.common.R.string.general_collapse_action)
     private val logSizeBytes = 24_000L
+    private val renameLabel = context.getString(R.string.bugreport_rename_action)
 
     // No error fields: the detail then renders without the error card, which keeps the log section
     // on screen in Robolectric's fixed-size wrapper.
@@ -64,6 +65,8 @@ class BugReportDetailContentTest : ComposeTest() {
         logState: BugReportWorkspaceViewModel.LogState,
         isLogExpanded: Boolean,
         onToggleLog: (Boolean) -> Unit = {},
+        info: BugReportInfo = this.info,
+        onRename: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             PreviewWrapper {
@@ -75,7 +78,7 @@ class BugReportDetailContentTest : ComposeTest() {
                         isLogExpanded = isLogExpanded,
                     ),
                     onBack = {},
-                    onRename = {},
+                    onRename = onRename,
                     onShare = {},
                     onDelete = {},
                     onToggleLog = onToggleLog,
@@ -128,6 +131,35 @@ class BugReportDetailContentTest : ComposeTest() {
         composeTestRule.onNodeWithText(logSectionTitle).performSemanticsAction(SemanticsActions.OnClick)
 
         composeTestRule.runOnIdle { toggledTo shouldBe true }
+    }
+
+    @Test
+    fun `the toolbar shows the report's name when it has one`() {
+        setContent(
+            logState = BugReportWorkspaceViewModel.LogState.Idle,
+            isLogExpanded = false,
+            info = info.copy(report = info.report.copy(label = "Copy stalls on SD card")),
+        )
+
+        composeTestRule.onNodeWithText("Copy stalls on SD card").assertExists()
+    }
+
+    @Test
+    fun `the rename control reports the request`() {
+        var renames = 0
+        setContent(
+            logState = BugReportWorkspaceViewModel.LogState.Idle,
+            isLogExpanded = false,
+            onRename = { renames++ },
+        )
+
+        // Via the semantics action, not performClick: in this fixed-size wrapper a laid-out but
+        // off-screen node swallows a click without reporting a failure.
+        composeTestRule
+            .onNodeWithContentDescription(renameLabel)
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeTestRule.runOnIdle { renames shouldBe 1 }
     }
 
     companion object {

--- a/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContentTest.kt
+++ b/app-workspace-bugreport/src/test/java/eu/darken/butler/bugreport/ui/detail/BugReportDetailContentTest.kt
@@ -75,6 +75,7 @@ class BugReportDetailContentTest : ComposeTest() {
                         isLogExpanded = isLogExpanded,
                     ),
                     onBack = {},
+                    onRename = {},
                     onShare = {},
                     onDelete = {},
                     onToggleLog = onToggleLog,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/CustomNameDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/CustomNameDialog.kt
@@ -1,0 +1,166 @@
+package eu.darken.butler.workspace.ui.dialogs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.ui.dialogs.AdaptiveAlertDialog
+import eu.darken.butler.workspace.ui.modal.LocalLayerActive
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import eu.darken.butler.common.R as CommonR
+
+/**
+ * Sets or clears a user-set name for something that also has an automatic one ([autoName], shown as
+ * the placeholder). An empty field is a valid action: it clears the name and restores the automatic
+ * one, which is why confirm is always enabled. "Clear" does the same in one press and is offered
+ * whenever there is a name to clear.
+ *
+ * [maxLength] only exists to give immediate feedback while typing; the store the name goes to stays
+ * authoritative on normalization (trimming, control characters, length). It counts code points, so
+ * the field cannot cut a surrogate pair in half.
+ */
+@Composable
+fun CustomNameDialog(
+    currentName: String?,
+    autoName: String,
+    dialogTitle: String,
+    fieldLabel: String,
+    fieldHint: String,
+    maxLength: Int,
+    onConfirm: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    // Snapshotted at open time, exactly like the text field's own initial value: if the name is
+    // changed from elsewhere while this is open, the button and the field can never disagree.
+    val canClear = remember { currentName != null }
+
+    val focusRequester = remember { FocusRequester() }
+
+    val initialText = currentName ?: ""
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(initialText, TextRange(0, initialText.length)))
+    }
+
+    val handleConfirm = {
+        onConfirm(textFieldValue.text.trim().takeIf { it.isNotEmpty() })
+    }
+
+    // Only pull focus while this is the layer the user is talking to. Outside a pane there is no
+    // layer stack and this is always true, so the window variant behaves as before.
+    val layerActive = LocalLayerActive.current
+    LaunchedEffect(layerActive) {
+        if (layerActive) focusRequester.requestFocus()
+    }
+
+    AdaptiveAlertDialog(
+        onDismissRequest = onDismiss,
+        includeImePadding = true,
+        title = {
+            Text(
+                text = dialogTitle,
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
+                    value = textFieldValue,
+                    onValueChange = { new ->
+                        textFieldValue = if (new.text.codePointCount(0, new.text.length) > maxLength) {
+                            new.copy(text = new.text.substring(0, new.text.offsetByCodePoints(0, maxLength)))
+                        } else {
+                            new
+                        }
+                    },
+                    label = { Text(fieldLabel) },
+                    placeholder = { Text(autoName) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { handleConfirm() }),
+                    supportingText = { Text(fieldHint) },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = handleConfirm) {
+                Text(stringResource(CommonR.string.general_rename_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+        neutralButton = if (canClear) {
+            {
+                TextButton(onClick = { onConfirm(null) }) {
+                    Text(stringResource(CommonR.string.general_clear_action))
+                }
+            }
+        } else {
+            null
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun CustomNameDialogPreview() {
+    CustomNameDialog(
+        currentName = "Holiday photos",
+        autoName = "New tab",
+        dialogTitle = "Name this tab",
+        fieldLabel = "Custom name",
+        fieldHint = "Leave empty to use the automatic name",
+        maxLength = 128,
+        onConfirm = {},
+        onDismiss = {},
+    )
+}
+
+/** Inside a pane: composing it under a [PaneLayerHost] is what makes it pane-bound. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun PaneBoundCustomNameDialogPreview() {
+    PreviewWrapper {
+        PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+            CustomNameDialog(
+                currentName = null,
+                autoName = "New tab",
+                dialogTitle = "Name this tab",
+                fieldLabel = "Custom name",
+                fieldHint = "Leave empty to use the automatic name",
+                maxLength = 128,
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceRenameDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceRenameDialog.kt
@@ -1,45 +1,19 @@
 package eu.darken.butler.workspace.ui.dialogs
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
-import eu.darken.butler.common.ui.dialogs.AdaptiveAlertDialog
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.WorkspaceAction.Rename.Companion.MAX_CUSTOM_TITLE_LENGTH
-import eu.darken.butler.workspace.ui.modal.LocalLayerActive
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
-import eu.darken.butler.common.R as CommonR
 
 /**
- * Sets or clears the user-set name of a workspace. An empty field is a valid action: it clears the
- * name and restores the automatic one, which is why confirm is always enabled. "Clear" does the
- * same in one press and is offered whenever there is a custom name to clear.
- *
- * The input cap mirrors the repo's for immediate feedback; the repo stays authoritative on
- * normalization (trimming, control characters, length).
+ * Sets or clears the user-set name of a workspace.
  *
  * One composable for every caller: the host follows from where it is composed. Reached from inside
  * a pane — the Templates tab's name row — it is pane-bound, so it leaves the other panes alone and
@@ -53,79 +27,15 @@ fun WorkspaceRenameDialog(
     onConfirm: (String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    // Snapshotted at open time, exactly like the text field's own initial value: if the workspace is
-    // renamed from elsewhere while this is open, the button and the field can never disagree.
-    val canClear = remember { currentCustomTitle != null }
-
-    val focusRequester = remember { FocusRequester() }
-
-    val initialText = currentCustomTitle ?: ""
-    var textFieldValue by remember {
-        mutableStateOf(TextFieldValue(initialText, TextRange(0, initialText.length)))
-    }
-
-    val handleConfirm = {
-        onConfirm(textFieldValue.text.trim().takeIf { it.isNotEmpty() })
-    }
-
-    // Only pull focus while this is the layer the user is talking to. Outside a pane there is no
-    // layer stack and this is always true, so the window variant behaves as before.
-    val layerActive = LocalLayerActive.current
-    LaunchedEffect(layerActive) {
-        if (layerActive) focusRequester.requestFocus()
-    }
-
-    AdaptiveAlertDialog(
-        onDismissRequest = onDismiss,
-        includeImePadding = true,
-        title = {
-            Text(
-                text = stringResource(R.string.workspace_rename_dialog_title),
-                style = MaterialTheme.typography.headlineSmall,
-            )
-        },
-        text = {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                OutlinedTextField(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester),
-                    value = textFieldValue,
-                    onValueChange = { new ->
-                        textFieldValue = if (new.text.length > MAX_CUSTOM_TITLE_LENGTH) {
-                            new.copy(text = new.text.take(MAX_CUSTOM_TITLE_LENGTH))
-                        } else {
-                            new
-                        }
-                    },
-                    label = { Text(stringResource(R.string.workspace_rename_name_label)) },
-                    placeholder = { Text(autoTitle) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                    keyboardActions = KeyboardActions(onDone = { handleConfirm() }),
-                    supportingText = { Text(stringResource(R.string.workspace_rename_name_hint)) },
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = handleConfirm) {
-                Text(stringResource(CommonR.string.general_rename_action))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(CommonR.string.general_cancel_action))
-            }
-        },
-        neutralButton = if (canClear) {
-            {
-                TextButton(onClick = { onConfirm(null) }) {
-                    Text(stringResource(CommonR.string.general_clear_action))
-                }
-            }
-        } else {
-            null
-        },
+    CustomNameDialog(
+        currentName = currentCustomTitle,
+        autoName = autoTitle,
+        dialogTitle = stringResource(R.string.workspace_rename_dialog_title),
+        fieldLabel = stringResource(R.string.workspace_rename_name_label),
+        fieldHint = stringResource(R.string.workspace_rename_name_hint),
+        maxLength = MAX_CUSTOM_TITLE_LENGTH,
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
     )
 }
 

--- a/app/src/main/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormScreen.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormScreen.kt
@@ -484,6 +484,7 @@ fun SupportContactFormScreen(
 
 @Composable
 private fun reportTitle(info: BugReportInfo): String {
+    info.report.label?.let { return it }
     val typeLabel = when (info.report.type) {
         BugReport.Type.CRASH -> stringResource(R.string.support_contact_report_type_crash)
         BugReport.Type.REPORTED -> stringResource(R.string.support_contact_report_type_reported)
@@ -515,7 +516,13 @@ private val SupportContactFormViewModel.WorkspaceType.labelRes: Int
         SupportContactFormViewModel.WorkspaceType.EDITOR -> R.string.support_contact_workspace_editor
     }
 
-private fun previewReport(id: String, type: BugReport.Type, createdAt: Long, errorClass: String?) = BugReportInfo(
+private fun previewReport(
+    id: String,
+    type: BugReport.Type,
+    createdAt: Long,
+    errorClass: String?,
+    label: String? = null,
+) = BugReportInfo(
     report = BugReport(
         id = id,
         createdAt = Instant.fromEpochMilliseconds(createdAt),
@@ -528,6 +535,7 @@ private fun previewReport(id: String, type: BugReport.Type, createdAt: Long, err
         buildType = "DEBUG",
         installId = "id",
         locale = "en",
+        label = label,
     ),
     isSeen = true,
 )
@@ -556,7 +564,13 @@ private fun SupportContactFormBugPreview() {
             expectedBehavior = "The file list should scroll smoothly without crashing even with many files in the directory",
             reports = listOf(
                 previewReport("crash_1705312200000_abcd1234", BugReport.Type.CRASH, 1705312200000L, "java.lang.IllegalStateException"),
-                previewReport("recording_1705221300000_efgh5678", BugReport.Type.RECORDING, 1705221300000L, null),
+                previewReport(
+                    "recording_1705221300000_efgh5678",
+                    BugReport.Type.RECORDING,
+                    1705221300000L,
+                    null,
+                    label = "Copy stalls on SD card",
+                ),
             ),
             selectedReportId = "crash_1705312200000_abcd1234",
         ),

--- a/app/src/main/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormViewModel.kt
@@ -190,6 +190,10 @@ class SupportContactFormViewModel @Inject constructor(
         appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL} (${Build.DEVICE})")
         appendLine("Android: ${Build.VERSION.RELEASE} (API ${BuildWrap.VERSION.SDK_INT})")
         appendLine("Fingerprint: ${BuildWrap.FINGERPRINT}")
+        // What the user called the attached report, so a mail and a zip can be matched up by name.
+        state.reports.firstOrNull { it.id == state.selectedReportId }?.report?.label?.let {
+            appendLine("Report: $it")
+        }
     }
 
     private suspend fun buildAttachment(reportId: String?): Uri? {

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -185,7 +185,7 @@ class WorkspaceRepo @Inject constructor(
     private fun normalizeCustomTitle(raw: String?): String? = raw
         ?.filterNot { it.isISOControl() }
         ?.trim()
-        ?.take(WorkspaceAction.Rename.MAX_CUSTOM_TITLE_LENGTH)
+        ?.takeCodePoints(WorkspaceAction.Rename.MAX_CUSTOM_TITLE_LENGTH)
         ?.trim()
         ?.takeIf { it.isNotEmpty() }
 
@@ -2352,4 +2352,10 @@ class WorkspaceRepo @Inject constructor(
         const val FREE_TIER_WORKSPACE_LIMIT = 5
     }
 
+}
+
+/** [String.take] on code points, so the cap can never cut a surrogate pair in half. */
+private fun String.takeCodePoints(max: Int): String {
+    if (codePointCount(0, length) <= max) return this
+    return substring(0, offsetByCodePoints(0, max))
 }

--- a/app/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareIntentTest.kt
+++ b/app/src/test/java/eu/darken/butler/common/debug/bugreport/BugReportShareIntentTest.kt
@@ -53,7 +53,7 @@ class BugReportShareIntentTest : BaseTest() {
         )
     }
 
-    private fun writeReportDir(id: String): BugReport {
+    private fun writeReportDir(id: String, label: String? = null): BugReport {
         val dir = File(storageLayout.writeRoot, id).apply { mkdirs() }
         val report = BugReport(
             id = id,
@@ -68,6 +68,7 @@ class BugReportShareIntentTest : BaseTest() {
             buildType = "DEBUG",
             installId = "iid",
             locale = "en",
+            label = label,
         )
         File(dir, "meta.json").writeText(json.encodeToString(BugReport.serializer(), report))
         File(dir, "report.log").writeText("log line")
@@ -100,5 +101,25 @@ class BugReportShareIntentTest : BaseTest() {
         uri.toString() shouldContain "crash_1.zip"
         intent.clipData!!.getItemAt(0).uri shouldBe uri
         (intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION) shouldBe Intent.FLAG_GRANT_READ_URI_PERMISSION
+    }
+
+    @Test
+    fun `a named report is named in the subject and in the attachment`() = runTest {
+        val repo = createRepo()
+        writeReportDir("crash_2", label = "Copy stalls")
+
+        val intent = repo.buildShareIntent("crash_2")
+
+        intent.getStringExtra(Intent.EXTRA_SUBJECT) shouldBe context.getString(
+            R.string.general_bug_report_subject_labeled,
+            context.getString(R.string.app_name),
+            "Copy stalls",
+            "crash_2",
+        )
+        intent.getStringExtra(Intent.EXTRA_TEXT)!! shouldContain "Name: Copy stalls"
+
+        val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)!!
+        // Decoded: the provider percent-encodes the space in the file name.
+        Uri.decode(uri.toString()) shouldContain "Copy stalls_crash_2.zip"
     }
 }

--- a/app/src/test/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormBodyTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormBodyTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.butler.main.ui.settings.support.contactform
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.EmailTool
+import eu.darken.butler.common.debug.bugreport.BugReport
+import eu.darken.butler.common.debug.bugreport.BugReportInfo
+import eu.darken.butler.common.debug.bugreport.BugReportRecorder
+import eu.darken.butler.common.debug.bugreport.BugReportRepo
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Instant
+
+/** The support mail names the report the user attached, so a mail and a zip can be matched up. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SupportContactFormBodyTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val recorderState = MutableStateFlow(BugReportRecorder.State())
+    private val reportsFlow = MutableStateFlow<List<BugReportInfo>>(emptyList())
+    private val emailTool = mockk<EmailTool>()
+    private val emailSlot = slot<EmailTool.Email>()
+
+    private fun info(id: String, label: String?) = BugReportInfo(
+        report = BugReport(
+            id = id,
+            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+            type = BugReport.Type.CRASH,
+            errorClass = "java.lang.IllegalStateException",
+            appVersion = "1.0",
+            deviceFingerprint = "fp",
+            apiLevel = "34",
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            installId = "iid",
+            locale = "en",
+            label = label,
+        ),
+        isSeen = true,
+    )
+
+    private fun createVM(): SupportContactFormViewModel {
+        every { emailTool.build(capture(emailSlot), any()) } returns Intent()
+        return SupportContactFormViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            context = context,
+            bugReportRecorder = mockk(relaxed = true) {
+                every { state } returns recorderState
+            },
+            bugReportRepo = mockk(relaxed = true) {
+                every { reports } returns reportsFlow
+                coEvery { buildShareUri(any()) } returns Uri.parse("content://test/zip")
+            },
+            emailTool = emailTool,
+        )
+    }
+
+    private fun SupportContactFormViewModel.fillAndSend(selectedId: String) {
+        updateCategory(SupportContactFormViewModel.Category.BUG)
+        updateDescription(List(25) { "word$it" }.joinToString(" "))
+        updateExpectedBehavior(List(15) { "word$it" }.joinToString(" "))
+        selectReport(selectedId)
+        send()
+    }
+
+    @Test
+    fun `the body names the selected report`() = runTest {
+        reportsFlow.value = listOf(info("crash_1", label = "Copy stalls on SD card"))
+        val vm = createVM()
+
+        vm.fillAndSend("crash_1")
+
+        emailSlot.captured.body shouldContain "Report: Copy stalls on SD card"
+    }
+
+    @Test
+    fun `an unnamed report adds no report line`() = runTest {
+        reportsFlow.value = listOf(info("crash_2", label = null))
+        val vm = createVM()
+
+        vm.fillAndSend("crash_2")
+
+        emailSlot.captured.body shouldNotContain "Report:"
+    }
+}

--- a/app/src/test/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormReportNameTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/ui/settings/support/contactform/SupportContactFormReportNameTest.kt
@@ -1,0 +1,66 @@
+package eu.darken.butler.main.ui.settings.support.contactform
+
+import android.content.Context
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.debug.bugreport.BugReport
+import eu.darken.butler.common.debug.bugreport.BugReportInfo
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import kotlin.time.Instant
+
+/** A user-set report name replaces the automatic "Crash report · IllegalStateException" identification. */
+@Config(qualifiers = "w400dp-h800dp")
+class SupportContactFormReportNameTest : ComposeTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun info(id: String, label: String?) = BugReportInfo(
+        report = BugReport(
+            id = id,
+            createdAt = Instant.parse("2026-06-15T10:00:00Z"),
+            type = BugReport.Type.CRASH,
+            errorClass = "java.lang.IllegalStateException",
+            appVersion = "1.0",
+            deviceFingerprint = "fp",
+            apiLevel = "34",
+            flavor = "FOSS",
+            buildType = "DEBUG",
+            installId = "iid",
+            locale = "en",
+            label = label,
+        ),
+        isSeen = true,
+    )
+
+    private fun setContent(vararg reports: BugReportInfo) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SupportContactFormScreen(
+                    state = SupportContactFormViewModel.State(
+                        category = SupportContactFormViewModel.Category.BUG,
+                        reports = reports.toList(),
+                    ),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a named report is listed under its name`() {
+        setContent(info("crash_1", label = "Copy stalls on SD card"))
+
+        composeTestRule.onNodeWithText("Copy stalls on SD card").assertExists()
+    }
+
+    @Test
+    fun `an unnamed report keeps its automatic identification`() {
+        setContent(info("crash_2", label = null))
+
+        val expected = context.getString(R.string.support_contact_report_type_crash) + " · IllegalStateException"
+        composeTestRule.onNodeWithText(expected).assertExists()
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -2981,6 +2981,19 @@ class WorkspaceRepoTest : BaseTest() {
     }
 
     @Test
+    fun `an emoji title within the cap survives whole`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo()
+        val id = repo.createTab()
+        // 100 code points but 200 UTF-16 units: capping on chars would truncate it, and the cut would
+        // land inside a surrogate pair.
+        val emoji = "\uD83D\uDE42".repeat(100)
+
+        repo.rename(id, emoji)
+
+        repo.infoFor(id).customTitle shouldBe emoji
+    }
+
+    @Test
     fun `renaming an unknown id fails and mutates nothing`() = runTest(UnconfinedTestDispatcher()) {
         val repo = createRepo()
         val id = repo.createTab()


### PR DESCRIPTION
## What changed

Bug reports can now be given a name. Open a report, use the rename button in its toolbar, and type whatever helps you recognize it later. Clearing the field restores the automatic name.

The name then shows up wherever a report is identified: in the report list, with the automatic title on the line beneath it, in the report's detail view, and in the picker used to attach a report to a support mail.

Sharing a named report carries the name along. It goes into the mail subject, into the mail body, and into the zip file's own name, so a report that arrives by email is recognizable instead of being one timestamp among several.

Naming is optional. A report you never name looks and behaves exactly as it did before.

## Technical Context

- The name is a new optional field on the stored report. The report's id stays its storage key, so a rename never moves anything on disk, and reports written by older versions load unchanged.
- The share zip becomes `<name>_<id>.zip`. Keeping the id means the file still maps back to exactly one report, and the delete/prune paths can still find it under any name it has previously carried. Non-ASCII names survive into the file name; only path separators, platform-reserved characters and control characters are replaced.
- Building a share zip and renaming a report both take a repository lock, and the report is resolved inside that lock rather than before it. Resolving outside produced a zip named after the old name whose sealed `meta.json` carried the new one.
- The tab rename dialog was generalized so the bug-report rename could reuse it. That moved its input cap from UTF-16 units to code points, which forced the same change in the workspace title store; without it a pasted emoji tab name could be truncated mid-character. That fix is why this branch touches `WorkspaceRepo` despite being a bug-report feature.
- Worth close review: the locking in `BugReportRepo` (the mutex is not reentrant, so lock order and one-acquisition-per-path both matter) and the concurrency test that guards it, which is written to fail both if the lock is removed and if the resolve is moved back outside it.
