### PR TITLE
Workspace: Filter the tab manager by paused tabs and unsaved changes

### DIFF
--- a/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
@@ -472,6 +472,9 @@ private fun WorkspaceManagerBody() {
             showBadgeExplanation = false,
             operationsCount = 2,
             attentionCount = 1,
+            // Derived from the items above by the real ViewModel; the mock has to state it itself,
+            // and a mismatch would show a chip row that contradicts the cards under it.
+            pausedCount = 1,
         ),
         onCloseWorkspace = {},
         onReorderWorkspaces = {},

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/AdaptiveWorkspaceManagerContent.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/AdaptiveWorkspaceManagerContent.kt
@@ -37,8 +37,7 @@ fun AdaptiveWorkspaceManagerContent(
     onNewTabClick: () -> Unit = {},
     onTabsClick: () -> Unit = {},
     onClearSelection: () -> Unit = {},
-    onOperationsFilterClick: () -> Unit = {},
-    onAttentionFilterClick: () -> Unit = {},
+    onFilterClick: (WorkspaceManagerFilter) -> Unit = {},
     lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
     BoxWithConstraints(
@@ -73,8 +72,7 @@ fun AdaptiveWorkspaceManagerContent(
             onNewTabClick = onNewTabClick,
             onTabsClick = onTabsClick,
             onClearSelection = onClearSelection,
-            onOperationsFilterClick = onOperationsFilterClick,
-            onAttentionFilterClick = onAttentionFilterClick,
+            onFilterClick = onFilterClick,
             lazyGridState = lazyGridState,
         )
     }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerFilter.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerFilter.kt
@@ -1,0 +1,14 @@
+package eu.darken.butler.workspace.ui.manager
+
+/**
+ * Which subset of tabs the manager grid shows. Facets are mutually exclusive: several of the
+ * combinations an AND model would allow are provably empty, because a tab that can be paused has
+ * no operations, no attention items and no unsaved changes, and a paused stand-in cannot acquire
+ * any of them while it is down.
+ */
+enum class WorkspaceManagerFilter {
+    OPERATIONS,
+    ATTENTION,
+    PAUSED,
+    UNSAVED,
+}

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
@@ -57,8 +57,7 @@ fun WorkspaceManagerGridLayout(
     onNewTabClick: () -> Unit = {},
     onTabsClick: () -> Unit = {},
     onClearSelection: () -> Unit = {},
-    onOperationsFilterClick: () -> Unit = {},
-    onAttentionFilterClick: () -> Unit = {},
+    onFilterClick: (WorkspaceManagerFilter) -> Unit = {},
     lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
     val tag = logTag("Workspace", "Manager", "GridLayout")
@@ -125,13 +124,13 @@ fun WorkspaceManagerGridLayout(
                     workspaceCount = state.workspaceCount,
                     operationsCount = state.operationsCount,
                     attentionCount = state.attentionCount,
-                    isOperationsFilterActive = state.filterOperations,
-                    isAttentionFilterActive = state.filterAttention,
+                    pausedCount = state.pausedCount,
+                    unsavedCount = state.unsavedCount,
+                    activeFilter = state.activeFilter,
                     selectedCount = state.selectedIds?.size,
                     onTabsClick = onTabsClick,
                     onClearSelection = onClearSelection,
-                    onOperationsClick = onOperationsFilterClick,
-                    onAttentionClick = onAttentionFilterClick,
+                    onFilterClick = onFilterClick,
                 )
             }
         }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
@@ -80,8 +80,7 @@ fun WorkspaceManagerScreen(
     onPauseSelectedWorkspaces: () -> Unit = {},
     onRenameWorkspace: (Workspace.Id, String?) -> Unit = { _, _ -> },
     onTabsClick: () -> Unit = {},
-    onOperationsFilterClick: () -> Unit = {},
-    onAttentionFilterClick: () -> Unit = {},
+    onFilterClick: (WorkspaceManagerFilter) -> Unit = {},
     lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
     var showCloseAllDialog by remember { mutableStateOf(false) }
@@ -174,8 +173,7 @@ fun WorkspaceManagerScreen(
                 onNewTabClick = { onCreateWorkspace(Workspace.Type.TEMPLATES) },
                 onTabsClick = onTabsClick,
                 onClearSelection = onClearSelection,
-                onOperationsFilterClick = onOperationsFilterClick,
-                onAttentionFilterClick = onAttentionFilterClick,
+                onFilterClick = onFilterClick,
                 lazyGridState = lazyGridState,
             )
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -41,8 +41,7 @@ class WorkspaceManagerViewModel @Inject constructor(
     workspaceTemplates: Set<@JvmSuppressWildcards WorkspaceTemplate>,
 ) : ViewModel4(dispatchers, logTag("Workspace", "Manager", "VM")) {
 
-    private val filterOperationsFlow = MutableStateFlow(false)
-    private val filterAttentionFlow = MutableStateFlow(false)
+    private val filterFlow = MutableStateFlow<WorkspaceManagerFilter?>(null)
 
     /**
      * Null means selection mode is off; a set (never empty) means it is on. Ids can name tabs that
@@ -59,11 +58,10 @@ class WorkspaceManagerViewModel @Inject constructor(
         workspaceSettings.showTipBadgeExplanation.flow,
         workspaceSettings.livePreview.flow,
         workspacePageManager.state,
-        filterOperationsFlow,
-        filterAttentionFlow,
+        filterFlow,
         quickCreateItems,
         selectionFlow,
-    ) { repoState, showBadge, livePreview, pageManagerState, filterOps, filterAtt, quickCreate, selection ->
+    ) { repoState, showBadge, livePreview, pageManagerState, filter, quickCreate, selection ->
         val stacks = WorkspaceStacks(repoState.infos)
         val focusedId = pageManagerState.focusedWorkspaceId
         val topChains = stacks.topChainByRoot(focusedId)
@@ -71,43 +69,47 @@ class WorkspaceManagerViewModel @Inject constructor(
         // Pane chips describe where a workspace is on screen, so they follow the layout's own panes
         // rather than the raw selection map, which retains indices from wider layouts.
         val visibleAssignments = pageManagerState.visiblePaneAssignments
+        val items = stacks.unitOwners.map { owner ->
+            val chain = topChains[owner.id]
+            val top = chain?.leaf ?: owner
+            // Counts belong to the unit, not to one member: an overlay's running operation or
+            // attention badge is the tab's, and the manager's filters read these per card.
+            val members = membersByOwner[owner.id].orEmpty().ifEmpty { listOf(owner) }
+            WorkspaceItem(
+                id = owner.id,
+                topId = top.id,
+                type = top.type,
+                title = owner.customTitle?.toCaString() ?: top.title,
+                subtitle = top.subtitle,
+                autoTitle = top.title,
+                customTitle = owner.customTitle,
+                // A pane holds tabs, so pane placement and focus are the owner's; focus may sit
+                // anywhere in the unit
+                isFocused = members.any { it.id == focusedId },
+                isVisibleInPane = visibleAssignments.values.contains(owner.id),
+                paneNumber = visibleAssignments.entries.find { it.value == owner.id }?.key,
+                operationCount = members.sumOf { it.operationCount },
+                attentionCount = members.sumOf { it.attentionCount },
+                hasUnsavedChanges = members.any { it.hasUnsavedChanges },
+                isSubWorkspace = owner.isSubWorkspace,
+                isRecovery = stacks.recoveryUnits.containsKey(owner.id),
+                isPaused = owner.isPaused,
+                canPause = owner.canBePausedManually(stacks, focusedId),
+                stackDepth = chain?.modals?.size ?: 0,
+            )
+        }
         State(
-            workspaces = stacks.unitOwners.map { owner ->
-                val chain = topChains[owner.id]
-                val top = chain?.leaf ?: owner
-                // Counts belong to the unit, not to one member: an overlay's running operation or
-                // attention badge is the tab's, and the manager's filters read these per card.
-                val members = membersByOwner[owner.id].orEmpty().ifEmpty { listOf(owner) }
-                WorkspaceItem(
-                    id = owner.id,
-                    topId = top.id,
-                    type = top.type,
-                    title = owner.customTitle?.toCaString() ?: top.title,
-                    subtitle = top.subtitle,
-                    autoTitle = top.title,
-                    customTitle = owner.customTitle,
-                    // A pane holds tabs, so pane placement and focus are the owner's; focus may sit
-                    // anywhere in the unit
-                    isFocused = members.any { it.id == focusedId },
-                    isVisibleInPane = visibleAssignments.values.contains(owner.id),
-                    paneNumber = visibleAssignments.entries.find { it.value == owner.id }?.key,
-                    operationCount = members.sumOf { it.operationCount },
-                    attentionCount = members.sumOf { it.attentionCount },
-                    hasUnsavedChanges = members.any { it.hasUnsavedChanges },
-                    isSubWorkspace = owner.isSubWorkspace,
-                    isRecovery = stacks.recoveryUnits.containsKey(owner.id),
-                    isPaused = owner.isPaused,
-                    canPause = owner.canBePausedManually(stacks, focusedId),
-                    stackDepth = chain?.modals?.size ?: 0,
-                )
-            },
+            workspaces = items,
             useLivePreview = livePreview,
             showBadgeExplanation = showBadge,
             operationsCount = repoState.operationCount,
             attentionCount = repoState.attentionCount,
+            // Tab counts, not item counts like the two above: these facets have nothing to tally per
+            // tab, and the chips they feed say "Paused"/"Unsaved" rather than naming a unit of work.
+            pausedCount = items.count { it.isPaused },
+            unsavedCount = items.count { it.hasUnsavedChanges },
             currentPaneCount = pageManagerState.currentPaneCount,
-            filterOperations = filterOps,
-            filterAttention = filterAtt,
+            activeFilter = filter,
             quickCreateItems = quickCreate,
             hasUnsavedChanges = repoState.infos.any { it.hasUnsavedChanges },
             selectedIds = selection
@@ -279,8 +281,16 @@ class WorkspaceManagerViewModel @Inject constructor(
         workspaceRepo.execute(WorkspaceAction.CloseAll)
     }
 
+    /**
+     * Clears the active facet, the same reason [selectAllTabs] does: a selection must never hold a
+     * card the grid is hiding. A tab whose status changes while it is selected would otherwise drop
+     * out of the facet but stay in the batch, leaving a count that outnumbers the cards on screen
+     * and no way to widen the grid, since the chips are inert while selecting. Clearing only ever
+     * shows more cards, so the long-pressed one stays put.
+     */
     fun startSelection(id: Workspace.Id) {
         log(tag) { "startSelection($id)" }
+        filterFlow.value = null
         selectionFlow.value = setOf(id)
     }
 
@@ -300,8 +310,7 @@ class WorkspaceManagerViewModel @Inject constructor(
     fun selectAllTabs() = launch {
         val all = workspaceRepo.peekStacks().unitOwners.map { it.id }.toSet()
         log(tag) { "selectAllTabs() -> ${all.size}" }
-        filterOperationsFlow.value = false
-        filterAttentionFlow.value = false
+        filterFlow.value = null
         selectionFlow.value = all.ifEmpty { null }
     }
 
@@ -380,20 +389,15 @@ class WorkspaceManagerViewModel @Inject constructor(
         launch { workspacePreviewManager.invalidateFocusedWorkspacePreview() }
     }
 
-    fun toggleOperationsFilter() {
-        log(tag) { "toggleOperationsFilter() - current: ${filterOperationsFlow.value}" }
-        filterOperationsFlow.value = !filterOperationsFlow.value
-    }
-
-    fun toggleAttentionFilter() {
-        log(tag) { "toggleAttentionFilter() - current: ${filterAttentionFlow.value}" }
-        filterAttentionFlow.value = !filterAttentionFlow.value
+    /** Facets are mutually exclusive, so tapping the active one is the only way to see everything again. */
+    fun toggleFilter(filter: WorkspaceManagerFilter) {
+        log(tag) { "toggleFilter($filter) - current: ${filterFlow.value}" }
+        filterFlow.value = if (filterFlow.value == filter) null else filter
     }
 
     fun clearFilters() {
         log(tag) { "clearFilters()" }
-        filterOperationsFlow.value = false
-        filterAttentionFlow.value = false
+        filterFlow.value = null
     }
 
     data class State(
@@ -402,9 +406,10 @@ class WorkspaceManagerViewModel @Inject constructor(
         val useLivePreview: Boolean = true,
         val operationsCount: Int = 0,
         val attentionCount: Int = 0,
+        val pausedCount: Int = 0,
+        val unsavedCount: Int = 0,
         val currentPaneCount: Int = 1,
-        val filterOperations: Boolean = false,
-        val filterAttention: Boolean = false,
+        val activeFilter: WorkspaceManagerFilter? = null,
         val quickCreateItems: List<QuickCreateItem> = emptyList(),
         val hasUnsavedChanges: Boolean = false,
         /** Null when selection mode is off. Pruned to tabs that are still open. */
@@ -435,15 +440,12 @@ class WorkspaceManagerViewModel @Inject constructor(
             ?: false
 
         val filteredWorkspaces: List<WorkspaceItem>
-            get() {
-                // If no filters active, return all workspaces
-                if (!filterOperations && !filterAttention) return workspaces
-
-                return workspaces.filter { workspace ->
-                    val matchesOperations = !filterOperations || workspace.operationCount > 0
-                    val matchesAttention = !filterAttention || workspace.attentionCount > 0
-                    matchesOperations && matchesAttention
-                }
+            get() = when (activeFilter) {
+                null -> workspaces
+                WorkspaceManagerFilter.OPERATIONS -> workspaces.filter { it.operationCount > 0 }
+                WorkspaceManagerFilter.ATTENTION -> workspaces.filter { it.attentionCount > 0 }
+                WorkspaceManagerFilter.PAUSED -> workspaces.filter { it.isPaused }
+                WorkspaceManagerFilter.UNSAVED -> workspaces.filter { it.hasUnsavedChanges }
             }
     }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceStatusCard.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceStatusCard.kt
@@ -8,12 +8,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.CheckBox
-import androidx.compose.material.icons.twotone.CheckCircle
+import androidx.compose.material.icons.twotone.Edit
+import androidx.compose.material.icons.twotone.Pause
 import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material.icons.twotone.Tab
 import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -21,11 +24,14 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.R
 import eu.darken.butler.common.compose.ButlerChip
+import eu.darken.butler.common.compose.ButlerChipColors
 import eu.darken.butler.common.compose.ButlerChipDefaults
 import eu.darken.butler.common.compose.ButlerChipSize
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.manager.WorkspaceManagerFilter
+import eu.darken.butler.workspace.R as WorkspaceR
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -34,13 +40,13 @@ fun WorkspaceStatusCard(
     operationsCount: Int,
     attentionCount: Int,
     modifier: Modifier = Modifier,
-    isOperationsFilterActive: Boolean = false,
-    isAttentionFilterActive: Boolean = false,
+    pausedCount: Int = 0,
+    unsavedCount: Int = 0,
+    activeFilter: WorkspaceManagerFilter? = null,
     selectedCount: Int? = null,
     onTabsClick: () -> Unit = {},
     onClearSelection: () -> Unit = {},
-    onOperationsClick: () -> Unit = {},
-    onAttentionClick: () -> Unit = {},
+    onFilterClick: (WorkspaceManagerFilter) -> Unit = {},
 ) {
     val isSelecting = selectedCount != null
     val tabsLabel = if (workspaceCount == 1) {
@@ -48,16 +54,8 @@ fun WorkspaceStatusCard(
     } else {
         stringResource(R.string.workspace_status_tab_plural)
     }
-    val operationsLabel = if (operationsCount == 1) {
-        stringResource(R.string.workspace_status_operation_singular)
-    } else {
-        stringResource(R.string.workspace_status_operation_plural)
-    }
-    val attentionLabel = stringResource(R.string.workspace_status_attention_label)
     val tabsDesc = stringResource(R.string.workspace_manager_select_all_tabs_desc)
     val selectionDesc = stringResource(R.string.workspace_manager_selection_clear_content_desc)
-    val operationsDesc = stringResource(R.string.workspace_status_filter_operations_desc)
-    val attentionDesc = stringResource(R.string.workspace_status_filter_attention_desc)
 
     FlowRow(
         modifier = modifier
@@ -90,40 +88,79 @@ fun WorkspaceStatusCard(
             )
         }
 
-        ButlerChip(
-            modifier = Modifier.semantics { contentDescription = operationsDesc },
-            label = "$operationsCount $operationsLabel",
-            leadingIcon = if (isOperationsFilterActive) Icons.TwoTone.CheckCircle else Icons.TwoTone.Sync,
-            size = ButlerChipSize.Large,
-            enabled = operationsCount > 0 && !isSelecting,
-            selected = isOperationsFilterActive,
-            colors = if (isOperationsFilterActive) {
-                ButlerChipDefaults.highlightColors()
-            } else if (operationsCount > 0) {
-                ButlerChipDefaults.accentedColors()
-            } else {
-                ButlerChipDefaults.colors()
-            },
-            onClick = onOperationsClick,
-        )
-
-        ButlerChip(
-            modifier = Modifier.semantics { contentDescription = attentionDesc },
-            label = "$attentionCount $attentionLabel",
-            leadingIcon = if (isAttentionFilterActive) Icons.TwoTone.CheckCircle else Icons.TwoTone.Warning,
-            size = ButlerChipSize.Large,
-            enabled = attentionCount > 0 && !isSelecting,
-            selected = isAttentionFilterActive,
-            colors = if (isAttentionFilterActive) {
-                ButlerChipDefaults.errorColors()
-            } else if (attentionCount > 0) {
-                ButlerChipDefaults.accentedColors()
-            } else {
-                ButlerChipDefaults.colors()
-            },
-            onClick = onAttentionClick,
-        )
+        WorkspaceManagerFilter.entries.forEach { filter ->
+            val count = when (filter) {
+                WorkspaceManagerFilter.OPERATIONS -> operationsCount
+                WorkspaceManagerFilter.ATTENTION -> attentionCount
+                WorkspaceManagerFilter.PAUSED -> pausedCount
+                WorkspaceManagerFilter.UNSAVED -> unsavedCount
+            }
+            val isActive = activeFilter == filter
+            // A facet with nothing to show is left out rather than shown dead: with four of them the
+            // row would otherwise open on a wall of zeroes. The active one stays regardless, so the
+            // chip holding the filter can never vanish under the tap that emptied it and strand the
+            // user on an empty grid with nothing left to clear.
+            if (count == 0 && !isActive) return@forEach
+            // Keyed by facet, not by position: a chip that drops out shifts every later one, and
+            // without a key they would inherit each other's slot.
+            key(filter) {
+                val filterDesc = filter.filterDescription()
+                ButlerChip(
+                    modifier = Modifier.semantics { contentDescription = filterDesc },
+                    label = "$count ${filter.label(count)}",
+                    leadingIcon = filter.icon,
+                    size = ButlerChipSize.Default,
+                    enabled = !isSelecting,
+                    selected = isActive,
+                    colors = filter.colors(isActive),
+                    onClick = { onFilterClick(filter) },
+                )
+            }
+        }
     }
+}
+
+private val WorkspaceManagerFilter.icon: ImageVector
+    get() = when (this) {
+        WorkspaceManagerFilter.OPERATIONS -> Icons.TwoTone.Sync
+        WorkspaceManagerFilter.ATTENTION -> Icons.TwoTone.Warning
+        WorkspaceManagerFilter.PAUSED -> Icons.TwoTone.Pause
+        // Same icon the card's own unsaved marker uses, so the chip and the badge read as one thing.
+        WorkspaceManagerFilter.UNSAVED -> Icons.TwoTone.Edit
+    }
+
+@Composable
+private fun WorkspaceManagerFilter.label(count: Int): String = when (this) {
+    WorkspaceManagerFilter.OPERATIONS -> if (count == 1) {
+        stringResource(R.string.workspace_status_operation_singular)
+    } else {
+        stringResource(R.string.workspace_status_operation_plural)
+    }
+    WorkspaceManagerFilter.ATTENTION -> stringResource(R.string.workspace_status_attention_label)
+    // Same word the card's own paused overlay uses, so both come from one translation.
+    WorkspaceManagerFilter.PAUSED -> stringResource(WorkspaceR.string.workspace_paused_label)
+    WorkspaceManagerFilter.UNSAVED -> stringResource(R.string.workspace_status_unsaved_label)
+}
+
+@Composable
+private fun WorkspaceManagerFilter.filterDescription(): String = when (this) {
+    WorkspaceManagerFilter.OPERATIONS -> stringResource(R.string.workspace_status_filter_operations_desc)
+    WorkspaceManagerFilter.ATTENTION -> stringResource(R.string.workspace_status_filter_attention_desc)
+    WorkspaceManagerFilter.PAUSED -> stringResource(R.string.workspace_status_filter_paused_desc)
+    WorkspaceManagerFilter.UNSAVED -> stringResource(R.string.workspace_status_filter_unsaved_desc)
+}
+
+/**
+ * Error red is reserved for attention, the only facet describing a fault. An unsaved edit and a
+ * paused tab are working states, and their cards say so too: a tertiary pencil and a plain grey
+ * "Paused" label rather than the attention glow.
+ */
+@Composable
+private fun WorkspaceManagerFilter.colors(isActive: Boolean): ButlerChipColors = when {
+    isActive && this == WorkspaceManagerFilter.ATTENTION -> ButlerChipDefaults.errorColors()
+    isActive -> ButlerChipDefaults.highlightColors()
+    this == WorkspaceManagerFilter.PAUSED -> ButlerChipDefaults.colors()
+    else -> ButlerChipDefaults.accentedColors()
 }
 
 @Preview2
@@ -151,21 +188,45 @@ private fun WorkspaceStatusCardEmptyPreview() {
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
+private fun WorkspaceStatusCardAllFacetsPreview() {
+    WorkspaceStatusCard(
+        workspaceCount = 8,
+        operationsCount = 3,
+        attentionCount = 2,
+        pausedCount = 4,
+        unsavedCount = 1,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
 private fun WorkspaceStatusCardFilterActivePreview() {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        WorkspaceStatusCard(
-            workspaceCount = 5,
-            operationsCount = 3,
-            attentionCount = 2,
-            isOperationsFilterActive = true,
-        )
-        WorkspaceStatusCard(
-            workspaceCount = 5,
-            operationsCount = 3,
-            attentionCount = 2,
-            isAttentionFilterActive = true,
-        )
+        WorkspaceManagerFilter.entries.forEach { filter ->
+            WorkspaceStatusCard(
+                workspaceCount = 8,
+                operationsCount = 3,
+                attentionCount = 2,
+                pausedCount = 4,
+                unsavedCount = 1,
+                activeFilter = filter,
+            )
+        }
     }
+}
+
+/** The active facet stays in the row after its count drops to zero, so it can still be cleared. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceStatusCardEmptiedFilterPreview() {
+    WorkspaceStatusCard(
+        workspaceCount = 5,
+        operationsCount = 0,
+        attentionCount = 0,
+        activeFilter = WorkspaceManagerFilter.OPERATIONS,
+    )
 }
 
 @Preview2
@@ -183,6 +244,8 @@ private fun WorkspaceStatusCardSelectionPreview() {
             workspaceCount = 5,
             operationsCount = 3,
             attentionCount = 2,
+            pausedCount = 4,
+            unsavedCount = 1,
             selectedCount = 5,
         )
     }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -521,8 +521,7 @@ fun WorkspacesScreenHost(
                     onPauseSelectedWorkspaces = managerVm::pauseSelectedWorkspaces,
                     onRenameWorkspace = managerVm::renameWorkspace,
                     onTabsClick = managerVm::selectAllTabs,
-                    onOperationsFilterClick = managerVm::toggleOperationsFilter,
-                    onAttentionFilterClick = managerVm::toggleAttentionFilter,
+                    onFilterClick = managerVm::toggleFilter,
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,9 +242,12 @@
     <string name="workspace_status_operation_singular">Operation</string>
     <string name="workspace_status_operation_plural">Operations</string>
     <string name="workspace_status_attention_label">Attention</string>
+    <string name="workspace_status_unsaved_label">Unsaved</string>
     <string name="workspace_status_filter_tabs_desc">Show all tabs</string>
     <string name="workspace_status_filter_operations_desc">Filter by tabs with operations</string>
     <string name="workspace_status_filter_attention_desc">Filter by tabs needing attention</string>
+    <string name="workspace_status_filter_paused_desc">Filter by paused tabs</string>
+    <string name="workspace_status_filter_unsaved_desc">Filter by tabs with unsaved changes</string>
 
     <!-- Acknowledgements -->
     <string name="acknowledgement_android_title">Android</string>

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
@@ -31,6 +31,8 @@ class WorkspaceManagerViewModelTest : BaseTest() {
 
     private val idA = Workspace.Id()
     private val idB = Workspace.Id()
+    private val idC = Workspace.Id()
+    private val idD = Workspace.Id()
 
     private val repoState = MutableStateFlow(WorkspaceRemote.State())
     private val pageState = MutableStateFlow(WorkspacePageManager.State())
@@ -502,6 +504,100 @@ class WorkspaceManagerViewModelTest : BaseTest() {
             }
         }
 
+    @Test
+    fun `each facet shows only its own tabs`() = runTest(UnconfinedTestDispatcher()) {
+        val busy = readyInfo(idA).copy(operationCount = 1)
+        val stuck = readyInfo(idB).copy(attentionCount = 2)
+        val paused = readyInfo(idC).copy(lifecycleState = Workspace.LifecycleState.Paused())
+        val dirty = readyInfo(idD).copy(hasUnsavedChanges = true)
+        repoState.value = WorkspaceRemote.State(infos = listOf(busy, stuck, paused, dirty))
+        val vm = createViewModel()
+
+        vm.currentState().let {
+            it.operationsCount shouldBe 1
+            it.attentionCount shouldBe 2
+            it.pausedCount shouldBe 1
+            it.unsavedCount shouldBe 1
+        }
+
+        vm.toggleFilter(WorkspaceManagerFilter.OPERATIONS)
+        vm.currentState().filteredWorkspaces.map { it.id } shouldBe listOf(idA)
+
+        vm.toggleFilter(WorkspaceManagerFilter.ATTENTION)
+        vm.currentState().filteredWorkspaces.map { it.id } shouldBe listOf(idB)
+
+        vm.toggleFilter(WorkspaceManagerFilter.PAUSED)
+        vm.currentState().filteredWorkspaces.map { it.id } shouldBe listOf(idC)
+
+        vm.toggleFilter(WorkspaceManagerFilter.UNSAVED)
+        vm.currentState().filteredWorkspaces.map { it.id } shouldBe listOf(idD)
+    }
+
+    /**
+     * Switching straight from one facet to another, rather than having to clear the first: the
+     * facets are mutually exclusive, so there is no combination for the second tap to build.
+     */
+    @Test
+    fun `picking a facet replaces the active one and tapping it again clears`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val busy = readyInfo(idA).copy(operationCount = 1)
+            repoState.value = WorkspaceRemote.State(infos = listOf(busy, readyInfo(idB)))
+            val vm = createViewModel()
+
+            vm.toggleFilter(WorkspaceManagerFilter.OPERATIONS)
+            vm.currentState().activeFilter shouldBe WorkspaceManagerFilter.OPERATIONS
+
+            vm.toggleFilter(WorkspaceManagerFilter.PAUSED)
+            vm.currentState().activeFilter shouldBe WorkspaceManagerFilter.PAUSED
+
+            vm.toggleFilter(WorkspaceManagerFilter.PAUSED)
+            vm.currentState().let {
+                it.activeFilter shouldBe null
+                it.filteredWorkspaces.map { w -> w.id } shouldBe listOf(idA, idB)
+            }
+        }
+
+    /**
+     * A modal child's unsaved buffer belongs to the tab that owns it, the same way its operation and
+     * attention counts do - the grid has one card per tab, so a facet that missed the child would
+     * hide a tab that does have unsaved work.
+     */
+    @Test
+    fun `the unsaved facet sees a modal child's changes`() = runTest(UnconfinedTestDispatcher()) {
+        val child = childInfo(caller = idA, pausableAsChild = true).copy(hasUnsavedChanges = true)
+        repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA), child, readyInfo(idB)))
+        val vm = createViewModel()
+
+        vm.toggleFilter(WorkspaceManagerFilter.UNSAVED)
+
+        vm.currentState().let {
+            it.unsavedCount shouldBe 1
+            it.filteredWorkspaces.map { w -> w.id } shouldBe listOf(idA)
+        }
+    }
+
+    /**
+     * Same invariant [selectAllTabs] keeps: a selection must never hold a card the grid is hiding.
+     * The filter chips go inert while selecting, so a facet left on would trap the user with a
+     * selection larger than what is on screen and no way to widen it.
+     */
+    @Test
+    fun `long-pressing a card clears the active facet`() = runTest(UnconfinedTestDispatcher()) {
+        val busy = readyInfo(idA).copy(operationCount = 1)
+        repoState.value = WorkspaceRemote.State(infos = listOf(busy, readyInfo(idB)))
+        val vm = createViewModel()
+        vm.toggleFilter(WorkspaceManagerFilter.OPERATIONS)
+        vm.currentState().filteredWorkspaces.map { it.id } shouldBe listOf(idA)
+
+        vm.startSelection(idA)
+
+        vm.currentState().let {
+            it.activeFilter shouldBe null
+            it.selectedIds shouldBe setOf(idA)
+            it.filteredWorkspaces.map { w -> w.id } shouldBe listOf(idA, idB)
+        }
+    }
+
     /**
      * The chip that triggers this shows the unfiltered tab count, so it has to deliver that many.
      * Clearing the filters in the same step is what keeps the selection from holding cards the grid
@@ -512,7 +608,7 @@ class WorkspaceManagerViewModelTest : BaseTest() {
         val busy = readyInfo(idA).copy(operationCount = 1)
         repoState.value = WorkspaceRemote.State(infos = listOf(busy, readyInfo(idB)))
         val vm = createViewModel()
-        vm.toggleOperationsFilter()
+        vm.toggleFilter(WorkspaceManagerFilter.OPERATIONS)
         vm.currentState().filteredWorkspaces.map { it.id } shouldBe listOf(idA)
 
         vm.selectAllTabs()
@@ -520,7 +616,7 @@ class WorkspaceManagerViewModelTest : BaseTest() {
         vm.currentState().let {
             it.selectedIds shouldBe setOf(idA, idB)
             it.allSelected shouldBe true
-            it.filterOperations shouldBe false
+            it.activeFilter shouldBe null
             it.filteredWorkspaces.map { w -> w.id } shouldBe listOf(idA, idB)
         }
     }
@@ -537,12 +633,12 @@ class WorkspaceManagerViewModelTest : BaseTest() {
         coEvery { workspaceRepo.execute(any<WorkspaceAction.Create>()) } returns
             WorkspaceAction.Create.Result.Success(Workspace.Id())
         val vm = createViewModel()
-        vm.toggleOperationsFilter()
-        vm.currentState().filterOperations shouldBe true
+        vm.toggleFilter(WorkspaceManagerFilter.OPERATIONS)
+        vm.currentState().activeFilter shouldBe WorkspaceManagerFilter.OPERATIONS
 
         vm.createWorkspace(Workspace.Type.TEMPLATES)
 
-        vm.currentState().filterOperations shouldBe false
+        vm.currentState().activeFilter shouldBe null
     }
 
     /**

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceStatusCardTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/rows/WorkspaceStatusCardTest.kt
@@ -1,5 +1,8 @@
 package eu.darken.butler.workspace.ui.manager.rows
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.filterToOne
@@ -11,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.manager.WorkspaceManagerFilter
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
@@ -134,8 +138,7 @@ class WorkspaceStatusCardTest : ComposeTest() {
      */
     @Test
     fun `filter chips are inert while selecting`() {
-        var operations = 0
-        var attention = 0
+        val clicks = mutableListOf<WorkspaceManagerFilter>()
 
         composeTestRule.setContent {
             PreviewWrapper {
@@ -143,57 +146,148 @@ class WorkspaceStatusCardTest : ComposeTest() {
                     workspaceCount = 5,
                     operationsCount = 3,
                     attentionCount = 2,
+                    pausedCount = 1,
+                    unsavedCount = 1,
                     selectedCount = 2,
-                    onOperationsClick = { operations++ },
-                    onAttentionClick = { attention++ },
+                    onFilterClick = { clicks.add(it) },
                 )
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("Filter by tabs with operations").performClick()
-        composeTestRule.onNodeWithContentDescription("Filter by tabs needing attention").performClick()
+        FILTER_DESCRIPTIONS.values.forEach {
+            composeTestRule.onNodeWithContentDescription(it).performClick()
+        }
 
-        operations shouldBe 0
-        attention shouldBe 0
+        clicks shouldBe emptyList()
     }
 
     @Test
-    fun `operations click callback is invoked`() {
-        var clicked = false
+    fun `each filter chip reports its own facet`() {
+        val clicks = mutableListOf<WorkspaceManagerFilter>()
 
         composeTestRule.setContent {
             PreviewWrapper {
                 WorkspaceStatusCard(
-                    workspaceCount = 1,
+                    workspaceCount = 4,
+                    operationsCount = 3,
+                    attentionCount = 2,
+                    pausedCount = 1,
+                    unsavedCount = 1,
+                    onFilterClick = { clicks.add(it) },
+                )
+            }
+        }
+
+        WorkspaceManagerFilter.entries.forEach { filter ->
+            composeTestRule.onNodeWithContentDescription(FILTER_DESCRIPTIONS.getValue(filter)).performClick()
+        }
+
+        clicks shouldBe WorkspaceManagerFilter.entries
+    }
+
+    /** Four facets would otherwise open the manager on a wall of zeroes. */
+    @Test
+    fun `a facet with nothing to show is left out`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceStatusCard(
+                    workspaceCount = 5,
                     operationsCount = 3,
                     attentionCount = 0,
-                    onOperationsClick = { clicked = true },
+                    pausedCount = 0,
+                    unsavedCount = 0,
                 )
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("Filter by tabs with operations").performClick()
-
-        clicked shouldBe true
+        composeTestRule.onNodeWithContentDescription(
+            FILTER_DESCRIPTIONS.getValue(WorkspaceManagerFilter.OPERATIONS)
+        ).assertIsDisplayed()
+        listOf(
+            WorkspaceManagerFilter.ATTENTION,
+            WorkspaceManagerFilter.PAUSED,
+            WorkspaceManagerFilter.UNSAVED,
+        ).forEach {
+            composeTestRule
+                .onAllNodesWithContentDescription(FILTER_DESCRIPTIONS.getValue(it))
+                .assertCountEquals(0)
+        }
     }
 
+    /**
+     * The last operation finishing while its filter is on must not take the chip with it: the grid
+     * is empty at that moment and that chip is the only way back.
+     */
     @Test
-    fun `attention click callback is invoked`() {
-        var clicked = false
+    fun `the active facet stays after its count drops to zero`() {
+        var clicked: WorkspaceManagerFilter? = null
+        var operations by mutableStateOf(3)
 
         composeTestRule.setContent {
             PreviewWrapper {
                 WorkspaceStatusCard(
-                    workspaceCount = 1,
-                    operationsCount = 0,
-                    attentionCount = 2,
-                    onAttentionClick = { clicked = true },
+                    workspaceCount = 5,
+                    operationsCount = operations,
+                    attentionCount = 0,
+                    activeFilter = WorkspaceManagerFilter.OPERATIONS,
+                    onFilterClick = { clicked = it },
                 )
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("Filter by tabs needing attention").performClick()
+        operations = 0
+        composeTestRule.waitForIdle()
 
-        clicked shouldBe true
+        val chip = composeTestRule.onNodeWithContentDescription(
+            FILTER_DESCRIPTIONS.getValue(WorkspaceManagerFilter.OPERATIONS)
+        )
+        chip.assertIsDisplayed()
+        chip.performClick()
+
+        clicked shouldBe WorkspaceManagerFilter.OPERATIONS
+    }
+
+    /**
+     * A facet dropping out shifts every chip after it. Without a key per facet those would inherit
+     * each other's slot, so the tap that follows would report the wrong one.
+     */
+    @Test
+    fun `a chip vanishing mid-row leaves the later ones reporting themselves`() {
+        var clicked: WorkspaceManagerFilter? = null
+        var attention by mutableStateOf(2)
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceStatusCard(
+                    workspaceCount = 5,
+                    operationsCount = 3,
+                    attentionCount = attention,
+                    pausedCount = 1,
+                    unsavedCount = 1,
+                    onFilterClick = { clicked = it },
+                )
+            }
+        }
+
+        attention = 0
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onAllNodesWithContentDescription(FILTER_DESCRIPTIONS.getValue(WorkspaceManagerFilter.ATTENTION))
+            .assertCountEquals(0)
+        composeTestRule
+            .onNodeWithContentDescription(FILTER_DESCRIPTIONS.getValue(WorkspaceManagerFilter.PAUSED))
+            .performClick()
+
+        clicked shouldBe WorkspaceManagerFilter.PAUSED
+    }
+
+    companion object {
+        private val FILTER_DESCRIPTIONS = mapOf(
+            WorkspaceManagerFilter.OPERATIONS to "Filter by tabs with operations",
+            WorkspaceManagerFilter.ATTENTION to "Filter by tabs needing attention",
+            WorkspaceManagerFilter.PAUSED to "Filter by paused tabs",
+            WorkspaceManagerFilter.UNSAVED to "Filter by tabs with unsaved changes",
+        )
     }
 }


### PR DESCRIPTION
## What changed

The tab manager's status row gains two new filters. Alongside Operations and Attention you can now narrow the grid to paused tabs, or to tabs holding unsaved changes.

The filters are now one at a time rather than combinable. Tapping a second one switches to it; tapping the active one goes back to showing everything.

Chips only appear when they have something to show, so a fresh session shows just the tab count instead of a row of zeroes. The chip for the filter you currently have on always stays, even after its count drops to zero, so a filter whose last match disappeared can still be switched off.

Long-pressing a card to start selecting now clears an active filter, so the number of selected tabs always matches the number of cards on screen.

## Technical Context

- Single-select rather than the previous AND combination because several combinations that model allows are provably empty: `canBePausedManually` rejects a tab with operations, attention items or unsaved changes, and a paused tab is swapped for a stand-in with no live instance, so it cannot acquire any of them while down. Paused combined with any other facet would always render an empty grid.
- Paused and unsaved counts are counts of tabs, derived from the same ownership-unit list that builds the cards, so the chip numbers match the cards the filter shows. Operations and Attention remain counts of items (an operation, an attention entry), as they were. That mixes units within one row, which the labels make explicit.
- The chips are keyed by facet. A facet dropping out of the row shifts every chip after it, and unkeyed siblings would inherit each other's slot. Two Compose tests exercise this through a real recomposition rather than a static zero.
- The Paused chip reuses the existing `workspace_paused_label`, so it and the card's own paused overlay come from one translation. Error red stays exclusive to Attention: an unsaved edit and a paused tab are working states, not faults, which is what the cards already say with a tertiary pencil and a plain grey label.
- Worth a close look: `startSelection` clearing the filter is a deliberate behavior change with a cost. Filtering to a facet and long-pressing one result now drops you back to the full tab list to pick the rest by hand. The alternative, keeping the filter, leaves a selection that outnumbers the visible cards once a selected tab's status changes, with the chips inert and no way to widen the grid.
