### PR TITLE
Templates: Rename a tab straight from the picker headline

### DIFF
--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesPersistedKeys.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesPersistedKeys.kt
@@ -8,5 +8,5 @@ package eu.darken.butler.templates.ui
  * top.
  */
 internal object TemplatesScrollSlots {
-    const val LIST = "templates"
+    const val LIST = "templates.v2"
 }

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
@@ -17,10 +17,8 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Add
-import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Edit
 import androidx.compose.material.icons.twotone.Settings
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -28,7 +26,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -80,9 +77,10 @@ import eu.darken.butler.workspace.ui.tour.WorkspaceTourTargets
 
 object TemplatesWorkspacePageDefaults {
     const val SETTINGS_CARD_TEST_TAG = "templates.settingsCard"
+    const val EDIT_NAME_TEST_TAG = "templates.editName"
 
-    /** Template cards follow the header and the tab-name row, so the first one is the third item. */
-    const val FIRST_TEMPLATE_ITEM_INDEX = 2
+    /** Template cards follow the header, so the first one is the second item. */
+    const val FIRST_TEMPLATE_ITEM_INDEX = 1
 }
 
 @Composable
@@ -129,7 +127,6 @@ fun TemplatesWorkspacePageHost(
             listState = listState,
             onNavToSettings = { vm.navTo(Nav.Main.settings()) },
             onCreateWorkspace = { vm.createWorkspace(it) },
-            onRename = { vm.renameWorkspace(it) },
             onEditName = { vm.showRenameDialog() },
         )
     }
@@ -143,7 +140,6 @@ fun TemplatesWorkspacePage(
     listState: LazyListState = rememberWorkspaceLazyListState(workspaceId, slot = TemplatesScrollSlots.LIST),
     onNavToSettings: () -> Unit,
     onCreateWorkspace: (WorkspaceAction.Create) -> Unit = {},
-    onRename: (String?) -> Unit = {},
     onEditName: () -> Unit = {},
 ) {
     // Previews and screenshot renders must be reproducible, a random slogan is not.
@@ -180,25 +176,41 @@ fun TemplatesWorkspacePage(
         ) {
             item {
                 Column(modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)) {
-                    Text(
-                        text = stringResource(R.string.workspace_templates_choose_title),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
+                    Row(
+                        // The floating Butler button overlays this row's trailing edge in
+                        // single-pane; without the reserve, a long custom title pushes the pencil
+                        // underneath it.
+                        modifier = Modifier.padding(end = if (design.isSingle) 40.dp else 0.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            // fill = false is what keeps the icon adjacent to a short title while
+                            // a long custom name ellipsizes instead of pushing the icon out.
+                            modifier = Modifier.weight(1f, fill = false),
+                            text = state.customTitle?.takeIf { it.isNotBlank() }
+                                ?: stringResource(R.string.workspace_templates_choose_title),
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.MiddleEllipsis,
+                        )
+                        IconButton(
+                            modifier = Modifier.testTag(TemplatesWorkspacePageDefaults.EDIT_NAME_TEST_TAG),
+                            onClick = onEditName,
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(20.dp),
+                                imageVector = Icons.TwoTone.Edit,
+                                contentDescription = stringResource(R.string.workspace_templates_name_tab_action),
+                            )
+                        }
+                    }
                     Text(
                         text = stringResource(R.string.workspace_templates_choose_subtitle),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                     )
                 }
-            }
-            item {
-                TabNameRow(
-                    modifier = Modifier.padding(horizontal = 8.dp),
-                    customTitle = state.customTitle,
-                    onEdit = onEditName,
-                    onClear = { onRename(null) },
-                )
             }
             items(state.templates.size) { index ->
                 val template = state.templates[index]
@@ -316,66 +328,6 @@ fun TemplatesWorkspacePage(
     }
 
     // The rename dialog lives in the page host's overlay slot, see TemplatesWorkspaceOverlays
-}
-
-/**
- * Lets the user name the tab before it becomes something: the name survives the template morph,
- * so it carries onto the resulting Explorer/Searcher/… tab.
- */
-@Composable
-private fun TabNameRow(
-    modifier: Modifier = Modifier,
-    customTitle: String?,
-    onEdit: () -> Unit,
-    onClear: () -> Unit,
-) {
-    if (customTitle == null) {
-        TextButton(
-            modifier = modifier,
-            onClick = onEdit,
-        ) {
-            Icon(
-                modifier = Modifier.size(18.dp),
-                imageVector = Icons.TwoTone.Edit,
-                contentDescription = null,
-            )
-            Text(
-                modifier = Modifier.padding(start = 8.dp),
-                text = stringResource(R.string.workspace_templates_name_tab_action),
-            )
-        }
-    } else {
-        AssistChip(
-            modifier = modifier,
-            onClick = onEdit,
-            label = {
-                Text(
-                    text = customTitle,
-                    maxLines = 1,
-                    overflow = TextOverflow.MiddleEllipsis,
-                )
-            },
-            leadingIcon = {
-                Icon(
-                    modifier = Modifier.size(18.dp),
-                    imageVector = Icons.TwoTone.Edit,
-                    contentDescription = null,
-                )
-            },
-            trailingIcon = {
-                IconButton(
-                    modifier = Modifier.size(24.dp),
-                    onClick = onClear,
-                ) {
-                    Icon(
-                        modifier = Modifier.size(18.dp),
-                        imageVector = Icons.TwoTone.Close,
-                        contentDescription = stringResource(R.string.workspace_templates_name_tab_clear_content_desc),
-                    )
-                }
-            },
-        )
-    }
 }
 
 private data class TemplateCardColors(
@@ -551,6 +503,21 @@ private fun TemplatesWorkspacePageNamedPreview() {
     TemplatesWorkspacePage(
         workspaceId = workspaceId,
         state = TemplatesMockDataProvider.createMockState(workspaceId, customTitle = "Holiday photos"),
+        onNavToSettings = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun TemplatesWorkspacePageLongNamePreview() {
+    val workspaceId = Workspace.Id()
+    TemplatesWorkspacePage(
+        workspaceId = workspaceId,
+        state = TemplatesMockDataProvider.createMockState(
+            workspaceId,
+            customTitle = "Photos from the summer trip to the coast and back again",
+        ),
         onNavToSettings = {},
     )
 }

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/tour/TemplatesTour.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/tour/TemplatesTour.kt
@@ -24,8 +24,8 @@ object TemplatesTour : GuidedTour {
 
     /**
      * [prepareFirstTemplate] scrolls the template list so the first card is composed before the
-     * step is published. It is required, not optional: the template items sit after two other list
-     * items and the list restores its saved scroll offset, so on a short window, at large font
+     * step is published. It is required, not optional: the template items sit after the header item
+     * and the list restores its saved scroll offset, so on a short window, at large font
      * scale, or on a restored tab that was scrolled, the card would not be composed at all — its
      * anchor never registers and the host grace-skips the step.
      *

--- a/app-workspace-templates/src/main/res/values/strings.xml
+++ b/app-workspace-templates/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <string name="workspace_templates_choose_title">New tab</string>
     <string name="workspace_templates_choose_subtitle">Select a tab type. How can I help?</string>
     <string name="workspace_templates_name_tab_action">Name this tab</string>
-    <string name="workspace_templates_name_tab_clear_content_desc">Clear custom name</string>
 
     <!-- Guided tour -->
     <string name="tour_templates_picker_title">Pick a tool</string>

--- a/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
+++ b/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
@@ -214,11 +214,11 @@ class TemplatesWorkspacePageTest : ComposeTest() {
         runBlocking { prepare() }
         composeTestRule.waitForIdle()
 
-        // A bare `has` check passes even on a stale index: the list composes items backward into
-        // the content padding, so an over-scrolled card is still registered, just above the top.
-        val registered = registry.get(TemplatesTour.FIRST_TEMPLATE_TARGET)
-        (registered != null) shouldBe true
-        val top = with(composeTestRule.density) { registered!!.top.toDp() }
-        (top >= 0.dp) shouldBe true
+        registry.has(TemplatesTour.FIRST_TEMPLATE_TARGET) shouldBe true
+        // The registered bounds are clipped to the viewport, so they read a top of 0 whether the
+        // card sits at the content padding or one item above it. The card's own unclipped bounds
+        // separate the two.
+        val cardTop = composeTestRule.onNodeWithText("Template 0").getUnclippedBoundsInRoot().top
+        (cardTop >= 0.dp) shouldBe true
     }
 }

--- a/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
+++ b/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -41,13 +42,16 @@ class TemplatesWorkspacePageTest : ComposeTest() {
     private val explorerTemplate = template(Workspace.Type.EXPLORER, "Explorer")
     private val searcherTemplate = template(Workspace.Type.SEARCHER, "Searcher")
 
-    private fun state(templates: List<WorkspaceTemplate> = listOf(explorerTemplate)) =
-        TemplatesWorkspaceViewModel.State(
-            id = workspaceId,
-            isUpgraded = false,
-            templates = templates,
-            versionDescription = "1.0.0-test",
-        )
+    private fun state(
+        templates: List<WorkspaceTemplate> = listOf(explorerTemplate),
+        customTitle: String? = null,
+    ) = TemplatesWorkspaceViewModel.State(
+        id = workspaceId,
+        isUpgraded = false,
+        templates = templates,
+        versionDescription = "1.0.0-test",
+        customTitle = customTitle,
+    )
 
     private fun setPage(design: WorkspaceDesign, onNavToSettings: () -> Unit = {}) {
         // Single-pane composes WorkspaceButton, whose default mascot is an infinite Lottie
@@ -75,6 +79,8 @@ class TemplatesWorkspacePageTest : ComposeTest() {
         templates: List<WorkspaceTemplate> = listOf(explorerTemplate, searcherTemplate),
         layerActive: Boolean = true,
         listState: LazyListState? = null,
+        customTitle: String? = null,
+        onEditName: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             PreviewWrapper {
@@ -85,9 +91,10 @@ class TemplatesWorkspacePageTest : ComposeTest() {
                     TemplatesWorkspacePage(
                         workspaceId = workspaceId,
                         design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
-                        state = state(templates),
+                        state = state(templates, customTitle = customTitle),
                         listState = listState ?: LazyListState(),
                         onNavToSettings = {},
+                        onEditName = onEditName,
                     )
                 }
             }
@@ -128,6 +135,35 @@ class TemplatesWorkspacePageTest : ComposeTest() {
         WorkspaceDesign.Layout.entries.forEach { layout ->
             WorkspaceDesign(layout = layout).isSingle shouldBe (layout == WorkspaceDesign.Layout.SINGLE)
         }
+    }
+
+    @Test
+    fun `header shows the automatic title when the tab has no custom name`() {
+        setTourPage(TourTargetRegistry(), customTitle = null)
+        composeTestRule.onNodeWithText("New tab").assertIsDisplayed()
+    }
+
+    @Test
+    fun `header shows the custom name in place of the automatic title`() {
+        setTourPage(TourTargetRegistry(), customTitle = "Holiday photos")
+        composeTestRule.onNodeWithText("Holiday photos").assertIsDisplayed()
+        composeTestRule.onNodeWithText("New tab").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the standalone name row is gone in the unnamed state`() {
+        setTourPage(TourTargetRegistry(), customTitle = null)
+        composeTestRule.onNodeWithText("Name this tab").assertDoesNotExist()
+    }
+
+    @Test
+    fun `clicking the edit icon requests the rename dialog`() {
+        var requested = false
+        setTourPage(TourTargetRegistry(), onEditName = { requested = true })
+        composeTestRule
+            .onNodeWithTag(TemplatesWorkspacePageDefaults.EDIT_NAME_TEST_TAG)
+            .performClick()
+        requested shouldBe true
     }
 
     @Test
@@ -178,6 +214,11 @@ class TemplatesWorkspacePageTest : ComposeTest() {
         runBlocking { prepare() }
         composeTestRule.waitForIdle()
 
-        registry.has(TemplatesTour.FIRST_TEMPLATE_TARGET) shouldBe true
+        // A bare `has` check passes even on a stale index: the list composes items backward into
+        // the content padding, so an over-scrolled card is still registered, just above the top.
+        val registered = registry.get(TemplatesTour.FIRST_TEMPLATE_TARGET)
+        (registered != null) shouldBe true
+        val top = with(composeTestRule.density) { registered!!.top.toDp() }
+        (top >= 0.dp) shouldBe true
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceRenameDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/WorkspaceRenameDialog.kt
@@ -16,8 +16,8 @@ import eu.darken.butler.workspace.ui.modal.PaneLayerHost
  * Sets or clears the user-set name of a workspace.
  *
  * One composable for every caller: the host follows from where it is composed. Reached from inside
- * a pane — the Templates tab's name row — it is pane-bound, so it leaves the other panes alone and
- * takes part in that pane's back, focus and accessibility containment. Reached from the tab rail or
+ * a pane, the Templates tab's headline edit icon, it is pane-bound, so it leaves the other panes
+ * alone and takes part in that pane's back, focus and accessibility containment. Reached from the tab rail or
  * the tab manager, which act on the whole screen, it is a window dialog.
  */
 @Composable


### PR DESCRIPTION
## What changed

Naming a new tab is no longer a separate row on the tab picker. The pencil now sits directly after the "New tab" headline, and once you give the tab a name, the headline itself shows that name. The separate "Name this tab" button and the chip it turned into are gone, which gives the template list back the vertical space they occupied.

Nothing is lost by removing the chip's clear button: the rename dialog already offers "Clear" whenever a name is set.

A restored Templates tab now starts scrolled to the top once, after updating.

## Technical Context

- The title row reserves 40dp at its trailing edge in single-pane. Header content already ends 28dp from the pane edge (12dp content padding plus 16dp header padding) while the floating 48dp Butler button occupies 16-64dp from that edge and draws over the list, so without the reserve a long custom title (the limit is 128 characters) pushed the pencil underneath it. The reserve sits on the title row only, so the subtitle keeps its full-width line. Multi-pane renders no Butler button on this page, so the reserve is zero there.
- `TemplatesScrollSlots.LIST` moves to `templates.v2`. Removing a list item shifts every persisted scroll ordinal by one and the stored value is a raw index, so the old positions are deliberately orphaned rather than migrated — the slot's own KDoc documents renaming as the reset mechanism.
- `FIRST_TEMPLATE_ITEM_INDEX` drops from 2 to 1 with the removed row. It drives the guided tour's scroll-into-view hook, so a stale value would anchor the tour's first step on the wrong card.
- Worth a close look: the second commit. The assertion guarding that index did not actually discriminate a wrong value — `guidedTourTarget` records `boundsInRoot()`, which clips to the viewport, so an over-scrolled first card reports a clipped top of exactly 0 rather than a negative one. Measured 16.0dp at the correct index against 0.0dp at the stale one, both satisfying the old check. The test now asserts the card's own unclipped bounds, which was verified to fail at the stale index and pass at the correct one.
- Not included: the committed Play Store screenshots under `fastlane/` still show the removed row. Regenerating them (`generate_screenshots.sh --english` plus `copy_screenshots.sh --clean`) was deliberately left out of this change.
