### PR TITLE
Apps: Show the package name for apps with an empty name

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/pkgs/PackageManagerExtensions.kt
@@ -28,6 +28,10 @@ fun PackageManager.getPackageInfo2(
     null
 }
 
+/**
+ * A blank label counts as no label: callers fall back to the package name on null, and an app whose
+ * label resource resolves to "" would otherwise render as an empty title with nothing beside it.
+ */
 fun PackageManager.getLabel2(
     pkgId: Pkg.Id,
 ): String? = getPackageInfo2(pkgId)
@@ -36,6 +40,7 @@ fun PackageManager.getLabel2(
         if (it.labelRes != 0) it.loadLabel(this).toString()
         else it.nonLocalizedLabel?.toString()
     }
+    ?.takeIf { it.isNotBlank() }
 
 fun PackageManager.getIcon2(
     pkgId: Pkg.Id,

--- a/app-common-io/src/main/java/eu/darken/butler/common/pkgs/container/LibraryPkg.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/pkgs/container/LibraryPkg.kt
@@ -50,7 +50,7 @@ data class LibraryPkg(
 
     override val label: CaString = caString { context ->
         context.packageManager.getLabel2(id)
-            ?: sharedLibraryInfo.name
+            ?: sharedLibraryInfo.name?.takeIf { it.isNotBlank() }
             ?: id.name
     }.cache()
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/pkgs/PackageManagerLabelTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/pkgs/PackageManagerLabelTest.kt
@@ -1,0 +1,70 @@
+package eu.darken.butler.common.pkgs
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class PackageManagerLabelTest : BaseTest() {
+
+    private val pkgId = "eu.test.pkg".toPkgId()
+
+    private fun packageManager(
+        labelRes: Int = 0,
+        nonLocalizedLabel: CharSequence? = null,
+        resolvedLabel: CharSequence = "",
+    ): PackageManager {
+        val appInfo = ApplicationInfo().apply {
+            packageName = pkgId.name
+            this.labelRes = labelRes
+            this.nonLocalizedLabel = nonLocalizedLabel
+        }
+        val pkgInfo = PackageInfo().apply {
+            packageName = pkgId.name
+            applicationInfo = appInfo
+        }
+        return mockk {
+            every { getPackageInfo(pkgId.name, 0) } returns pkgInfo
+            // PackageItemInfo.loadLabel() resolves labelRes through PackageManager.getText().
+            every { getText(pkgId.name, labelRes, any()) } returns resolvedLabel
+        }
+    }
+
+    @Test
+    fun `non localized label is used as is`() {
+        packageManager(nonLocalizedLabel = "Test App").getLabel2(pkgId) shouldBe "Test App"
+    }
+
+    @Test
+    fun `label resource is resolved`() {
+        packageManager(labelRes = 42, resolvedLabel = "Resolved App").getLabel2(pkgId) shouldBe "Resolved App"
+    }
+
+    @Test
+    fun `an empty non localized label counts as no label`() {
+        packageManager(nonLocalizedLabel = "").getLabel2(pkgId).shouldBeNull()
+    }
+
+    @Test
+    fun `a label resource resolving to whitespace counts as no label`() {
+        packageManager(labelRes = 42, resolvedLabel = "   ").getLabel2(pkgId).shouldBeNull()
+    }
+
+    @Test
+    fun `a missing package has no label`() {
+        val pm = mockk<PackageManager> {
+            every { getPackageInfo(pkgId.name, 0) } throws PackageManager.NameNotFoundException()
+        }
+        pm.getLabel2(pkgId).shouldBeNull()
+    }
+}


### PR DESCRIPTION
## What changed

Apps with no name of their own now show their package name everywhere, instead of an empty title.

Some apps ship an empty app name (the name resource resolves to an empty or whitespace-only string). Butler treated that as a real name: the apps list drew a blank first line above the package name, and the app details header showed only the app icon with no text next to it.

## Technical Context

- Root cause: `getLabel2()` only mapped a *missing* label to null, so `""` flowed through the `?: id.name` fallbacks in every `Pkg` container untouched. Those fallbacks are null-checks, not blank-checks.
- The fix is at the resolution point rather than in each container, so all six containers (`NormalPkg`, `HiddenPkg`, `ArchivedPkg`, `UninstalledPkg`, `PkgArchive`, `LibraryPkg`) inherit it.
- `LibraryPkg` also falls back to `sharedLibraryInfo.name` before the package name, so it needed the same guard.
- `AppDetailsToolbarCard` already filtered a blank title, which is why the details header lost its text entirely rather than showing an empty line: on the overview there is no subtitle to fall back to.
- The two blank cases in the new `PackageManagerLabelTest` fail against the old resolution logic.
