### PR TITLE
Workspace: Keep the New tab tile with the tabs instead of below the tip card

### DIFF
--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayout.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.Dp
@@ -31,12 +32,36 @@ import eu.darken.butler.workspace.ui.manager.rows.NewTabCard
 import eu.darken.butler.workspace.ui.manager.rows.WorkspaceBadgeExplanationCard
 import eu.darken.butler.workspace.ui.manager.rows.WorkspaceGridItem
 import eu.darken.butler.workspace.ui.manager.rows.WorkspaceStatusCard
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyGridState
+import kotlin.time.Duration.Companion.seconds
 
 object WorkspaceManagerGridDefaults {
     /** The status card occupies grid slot 0 whenever there is at least one tab. */
     const val FIRST_WORKSPACE_CARD_INDEX = 1
+
+    private val LAYOUT_WAIT = 1.seconds
+
+    /**
+     * Brings the new-tab placeholder into view for the tour. The explanation card is the only item
+     * after it, so where the end of the grid does not show the placeholder, one item back does.
+     *
+     * A grid state from a composition that has not been measured yet reports no items, and scrolling
+     * by that count would park a long grid at the top.
+     */
+    suspend fun scrollToNewTabCard(gridState: LazyGridState) {
+        val itemCount = withTimeoutOrNull(LAYOUT_WAIT) {
+            snapshotFlow { gridState.layoutInfo.totalItemsCount }.first { it > 0 }
+        } ?: return
+        val lastIndex = itemCount - 1
+        gridState.scrollToItem(lastIndex)
+        val isPlaceholderVisible = gridState.layoutInfo.visibleItemsInfo.any {
+            it.key == WorkspaceManagerColumnItemKey.NewTab
+        }
+        if (!isPlaceholderVisible) gridState.scrollToItem((lastIndex - 1).coerceAtLeast(0))
+    }
 }
 
 @Composable
@@ -75,9 +100,6 @@ fun WorkspaceManagerGridLayout(
         screenWidth < 840.dp -> 2
         else -> 3
     }
-
-    // Calculate span for explanation cards - use 2 columns on large screens, full width otherwise
-    val explanationSpan = if (columns == 3) 2 else columns
 
     val reorderableLazyGridState = rememberReorderableLazyGridState(
         lazyGridState = lazyGridState
@@ -182,23 +204,25 @@ fun WorkspaceManagerGridLayout(
             }
         }
 
-        // Explanation cards with responsive column spans
-        if (state.showBadgeExplanation && !state.isSelectionActive) {
-            item(
-                key = WorkspaceManagerColumnItemKey.Explanation.BadgeExplanation,
-                span = { GridItemSpan(explanationSpan) }
-            ) {
-                WorkspaceBadgeExplanationCard(
-                    onDismiss = onDismissBadgeExplanation
-                )
-            }
-        }
-
+        // The placeholder stays with the tab cards, above the explanation cards below it.
         if (!state.isSelectionActive) {
             item(key = WorkspaceManagerColumnItemKey.NewTab, span = { GridItemSpan(1) }) {
                 NewTabCard(
                     modifier = Modifier.animateItem(),
                     onClick = onNewTabClick,
+                )
+            }
+        }
+
+        // Explanation cards with responsive column spans
+        if (state.showBadgeExplanation && !state.isSelectionActive) {
+            item(
+                key = WorkspaceManagerColumnItemKey.Explanation.BadgeExplanation,
+                // A full line, so the placeholder above never ends up beside it on a wide grid.
+                span = { GridItemSpan(maxLineSpan) }
+            ) {
+                WorkspaceBadgeExplanationCard(
+                    onDismiss = onDismissBadgeExplanation
                 )
             }
         }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTour.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/tour/WorkspaceManagerTour.kt
@@ -23,8 +23,8 @@ import eu.darken.butler.common.compose.tour.TourStep
  * chips and each preview is a fixed 160dp, so in a short window at large font scale the first
  * card's preview sits below the viewport and never registers. The button step prepares in the
  * other direction: it hides on scroll, so stepping back to it has to restore the top of the grid.
- * The placeholder is the grid's last item whenever selection is off, so its step scrolls to the
- * end.
+ * The placeholder sits at the end of the tab cards with the explanation cards below it, so its
+ * step scrolls to the end of the grid and, if needed, one item back.
  */
 object WorkspaceManagerTour : GuidedTour {
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -389,9 +389,7 @@ fun WorkspacesScreenHost(
                 managerGridState.scrollToItem(WorkspaceManagerGridDefaults.FIRST_WORKSPACE_CARD_INDEX)
             },
             prepareNewTab = {
-                managerGridState.scrollToItem(
-                    (managerGridState.layoutInfo.totalItemsCount - 1).coerceAtLeast(0),
-                )
+                WorkspaceManagerGridDefaults.scrollToNewTabCard(managerGridState)
             },
         )
     }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayoutNewTabTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerGridLayoutNewTabTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -14,6 +15,7 @@ import eu.darken.butler.common.compose.tour.TourTargetRegistry
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.manager.rows.TEST_TAG_NEW_TAB_CARD
 import eu.darken.butler.workspace.ui.manager.tour.WorkspaceManagerTour
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.Test
@@ -22,7 +24,7 @@ import testhelpers.ComposeTest
 
 /**
  * The placeholder is the manager's only route to "pick any tool", so it has to be there whenever
- * selection is off - and it has to be the grid's last item, which is where the tour scrolls to.
+ * selection is off - and it belongs with the tab cards, above the explanation cards.
  */
 @Config(qualifiers = "w720dp-h1600dp")
 class WorkspaceManagerGridLayoutNewTabTest : ComposeTest() {
@@ -59,6 +61,7 @@ class WorkspaceManagerGridLayoutNewTabTest : ComposeTest() {
         onNewTabClick: () -> Unit = {},
         registry: TourTargetRegistry = TourTargetRegistry(),
         onGridState: (LazyGridState) -> Unit = {},
+        screenWidth: Dp = 720.dp,
     ) {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalTourTargetRegistry provides registry) {
@@ -68,7 +71,7 @@ class WorkspaceManagerGridLayoutNewTabTest : ComposeTest() {
                     WorkspaceManagerGridLayout(
                         state = state,
                         paddingValues = PaddingValues(),
-                        screenWidth = 720.dp,
+                        screenWidth = screenWidth,
                         onCloseWorkspace = {},
                         onReorderWorkspaces = {},
                         onSelectWorkspace = {},
@@ -116,11 +119,38 @@ class WorkspaceManagerGridLayoutNewTabTest : ComposeTest() {
         registry.get(WorkspaceManagerTour.NEW_TAB_TARGET) shouldNotBe null
     }
 
+    /**
+     * Also the premise of [WorkspaceManagerGridDefaults.scrollToNewTabCard]: the end of the grid is
+     * at most one item past the placeholder.
+     */
     @Test
-    fun `the placeholder is the last item, even below the explanation card`() {
+    fun `the placeholder sits directly above the explanation card`() {
         lateinit var gridState: LazyGridState
         compose(state(showBadgeExplanation = true), onGridState = { gridState = it })
 
-        gridState.layoutInfo.visibleItemsInfo.last().key shouldBe WorkspaceManagerColumnItemKey.NewTab
+        val keys = gridState.layoutInfo.visibleItemsInfo.map { it.key }
+        keys.drop(keys.indexOf(WorkspaceManagerColumnItemKey.NewTab) + 1) shouldBe
+            listOf(WorkspaceManagerColumnItemKey.Explanation.BadgeExplanation)
+    }
+
+    /**
+     * Three columns fit a one-column placeholder and a two-column card on one line, so the tab count
+     * would decide whether the explanation card lands beside the placeholder or below it.
+     */
+    @Config(qualifiers = "w1000dp-h2400dp")
+    @Test
+    fun `three columns keep the explanation card on its own line`() {
+        lateinit var gridState: LazyGridState
+        val threeTabs = listOf(item(idA, "Tab one"), item(idB, "Tab two"), item(Workspace.Id(), "Tab three"))
+        compose(
+            state(workspaces = threeTabs, showBadgeExplanation = true),
+            onGridState = { gridState = it },
+            screenWidth = 900.dp,
+        )
+
+        val items = gridState.layoutInfo.visibleItemsInfo.associateBy { it.key }
+        val placeholder = items.getValue(WorkspaceManagerColumnItemKey.NewTab)
+        val explanation = items.getValue(WorkspaceManagerColumnItemKey.Explanation.BadgeExplanation)
+        placeholder.row shouldBeLessThan explanation.row
     }
 }


### PR DESCRIPTION
## What changed

In the tab manager, the "New tab" tile used to sit below the tip card, separated from the tabs it belongs with. It now sits directly after the last tab, and the tip card moved below it.

On wide screens the tip card also takes a full row of its own. It previously took two of three columns, so with a tab count divisible by three it ended up sharing a row with the "New tab" tile instead of sitting under it.

## Technical Context

- The tip card's span changed from two columns to the full line on 3-column layouts. That is what guarantees the placement rather than the reorder alone: the grid packs greedily, so a 2-span card still fits beside the 1-span placeholder.
- The guided tour's final step scrolls to the "New tab" card and previously did that by scrolling to the grid's last index. That assumption is gone, so the scroll now lives in `WorkspaceManagerGridDefaults.scrollToNewTabCard`, which scrolls to the end and steps back one item if the placeholder is not on screen.
- The same helper now waits for the grid's first layout. On activity recreation while the tour is on that step, the refreshed hook receives a `LazyGridState` that has not been measured and reports zero items; the old count-based scroll then jumped to the top of a long grid and the step got skipped. Pre-existing, fixed here because the hook was being rewritten anyway.
- Worth a close look: the one-item step-back in the helper is only correct while the tip card is the sole item emitted after the placeholder. `WorkspaceManagerGridLayoutNewTabTest` pins that.
