### PR TITLE
Workspace: Move the tab rail to the bottom edge in portrait

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/FloatingBarStackState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/floatingbar/FloatingBarStackState.kt
@@ -388,10 +388,14 @@ internal fun imeInsetExtraPx(imeBottomPx: Float, navBottomPx: Float): Float =
  * @param includeSystemBarInset Whether to include the relevant system bar inset
  *        (status bar for TOP position, navigation bar for BOTTOM position).
  * @param includeImeInset Whether bars and content should rise above the soft keyboard. Only
- *        meaningful for a BOTTOM stack that also includes the system bar inset, and only stacks
+ *        meaningful for a BOTTOM stack that reaches the keyboard - one that includes the system bar
+ *        inset, or one separated from the window edge by [bottomChromePx] only - and only stacks
  *        that host a text input which must stay above the keyboard (e.g. the editor) should opt
  *        in. Non-input action bars leave this `false` so a stale host IME inset (which can linger
  *        after a dialog's keyboard is dismissed) never pushes them up.
+ * @param bottomChromePx Chrome of the app's own between this stack and the bottom window edge (the
+ *        navigation rail in its bottom placement). The keyboard covers it, so it is subtracted from
+ *        the IME extra rather than added to it.
  * @param estimatedContentPadding Estimated total content padding for first-frame rendering.
  *        Used when bars haven't registered yet (e.g. screenshot tests, first composition frame).
  *        Once bars register, the actual calculated padding takes over.
@@ -404,6 +408,7 @@ fun rememberFloatingBarStackState(
     contentPadding: Dp = 0.dp,
     includeSystemBarInset: Boolean = true,
     includeImeInset: Boolean = false,
+    bottomChromePx: Float = 0f,
     estimatedContentPadding: Dp = Dp.Unspecified,
 ): FloatingBarStackState {
     val density = LocalDensity.current
@@ -433,9 +438,16 @@ fun rememberFloatingBarStackState(
     // IME contribution as an extra over the nav bar so nav+extra == max(nav, ime) (no double
     // count when the IME inset already spans the nav bar region, e.g. 3-button navigation).
     // Only BOTTOM stacks that opt in track the keyboard; reading WindowInsets.ime is confined to
-    // this branch so non-opted-in stacks never react to a stale host IME inset.
-    val imeExtraPx = if (includeImeInset && includeSystemBarInset && position == BarPosition.BOTTOM) {
-        imeInsetExtraPx(WindowInsets.ime.getBottom(density).toFloat(), systemBarInsetPx)
+    // this branch so non-opted-in stacks never react to a stale host IME inset. A stack that does
+    // not touch the bottom window edge still does when app chrome is all that separates it from the
+    // keyboard, and that chrome's own height is already below the stack.
+    val imeExtraPx = if (
+        includeImeInset &&
+        position == BarPosition.BOTTOM &&
+        (includeSystemBarInset || bottomChromePx > 0f)
+    ) {
+        (imeInsetExtraPx(WindowInsets.ime.getBottom(density).toFloat(), systemBarInsetPx) - bottomChromePx)
+            .coerceAtLeast(0f)
     } else {
         0f
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/insets/WorkspacePaneInsets.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/insets/WorkspacePaneInsets.kt
@@ -118,6 +118,15 @@ val LocalPaneEdges = compositionLocalOf {
 }
 
 /**
+ * How much chrome of the app's own sits below the enclosing pane, e.g. the navigation rail in its
+ * bottom placement. Non-zero only for the pane that would touch the bottom window edge if that
+ * chrome weren't there — the keyboard reaches no other pane.
+ *
+ * Defaults to nothing, so a pane with the window edge below it behaves exactly as it did.
+ */
+val LocalPaneBottomChrome = compositionLocalOf { 0.dp }
+
+/**
  * Pads content away from the horizontal system bars / cutouts its pane touches.
  *
  * Applied to what the user reads — page content, banners, the surface of a dialog or sheet — and
@@ -168,6 +177,8 @@ fun rememberPaneFloatingBarStackState(
     includeImeInset: Boolean = false,
     estimatedContentPadding: Dp = Dp.Unspecified,
 ): FloatingBarStackState {
+    val density = LocalDensity.current
+    val bottomChrome = LocalPaneBottomChrome.current
     val state = rememberFloatingBarStackState(
         position = position,
         defaultSpacing = defaultSpacing,
@@ -175,6 +186,7 @@ fun rememberPaneFloatingBarStackState(
         contentPadding = contentPadding,
         includeSystemBarInset = design.paneEdges.includesSystemBarInset(position),
         includeImeInset = includeImeInset,
+        bottomChromePx = with(density) { bottomChrome.toPx() },
         estimatedContentPadding = estimatedContentPadding,
     )
     PersistBarCollapse(workspaceId = workspaceId, position = position, state = state)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesign.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesign.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.workspace.ui.manager
 data class WorkspaceDesign(
     val layout: Layout = Layout.SINGLE,
     val paneEdges: PaneEdges = PaneEdges.All,
+    val railPlacement: RailPlacement = RailPlacement.START,
 ) {
 
     val isSingle: Boolean
@@ -125,6 +126,16 @@ data class WorkspaceDesign(
         TRIPLE_MAIN_LEFT,
         TRIPLE_MAIN_RIGHT,
         QUAD_GRID,
+        ;
+    }
+
+    /**
+     * Which window edge the navigation rail occupies. A property of the window rather than of the
+     * layout: a single-pane window carries one too, even though it composes no rail.
+     */
+    enum class RailPlacement {
+        START,
+        BOTTOM,
         ;
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/insets/EditorImeInsetTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/insets/EditorImeInsetTest.kt
@@ -1,0 +1,107 @@
+package eu.darken.butler.workspace.ui.insets
+
+import android.view.View
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import eu.darken.butler.workspace.ui.floatingbar.BarPosition
+import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStackState
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign.PaneEdges
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The Editor is the only production stack that asks to rise above the keyboard, and that used to
+ * require the pane to touch the bottom window edge. Chrome the app draws below a pane (the bottom
+ * navigation rail) clears that edge without moving the pane away from the keyboard, so the opt-in
+ * now follows [LocalPaneBottomChrome] as well - reduced by the chrome, which the stack already sits
+ * above.
+ *
+ * The environment supplies no window insets of its own, so a keyboard is dispatched to the compose
+ * view; without it there is no extra to measure.
+ */
+class EditorImeInsetTest : ComposeTest() {
+
+    private val floatingPane = PaneEdges(
+        touchesTop = true,
+        touchesBottom = false,
+        touchesStart = true,
+        touchesEnd = true,
+    )
+
+    private lateinit var density: Density
+
+    private fun renderStack(bottomChrome: Dp): FloatingBarStackState {
+        var view: View? = null
+        lateinit var state: FloatingBarStackState
+
+        composeTestRule.setContent {
+            view = LocalView.current
+            density = LocalDensity.current
+            CompositionLocalProvider(LocalPaneBottomChrome provides bottomChrome) {
+                state = rememberPaneFloatingBarStackState(
+                    position = BarPosition.BOTTOM,
+                    design = WorkspaceDesign(paneEdges = floatingPane),
+                    edgePadding = EDGE_PADDING,
+                    includeImeInset = true,
+                )
+            }
+        }
+
+        composeTestRule.runOnUiThread {
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars(),
+                    Insets.of(0, 0, 0, NAV_INSET_PX),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.ime(),
+                    Insets.of(0, 0, 0, IME_INSET_PX),
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(view!!, insets)
+        }
+        composeTestRule.waitForIdle()
+
+        return state
+    }
+
+    @Test
+    fun `a pane with chrome below it still rises above the keyboard`() {
+        val state = renderStack(bottomChrome = CHROME)
+
+        val chromePx = with(density) { CHROME.toPx() }
+        val edgePaddingPx = with(density) { EDGE_PADDING.toPx() }
+
+        // The pane does not touch the window edge, so no system bar inset is in play - only the
+        // keyboard, less the chrome that already stands between the two.
+        state.contentPaddingPx shouldBe (IME_INSET_PX.toFloat() - chromePx + edgePaddingPx)
+    }
+
+    @Test
+    fun `a pane with neither the window edge nor chrome below it gets no keyboard extra`() {
+        val state = renderStack(bottomChrome = 0.dp)
+
+        val edgePaddingPx = with(density) { EDGE_PADDING.toPx() }
+
+        state.contentPaddingPx shouldBe edgePaddingPx
+    }
+
+    companion object {
+        private val EDGE_PADDING = 8.dp
+
+        /** Stand-in for the navigation rail in its bottom placement */
+        private val CHROME = 60.dp
+
+        private const val NAV_INSET_PX = 36
+        private const val IME_INSET_PX = 300
+    }
+}

--- a/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
@@ -130,8 +130,21 @@ internal fun ScreenshotPaneFrame(
     layout: WorkspaceDesign.Layout? = null,
     railExtras: List<Workspace.Info> = emptyList(),
 ) {
-    val resolvedLayout = layout ?: rememberWindowSizeInfo().recommendedLayout
-    val design = remember(resolvedLayout) { WorkspaceDesign(layout = resolvedLayout) }
+    val windowSizeInfo = rememberWindowSizeInfo()
+    val resolvedLayout = layout ?: windowSizeInfo.recommendedLayout
+    // This bypasses rememberWorkspaceDesign, so the rail's edge is derived here from the same thing
+    // the app derives it from: whether the window is portrait.
+    val isPortrait = windowSizeInfo.heightDp >= windowSizeInfo.widthDp
+    val design = remember(resolvedLayout, isPortrait) {
+        WorkspaceDesign(
+            layout = resolvedLayout,
+            railPlacement = if (isPortrait) {
+                WorkspaceDesign.RailPlacement.BOTTOM
+            } else {
+                WorkspaceDesign.RailPlacement.START
+            },
+        )
+    }
 
     // Drives the navigation rail; an inconsistent list leaves the rail without tabs.
     val workspaces = remember(panes, railExtras) {

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.workspace.ui.workspaces
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.relocation.BringIntoViewRequester
@@ -16,14 +17,18 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.DragAndDropEvent
 import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
 import eu.darken.butler.workspace.ui.dnd.dropTargetHighlight
 import eu.darken.butler.workspace.ui.dnd.workspaceDragPayload
+import eu.darken.butler.workspace.ui.insets.LocalPaneBottomChrome
 import eu.darken.butler.workspace.ui.insets.paneHorizontalInsetPadding
 import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign.RailPlacement
 import eu.darken.butler.workspace.ui.workspaces.adaptive.AdaptiveWorkspaceContainer
 import eu.darken.butler.workspace.ui.workspaces.adaptive.DividerPositions
 import eu.darken.butler.workspace.ui.workspaces.adaptive.DragDropState
@@ -60,18 +65,16 @@ fun AdaptiveWorkspaceLayout(
     firstTabTourPaneNumber: Int? = null,
     /** Scrolls the add-tab card into view before the tour's step is published. */
     firstTabTourRequester: BringIntoViewRequester? = null,
+    /** The rail's measured height in its bottom placement, owned by the host that draws chrome too. */
+    railThickness: Dp = 0.dp,
+    onRailThicknessChanged: (Dp) -> Unit = {},
     onShareError: (Workspace.Id, Throwable) -> Unit,
 ) {
     val dragDropState = remember { DragDropState() }
     val workspaceActionHandler = LocalWorkspaceButtonProvider.current
-    val currentOnScreenAction by rememberUpdatedState(onScreenAction)
 
     CompositionLocalProvider(LocalDragDropState provides dragDropState) {
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-        ) {
+        val rail: @Composable () -> Unit = {
             WorkspaceNavigationRail(
                 design = design,
                 workspaces = workspaces,
@@ -122,120 +125,227 @@ fun AdaptiveWorkspaceLayout(
                 },
                 onRename = onRenameWorkspace,
                 onPaneMenuToggle = onPaneMenuToggle,
+                onRailThicknessChanged = onRailThicknessChanged,
             )
+        }
 
-            AdaptiveWorkspaceContainer(
+        when (design.railPlacement) {
+            RailPlacement.START -> Row(
                 modifier = Modifier
-                    .weight(1f),
-                design = design,
-                selected = selected,
-                focusedTabId = focusedId,
-                dividerPositions = dividerPositions,
-                onDividerPositionsChange = onDividerPositionsChange,
-                onTabFocus = { id ->
-                    onScreenAction(WorkspaceScreenAction.Focus(id))
-                },
-                showPaneNumbers = showPaneNumbers,
-                showPaneOverlay = showPaneOverlay,
-                paneContent = { info, paneNumber ->
-                    // The navigation rail occupies the start edge, so no pane reaches it.
-                    val paneDesign = design.forPane(paneNumber).withoutEdges(start = true)
-                    if (info != null) {
-                        key(info.id) {
-                            val chain = paneLocalModalChains[info.id].orEmpty()
-                            // A modal covering everything takes focus away from the panes below it,
-                            // exactly like the tab manager overlay does.
-                            val focusSuppressed = isOverlayVisible || fullScreenModalVisible
-                            val paneIsFocused = !focusSuppressed &&
-                                (focusedId == info.id || chain.any { it.id == focusedId })
-                            // Deepest layer is the active one; global focus can sit on a covered
-                            // ancestor (launchPicker never moves it).
-                            val activeId = (chain.lastOrNull()?.id ?: info.id).takeIf { paneIsFocused }
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+            ) {
+                rail()
+                PaneArea(
+                    modifier = Modifier.weight(1f),
+                    design = design,
+                    railThickness = railThickness,
+                    selected = selected,
+                    focusedId = focusedId,
+                    dividerPositions = dividerPositions,
+                    onDividerPositionsChange = onDividerPositionsChange,
+                    showPaneNumbers = showPaneNumbers,
+                    showPaneOverlay = showPaneOverlay,
+                    onScreenAction = onScreenAction,
+                    managerDialogStates = managerDialogStates,
+                    bannerStates = bannerStates,
+                    onDismissBanner = onDismissBanner,
+                    clickToFocus = clickToFocus,
+                    paneLocalModalChains = paneLocalModalChains,
+                    isUpgraded = isUpgraded,
+                    isOverlayVisible = isOverlayVisible,
+                    fullScreenModalVisible = fullScreenModalVisible,
+                    firstTabTourPaneNumber = firstTabTourPaneNumber,
+                    firstTabTourRequester = firstTabTourRequester,
+                    onShareError = onShareError,
+                )
+            }
+            RailPlacement.BOTTOM -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+            ) {
+                PaneArea(
+                    modifier = Modifier.weight(1f),
+                    design = design,
+                    railThickness = railThickness,
+                    selected = selected,
+                    focusedId = focusedId,
+                    dividerPositions = dividerPositions,
+                    onDividerPositionsChange = onDividerPositionsChange,
+                    showPaneNumbers = showPaneNumbers,
+                    showPaneOverlay = showPaneOverlay,
+                    onScreenAction = onScreenAction,
+                    managerDialogStates = managerDialogStates,
+                    bannerStates = bannerStates,
+                    onDismissBanner = onDismissBanner,
+                    clickToFocus = clickToFocus,
+                    paneLocalModalChains = paneLocalModalChains,
+                    isUpgraded = isUpgraded,
+                    isOverlayVisible = isOverlayVisible,
+                    fullScreenModalVisible = fullScreenModalVisible,
+                    firstTabTourPaneNumber = firstTabTourPaneNumber,
+                    firstTabTourRequester = firstTabTourRequester,
+                    onShareError = onShareError,
+                )
+                rail()
+            }
+        }
+    }
+}
 
-                            WorkspacePane(
-                                info = info,
-                                design = paneDesign,
-                                // Any occupant counts as focusing the pane, and every layer requests
-                                // focus for the tab: a Focus() for a modal is silently dropped,
-                                // which would leave another pane active.
-                                paneFocused = paneIsFocused,
-                                clickToFocus = clickToFocus,
-                                onRequestPaneFocus = {
-                                    onScreenAction(WorkspaceScreenAction.Focus(info.id))
-                                },
-                                childModals = chain.map { it.asPaneInfo() },
-                                activeWorkspaceId = activeId,
-                                managerDialogStates = managerDialogStates,
-                                onScreenAction = onScreenAction,
-                                bannerStates = bannerStates,
-                                onDismissBanner = onDismissBanner,
-                                paneEdges = paneDesign.paneEdges,
-                                onShareError = onShareError,
-                                onCloseWorkspace = { workspaceId ->
-                                    workspaceActionHandler?.executeWorkspaceAction(
-                                        WorkspaceAction.Close(workspaceId)
-                                    )
-                                },
-                                onResumeWorkspace = { workspaceId ->
-                                    onScreenAction(WorkspaceScreenAction.ResumeWorkspace(workspaceId))
-                                },
-                            )
-                        }
-                    } else {
-                        // An empty pane opens exactly one dropped item, the same way tapping it
-                        // would (folder -> Explorer, text -> Editor, anything else -> Viewer).
-                        val paneIndex = paneNumber - 1
-                        val isDropHovered = remember { mutableStateOf(false) }
-                        val dropTarget = remember(paneIndex) {
-                            object : DragAndDropTarget {
-                                override fun onEntered(event: DragAndDropEvent) {
-                                    isDropHovered.value = true
-                                }
+/**
+ * The panes, without the rail. Takes no scope receiver of its own: each placement hands it the
+ * weight modifier of the row or column it is a child of.
+ */
+@Composable
+private fun PaneArea(
+    modifier: Modifier = Modifier,
+    design: WorkspaceDesign,
+    railThickness: Dp,
+    selected: Map<Int, WorkspacePaneInfo>,
+    focusedId: Workspace.Id?,
+    dividerPositions: DividerPositions,
+    onDividerPositionsChange: (DividerPositions) -> Unit,
+    showPaneNumbers: Boolean,
+    showPaneOverlay: Boolean,
+    onScreenAction: (WorkspaceScreenAction) -> Unit,
+    managerDialogStates: Map<Workspace.Id, ManagerDialog.WorkspaceTargeted>,
+    bannerStates: Map<Workspace.Id, eu.darken.butler.workspace.ui.feedback.BannerState>,
+    onDismissBanner: (Workspace.Id) -> Unit,
+    clickToFocus: Boolean,
+    paneLocalModalChains: Map<Workspace.Id, List<Workspace.Info>>,
+    isUpgraded: Boolean,
+    isOverlayVisible: Boolean,
+    fullScreenModalVisible: Boolean,
+    firstTabTourPaneNumber: Int?,
+    firstTabTourRequester: BringIntoViewRequester?,
+    onShareError: (Workspace.Id, Throwable) -> Unit,
+) {
+    val workspaceActionHandler = LocalWorkspaceButtonProvider.current
+    val currentOnScreenAction by rememberUpdatedState(onScreenAction)
+    val placement = design.railPlacement
 
-                                override fun onExited(event: DragAndDropEvent) {
-                                    isDropHovered.value = false
-                                }
+    AdaptiveWorkspaceContainer(
+        modifier = modifier,
+        design = design,
+        selected = selected,
+        focusedTabId = focusedId,
+        dividerPositions = dividerPositions,
+        onDividerPositionsChange = onDividerPositionsChange,
+        onTabFocus = { id ->
+            onScreenAction(WorkspaceScreenAction.Focus(id))
+        },
+        showPaneNumbers = showPaneNumbers,
+        showPaneOverlay = showPaneOverlay,
+        paneContent = { info, paneNumber ->
+            // Read before the rail's edge is cleared: it is what says the rail is the only thing
+            // between this pane and the bottom of the window.
+            val isBottomPane = design.forPane(paneNumber).paneEdges.touchesBottom
+            // The navigation rail occupies one window edge, so no pane reaches it.
+            val paneDesign = design.forPane(paneNumber).withoutEdges(
+                start = placement == RailPlacement.START,
+                bottom = placement == RailPlacement.BOTTOM,
+            )
+            val bottomChrome = when {
+                isBottomPane && placement == RailPlacement.BOTTOM -> railThickness
+                else -> 0.dp
+            }
+            CompositionLocalProvider(LocalPaneBottomChrome provides bottomChrome) {
+                if (info != null) {
+                    key(info.id) {
+                        val chain = paneLocalModalChains[info.id].orEmpty()
+                        // A modal covering everything takes focus away from the panes below it,
+                        // exactly like the tab manager overlay does.
+                        val focusSuppressed = isOverlayVisible || fullScreenModalVisible
+                        val paneIsFocused = !focusSuppressed &&
+                            (focusedId == info.id || chain.any { it.id == focusedId })
+                        // Deepest layer is the active one; global focus can sit on a covered
+                        // ancestor (launchPicker never moves it).
+                        val activeId = (chain.lastOrNull()?.id ?: info.id).takeIf { paneIsFocused }
 
-                                override fun onEnded(event: DragAndDropEvent) {
-                                    isDropHovered.value = false
-                                }
-
-                                override fun onDrop(event: DragAndDropEvent): Boolean {
-                                    isDropHovered.value = false
-                                    val payload = event.workspaceDragPayload()
-                                        ?.takeIf { it.items.size == 1 }
-                                        ?: return false
-                                    currentOnScreenAction(
-                                        WorkspaceScreenAction.OpenDropInPane(paneIndex, payload)
-                                    )
-                                    return true
-                                }
-                            }
-                        }
-
-                        EmptyAdaptiveWorkspaceContent(
-                            modifier = Modifier
-                                .weight(1f)
-                                .paneHorizontalInsetPadding(paneDesign.paneEdges)
-                                .dragAndDropTarget(
-                                    shouldStartDragAndDrop = { event ->
-                                        event.workspaceDragPayload()?.items?.size == 1
-                                    },
-                                    target = dropTarget,
-                                )
-                                .dropTargetHighlight(isDropHovered.value),
-                            paneNumber = paneNumber,
+                        WorkspacePane(
+                            info = info,
+                            design = paneDesign,
+                            // Any occupant counts as focusing the pane, and every layer requests
+                            // focus for the tab: a Focus() for a modal is silently dropped,
+                            // which would leave another pane active.
+                            paneFocused = paneIsFocused,
+                            clickToFocus = clickToFocus,
+                            onRequestPaneFocus = {
+                                onScreenAction(WorkspaceScreenAction.Focus(info.id))
+                            },
+                            childModals = chain.map { it.asPaneInfo() },
+                            activeWorkspaceId = activeId,
+                            managerDialogStates = managerDialogStates,
+                            onScreenAction = onScreenAction,
+                            bannerStates = bannerStates,
+                            onDismissBanner = onDismissBanner,
                             paneEdges = paneDesign.paneEdges,
-                            isUpgraded = isUpgraded,
-                            isTourTarget = paneNumber == firstTabTourPaneNumber,
-                            tourRequester = firstTabTourRequester,
-                            onAddWorkspace = {
-                                onScreenAction(WorkspaceScreenAction.CreateForPane(paneNumber - 1))
+                            onShareError = onShareError,
+                            onCloseWorkspace = { workspaceId ->
+                                workspaceActionHandler?.executeWorkspaceAction(
+                                    WorkspaceAction.Close(workspaceId)
+                                )
+                            },
+                            onResumeWorkspace = { workspaceId ->
+                                onScreenAction(WorkspaceScreenAction.ResumeWorkspace(workspaceId))
                             },
                         )
                     }
+                } else {
+                    // An empty pane opens exactly one dropped item, the same way tapping it
+                    // would (folder -> Explorer, text -> Editor, anything else -> Viewer).
+                    val paneIndex = paneNumber - 1
+                    val isDropHovered = remember { mutableStateOf(false) }
+                    val dropTarget = remember(paneIndex) {
+                        object : DragAndDropTarget {
+                            override fun onEntered(event: DragAndDropEvent) {
+                                isDropHovered.value = true
+                            }
+
+                            override fun onExited(event: DragAndDropEvent) {
+                                isDropHovered.value = false
+                            }
+
+                            override fun onEnded(event: DragAndDropEvent) {
+                                isDropHovered.value = false
+                            }
+
+                            override fun onDrop(event: DragAndDropEvent): Boolean {
+                                isDropHovered.value = false
+                                val payload = event.workspaceDragPayload()
+                                    ?.takeIf { it.items.size == 1 }
+                                    ?: return false
+                                currentOnScreenAction(
+                                    WorkspaceScreenAction.OpenDropInPane(paneIndex, payload)
+                                )
+                                return true
+                            }
+                        }
+                    }
+
+                    EmptyAdaptiveWorkspaceContent(
+                        modifier = Modifier
+                            .paneHorizontalInsetPadding(paneDesign.paneEdges)
+                            .dragAndDropTarget(
+                                shouldStartDragAndDrop = { event ->
+                                    event.workspaceDragPayload()?.items?.size == 1
+                                },
+                                target = dropTarget,
+                            )
+                            .dropTargetHighlight(isDropHovered.value),
+                        paneNumber = paneNumber,
+                        paneEdges = paneDesign.paneEdges,
+                        isUpgraded = isUpgraded,
+                        isTourTarget = paneNumber == firstTabTourPaneNumber,
+                        tourRequester = firstTabTourRequester,
+                        onAddWorkspace = {
+                            onScreenAction(WorkspaceScreenAction.CreateForPane(paneNumber - 1))
+                        },
+                    )
                 }
-            )
+            }
         }
-    }
+    )
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
@@ -72,6 +73,7 @@ import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarScope
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
 import eu.darken.butler.workspace.ui.floatingbar.LocalWorkspaceBarCollapseStates
+import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.rememberWindowSizeInfo
 import eu.darken.butler.workspace.ui.scroll.LocalWorkspaceScrollPositions
 import eu.darken.butler.workspace.ui.workspaces.adaptive.DividerPositions
@@ -99,6 +101,9 @@ fun WorkspaceScreen(
     onDismissBanner: (Workspace.Id) -> Unit = {},
     onShareError: (Workspace.Id, Throwable) -> Unit = { _, _ -> },
     design: WorkspaceDesign = rememberWorkspaceDesign(state),
+    /** The rail's measured height in its bottom placement; owned by the host, which draws over it. */
+    railThickness: Dp = 0.dp,
+    onRailThicknessChanged: (Dp) -> Unit = {},
 ) {
     val workspaceActionHandler = LocalWorkspaceButtonProvider.current
 
@@ -176,6 +181,8 @@ fun WorkspaceScreen(
                 fullScreenModalVisible = state.fullScreenModalWorkspace != null,
                 firstTabTourPaneNumber = firstTabTourPaneNumber,
                 firstTabTourRequester = createTabRequester,
+                railThickness = railThickness,
+                onRailThicknessChanged = onRailThicknessChanged,
                 onShareError = onShareError,
             )
         } else {
@@ -268,9 +275,15 @@ fun WorkspaceScreen(
 }
 
 /**
- * The pane layout the window gets, from the orientation's panel mode setting and the window size.
+ * The pane layout the window gets, from the orientation's panel mode setting and the window size,
+ * plus the window edge the navigation rail takes.
+ *
  * Shared by the screen and its host: the host draws chrome outside every pane (the close-undo bar)
- * and has to know whether the navigation rail takes the start edge.
+ * and has to know where the rail is.
+ *
+ * The placement follows the window, not the layout: a portrait window that ends up single-pane also
+ * says BOTTOM even though it composes no rail. Everything reading it therefore gates on the rail
+ * being visible rather than on the placement alone.
  */
 @Composable
 fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
@@ -294,7 +307,14 @@ fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
         WorkspacePanelMode.QUAD_GRID -> WorkspaceDesign.Layout.QUAD_GRID
     }
 
-    return WorkspaceDesign(layout = effectivePaneLayout)
+    return WorkspaceDesign(
+        layout = effectivePaneLayout,
+        railPlacement = if (isLandscape) {
+            WorkspaceDesign.RailPlacement.START
+        } else {
+            WorkspaceDesign.RailPlacement.BOTTOM
+        },
+    )
 }
 
 /**
@@ -414,6 +434,10 @@ fun WorkspacesScreenHost(
     val revealOrigin = remember { WorkspaceRevealOrigin() }
     val revealState = rememberManagerRevealState(visible = pageManagerState.isManagerOverlayVisible)
 
+    // Measured rather than assumed: the entries grow with the font scale, so the bottom rail is not
+    // a constant the chrome outside it could hard-code.
+    var railThickness by remember { mutableStateOf(0.dp) }
+
     // Selection mode is a state inside the overlay, so back leaves it first; dismissing the manager
     // outright would drop a selection the user is still assembling.
     // Gated on the layer rather than the logical flag, same as the pane suppression below: both
@@ -465,6 +489,8 @@ fun WorkspacesScreenHost(
                 onReviewNow = { vm.reviewNow(it) },
                 onDismissBanner = { vm.dismissBanner(it) },
                 onShareError = { workspaceId, error -> vm.shareWorkspaceError(workspaceId, error) },
+                railThickness = railThickness,
+                onRailThicknessChanged = { railThickness = it },
             )
         }
 
@@ -531,27 +557,18 @@ fun WorkspacesScreenHost(
         // most likely first use of this feature. The dialogs below still cover it, which is right:
         // anything asking the user a question outranks an offer they can also just ignore.
         closedFeedback?.let { feedback ->
-            // The rail sits inside the window's start inset and is 80dp beyond it. Only while the
-            // manager is down: the overlay covers the rail, and a bar offset over a full-width grid
-            // would look misplaced.
+            // Only while the manager is down: the overlay covers the rail, and a bar offset over a
+            // full-width grid would look misplaced.
             val railVisible = design?.isSingle == false && !pageManagerState.isManagerOverlayVisible
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .windowInsetsPadding(systemBarsWithOptionalCutout().only(WindowInsetsSides.Horizontal))
-                    .padding(start = if (railVisible) WorkspaceNavigationRailDefaults.Width else 0.dp),
-            ) {
-                FloatingBarStack(
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    position = BarPosition.BOTTOM,
-                ) {
-                    WorkspaceClosedUndoBar(
-                        feedback = feedback,
-                        onUndo = { vm.undoClose() },
-                        onDismiss = { vm.dismissClosedFeedback(feedback.closeToken) },
-                    )
-                }
-            }
+            val bottomRailVisible = railVisible && design?.railPlacement == WorkspaceDesign.RailPlacement.BOTTOM
+            WorkspaceClosedUndoBarHost(
+                feedback = feedback,
+                startRailVisible = railVisible && !bottomRailVisible,
+                bottomRailVisible = bottomRailVisible,
+                railThickness = railThickness,
+                onUndo = { vm.undoClose() },
+                onDismiss = { vm.dismissClosedFeedback(feedback.closeToken) },
+            )
         }
 
         if (showClearSessionConfirmation) {
@@ -631,6 +648,50 @@ fun WorkspacesScreenHost(
                     onCloseSelected = { vm.onCloseSelectedFromLimitDialog(it) },
                 )
             }
+        }
+    }
+}
+
+/**
+ * Where the close-undo bar sits relative to the navigation rail: beside it in the start placement,
+ * above it in the bottom one. Separate from its caller so a test can drive the geometry with a rail
+ * thickness of its own.
+ *
+ * The bar clears the bottom rail by the rail's measured height, which already contains the
+ * navigation bar inset the rail padded for - hence the stack that leaves that inset out.
+ */
+@Composable
+internal fun WorkspaceClosedUndoBarHost(
+    modifier: Modifier = Modifier,
+    feedback: ClosedWorkspaceFeedback,
+    startRailVisible: Boolean,
+    bottomRailVisible: Boolean,
+    railThickness: Dp,
+    onUndo: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(systemBarsWithOptionalCutout().only(WindowInsetsSides.Horizontal))
+            .padding(
+                start = if (startRailVisible) WorkspaceNavigationRailDefaults.Thickness else 0.dp,
+                bottom = if (bottomRailVisible) railThickness else 0.dp,
+            ),
+    ) {
+        FloatingBarStack(
+            modifier = Modifier.align(Alignment.BottomCenter),
+            position = BarPosition.BOTTOM,
+            state = rememberFloatingBarStackState(
+                position = BarPosition.BOTTOM,
+                includeSystemBarInset = !bottomRailVisible,
+            ),
+        ) {
+            WorkspaceClosedUndoBar(
+                feedback = feedback,
+                onUndo = onUndo,
+                onDismiss = onDismiss,
+            )
         }
     }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -560,7 +560,7 @@ fun WorkspacesScreenHost(
             // Only while the manager is down: the overlay covers the rail, and a bar offset over a
             // full-width grid would look misplaced.
             val railVisible = design?.isSingle == false && !pageManagerState.isManagerOverlayVisible
-            val bottomRailVisible = railVisible && design?.railPlacement == WorkspaceDesign.RailPlacement.BOTTOM
+            val bottomRailVisible = railVisible && design.railPlacement == WorkspaceDesign.RailPlacement.BOTTOM
             WorkspaceClosedUndoBarHost(
                 feedback = feedback,
                 startRailVisible = railVisible && !bottomRailVisible,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,6 +40,7 @@ import androidx.compose.material.icons.twotone.Looks4
 import androidx.compose.material.icons.twotone.LooksOne
 import androidx.compose.material.icons.twotone.LooksTwo
 import androidx.compose.material.icons.twotone.RemoveCircleOutline
+import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FloatingActionButton
@@ -47,7 +49,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -394,14 +395,20 @@ fun WorkspaceNavigationRail(
 }
 
 /**
- * Material3's [VerticalDivider] fills the height it is offered, which in [RailPlacement.BOTTOM] is
- * the whole window - the rail is the unweighted child of the layout's column. A finite height keeps
- * it inside what the entries already impose on the rail's cross-axis.
+ * In [RailPlacement.BOTTOM] the divider is drawn as a sized [Box] rather than Material3's
+ * `VerticalDivider`: that one fills the height it is offered, which here is the whole window - the
+ * rail is the unweighted child of the layout's column. The explicit height keeps the divider inside
+ * what the entries already impose on the rail's cross-axis.
  */
 @Composable
 private fun RailSectionDivider(placement: RailPlacement) = when (placement) {
     RailPlacement.START -> HorizontalDivider()
-    RailPlacement.BOTTOM -> VerticalDivider(modifier = Modifier.height(RailItemHeight))
+    RailPlacement.BOTTOM -> Box(
+        Modifier
+            .width(DividerDefaults.Thickness)
+            .height(RailItemHeight)
+            .background(DividerDefaults.color),
+    )
 }
 
 /**

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -45,8 +47,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -57,7 +61,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
@@ -69,6 +75,7 @@ import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.R
@@ -84,6 +91,7 @@ import eu.darken.butler.workspace.ui.common.CutoutTopRightCornerShape
 import eu.darken.butler.workspace.ui.manager.PaneLayoutGlyph
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign.RailPlacement
 import eu.darken.butler.workspace.ui.manager.paneCells
 import eu.darken.butler.workspace.ui.tour.WorkspaceTourTargets
 import eu.darken.butler.workspace.ui.workspaces.WorkspacePaneInfo
@@ -94,8 +102,8 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapp
 import eu.darken.butler.common.R as CommonR
 
 object WorkspaceNavigationRailDefaults {
-    /** Width past the start window inset the rail pads for itself. */
-    val Width = 80.dp
+    /** Cross-axis extent past the window inset the rail pads for itself. */
+    val Thickness = 80.dp
 
     const val SURFACE_TEST_TAG = "workspace.rail.surface"
     const val CONTENT_TEST_TAG = "workspace.rail.content"
@@ -222,7 +230,12 @@ fun WorkspaceNavigationRail(
     onPaneUnassign: (workspaceId: Workspace.Id) -> Unit,
     onRename: (Workspace.Id) -> Unit = {},
     onPaneMenuToggle: (Boolean) -> Unit = {},
+    /** How much of the bottom edge the rail covers, so chrome outside it can clear the rail. */
+    onRailThicknessChanged: (Dp) -> Unit = {},
 ) {
+    // Taken from the design rather than from a parameter of its own: two sources could disagree.
+    val placement = design.railPlacement
+
     // Local state for reordering
     var localWorkspaces by remember { mutableStateOf(workspaces) }
     var isDragging by remember { mutableStateOf(false) }
@@ -254,8 +267,10 @@ fun WorkspaceNavigationRail(
 
     // A workspace can gain focus without being on screen (opened from a pane far down the list), and
     // an off-screen focused entry leaves the rail looking like nothing happened.
+    // Keyed on the placement too: the two viewports differ in length, so an entry that fits the
+    // vertical one can fall outside the horizontal one without focus or order changing.
     val revealKey = railRevealKey(focusedId, localWorkspaces)
-    LaunchedEffect(revealKey) {
+    LaunchedEffect(revealKey, placement) {
         val focusedIndex = revealKey.orderedIds.indexOf(revealKey.focusedId)
         val layoutInfo = lazyListState.layoutInfo
         // visibleItemsInfo includes items clipped by the viewport, so filter down to the entries that
@@ -272,69 +287,92 @@ fun WorkspaceNavigationRail(
         if (shouldReveal) lazyListState.animateScrollToItem(focusedIndex)
     }
 
-    WorkspaceRailContainer(modifier = modifier) {
+    val railItems: LazyListScope.() -> Unit = {
+        items(
+            items = localWorkspaces,
+            key = { it.id }
+        ) { ws ->
+            ReorderableItem(
+                reorderableLazyListState,
+                key = ws.id
+            ) { isDraggingItem ->
+                val paneIndex = selected.entries.find { it.value.id == ws.id }?.key
+                DraggableWorkspaceRailItem(
+                    workspace = ws,
+                    isFocused = focusedId == ws.id,
+                    currentPaneIndex = paneIndex,
+                    closeHostId = railCloseHost(
+                        closingPaneIndex = paneIndex,
+                        visibleAssignments = selected,
+                        focusedId = focusedId,
+                    ),
+                    onTabAction = onTabAction,
+                    onPaneAssignment = onPaneAssignment,
+                    onPaneUnassign = onPaneUnassign,
+                    onRename = onRename,
+                    design = design,
+                    placement = placement,
+                    onPaneMenuToggle = onPaneMenuToggle,
+                    isDraggingItem = isDraggingItem,
+                    onDragStarted = {
+                        isDragging = true
+                    },
+                    onDragStopped = {
+                        isDragging = false
+                        // Trigger reorder action with new order
+                        val newOrder = localWorkspaces.map { it.id }
+                        onTabAction(WorkspaceAction.Reorder(newOrder))
+                    },
+                    reorderableScope = this,
+                )
+            }
+        }
+    }
+
+    val sectionSpacer = when (placement) {
+        RailPlacement.START -> Modifier.height(RailSectionPadding)
+        RailPlacement.BOTTOM -> Modifier.width(RailSectionPadding)
+    }
+
+    WorkspaceRailContainer(
+        modifier = modifier,
+        placement = placement,
+        onRailThicknessChanged = onRailThicknessChanged,
+    ) { listModifier ->
         // Unconditional: the rail exists once per screen, and only in multi-pane - where the
         // Templates page renders no Butler button of its own.
         WorkspaceButton(
-            modifier = Modifier
-                .padding(vertical = RailSectionPadding)
-                .guidedTourTarget(WorkspaceTourTargets.BUTLER_BUTTON),
+            modifier = when (placement) {
+                RailPlacement.START -> Modifier.padding(vertical = RailSectionPadding)
+                RailPlacement.BOTTOM -> Modifier.padding(horizontal = RailSectionPadding)
+            }.guidedTourTarget(WorkspaceTourTargets.BUTLER_BUTTON),
             currentWorkspaceId = focusedId,
         )
 
-        HorizontalDivider()
+        RailSectionDivider(placement = placement)
 
-        LazyColumn(
-            modifier = Modifier
-                .weight(1f)
-                .padding(vertical = RailSectionPadding)
-                .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
-            state = lazyListState,
-            verticalArrangement = Arrangement.spacedBy(RailItemSpacing),
-        ) {
-            items(
-                items = localWorkspaces,
-                key = { it.id }
-            ) { ws ->
-                ReorderableItem(
-                    reorderableLazyListState,
-                    key = ws.id
-                ) { isDraggingItem ->
-                    val paneIndex = selected.entries.find { it.value.id == ws.id }?.key
-                    DraggableWorkspaceRailItem(
-                        workspace = ws,
-                        isFocused = focusedId == ws.id,
-                        currentPaneIndex = paneIndex,
-                        closeHostId = railCloseHost(
-                            closingPaneIndex = paneIndex,
-                            visibleAssignments = selected,
-                            focusedId = focusedId,
-                        ),
-                        onTabAction = onTabAction,
-                        onPaneAssignment = onPaneAssignment,
-                        onPaneUnassign = onPaneUnassign,
-                        onRename = onRename,
-                        design = design,
-                        onPaneMenuToggle = onPaneMenuToggle,
-                        isDraggingItem = isDraggingItem,
-                        onDragStarted = {
-                            isDragging = true
-                        },
-                        onDragStopped = {
-                            isDragging = false
-                            // Trigger reorder action with new order
-                            val newOrder = localWorkspaces.map { it.id }
-                            onTabAction(WorkspaceAction.Reorder(newOrder))
-                        },
-                        reorderableScope = this,
-                    )
-                }
-            }
+        when (placement) {
+            RailPlacement.START -> LazyColumn(
+                modifier = listModifier
+                    .padding(vertical = RailSectionPadding)
+                    .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
+                state = lazyListState,
+                verticalArrangement = Arrangement.spacedBy(RailItemSpacing),
+                content = railItems,
+            )
+            RailPlacement.BOTTOM -> LazyRow(
+                modifier = listModifier
+                    .padding(horizontal = RailSectionPadding)
+                    .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
+                state = lazyListState,
+                horizontalArrangement = Arrangement.spacedBy(RailItemSpacing),
+                content = railItems,
+            )
         }
 
-        HorizontalDivider()
+        RailSectionDivider(placement = placement)
 
-        Spacer(modifier = Modifier.height(RailSectionPadding))
+        Spacer(modifier = sectionSpacer)
 
         FloatingActionButton(
             onClick = {
@@ -351,40 +389,94 @@ fun WorkspaceNavigationRail(
             )
         }
 
-        Spacer(modifier = Modifier.height(RailSectionPadding))
+        Spacer(modifier = sectionSpacer)
     }
 }
 
+/**
+ * Material3's [VerticalDivider] fills the height it is offered, which in [RailPlacement.BOTTOM] is
+ * the whole window - the rail is the unweighted child of the layout's column. A finite height keeps
+ * it inside what the entries already impose on the rail's cross-axis.
+ */
+@Composable
+private fun RailSectionDivider(placement: RailPlacement) = when (placement) {
+    RailPlacement.START -> HorizontalDivider()
+    RailPlacement.BOTTOM -> VerticalDivider(modifier = Modifier.height(RailItemHeight))
+}
+
+/**
+ * The rail's surface and the axis its content runs along.
+ *
+ * [content] receives the modifier the tab list has to carry: `weight(1f)` is the one scoped call in
+ * the rail's body, and its receiver differs between the two placements.
+ */
 @Composable
 internal fun WorkspaceRailContainer(
     modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.() -> Unit,
+    placement: RailPlacement = RailPlacement.START,
+    onRailThicknessChanged: (Dp) -> Unit = {},
+    content: @Composable (listModifier: Modifier) -> Unit,
 ) {
+    val density = LocalDensity.current
+    DisposableEffect(placement) {
+        onDispose { onRailThicknessChanged(0.dp) }
+    }
     Surface(
         modifier = modifier
-            .fillMaxHeight()
+            .then(
+                when (placement) {
+                    RailPlacement.START -> Modifier.fillMaxHeight()
+                    RailPlacement.BOTTOM -> Modifier.fillMaxWidth()
+                },
+            )
+            .onSizeChanged { size ->
+                if (placement == RailPlacement.BOTTOM) {
+                    onRailThicknessChanged(with(density) { size.height.toDp() })
+                }
+            }
             .testTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG),
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxHeight()
-                // Only the start side: the rail doesn't touch the end edge, and padding for an end-side
-                // navigation bar here would widen the rail while the end pane pads for it as well.
-                .windowInsetsPadding(
-                    systemBarsWithOptionalCutout()
-                        .only(WindowInsetsSides.Start + WindowInsetsSides.Vertical)
-                )
-                .width(WorkspaceNavigationRailDefaults.Width)
-                .testTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
-                // Inside the tagged 80dp, so the rail's own width is unaffected. Kept tight because
-                // the entry's spare width is what the pane glyph's notch is carved out of, and what
-                // the label has left after the type icon.
-                .padding(horizontal = RailItemInset),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            content = content,
-        )
+        when (placement) {
+            RailPlacement.START -> Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    // Only the start side: the rail doesn't touch the end edge, and padding for an end-side
+                    // navigation bar here would widen the rail while the end pane pads for it as well.
+                    .windowInsetsPadding(
+                        systemBarsWithOptionalCutout()
+                            .only(WindowInsetsSides.Start + WindowInsetsSides.Vertical)
+                    )
+                    .width(WorkspaceNavigationRailDefaults.Thickness)
+                    .testTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
+                    // Inside the tagged 80dp, so the rail's own width is unaffected. Kept tight because
+                    // the entry's spare width is what the pane glyph's notch is carved out of, and what
+                    // the label has left after the type icon.
+                    .padding(horizontal = RailItemInset),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                content(Modifier.weight(1f))
+            }
+            // A minimum rather than a fixed extent: an entry grows with the font scale, and along
+            // this axis that growth runs across the rail instead of along its scroll direction.
+            RailPlacement.BOTTOM -> Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Only the bottom side: the rail doesn't touch the top edge, and the panes above
+                    // it pad for the status bar themselves.
+                    .windowInsetsPadding(
+                        systemBarsWithOptionalCutout()
+                            .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
+                    )
+                    .heightIn(min = WorkspaceNavigationRailDefaults.Thickness)
+                    .testTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
+                    .padding(vertical = RailItemInset),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                content(Modifier.weight(1f))
+            }
+        }
     }
 }
 
@@ -412,6 +504,7 @@ internal fun WorkspaceRailItem(
     paneIndex: Int?,
     isFocused: Boolean,
     layout: WorkspaceDesign.Layout = WorkspaceDesign.Layout.SINGLE,
+    placement: RailPlacement = RailPlacement.START,
     isDraggingItem: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
     onClick: () -> Unit,
@@ -458,7 +551,15 @@ internal fun WorkspaceRailItem(
 
     Box(
         modifier = modifier
-            .fillMaxWidth()
+            .then(
+                when (placement) {
+                    // The list is the sized axis in START and the scrolling one in BOTTOM, so the
+                    // entry takes the rail's width from the container in one and states it here in
+                    // the other.
+                    RailPlacement.START -> Modifier.fillMaxWidth()
+                    RailPlacement.BOTTOM -> Modifier.width(WorkspaceNavigationRailDefaults.Thickness)
+                },
+            )
             .scale(scale),
     ) {
         Surface(
@@ -558,61 +659,95 @@ private fun WorkspaceRailItemRtlPreview() {
     }
 }
 
+/** The bottom placement puts the same entries along the other axis. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun WorkspaceRailItemStates(layout: WorkspaceDesign.Layout) {
-    Column(
+private fun WorkspaceRailItemBottomPreview() {
+    WorkspaceRailItemStates(
+        layout = WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT,
+        placement = RailPlacement.BOTTOM,
+    )
+}
+
+@Composable
+private fun WorkspaceRailItemStates(
+    layout: WorkspaceDesign.Layout,
+    placement: RailPlacement = RailPlacement.START,
+) = when (placement) {
+    RailPlacement.START -> Column(
         modifier = Modifier
-            .width(WorkspaceNavigationRailDefaults.Width)
+            .width(WorkspaceNavigationRailDefaults.Thickness)
             .padding(horizontal = RailItemInset),
         verticalArrangement = Arrangement.spacedBy(RailItemSpacing),
     ) {
-        WorkspaceRailItem(
-            workspace = Workspace.Info(
-                id = Workspace.Id(),
-                type = Workspace.Type.EXPLORER,
-                title = "Explorer".toCaString(),
-            ),
-            paneIndex = null,
-            isFocused = false,
-            layout = layout,
-            onClick = {},
-        )
-        // Assigned but not focused: the border has to follow the notch.
-        WorkspaceRailItem(
-            workspace = Workspace.Info(
-                id = Workspace.Id(),
-                type = Workspace.Type.SEARCHER,
-                title = "Search".toCaString(),
-            ),
-            paneIndex = 1,
-            isFocused = false,
-            layout = layout,
-            onClick = {},
-        )
-        WorkspaceRailItem(
-            workspace = Workspace.Info(
-                id = Workspace.Id(),
-                type = Workspace.Type.EDITOR,
-                title = "Editor".toCaString(),
-            ),
-            paneIndex = 0,
-            isFocused = true,
-            layout = layout,
-            onClick = {},
-        )
-        WorkspaceRailItem(
-            workspace = Workspace.Info(
-                id = Workspace.Id(),
-                type = Workspace.Type.TEMPLATES,
-                title = "Templates".toCaString(),
-            ),
-            paneIndex = 2,
-            isFocused = false,
-            layout = layout,
-            isDraggingItem = true,
-            onClick = {},
-        )
+        WorkspaceRailItemStateEntries(layout = layout, placement = placement)
     }
+    RailPlacement.BOTTOM -> Row(
+        modifier = Modifier
+            .heightIn(min = WorkspaceNavigationRailDefaults.Thickness)
+            .padding(vertical = RailItemInset),
+        horizontalArrangement = Arrangement.spacedBy(RailItemSpacing),
+    ) {
+        WorkspaceRailItemStateEntries(layout = layout, placement = placement)
+    }
+}
+
+@Composable
+private fun WorkspaceRailItemStateEntries(
+    layout: WorkspaceDesign.Layout,
+    placement: RailPlacement,
+) {
+    WorkspaceRailItem(
+        workspace = Workspace.Info(
+            id = Workspace.Id(),
+            type = Workspace.Type.EXPLORER,
+            title = "Explorer".toCaString(),
+        ),
+        paneIndex = null,
+        isFocused = false,
+        layout = layout,
+        placement = placement,
+        onClick = {},
+    )
+    // Assigned but not focused: the border has to follow the notch.
+    WorkspaceRailItem(
+        workspace = Workspace.Info(
+            id = Workspace.Id(),
+            type = Workspace.Type.SEARCHER,
+            title = "Search".toCaString(),
+        ),
+        paneIndex = 1,
+        isFocused = false,
+        layout = layout,
+        placement = placement,
+        onClick = {},
+    )
+    WorkspaceRailItem(
+        workspace = Workspace.Info(
+            id = Workspace.Id(),
+            type = Workspace.Type.EDITOR,
+            title = "Editor".toCaString(),
+        ),
+        paneIndex = 0,
+        isFocused = true,
+        layout = layout,
+        placement = placement,
+        onClick = {},
+    )
+    WorkspaceRailItem(
+        workspace = Workspace.Info(
+            id = Workspace.Id(),
+            type = Workspace.Type.TEMPLATES,
+            title = "Templates".toCaString(),
+        ),
+        paneIndex = 2,
+        isFocused = false,
+        layout = layout,
+        placement = placement,
+        isDraggingItem = true,
+        onClick = {},
+    )
 }
 
 @Composable
@@ -627,6 +762,7 @@ private fun DraggableWorkspaceRailItem(
     onPaneUnassign: (workspaceId: Workspace.Id) -> Unit,
     onRename: (Workspace.Id) -> Unit,
     design: WorkspaceDesign,
+    placement: RailPlacement,
     onPaneMenuToggle: (Boolean) -> Unit,
     isDraggingItem: Boolean,
     onDragStarted: () -> Unit,
@@ -646,6 +782,7 @@ private fun DraggableWorkspaceRailItem(
             paneIndex = currentPaneIndex,
             isFocused = isFocused,
             layout = design.layout,
+            placement = placement,
             isDraggingItem = isDraggingItem,
             dragHandleModifier = with(reorderableScope) {
                 // Long press, not press: the handle drags along the list's own scroll axis, so a
@@ -824,7 +961,16 @@ private fun WorkspaceRailItemMenuUnassignedPreview() {
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun WorkspaceNavigationRailPreview() {
+private fun WorkspaceNavigationRailPreview() = WorkspaceNavigationRailStates(RailPlacement.START)
+
+/** What a portrait window gets: the same rail along the bottom edge. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceNavigationRailBottomPreview() = WorkspaceNavigationRailStates(RailPlacement.BOTTOM)
+
+@Composable
+private fun WorkspaceNavigationRailStates(placement: RailPlacement) {
     val tabs = listOf(
         Workspace.Info(
             id = Workspace.Id(),
@@ -848,7 +994,10 @@ private fun WorkspaceNavigationRailPreview() {
         focusedId = tabs[0].id,
         // The rail only exists in multi-pane mode, so previewing the default SINGLE would show a
         // rail that can never occur - and no glyphs.
-        design = WorkspaceDesign(layout = WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT),
+        design = WorkspaceDesign(
+            layout = WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT,
+            railPlacement = placement,
+        ),
         onTabAction = {},
         onPaneAssignment = { _, _ -> },
         onPaneUnassign = {},

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceNavigationRailInsetBoundsTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceNavigationRailInsetBoundsTest.kt
@@ -2,9 +2,12 @@ package eu.darken.butler.workspace.ui.workspaces
 
 import android.view.View
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -20,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign.RailPlacement
 import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceNavigationRailDefaults
 import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceRailContainer
 import io.kotest.matchers.shouldBe
@@ -30,11 +34,13 @@ import testhelpers.ComposeTest
  * The rail is the one surface that touches the status bar, the gesture bar and the side cutout at
  * once. Its tonal background has to be painted across all of them, so the window insets belong on
  * the content column inside the surface, never on the surface itself: inset the surface and the
- * strips above and below the rail fall back to the window background.
+ * strips beside the rail fall back to the window background.
  *
  * The insets stay inside the surface, but they must not disappear from the rail's footprint either
- * — the pane beside it still has to start after the inset plus the full 80dp rail, and the content
- * column must keep those 80dp instead of being squeezed into 80dp including the inset.
+ * — the pane next to it still has to start after the inset plus the full 80dp rail, and the content
+ * must keep those 80dp instead of being squeezed into 80dp including the inset. Both placements are
+ * covered: they claim different sides, and the bottom one keeps its 80dp as a minimum rather than a
+ * fixed size.
  *
  * This drives [WorkspaceRailContainer] rather than the full rail: the rail's header renders the
  * Lottie-backed mascot, which Robolectric cannot draw, while the container holds all of the
@@ -45,7 +51,10 @@ import testhelpers.ComposeTest
  */
 class WorkspaceNavigationRailInsetBoundsTest : ComposeTest() {
 
-    private fun renderRail(layoutDirection: LayoutDirection): Density {
+    private fun renderRail(
+        layoutDirection: LayoutDirection,
+        placement: RailPlacement = RailPlacement.START,
+    ): Density {
         var view: View? = null
         lateinit var density: Density
 
@@ -55,21 +64,41 @@ class WorkspaceNavigationRailInsetBoundsTest : ComposeTest() {
             // No theme wrapper on purpose: Material's defaults are enough for the geometry under
             // test, and this test shares a JVM with the rest of the module's suite.
             CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
-                Row(
-                    modifier = Modifier
-                        .size(width = 300.dp, height = 500.dp)
-                        .testTag(ROOT_TAG),
-                ) {
-                    WorkspaceRailContainer {
-                        Box(modifier = Modifier.fillMaxSize())
-                    }
-                    // Stands in for the pane container beside the rail
-                    Box(
+                when (placement) {
+                    RailPlacement.START -> Row(
                         modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .testTag(SIBLING_TAG),
-                    )
+                            .size(width = 300.dp, height = 500.dp)
+                            .testTag(ROOT_TAG),
+                    ) {
+                        WorkspaceRailContainer(placement = placement) {
+                            Box(modifier = Modifier.fillMaxSize())
+                        }
+                        // Stands in for the pane container beside the rail
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .testTag(SIBLING_TAG),
+                        )
+                    }
+                    RailPlacement.BOTTOM -> Column(
+                        modifier = Modifier
+                            .size(width = 300.dp, height = 500.dp)
+                            .testTag(ROOT_TAG),
+                    ) {
+                        // Stands in for the pane container above the rail
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth()
+                                .testTag(SIBLING_TAG),
+                        )
+                        WorkspaceRailContainer(placement = placement) { listModifier ->
+                            // An entry-sized child rather than a filling one: the rail is the
+                            // unweighted child here, so a child that fills would claim the window.
+                            Box(modifier = listModifier.height(ENTRY_HEIGHT))
+                        }
+                    }
                 }
             }
         }
@@ -112,7 +141,7 @@ class WorkspaceNavigationRailInsetBoundsTest : ComposeTest() {
         (content.bottom < root.bottom) shouldBe true
 
         // ...without being squeezed: the inset is added to the rail, not taken out of it
-        (content.right - content.left) shouldBe RAIL_WIDTH
+        (content.right - content.left) shouldBe RAIL_THICKNESS
         (content.left - root.left) shouldBe sideInset
 
         // ...so the pane beside the rail keeps starting exactly where it did before
@@ -140,18 +169,81 @@ class WorkspaceNavigationRailInsetBoundsTest : ComposeTest() {
         (content.top > root.top) shouldBe true
         (content.bottom < root.bottom) shouldBe true
 
-        (content.right - content.left) shouldBe RAIL_WIDTH
+        (content.right - content.left) shouldBe RAIL_THICKNESS
         (root.right - content.right) shouldBe sideInset
 
         content.left shouldBe surface.left
         sibling.right shouldBe surface.left
     }
 
+    @Test
+    fun `the bottom rail surface spans the full width while its content is inset`() {
+        val density = renderRail(LayoutDirection.Ltr, RailPlacement.BOTTOM)
+        val sideInset = with(density) { SIDE_INSET_PX.toDp() }
+        val bottomInset = with(density) { BOTTOM_INSET_PX.toDp() }
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val surface = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+        val content = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+        val sibling = composeTestRule.onNodeWithTag(SIBLING_TAG).getUnclippedBoundsInRoot()
+
+        // The painted surface reaches the gesture bar and the side cutout
+        surface.left shouldBe root.left
+        surface.right shouldBe root.right
+        surface.bottom shouldBe root.bottom
+
+        // ...while what the user touches is moved clear of them
+        (content.bottom < root.bottom) shouldBe true
+        (content.left > root.left) shouldBe true
+
+        // ...without being squeezed: the inset is added to the rail, not taken out of it
+        (content.bottom - content.top) shouldBe RAIL_THICKNESS
+        (root.bottom - content.bottom) shouldBe bottomInset
+        (content.left - root.left) shouldBe sideInset
+
+        // ...so the pane above the rail ends exactly where the rail begins
+        content.top shouldBe surface.top
+        sibling.bottom shouldBe surface.top
+    }
+
+    @Test
+    fun `the bottom rail insets the side the navigation bar is on in right to left layouts`() {
+        val density = renderRail(LayoutDirection.Rtl, RailPlacement.BOTTOM)
+        val sideInset = with(density) { SIDE_INSET_PX.toDp() }
+        val bottomInset = with(density) { BOTTOM_INSET_PX.toDp() }
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val surface = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+        val content = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+        val sibling = composeTestRule.onNodeWithTag(SIBLING_TAG).getUnclippedBoundsInRoot()
+
+        surface.left shouldBe root.left
+        surface.right shouldBe root.right
+        surface.bottom shouldBe root.bottom
+
+        (content.bottom < root.bottom) shouldBe true
+        (content.right < root.right) shouldBe true
+
+        (content.bottom - content.top) shouldBe RAIL_THICKNESS
+        (root.bottom - content.bottom) shouldBe bottomInset
+        (root.right - content.right) shouldBe sideInset
+
+        content.top shouldBe surface.top
+        sibling.bottom shouldBe surface.top
+    }
+
     companion object {
         private const val ROOT_TAG = "rail.root"
         private const val SIBLING_TAG = "rail.sibling"
 
-        private val RAIL_WIDTH = 80.dp
+        private val RAIL_THICKNESS = 80.dp
+
+        /** Shorter than the rail, so the rail's own minimum is what decides its size */
+        private val ENTRY_HEIGHT = 24.dp
 
         /** Stand-ins for a side navigation bar, a status bar and a gesture bar */
         private const val SIDE_INSET_PX = 72

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailItemTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailItemTest.kt
@@ -71,6 +71,7 @@ class WorkspaceRailItemTest : ComposeTest() {
 
     private val paneIndexState = mutableStateOf<Int?>(null)
     private val layoutState = mutableStateOf(WorkspaceDesign.Layout.DUAL_VERTICAL)
+    private val placementState = mutableStateOf(WorkspaceDesign.RailPlacement.START)
     private var isRendered = false
 
     /**
@@ -85,9 +86,11 @@ class WorkspaceRailItemTest : ComposeTest() {
     private fun renderItem(
         paneIndex: Int?,
         layout: WorkspaceDesign.Layout = WorkspaceDesign.Layout.DUAL_VERTICAL,
+        placement: WorkspaceDesign.RailPlacement = WorkspaceDesign.RailPlacement.START,
     ) {
         paneIndexState.value = paneIndex
         layoutState.value = layout
+        placementState.value = placement
 
         if (isRendered) {
             composeTestRule.waitForIdle()
@@ -103,6 +106,7 @@ class WorkspaceRailItemTest : ComposeTest() {
                         paneIndex = paneIndexState.value,
                         isFocused = false,
                         layout = layoutState.value,
+                        placement = placementState.value,
                         onClick = {},
                     )
                     Text(
@@ -119,6 +123,10 @@ class WorkspaceRailItemTest : ComposeTest() {
     private fun heightOf(interaction: SemanticsNodeInteraction) = interaction
         .getUnclippedBoundsInRoot()
         .let { it.bottom - it.top }
+
+    private fun widthOf(interaction: SemanticsNodeInteraction) = interaction
+        .getUnclippedBoundsInRoot()
+        .let { it.right - it.left }
 
     private fun itemHeight() = heightOf(composeTestRule.onNodeWithTag(ITEM_TAG))
 
@@ -235,6 +243,28 @@ class WorkspaceRailItemTest : ComposeTest() {
         label shouldBe unconstrained
     }
 
+    /**
+     * Along the bottom edge the list scrolls horizontally, so the entry states the rail's
+     * cross-axis size itself instead of taking it from the container.
+     */
+    @Test
+    fun `a bottom placement entry is as wide as the rail is thick`() {
+        renderItem(paneIndex = null, placement = WorkspaceDesign.RailPlacement.BOTTOM)
+
+        widthOf(composeTestRule.onNodeWithTag(ITEM_TAG)) shouldBe RAIL_THICKNESS
+    }
+
+    /** The 80dp the entry gets there is more than the 64dp the start placement leaves it. */
+    @Test
+    fun `a bottom placement entry gives the label its whole line box`() {
+        renderItem(paneIndex = null, placement = WorkspaceDesign.RailPlacement.BOTTOM)
+
+        val label = heightOf(composeTestRule.onNodeWithText("Explorer", useUnmergedTree = true))
+        val unconstrained = heightOf(composeTestRule.onNodeWithTag(LABEL_REFERENCE_TAG, useUnmergedTree = true))
+
+        label shouldBe unconstrained
+    }
+
     @Test
     fun `the item is labelled with the workspace title`() {
         renderItem(paneIndex = null)
@@ -248,5 +278,7 @@ class WorkspaceRailItemTest : ComposeTest() {
         private const val LABEL_REFERENCE_TAG = "workspace.rail.item.label.reference"
 
         private val ITEM_MIN_HEIGHT = 56.dp
+
+        private val RAIL_THICKNESS = 80.dp
     }
 }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailPlacementTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailPlacementTest.kt
@@ -1,0 +1,158 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceNavigationRailDefaults
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+
+/**
+ * Which window edge the rail lands on is decided by [rememberWorkspaceDesign] from the window's
+ * orientation, so the whole screen is driven rather than the layout below it: [AdaptiveWorkspaceLayout]
+ * takes the design as a parameter and never reads the configuration itself, and Robolectric's default
+ * compact width resolves to SINGLE, which composes no rail at all.
+ *
+ * The rail's height is asserted as well as its edge: it is the unweighted child of the layout's
+ * column, so a descendant that fills the height it is offered would take the whole window and leave
+ * the panes measuring zero - a rail on the right edge with nothing above it.
+ */
+class WorkspaceRailPlacementTest : ComposeTest() {
+
+    private val firstTab = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "Explorer".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    private val secondTab = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "Downloads".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    /** The real page instantiates Hilt ViewModels; this one only marks out the pane's bounds. */
+    private object PaneMarkerHost : WorkspacePageHostEntry {
+        @Composable
+        override fun Content(id: Workspace.Id, design: WorkspaceDesign) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(PANE_TAG),
+            )
+        }
+
+        @Composable
+        override fun Overlays(id: Workspace.Id, design: WorkspaceDesign) = Unit
+    }
+
+    private fun state() = WorkspacesViewModel.State(
+        state = WorkspaceRemote.State(
+            infos = listOf(firstTab, secondTab),
+            // Explicit per orientation: an AUTO mode would resolve by window size and could hand
+            // both cases the same layout, which is not what is under test.
+            portraitPanelMode = WorkspacePanelMode.DUAL_HORIZONTAL,
+            landscapePanelMode = WorkspacePanelMode.DUAL_VERTICAL,
+        ),
+        focusedWorkspace = firstTab.id,
+        selectedWorkspaces = mapOf(0 to firstTab.id, 1 to secondTab.id),
+        visiblePaneSelections = mapOf(0 to firstTab.id, 1 to secondTab.id),
+        isUpgraded = true,
+        swipeGesturesEnabled = false,
+        onDemandWorkspaceCreation = false,
+    )
+
+    private fun setScreen() {
+        // The Butler button's mascot animates on an endless loop, which never lets the clock idle.
+        // Nothing asserted here needs frames.
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalWorkspacePageHosts provides mapOf(Workspace.Type.EXPLORER to PaneMarkerHost),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(ROOT_TAG),
+                    ) {
+                        WorkspaceScreen(
+                            state = state(),
+                            managerDialogStates = emptyMap(),
+                            onScreenAction = {},
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun assertEveryPaneHasHeight() {
+        val panes = composeTestRule.onAllNodesWithTag(PANE_TAG, useUnmergedTree = true)
+        panes.assertCountEquals(2)
+        repeat(2) { index ->
+            val bounds = panes[index].getUnclippedBoundsInRoot()
+            (bounds.bottom - bounds.top > 0.dp) shouldBe true
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "w720dp-h1280dp-port")
+    fun `a portrait window puts the rail along the bottom edge`() {
+        setScreen()
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val rail = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+
+        rail.bottom shouldBe root.bottom
+        rail.left shouldBe root.left
+        rail.right shouldBe root.right
+        (rail.top > root.top) shouldBe true
+
+        assertEveryPaneHasHeight()
+    }
+
+    @Test
+    @Config(qualifiers = "w1280dp-h720dp-land")
+    fun `a landscape window keeps the rail on the start edge`() {
+        setScreen()
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val rail = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+
+        rail.left shouldBe root.left
+        rail.top shouldBe root.top
+        rail.bottom shouldBe root.bottom
+        (rail.right < root.right) shouldBe true
+
+        assertEveryPaneHasHeight()
+    }
+
+    companion object {
+        private const val ROOT_TAG = "rail.placement.root"
+        private const val PANE_TAG = "rail.placement.pane"
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailUndoBarClearanceTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailUndoBarClearanceTest.kt
@@ -1,0 +1,156 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import android.view.View
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onParent
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.undo.ClosedWorkspaceFeedback
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The close-undo bar is drawn outside every pane, so nothing about the layout keeps it off the
+ * navigation rail. In the bottom placement it has to clear the rail's measured height - measured,
+ * because the entries grow with the font scale - and it must not add the navigation bar inset on top
+ * of it, which the rail has already padded for.
+ *
+ * The thickness is injected rather than produced by a real rail: font scale cannot drive it here
+ * (Robolectric's stub font reports one fixed height whatever the scale, see `WorkspaceRailItemTest`),
+ * so an oversized rail stands in for a scaled-up one.
+ *
+ * The environment supplies no window insets of its own, so a navigation bar is dispatched to the
+ * compose view; without it the inset case cannot be told from the no-inset one.
+ */
+class WorkspaceRailUndoBarClearanceTest : ComposeTest() {
+
+    private val feedback = ClosedWorkspaceFeedback(
+        closeToken = 1L,
+        customTitle = null,
+        automaticTitle = "Downloads".toCaString(),
+    )
+
+    private fun renderHost(bottomRailVisible: Boolean, railThickness: Dp): Density {
+        var view: View? = null
+        lateinit var density: Density
+
+        composeTestRule.setContent {
+            view = LocalView.current
+            density = LocalDensity.current
+            PreviewWrapper {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(ROOT_TAG),
+                ) {
+                    WorkspaceClosedUndoBarHost(
+                        feedback = feedback,
+                        startRailVisible = false,
+                        bottomRailVisible = bottomRailVisible,
+                        railThickness = railThickness,
+                        onUndo = {},
+                        onDismiss = {},
+                    )
+                    if (bottomRailVisible) {
+                        // Stands in for the rail the bar has to stay clear of
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                .height(railThickness)
+                                .testTag(RAIL_TAG),
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.runOnUiThread {
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars(),
+                    Insets.of(0, 0, 0, NAV_INSET_PX),
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(view!!, insets)
+        }
+        composeTestRule.waitForIdle()
+
+        return density
+    }
+
+    private fun barBottom() = composeTestRule.onNodeWithText(MESSAGE)
+        .onParent()
+        .getUnclippedBoundsInRoot()
+        .bottom
+
+    @Test
+    fun `a rail taller than its nominal thickness still gets cleared`() {
+        val density = renderHost(bottomRailVisible = true, railThickness = SCALED_RAIL)
+        val navInset = with(density) { NAV_INSET_PX.toDp() }
+
+        val railTop = composeTestRule.onNodeWithTag(RAIL_TAG).getUnclippedBoundsInRoot().top
+
+        (barBottom() <= railTop) shouldBe true
+        // The rail's height already contains the navigation bar inset, so the gap above it stays
+        // smaller than that inset instead of counting it a second time.
+        ((railTop - barBottom()) < navInset) shouldBe true
+    }
+
+    @Test
+    fun `a rail at its nominal thickness gets cleared`() {
+        val density = renderHost(bottomRailVisible = true, railThickness = NOMINAL_RAIL)
+        val navInset = with(density) { NAV_INSET_PX.toDp() }
+
+        val railTop = composeTestRule.onNodeWithTag(RAIL_TAG).getUnclippedBoundsInRoot().top
+
+        (barBottom() <= railTop) shouldBe true
+        ((railTop - barBottom()) < navInset) shouldBe true
+    }
+
+    @Test
+    fun `without a bottom rail the bar keeps its navigation bar inset`() {
+        val density = renderHost(bottomRailVisible = false, railThickness = NOMINAL_RAIL)
+        val navInset = with(density) { NAV_INSET_PX.toDp() }
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val fromBottom = root.bottom - barBottom()
+
+        (fromBottom >= navInset) shouldBe true
+        // ...and nothing beyond it: no rail padding is taken when there is no rail
+        (fromBottom < NOMINAL_RAIL) shouldBe true
+    }
+
+    companion object {
+        private const val ROOT_TAG = "undo.root"
+        private const val RAIL_TAG = "undo.rail"
+
+        private const val MESSAGE = "Closed \"Downloads\""
+
+        private val NOMINAL_RAIL = 80.dp
+
+        /** What a large font scale makes of the rail on a device */
+        private val SCALED_RAIL = 140.dp
+
+        /** Stand-in for a gesture bar */
+        private const val NAV_INSET_PX = 36
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailPlacementRevealTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailPlacementRevealTest.kt
@@ -1,0 +1,151 @@
+package eu.darken.butler.workspace.ui.workspaces.adaptive
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+
+/**
+ * The two rail placements have viewports of very different length: on a phone-sized window the start
+ * edge shows the whole tab list at once, the bottom edge shows three entries. An entry that was
+ * comfortably on screen along one axis can therefore be far outside the other without focus or tab
+ * order changing, so the reveal has to run against the axis the rail actually ended up on.
+ */
+@Config(qualifiers = "w411dp-h891dp")
+class WorkspaceRailPlacementRevealTest : ComposeTest() {
+
+    private val tabs = (0 until TAB_COUNT).map {
+        Workspace.Info(
+            id = Workspace.Id(),
+            type = Workspace.Type.EXPLORER,
+            title = title(it).toCaString(),
+            lifecycleState = Workspace.LifecycleState.Ready,
+        )
+    }
+
+    private val focusedTab = tabs.last()
+    private val focusedTitle = title(TAB_COUNT - 1)
+
+    private var placement by mutableStateOf(WorkspaceDesign.RailPlacement.START)
+
+    private fun setRail() {
+        // The mascot on the Butler button animates on an endless loop, which never lets the clock idle.
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    WorkspaceNavigationRail(
+                        modifier = Modifier.align(
+                            when (placement) {
+                                WorkspaceDesign.RailPlacement.START -> Alignment.CenterStart
+                                WorkspaceDesign.RailPlacement.BOTTOM -> Alignment.BottomCenter
+                            },
+                        ),
+                        workspaces = tabs,
+                        selected = emptyMap(),
+                        focusedId = focusedTab.id,
+                        design = WorkspaceDesign(
+                            layout = WorkspaceDesign.Layout.DUAL_HORIZONTAL,
+                            railPlacement = placement,
+                        ),
+                        onTabAction = {},
+                        onPaneAssignment = { _, _ -> },
+                        onPaneUnassign = {},
+                    )
+                }
+            }
+        }
+        settle()
+    }
+
+    /** Enough frames for a reveal animation to run to completion, without an auto-advancing clock. */
+    private fun settle(rounds: Int = 30) {
+        repeat(rounds) {
+            composeTestRule.mainClock.advanceTimeBy(64)
+            composeTestRule.waitForIdle()
+        }
+    }
+
+    private fun focusedEntry() = composeTestRule.onAllNodesWithTag(ITEM_TAG).filter(hasText(focusedTitle))
+
+    private fun listBounds() = composeTestRule.onNodeWithTag(LIST_TAG).getUnclippedBoundsInRoot()
+
+    private fun describeFocusedEntry(): String {
+        val list = listBounds()
+        val entries = focusedEntry()
+        if (entries.fetchSemanticsNodes().isEmpty()) {
+            return "it is not composed at all, and the list spans " + list.left + " to " + list.right
+        }
+        val bounds = entries[0].getUnclippedBoundsInRoot()
+        return "it spans " + bounds.left + " to " + bounds.right +
+            " while the list spans " + list.left + " to " + list.right
+    }
+
+    private fun focusedEntryIsInsideList(): Boolean {
+        val list = listBounds()
+        val entries = focusedEntry()
+        if (entries.fetchSemanticsNodes().isEmpty()) return false
+        val bounds = entries[0].getUnclippedBoundsInRoot()
+        if (bounds.left.value.compareTo(list.left.value) < 0) return false
+        return bounds.right.value.compareTo(list.right.value) <= 0
+    }
+
+    /**
+     * The control: the focused entry is the last of [TAB_COUNT] and the start-edge list fits every
+     * one of them, so nothing has to scroll for it to be on screen. Without this the horizontal case
+     * would prove nothing - an entry already out of view before the switch could be left out of view
+     * for reasons that have nothing to do with the placement.
+     */
+    @Test
+    fun `the last tab is already on screen along the start edge`() {
+        setRail()
+
+        val list = listBounds()
+        val entry = focusedEntry()[0].getUnclippedBoundsInRoot()
+
+        withClue("The vertical rail has to fit every tab for the horizontal case to mean anything") {
+            (entry.top.value.compareTo(list.top.value) >= 0) shouldBe true
+            (entry.bottom.value.compareTo(list.bottom.value) <= 0) shouldBe true
+        }
+    }
+
+    @Test
+    fun `switching to the bottom edge reveals the focused tab on the new axis`() {
+        setRail()
+
+        composeTestRule.runOnIdle { placement = WorkspaceDesign.RailPlacement.BOTTOM }
+        settle()
+
+        withClue(
+            "Focused tab " + focusedTitle + " should have been scrolled into the viewport of the " +
+                "bottom rail, but " + describeFocusedEntry(),
+        ) {
+            focusedEntryIsInsideList() shouldBe true
+        }
+    }
+
+    companion object {
+        private const val TAB_COUNT = 10
+        private const val ITEM_TAG = WorkspaceNavigationRailDefaults.ITEM_TEST_TAG
+        private const val LIST_TAG = WorkspaceNavigationRailDefaults.LIST_TEST_TAG
+
+        private fun title(index: Int) = "Tab" + index
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailReorderTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailReorderTest.kt
@@ -1,0 +1,115 @@
+package eu.darken.butler.workspace.ui.workspaces.adaptive
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * Reordering has to keep working when the list runs along the other axis: the rail hands the generic
+ * reorderable state a `LazyRow` instead of a `LazyColumn` and relies on it taking the orientation
+ * from the list's own layout info, so nothing here is axis-specific except the direction of the drag.
+ */
+class WorkspaceRailReorderTest : ComposeTest() {
+
+    private fun tab(title: String) = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = title.toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    private val tabs = listOf(tab("One"), tab("Two"), tab("Three"))
+
+    private val actions = mutableListOf<WorkspaceAction>()
+
+    private fun setRail() {
+        // The Butler button's mascot animates on an endless loop, which never lets the clock idle.
+        // The gesture below advances the clock itself, so it does not need the automatic advance.
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    WorkspaceNavigationRail(
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                        workspaces = tabs,
+                        selected = emptyMap(),
+                        focusedId = null,
+                        design = WorkspaceDesign(
+                            layout = WorkspaceDesign.Layout.DUAL_HORIZONTAL,
+                            railPlacement = WorkspaceDesign.RailPlacement.BOTTOM,
+                        ),
+                        onTabAction = { actions += it },
+                        onPaneAssignment = { _, _ -> },
+                        onPaneUnassign = {},
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun advanceFrames(count: Int = 5) {
+        repeat(count) {
+            composeTestRule.mainClock.advanceTimeByFrame()
+            composeTestRule.waitForIdle()
+        }
+    }
+
+    @Test
+    fun `dragging an entry sideways reorders the tabs`() {
+        setRail()
+
+        val entries = composeTestRule.onAllNodesWithTag(ITEM_TAG)
+        entries.assertCountEquals(3)
+        val first = entries[0].getUnclippedBoundsInRoot()
+        // Measured rather than assumed: what an entry has to travel to change places with the next
+        // one is the distance between two entries, spacing included.
+        val pitch = entries[1].getUnclippedBoundsInRoot().left - first.left
+        val pitchPx = with(composeTestRule.density) { pitch.toPx() }
+
+        composeTestRule.onAllNodesWithTag(ITEM_TAG)[0].performTouchInput {
+            // The drag handle is the entry's icon, which sits above the label.
+            down(Offset(width / 2f, height * 0.25f))
+            advanceEventTime(viewConfiguration.longPressTimeoutMillis + 100)
+        }
+        advanceFrames()
+
+        // Past the second entry's centre but well short of the third's, so the entry ends up in the
+        // middle rather than at the end.
+        val list = composeTestRule.onNodeWithTag(LIST_TAG)
+        repeat(2) {
+            list.performTouchInput {
+                moveBy(Offset(pitchPx * 0.55f, 0f))
+                advanceEventTime(50)
+            }
+            advanceFrames()
+        }
+
+        list.performTouchInput { up() }
+        advanceFrames()
+
+        val reorders = actions.filterIsInstance<WorkspaceAction.Reorder>()
+        reorders.isNotEmpty() shouldBe true
+        reorders.last().ownerIds shouldBe listOf(tabs[1].id, tabs[0].id, tabs[2].id)
+    }
+
+    companion object {
+        private const val ITEM_TAG = WorkspaceNavigationRailDefaults.ITEM_TEST_TAG
+        private const val LIST_TAG = WorkspaceNavigationRailDefaults.LIST_TEST_TAG
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailReorderTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailReorderTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.ui.workspaces.adaptive
 
+import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
@@ -7,9 +8,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.Workspace
@@ -17,6 +21,7 @@ import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import io.kotest.matchers.shouldBe
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.ComposeTest
 
 /**
@@ -24,6 +29,11 @@ import testhelpers.ComposeTest
  * reorderable state a `LazyRow` instead of a `LazyColumn` and relies on it taking the orientation
  * from the list's own layout info, so nothing here is axis-specific except the direction of the drag.
  */
+// A portrait phone rather than Robolectric's 320dp default, and load-bearing: the list is what is
+// left of the window after the Butler button and the FAB, and the reorderable library turns a drag
+// within 48dp of either end of it into an edge scroll instead of a swap. At 320dp those two bands
+// leave no room between them.
+@Config(qualifiers = "w411dp-h891dp")
 class WorkspaceRailReorderTest : ComposeTest() {
 
     private fun tab(title: String) = Workspace.Info(
@@ -36,6 +46,10 @@ class WorkspaceRailReorderTest : ComposeTest() {
     private val tabs = listOf(tab("One"), tab("Two"), tab("Three"))
 
     private val actions = mutableListOf<WorkspaceAction>()
+
+    private val dragDescription: String
+        get() = ApplicationProvider.getApplicationContext<Context>()
+            .getString(R.string.workspace_dragging_description)
 
     private fun setRail() {
         // The Butler button's mascot animates on an endless loop, which never lets the clock idle.
@@ -61,6 +75,11 @@ class WorkspaceRailReorderTest : ComposeTest() {
             }
         }
         composeTestRule.waitForIdle()
+        // The reorderable state is remembered on the list's orientation, and a LazyRow reports
+        // Vertical until its first layout has been observed. Settling that here matters: the
+        // recomposition it causes rebuilds the state object, and a state rebuilt under the finger
+        // restarts the drag handle's gesture detector and swallows the long press.
+        advanceFrames()
     }
 
     private fun advanceFrames(count: Int = 5) {
@@ -82,20 +101,29 @@ class WorkspaceRailReorderTest : ComposeTest() {
         val pitch = entries[1].getUnclippedBoundsInRoot().left - first.left
         val pitchPx = with(composeTestRule.density) { pitch.toPx() }
 
+        var longPressMs = 0L
         composeTestRule.onAllNodesWithTag(ITEM_TAG)[0].performTouchInput {
+            longPressMs = viewConfiguration.longPressTimeoutMillis
             // The drag handle is the entry's icon, which sits above the label.
             down(Offset(width / 2f, height * 0.25f))
-            advanceEventTime(viewConfiguration.longPressTimeoutMillis + 100)
         }
+        // The handle waits out the long press on the composition clock, not on the timestamps the
+        // events carry, so only advancing the clock here lets the press mature into a drag.
+        composeTestRule.mainClock.advanceTimeBy(longPressMs + 100)
         advanceFrames()
+        // The entry swaps its type icon for the drag handle once the lift is under way, so this
+        // fails loudly if the gesture below ends up dragging nothing.
+        composeTestRule.onAllNodesWithContentDescription(dragDescription).assertCountEquals(1)
 
+        // Addressed on the list, not on the entry: the entry that started the gesture changes index
+        // as the reorder takes effect, while the pointer stays with the handler the down hit.
+        val list = composeTestRule.onNodeWithTag(LIST_TAG)
         // Past the second entry's centre but well short of the third's, so the entry ends up in the
         // middle rather than at the end.
-        val list = composeTestRule.onNodeWithTag(LIST_TAG)
         repeat(2) {
             list.performTouchInput {
                 moveBy(Offset(pitchPx * 0.55f, 0f))
-                advanceEventTime(50)
+                advanceEventTime(16)
             }
             advanceFrames()
         }


### PR DESCRIPTION
## What changed

In portrait, the tab rail now runs along the bottom edge instead of standing as a vertical strip down the left side. Both panes get that width back.

It is the same rail as before, just along the other axis: the tab list, drag-to-reorder, the pane assignment menu, close and rename, the Butler button and add-tab all behave as they did. Landscape is unchanged.

While the keyboard is open the rail stays behind it and reappears when the keyboard closes.

## Technical Context

- Pane keyboard tracking was gated on a pane owning the bottom system bar inset. Clearing that edge to make room for the rail would have silently switched off the Editor's keyboard avoidance, so the IME inset no longer depends on that gate: a pane-scoped composition local carries the rail's measured thickness and the keyboard inset is reduced by it. Only the pane that would otherwise touch the bottom edge gets a non-zero value, so a top pane in a stacked layout still receives none. This is the part worth reviewing closely.
- The close-undo bar offsets by the rail's measured height rather than a constant, because in this placement the rail's cross axis is the item height and grows with font scale. Checked on a device: at font scale 2.0 the rail grows from 113px to 168px and the clearance narrows from 46px to 24px, which a constant offset could not do.
- Material 3's `VerticalDivider` applies `fillMaxHeight`. The rail is the unweighted child of the layout's column and is measured against the full remaining window height, so that divider could have claimed the whole window and left the panes at zero height. The bottom separator is a sized `Box` instead.
- Placement is derived from the window orientation and carried on the design object, so a single-pane portrait window carries it too even though it composes no rail. Every consumer therefore gates on rail visibility rather than on placement alone, which is what keeps the undo bar's navigation bar inset correct where no rail exists.
- Known gap: the committed English Play Store screenshots under `fastlane/metadata` still show the old left-edge rail. The code that renders them was updated, but the images themselves need regenerating before the next release.
