### PR TITLE
Editor: Say why a file can't be edited instead of calling it binary

### DIFF
--- a/app-workspace-editor/src/main/res/values/strings.xml
+++ b/app-workspace-editor/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="editor_backup_banner_message">A backup from an interrupted save was found:\n%1$s</string>
 
     <!-- Binary file notice -->
-    <string name="editor_binary_banner_message">Binary file — read-only view</string>
+    <string name="editor_binary_banner_message">Editing as text isn\'t supported</string>
 
     <!-- Long-lines notice -->
     <string name="editor_long_lines_banner_title">Very long lines</string>
@@ -102,7 +102,7 @@
     <string name="editor_error_paste_too_large_label">File too large</string>
     <string name="editor_error_paste_too_large">This file is too large to paste (max %1$s).</string>
     <string name="editor_error_paste_binary_label">Not a text file</string>
-    <string name="editor_error_paste_binary">Binary file content can\'t be pasted.</string>
+    <string name="editor_error_paste_binary">This file\'s content can\'t be pasted as text.</string>
     <plurals name="editor_search_results_x_of_y">
         <item quantity="one">%1$d of %2$d result</item>
         <item quantity="other">%1$d of %2$d results</item>

--- a/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/elements/EditorBannerGroupTest.kt
+++ b/app-workspace-editor/src/test/java/eu/darken/butler/editor/ui/editor/elements/EditorBannerGroupTest.kt
@@ -105,7 +105,7 @@ class EditorBannerGroupTest : ComposeTest() {
         composeTestRule.onNodeWithText("Disk full").assertExists()
         composeTestRule.onNodeWithText("File changed on disk").assertExists()
         composeTestRule.onNodeWithText("notes.txt.butler-save-bak-1a2b3c4d", substring = true).assertExists()
-        composeTestRule.onNodeWithText("Binary file — read-only view").assertExists()
+        composeTestRule.onNodeWithText("Editing as text isn't supported").assertExists()
         composeTestRule.onAllNodesWithContentDescription("Dismiss").assertCountEquals(2)
     }
 
@@ -121,7 +121,7 @@ class EditorBannerGroupTest : ComposeTest() {
         setGroup()
 
         composeTestRule.onAllNodesWithContentDescription("Dismiss").assertCountEquals(0)
-        composeTestRule.onNodeWithText("Binary file — read-only view").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Editing as text isn't supported").assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
## What changed

Opening a file the Editor can't edit as text (a PDF, for example) showed a banner reading "Binary file — read-only view". It named a category instead of giving a reason, in vocabulary aimed at developers rather than at someone looking at their own file.

The banner now says what the Editor won't do: "Editing as text isn't supported". The paste error moves off the same word, becoming "This file's content can't be pasted as text."

## Technical Context

- The banner dropped its "read-only view" half rather than rewording it. The infobar already renders a Read-only chip whenever the document is read-only, and `isBinary` implies `isReadOnly`, so that half was duplicated on screen.
- Naming the file's type ("PDF document") was considered and rejected. The tab title is already the file name, so the label would repeat what the user can see, and it could only ever fire where the extension already names a known non-text type.
- Wording that asserts the file is not text was rejected because the detector can't support it. `ContentSource.File.isLikelyBinary` is a NUL scan of the first 8192 bytes, and `DocumentBufferEncodingRoundTripTest` pins a BOM-less UTF-16 file that is genuinely text and still gets flagged.
- `editor_error_paste_binary_label` keeps its existing "Not a text file" wording, and `ReadOnlyFileException`'s messages keep the word "binary". Those messages are internal and never reach the user, whose surface is `editor_infobar_read_only` and `editor_error_read_only`.
- Separate from this change: `FileDataSource` classifies with the NUL scan alone while the paste path also applies `TextDecoder.looksBinary`, so a file with no NUL in its first 8 KB opens editable. Worth its own look.
