### PR TITLE
IO: Stop reporting non-permission file errors as "Permission denied"

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifier.kt
@@ -54,12 +54,11 @@ object PermissionErrorClassifier {
             when (t) {
                 // A path that isn't there is not a path we were kept out of. Keyed on the marker
                 // rather than one concrete type, so a gone-error that is also a PathException does
-                // not fall through to the denial below. Like every branch in this loop it answers
-                // for the first chain link that matches, so a marker nested UNDER a generic
-                // PathException wrapper does not veto - the wrapper is reached first. No producer
-                // wraps one today; both are thrown at the top level.
+                // not fall through to the denial below.
                 is PathGoneError -> return null
-                is PathException -> return Reason.ACCESS_DENIED
+                // A wrapper with a cause carries no verdict of its own; the cause answers for itself
+                // further down the chain. Only a bare wrapper is read as a denial.
+                is PathException -> if (t.cause == null) return Reason.ACCESS_DENIED
                 is SecurityException -> return Reason.ACCESS_DENIED
                 is java.nio.file.AccessDeniedException -> return Reason.ACCESS_DENIED
                 is kotlin.io.AccessDeniedException -> return Reason.ACCESS_DENIED
@@ -76,6 +75,8 @@ object PermissionErrorClassifier {
             "read-only file system" in haystack -> Reason.READONLY_FILESYSTEM
             "operation not permitted" in haystack -> Reason.NOT_PERMITTED
             "permission" in haystack -> Reason.ACCESS_DENIED
+            // A nested nio denial crosses IPC as its toString(), see IpcErrorCodec.
+            haystack.startsWith("java.nio.file.accessdeniedexception") -> Reason.ACCESS_DENIED
             else -> null
         }
     }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
@@ -681,8 +681,8 @@ class SAFFileSystemOps @Inject constructor(
         return try {
             log(TAG, VERBOSE) { "file(readWrite=$readWrite): $path" }
 
-            if (readWrite && !canWrite(path)) throw IOException("writable=false")
-            else if (!canRead(path)) throw IOException("readable=false")
+            if (readWrite && !canWrite(path)) throw IOException("Permission denied: writable=false")
+            else if (!canRead(path)) throw IOException("Permission denied: readable=false")
 
             val pfd = openPFD(path, if (readWrite) FileMode.READ_WRITE else FileMode.READ)
             pfd.toFileHandle(readWrite)

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFGateway.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFGateway.kt
@@ -146,8 +146,8 @@ class SAFGateway @Inject constructor(
         try {
             log(TAG, VERBOSE) { "file(readWrite=$readWrite): $path" }
 
-            if (readWrite && !fileSystemOps.canWrite(path)) throw IOException("writable=false")
-            else if (!fileSystemOps.canRead(path)) throw IOException("readable=false")
+            if (readWrite && !fileSystemOps.canWrite(path)) throw IOException("Permission denied: writable=false")
+            else if (!fileSystemOps.canRead(path)) throw IOException("Permission denied: readable=false")
 
             val pfd = fileSystemOps.openPFD(path, if (readWrite) FileMode.READ_WRITE else FileMode.READ)
             pfd.toFileHandle(readWrite)

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/permissions/PermissionErrorClassifierTest.kt
@@ -185,16 +185,90 @@ class PermissionErrorClassifierTest : BaseTest() {
     }
 
     @Test
-    fun `a gone marker nested under a generic wrapper does not veto`() {
-        // Documents the limit rather than endorsing it: pass 4 answers for the first matching chain
-        // link, and the ReadException wrapper is reached before the marker underneath it. Nothing
-        // wraps a gone-error today; if something starts to, this is the test that will say so.
+    fun `a gone marker nested under a generic wrapper still vetoes`() {
         val wrapped = ReadException(
             path = LocalPath.build("/sdcard/gone.txt"),
             cause = PathNotFoundException(LocalPath.build("/sdcard/gone.txt")),
         )
 
+        PermissionErrorClassifier.classify(wrapped) shouldBe null
+    }
+
+    @Test
+    fun `a wrapper defers to a cause the kernel named as something other than a denial`() {
+        listOf(
+            "Is a directory",
+            "Not a directory",
+            "Directory not empty",
+            "File name too long",
+            "Device or resource busy",
+            "Too many levels of symbolic links",
+            "Too many open files",
+            "No such file or directory",
+            "File too large",
+            "Invalid argument",
+        ).forEach { errno ->
+            val wrapped = WriteException(path = LocalPath.build("/sdcard/foo"), cause = IOException(errno))
+
+            PermissionErrorClassifier.classify(wrapped) shouldBe null
+        }
+    }
+
+    @Test
+    fun `a wrapper defers to a typed denial underneath it`() {
+        val nio = WriteException(
+            path = LocalPath.build("/sdcard/foo"),
+            cause = java.nio.file.AccessDeniedException("/sdcard/foo"),
+        )
+        val security = ReadException(
+            path = LocalPath.build("/sdcard/foo"),
+            cause = SecurityException("not allowed"),
+        )
+
+        PermissionErrorClassifier.classify(nio) shouldBe Reason.ACCESS_DENIED
+        PermissionErrorClassifier.classify(security) shouldBe Reason.ACCESS_DENIED
+    }
+
+    @Test
+    fun `a wrapper defers to a nio denial that lost its type on the way over IPC`() {
+        // IpcErrorCodec rebuilds every nested cause as an IOException carrying the original toString().
+        val wrapped = WriteException(
+            path = LocalPath.build("/data/x"),
+            cause = IOException("java.nio.file.AccessDeniedException: /data/x"),
+        )
+
         PermissionErrorClassifier.classify(wrapped) shouldBe Reason.ACCESS_DENIED
+    }
+
+    @Test
+    fun `a path named after the nio denial does not become one`() {
+        val wrapped = WriteException(
+            path = LocalPath.build("/sdcard/AccessDeniedException"),
+            cause = IOException("Is a directory"),
+        )
+
+        PermissionErrorClassifier.classify(wrapped) shouldBe null
+    }
+
+    @Test
+    fun `a bare wrapper keeps its verdict when wrapped again`() {
+        val rewrapped = WriteException(
+            path = LocalPath.build("/sdcard/foo"),
+            cause = WriteException(path = LocalPath.build("/sdcard/foo")),
+        )
+
+        PermissionErrorClassifier.classify(rewrapped) shouldBe Reason.ACCESS_DENIED
+    }
+
+    @Test
+    fun `a wrapper around an unnamed failure is not a denial`() {
+        val wrapped = WriteException(
+            path = LocalPath.build("/sdcard/foo"),
+            cause = RuntimeException("injected failure"),
+        )
+
+        PermissionErrorClassifier.classify(wrapped) shouldBe null
+        PermissionErrorClassifier.isPermissionError(wrapped) shouldBe false
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
@@ -13,6 +13,7 @@ import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.files.permissions.PermissionErrorClassifier
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -219,6 +220,20 @@ class SAFFileSystemOpsTest : BaseTest() {
         })
 
         fileSystemOps.existsStrict(path) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `a document the provider marks read-only is a permission failure`() = runTest {
+        val path = SAFPath.build(testTreeUri, "readonly.txt")
+        val docFile = mockk<SAFDocFile> {
+            every { writable } returns false
+            every { readable } returns true
+        }
+        coEvery { mockLocationManager.getDocFileFor(path) } returns docFile
+
+        val error = shouldThrow<ReadException> { fileSystemOps.file(path, readWrite = true) }
+
+        PermissionErrorClassifier.isPermissionError(error) shouldBe true
     }
 
     companion object {


### PR DESCRIPTION
## What changed

A copy, move or delete that fails for a reason other than access (writing a file over a folder, a name that is too long for the file system, a file too large for an SD card, a folder that is not empty, and similar) was reported as "Permission denied", with a Setup hint instead of Retry. These failures now get the regular error sheet with Retry, and the final error of a failed operation is no longer relabelled as a denial.

Real denials are unchanged, including denials reported by the root/ADB host and documents a storage provider marks read-only.

## Technical Context

- Root cause: classifier pass 4 answered ACCESS_DENIED for any `PathException` in the cause chain, and the local file-system layer wraps every failure in one. The five-string non-denial list added in 3658dd54e was an allowlist against the errno table; ten realistic errnos still fell through.
- A wrapper with a cause now defers to that cause; a bare wrapper still reads as a denial. A survey of all 152 construction sites found one bare site that plausibly is a denial (the lookup fallback for a present file no probe can read), so the bare verdict was left alone rather than removed.
- Two denial shapes silently depended on the wrapper verdict and needed their own coverage: a nested nio `AccessDeniedException` arrives over IPC as an `IOException` carrying its `toString()`, and the SAF `file()` refusal used the message `writable=false`. Both are covered by new tests; the SAF one is pinned at the producer.
- Escalation is not affected: routed copy/move/delete plan access per path before running, synchronous lookups escalate on any `IOException`, and only `create()` consults the classifier first.
- Review focus: the `startsWith` anchor in pass 2 and the flipped test for a gone marker nested under a wrapper.
