### PR TITLE
Workspace: Show the end of a tab's path in the navigation rail

### DIFF
--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -623,7 +623,7 @@ internal fun WorkspaceRailItem(
                     style = MaterialTheme.typography.labelSmall,
                     textAlign = TextAlign.Center,
                     maxLines = 1,
-                    overflow = TextOverflow.MiddleEllipsis,
+                    overflow = TextOverflow.StartEllipsis,
                 )
             }
         }


### PR DESCRIPTION
## What changed

In multi-pane the navigation rail is the only tab list that stays on screen, and an Explorer tab is named after the folder it shows. The rail has room for about one short line, and it used to drop the middle of that name while keeping the beginning. Every path on a device starts the same way, so a Downloads tab and a Music tab both showed the same truncated stub and there was no way to tell them apart.

The rail now keeps the end of the name instead, which is the part that says which folder the tab is on.

Tabs on folders that share a name, `/a/backup` and `/b/backup`, still look alike. Renaming a tab is still the way to separate those.

## Technical Context

- The change is the `overflow` argument on the rail entry's label in `WorkspaceNavigationRail.kt`, from `TextOverflow.MiddleEllipsis` to `TextOverflow.StartEllipsis`. Nothing else changes.
- A `Directory` navigation target publishes `path.userReadablePath` as its label, so the rail draws a full path in roughly 64dp of width (80dp rail, 8dp inset per side). Middle ellipsis preserves the head of that string, which is identical for every path on the device, which is why the label carried no information.
- The workspace manager's card info bar and Explorer's collapsed breadcrumb label already use `StartEllipsis` for the same kind of string. This brings the rail in line with them rather than introducing a new convention.
- Workspace identity is deliberately untouched: no change to `Info.title`, `displayTitle`, or Explorer's navigation target labels, so the rename placeholder, the close confirmation and the undo bar keep the full path. Demoting the path to a subtitle was considered and rejected, since the rail draws no subtitle and `LocalPath.name` yields `0` for `/storage/emulated/0`.
- No test accompanies this. Nothing in the repository asserts a `TextOverflow` value at any of its roughly thirty sites, and Robolectric cannot draw, so an assertion here would pin a configuration token rather than the rendered result.
