### PR TITLE
Viewer: Remove the inert eye icon from the toolbar

### DIFF
--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCard.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -34,7 +35,6 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.viewer.R
 import eu.darken.butler.workspace.core.Workspace
-import eu.darken.butler.workspace.core.icon
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
@@ -64,8 +64,15 @@ fun ViewerToolbarCard(
         label = "cardPadding",
     )
 
+    val minHeight by animateDpAsState(
+        targetValue = if (isCollapsed) WorkspaceButtonDefaults.sizeCompact else WorkspaceButtonDefaults.sizeDefault,
+        label = "minHeight",
+    )
+
     CutoutCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .requiredHeightIn(min = minHeight),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(
@@ -88,12 +95,6 @@ fun ViewerToolbarCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 onBackClick?.let { ViewerBackButton(onClick = it) }
-                Icon(
-                    modifier = Modifier.size(24.dp),
-                    imageVector = Workspace.Type.VIEWER.icon,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
                 Text(
                     modifier = Modifier.weight(1f),
                     text = fileName,
@@ -115,15 +116,8 @@ fun ViewerToolbarCard(
                 ) {
                     onBackClick?.let {
                         ViewerBackButton(onClick = it)
-                        Spacer(modifier = Modifier.width(4.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
                     }
-                    Icon(
-                        modifier = Modifier.size(24.dp),
-                        imageVector = Workspace.Type.VIEWER.icon,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Spacer(modifier = Modifier.width(10.dp))
                     Text(
                         modifier = Modifier.weight(1f),
                         text = fileName,


### PR DESCRIPTION
## What changed

The viewer toolbar no longer shows an eye icon next to the filename. When a file is opened from the Explorer or a search result, the toolbar used to start with a back arrow followed by an eye glyph in the same size and colour, and only the arrow did anything on tap. The row now starts with the back arrow (or nothing, for a viewer tab of its own) and then the filename.

The collapsed toolbar keeps the same height as the other workspaces' toolbars in split-pane layouts, where the compact workspace button isn't there to hold it open.

## Technical Context

- The icon carried no content description and no click handler; it was `Workspace.Type.VIEWER.icon`, the same glyph for every file, and the only place in the app where it rendered inert directly beside a tappable control of the same size and tint.
- Removing it dropped the collapsed row's tallest element (24dp) below the compact workspace button size in the no-cutout layout. The card now pins its minimum height with `requiredHeightIn` to the workspace button size, the same mechanism the Editor and Explorer toolbars already use, rather than a leftover 24dp constant.
- The back-arrow-to-title spacer in the expanded row went from 4dp to 8dp so both rows of the card use the same gap, matching the Saver header.
- Worth a close look: the `requiredHeightIn` floor makes the split-pane collapsed card 4dp taller than before (40dp instead of 36dp), which is the deliberate part of this change beyond the icon removal.
