### PR TITLE
Workspace: Make the rail's "+" open and focus the Templates picker

### DIFF
--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModelTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModelTest.kt
@@ -156,6 +156,7 @@ class WorkspaceButtonViewModelTest : BaseTest() {
         val created = action.captured as WorkspaceAction.Create
         created.type shouldBe Workspace.Type.TEMPLATES
         created.sourceWorkspaceId shouldBe focused
+        created.allowLimitRecovery shouldBe true
         coVerify { workspaceRemote.emitEvent(WorkspaceEvent.SelectionRequested(newId, focused)) }
     }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
@@ -82,6 +82,7 @@ fun AdaptiveWorkspaceLayout(
                 selected = visibleSelected,
                 focusedId = focusedId,
                 onTabAction = { workspaceActionHandler?.executeWorkspaceAction(it) },
+                onAddTab = { workspaceActionHandler?.createTemplatesWorkspace() },
                 onPaneAssignment = { workspaceId, paneIndex ->
                     // Create new selection with the workspace at the specified pane index
                     val currentSelection = selected.toMutableMap()

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -227,6 +227,8 @@ fun WorkspaceNavigationRail(
     focusedId: Workspace.Id?,
     design: WorkspaceDesign = WorkspaceDesign(),
     onTabAction: (WorkspaceAction) -> Unit,
+    /** The "+" was tapped. The rail does not decide what a new tab is. */
+    onAddTab: () -> Unit,
     onPaneAssignment: (workspaceId: Workspace.Id, paneIndex: Int) -> Unit,
     onPaneUnassign: (workspaceId: Workspace.Id) -> Unit,
     onRename: (Workspace.Id) -> Unit = {},
@@ -376,11 +378,7 @@ fun WorkspaceNavigationRail(
         Spacer(modifier = sectionSpacer)
 
         FloatingActionButton(
-            onClick = {
-                onTabAction(
-                    WorkspaceAction.Create()
-                )
-            },
+            onClick = onAddTab,
             modifier = Modifier.size(48.dp),
             containerColor = MaterialTheme.colorScheme.primaryContainer,
         ) {
@@ -1006,6 +1004,7 @@ private fun WorkspaceNavigationRailStates(placement: RailPlacement) {
             railPlacement = placement,
         ),
         onTabAction = {},
+        onAddTab = {},
         onPaneAssignment = { _, _ -> },
         onPaneUnassign = {},
         onPaneMenuToggle = {},

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayoutAddTabTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayoutAddTabTest.kt
@@ -1,0 +1,113 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.manager.FakeWorkspaceButtonProvider
+import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
+import eu.darken.butler.workspace.ui.manager.WorkspaceButtonProvider
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.workspaces.adaptive.DividerPositions
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The rail's "+" and the Butler menu's "New tab" have to issue the same request: the Templates
+ * picker, created from the focused tab, focused, and allowed to recover from the tab limit. Nothing
+ * pinned the "+" before, and the rail file is rewritten often enough for that wiring to be lost
+ * without any other test noticing.
+ */
+class AdaptiveWorkspaceLayoutAddTabTest : ComposeTest() {
+
+    private val tab = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "Explorer".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    private class RecordingButtonProvider : WorkspaceButtonProvider by FakeWorkspaceButtonProvider() {
+        var templatesRequests = 0
+        val actions = mutableListOf<WorkspaceAction>()
+
+        override fun createTemplatesWorkspace() {
+            templatesRequests++
+        }
+
+        override fun executeWorkspaceAction(action: WorkspaceAction) {
+            actions += action
+        }
+    }
+
+    /** Stands in for the real page, which would instantiate Hilt ViewModels. */
+    private object StubPageHost : WorkspacePageHostEntry {
+
+        @Composable
+        override fun Content(id: Workspace.Id, design: WorkspaceDesign) {
+        }
+
+        @Composable
+        override fun Overlays(id: Workspace.Id, design: WorkspaceDesign) {
+        }
+    }
+
+    private val addTabDescription: String
+        get() = ApplicationProvider.getApplicationContext<Context>()
+            .getString(R.string.workspace_add_tab_description)
+
+    private fun setLayout(provider: RecordingButtonProvider) {
+        val pageHosts = mapOf<Workspace.Type, WorkspacePageHostEntry>(
+            Workspace.Type.EXPLORER to StubPageHost,
+        )
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalWorkspacePageHosts provides pageHosts,
+                    LocalWorkspaceButtonProvider provides provider,
+                ) {
+                    AdaptiveWorkspaceLayout(
+                        design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                        workspaces = listOf(tab),
+                        selected = mapOf(0 to tab.asPaneInfo()),
+                        focusedId = tab.id,
+                        dividerPositions = DividerPositions(),
+                        onDividerPositionsChange = {},
+                        showPaneNumbers = false,
+                        showPaneOverlay = false,
+                        onPaneMenuToggle = {},
+                        onScreenAction = {},
+                        managerDialogStates = emptyMap(),
+                        bannerStates = emptyMap(),
+                        onDismissBanner = {},
+                        clickToFocus = true,
+                        onShareError = { _, _ -> },
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `tapping the rail plus opens the templates picker the way the Butler menu does`() {
+        val provider = RecordingButtonProvider()
+        setLayout(provider)
+
+        composeTestRule.onNodeWithContentDescription(addTabDescription).performClick()
+        composeTestRule.waitForIdle()
+
+        provider.templatesRequests shouldBe 1
+        provider.actions.filterIsInstance<WorkspaceAction.Create>() shouldBe emptyList()
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailPlacementRevealTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailPlacementRevealTest.kt
@@ -66,6 +66,7 @@ class WorkspaceRailPlacementRevealTest : ComposeTest() {
                             railPlacement = placement,
                         ),
                         onTabAction = {},
+                        onAddTab = {},
                         onPaneAssignment = { _, _ -> },
                         onPaneUnassign = {},
                     )

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailReorderTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailReorderTest.kt
@@ -68,6 +68,7 @@ class WorkspaceRailReorderTest : ComposeTest() {
                             railPlacement = WorkspaceDesign.RailPlacement.BOTTOM,
                         ),
                         onTabAction = { actions += it },
+                        onAddTab = {},
                         onPaneAssignment = { _, _ -> },
                         onPaneUnassign = {},
                     )


### PR DESCRIPTION
## What changed

In multi-pane layouts, tapping the "+" in the tab rail now opens the "New tab" picker in front of you, the same way the Butler menu's "New tab" does: the picker is focused, placed next to the tab you were on, and the tab-limit dialog can offer to close a tab to make room. Before, with every pane occupied, the picker was created in the background without being shown, so reaching a tool took four taps (tap "+", tap the new rail entry, assign it to a pane, then pick the tool). With a free pane it landed there but did not take focus.

## Technical Context

- Root cause: the rail's "+" issued a bare create request with no source tab, no auto-focus and no limit recovery. The pane placement rule deliberately never evicts for such background creates (batch open, session restore, the tab manager), so a full layout left the picker unassigned.
- The rail stays callback-driven: it gains an `onAddTab` callback, and the adaptive layout, which already holds the button provider, routes it to the provider's templates-picker method. This keeps one encoding of "New tab" instead of a second create request that would bypass the selection event the Butler menu relies on.
- Not changed on purpose: the tab manager's quick-create still does not focus, and closing an unchosen picker still leaves its pane empty (shared with the Butler menu path).
- Review the new layout-level Robolectric test: it taps the "+" through the real layout and asserts the provider route fired once and no bare create was sent. The Butler-menu test now also asserts the limit-recovery flag, which nothing pinned before.
- Verified on a Pixel 7 emulator in landscape with both panes occupied: the picker takes focus, replaces the non-focused pane, and is inserted right after the focused tab in the rail.
