### PR TITLE
Workspace: Give every workspace toolbar the same minimum height

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -27,7 +27,9 @@ Compose UI tests run on Robolectric for fast local execution without an emulator
 
 - No native bitmap (`ImageBitmap()` causes NullPointerException)
 - No drawing (`captureToImage()` deadlocks)
-- Text measurement is inaccurate (fixed height, 1px width per char)
+- Text measurement is inaccurate (line height does not follow the text style, 1px width per char).
+  Annotate the class with `@GraphicsMode(GraphicsMode.Mode.NATIVE)` when an assertion needs real
+  font metrics.
 
 **Use for:** Testing component behavior, clicks, callbacks, content display
 **Not for:** Visual appearance, screenshot comparison, layout pixel precision

--- a/app-common-test/src/main/java/testhelpers/ComposeTest.kt
+++ b/app-common-test/src/main/java/testhelpers/ComposeTest.kt
@@ -12,7 +12,12 @@ import org.robolectric.annotation.Config
  * Known limitations with Robolectric Compose testing:
  * - No native bitmap (ImageBitmap() leads to NullPointerException)
  * - No drawing (captureToImage() deadlocks)
- * - Text measurement is incorrect (fixed ~20px height, 1px width per character)
+ * - Text measurement is synthetic: about 1px of width per character, and a line height that does
+ *   not follow the text style (labelSmall, bodyMedium and titleMedium all measure 36dp).
+ *
+ * A test whose assertion depends on real font metrics can annotate its class with
+ * `@GraphicsMode(GraphicsMode.Mode.NATIVE)`, which measures text through the real font stack
+ * (bodyMedium then measures its 20dp line height).
  *
  * Use for testing component behavior, clicks, and content - not visual appearance.
  */

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsToolbarCard.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsToolbarCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Search
@@ -35,6 +36,7 @@ import eu.darken.butler.workspace.ui.common.CutoutAwareColumn
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -59,7 +61,9 @@ fun AppsToolbarCard(
     val filterCount = filterConfig.includeTags.size + filterConfig.excludeTags.size
 
     CutoutCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsToolbarCard.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsToolbarCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
@@ -42,6 +43,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -108,7 +110,9 @@ fun AppDetailsToolbarCard(
     )
 
     CutoutCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
         ),

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/elements/AppsToolbarCardTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/elements/AppsToolbarCardTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.butler.apps.ui.apps.elements
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.text.input.TextFieldValue
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.contracts.apps.TagFilterConfig
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.GraphicsMode
+import testhelpers.ComposeTest
+
+// Real font metrics: the default graphics mode measures every line of text at 36dp (see
+// ComposeTest), which is taller than the height floor this case is about.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class AppsToolbarCardTest : ComposeTest() {
+
+    private val cardTag = "card"
+
+    @Test
+    fun `the collapsed toolbar is as tall as the other workspaces' toolbars`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                AppsToolbarCard(
+                    modifier = Modifier.testTag(cardTag),
+                    workspaceId = Workspace.Id(),
+                    searchQuery = TextFieldValue("Chrome"),
+                    onSearchQueryChange = {},
+                    filterConfig = TagFilterConfig(),
+                    onFilterAdd = {},
+                    onFilterRemove = { _, _ -> },
+                    // Split-pane layout: keeps the mascot-bearing workspace button, which
+                    // Robolectric cannot rasterise, out of the toolbar cutout.
+                    design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                    collapsedFraction = 1f,
+                )
+            }
+        }
+
+        val card = composeTestRule.onNodeWithTag(cardTag).getUnclippedBoundsInRoot()
+
+        (card.bottom - card.top) shouldBe WorkspaceToolbarDefaults.MinHeightCollapsed
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsToolbarCardTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsToolbarCardTest.kt
@@ -4,22 +4,34 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.text.input.TextFieldValue
 import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.matchers.shouldBe
 import org.junit.Test
+import org.robolectric.annotation.GraphicsMode
 import testhelpers.ComposeTest
 
+// Real font metrics: the default graphics mode measures every line of text at 36dp (see
+// ComposeTest), which is taller than the height floor the collapsed case is about.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
 class AppDetailsToolbarCardTest : ComposeTest() {
 
     // Every case renders multi-pane on purpose: that is the branch without a workspace button, and
     // the switcher's animated mascot never idles under Robolectric.
     private val multiPane = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL)
+
+    private val cardTag = "card"
 
     @Test
     fun `toolbar shows app name but not package name`() {
@@ -144,6 +156,29 @@ class AppDetailsToolbarCardTest : ComposeTest() {
         composeTestRule.onNodeWithText("Search name or package").assertIsDisplayed()
         composeTestRule.onNodeWithText("Chrome").assertDoesNotExist()
         composeTestRule.onNodeWithContentDescription("Close").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the collapsed toolbar is as tall as the other workspaces' toolbars`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                // The overview: without the back and search controls nothing inside the card
+                // reaches the floor on its own, so the height comes from the floor.
+                AppDetailsToolbarCard(
+                    modifier = Modifier.testTag(cardTag),
+                    app = AppsMockDataProvider.Presets.chrome,
+                    design = multiPane,
+                    collapsedFraction = 1f,
+                    onBackClick = null,
+                    searchActive = false,
+                    onSearchToggle = null,
+                )
+            }
+        }
+
+        val card = composeTestRule.onNodeWithTag(cardTag).getUnclippedBoundsInRoot()
+
+        (card.bottom - card.top) shouldBe WorkspaceToolbarDefaults.MinHeightCollapsed
     }
 
     @Test

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
@@ -81,6 +82,7 @@ import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
 import eu.darken.butler.workspace.ui.common.WorkspacePaddings
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
 import eu.darken.butler.workspace.ui.floatingbar.BarAnimation
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
@@ -293,7 +295,7 @@ private fun BugReportToolbarCard(
     val isRecordingExpanded = isRecording && !isCollapsed
     // Collapsed, the card should be exactly as tall as the compact workspace ("manager") button so it
     // lines up with the other workspaces' toolbars; expanded, it matches the default-size button.
-    val headerMinHeight = if (isCollapsed) WorkspaceButtonDefaults.sizeCompact else WorkspaceButtonDefaults.sizeDefault
+    val headerMinHeight = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)
     val horizontalPadding by animateDpAsState(
         targetValue = if (isCollapsed) CutoutCardDefaults.ContentPaddingCollapsed else CutoutCardDefaults.ContentPaddingExpanded,
         label = "bugReportCardPaddingH",
@@ -317,7 +319,9 @@ private fun BugReportToolbarCard(
     }
 
     CutoutCard(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .requiredHeightIn(min = headerMinHeight),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorToolbarCard.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorToolbarCard.kt
@@ -53,6 +53,7 @@ import eu.darken.butler.workspace.ui.common.CutoutAwareColumn
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -83,15 +84,10 @@ fun EditorToolbarCard(
         label = "cardPadding"
     )
 
-    val minHeight by animateDpAsState(
-        targetValue = if (isCollapsed) WorkspaceButtonDefaults.sizeCompact else WorkspaceButtonDefaults.sizeDefault,
-        label = "minHeight",
-    )
-
     CutoutCard(
         modifier = modifier
             .fillMaxWidth()
-            .requiredHeightIn(min = minHeight),
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerToolbarCard.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerToolbarCard.kt
@@ -55,6 +55,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -87,15 +88,10 @@ fun ExplorerToolbarCard(
         label = "cardPadding",
     )
 
-    val minHeight by animateDpAsState(
-        targetValue = if (isCollapsed) WorkspaceButtonDefaults.sizeCompact else WorkspaceButtonDefaults.sizeDefault,
-        label = "minHeight",
-    )
-
     CutoutCard(
         modifier = modifier
             .fillMaxWidth()
-            .requiredHeightIn(min = minHeight),
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
         cutoutContent = if (design.isSingle && pickerSelection == null) {
             {

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryToolbarCard.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryToolbarCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
@@ -38,6 +39,7 @@ import eu.darken.butler.workspace.core.operations.history.HistoryOutcome
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -68,7 +70,9 @@ fun HistoryToolbarCard(
     )
 
     CutoutCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryToolbarCardTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryToolbarCardTest.kt
@@ -1,0 +1,52 @@
+package eu.darken.butler.history.ui
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.operations.history.HistoryFilter
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.GraphicsMode
+import testhelpers.ComposeTest
+
+// Real font metrics: the default graphics mode measures every line of text at 36dp (see
+// ComposeTest), which is taller than the height floor this case is about.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class HistoryToolbarCardTest : ComposeTest() {
+
+    private val cardTag = "card"
+
+    @Test
+    fun `the collapsed unfiltered toolbar is as tall as the other workspaces' toolbars`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                HistoryToolbarCard(
+                    modifier = Modifier.testTag(cardTag),
+                    workspaceId = Workspace.Id(),
+                    // Split-pane layout: keeps the mascot-bearing workspace button, which
+                    // Robolectric cannot rasterise, out of the toolbar cutout.
+                    design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                    // Unfiltered: no clear-filter button to prop the row up to its own height.
+                    filter = HistoryFilter(),
+                    entryCount = 200,
+                    totalCount = 200,
+                    collapsedFraction = 1f,
+                    onRemoveOutcome = {},
+                    onRemoveKind = {},
+                    onRemovePathScope = {},
+                    onAddFilter = {},
+                    onClearFilter = {},
+                )
+            }
+        }
+
+        val card = composeTestRule.onNodeWithTag(cardTag).getUnclippedBoundsInRoot()
+
+        (card.bottom - card.top) shouldBe WorkspaceToolbarDefaults.MinHeightCollapsed
+    }
+}

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchToolbarCard.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchToolbarCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -50,6 +51,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -70,7 +72,9 @@ fun SearchToolbarCard(
     )
 
     CutoutCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(

--- a/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/elements/SearchToolbarCardTest.kt
+++ b/app-workspace-searcher/src/test/java/eu/darken/butler/searcher/ui/search/elements/SearchToolbarCardTest.kt
@@ -1,0 +1,55 @@
+package eu.darken.butler.searcher.ui.search.elements
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.searcher.core.SearcherWorkspace
+import eu.darken.butler.searcher.ui.search.SearcherWorkspaceViewModel
+import eu.darken.butler.workspace.contracts.searcher.SearchTarget
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.GraphicsMode
+import testhelpers.ComposeTest
+
+// Real font metrics: the default graphics mode measures every line of text at 36dp (see
+// ComposeTest), which is taller than the height floor this case is about.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SearchToolbarCardTest : ComposeTest() {
+
+    private val cardTag = "card"
+
+    @Test
+    fun `the collapsed toolbar is as tall as the other workspaces' toolbars`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SearchToolbarCard(
+                    modifier = Modifier.testTag(cardTag),
+                    workspaceId = Workspace.Id(),
+                    state = SearcherWorkspaceViewModel.State.Ready(
+                        workspaceState = SearcherWorkspace.State(
+                            searchTargets = listOf(
+                                SearchTarget.Path.from(LocalPath.build("/storage/emulated/0/Documents")),
+                            ),
+                        ),
+                        filenameQuery = "*.kt",
+                    ),
+                    // Split-pane layout: keeps the mascot-bearing workspace button, which
+                    // Robolectric cannot rasterise, out of the toolbar cutout.
+                    design = WorkspaceDesign(layout = WorkspaceDesign.Layout.DUAL_VERTICAL),
+                    collapsedFraction = 1f,
+                    onAction = {},
+                )
+            }
+        }
+
+        val card = composeTestRule.onNodeWithTag(cardTag).getUnclippedBoundsInRoot()
+
+        (card.bottom - card.top) shouldBe WorkspaceToolbarDefaults.MinHeightCollapsed
+    }
+}

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCard.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCard.kt
@@ -38,6 +38,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.ui.common.CutoutCard
 import eu.darken.butler.workspace.ui.common.CutoutCardDefaults
 import eu.darken.butler.workspace.ui.common.CutoutMode
+import eu.darken.butler.workspace.ui.common.WorkspaceToolbarDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
@@ -64,15 +65,10 @@ fun ViewerToolbarCard(
         label = "cardPadding",
     )
 
-    val minHeight by animateDpAsState(
-        targetValue = if (isCollapsed) WorkspaceButtonDefaults.sizeCompact else WorkspaceButtonDefaults.sizeDefault,
-        label = "minHeight",
-    )
-
     CutoutCard(
         modifier = modifier
             .fillMaxWidth()
-            .requiredHeightIn(min = minHeight),
+            .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed)),
         cutoutContent = if (design.isSingle) {
             {
                 WorkspaceButton(

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/common/WorkspaceToolbarDefaults.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/common/WorkspaceToolbarDefaults.kt
@@ -1,0 +1,30 @@
+package eu.darken.butler.workspace.ui.common
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.Dp
+import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
+
+/**
+ * Shared geometry for the workspace toolbar cards.
+ *
+ * In single-pane layouts the cutout's workspace button floors every toolbar card at the same
+ * height. Split-pane and stacked layouts have no cutout, so without this the collapsed card is
+ * only as tall as whatever that toolbar happens to contain, and the workspaces disagree.
+ */
+object WorkspaceToolbarDefaults {
+
+    val MinHeightCollapsed: Dp = WorkspaceButtonDefaults.sizeCompact
+
+    val MinHeightExpanded: Dp = WorkspaceButtonDefaults.sizeDefault
+
+    @Composable
+    fun animatedMinHeight(isCollapsed: Boolean): Dp {
+        val minHeight by animateDpAsState(
+            targetValue = if (isCollapsed) MinHeightCollapsed else MinHeightExpanded,
+            label = "toolbarMinHeight",
+        )
+        return minHeight
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/common/WorkspaceToolbarDefaultsTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/common/WorkspaceToolbarDefaultsTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.butler.workspace.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredHeightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class WorkspaceToolbarDefaultsTest : ComposeTest() {
+
+    private val cardTag = "card"
+
+    // 20dp plus 2 * 6dp padding stays below both floors, so the height comes from the floor alone.
+    private fun cardWith(isCollapsed: Boolean) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CutoutCard(
+                    modifier = Modifier
+                        .requiredHeightIn(min = WorkspaceToolbarDefaults.animatedMinHeight(isCollapsed))
+                        .testTag(cardTag),
+                    cutoutContent = null,
+                    contentPadding = CutoutCardDefaults.contentPadding(6.dp),
+                ) {
+                    Box(modifier = Modifier.size(20.dp))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a collapsed toolbar card is as tall as the compact workspace button`() {
+        cardWith(isCollapsed = true)
+
+        val card = composeTestRule.onNodeWithTag(cardTag).getUnclippedBoundsInRoot()
+
+        (card.bottom - card.top) shouldBe WorkspaceToolbarDefaults.MinHeightCollapsed
+    }
+
+    @Test
+    fun `an expanded toolbar card is as tall as the default workspace button`() {
+        cardWith(isCollapsed = false)
+
+        val card = composeTestRule.onNodeWithTag(cardTag).getUnclippedBoundsInRoot()
+
+        (card.bottom - card.top) shouldBe WorkspaceToolbarDefaults.MinHeightExpanded
+    }
+}


### PR DESCRIPTION
## What changed

Every workspace toolbar now collapses to the same height. Each workspace used to decide its own, so in split-pane and stacked layouts the toolbars in adjacent panes could sit at different heights depending on which workspace they belonged to. In single-pane layouts the workspace button in the toolbar's cutout already held them all at the same height, which is why this only ever showed up with more than one pane visible.

Collapsed, the Searcher, Apps and App details toolbars grow slightly and the History toolbar grows a little more, so all of them now line up with the Explorer, Editor and Viewer toolbars. The History toolbar with an active filter was already taller than the shared minimum and is unchanged.

## Technical Context

- The shared floor lives in a new `WorkspaceToolbarDefaults` in `app-workspace`, deriving both values from `WorkspaceButtonDefaults` (`sizeCompact`/`sizeDefault`) rather than introducing new literals, and owning the `animateDpAsState` between them. Editor, Explorer and Viewer each carried an identical copy of that block. BugReport keeps its inner header-row floor, which does a different job (keeping the header tappable inside a card that is much taller while recording-expanded), but now sources it from the same value and applies the floor to its card as well.
- Rejected alternatives: a `minHeight` parameter on `CutoutCard` deduplicates the application but leaves the animation copied at every call site; a `WorkspaceToolbarCard` wrapper would have to forward the `CutoutCard` parameters that genuinely differ per toolbar (`cutoutMode` is Corner, Auto and FullHeight across the eight, Explorer's cutout predicate adds `pickerSelection == null`, Editor's `contentPadding` is asymmetric, and BugReport animates vertical padding to 0).
- Single-pane settled heights do not change, but the collapse transition in the four newly-floored toolbars now eases where it previously snapped: `buttonSize` flips at the `collapsedFraction > 0.5f` threshold while the floor animates. That matches what Editor, Explorer and Viewer already did.
- Worth close review: the four new per-toolbar tests carry `@GraphicsMode(GraphicsMode.Mode.NATIVE)`, the first use of it here. Robolectric's default graphics mode measures every line of text at a synthetic 36dp that ignores the text style, which puts a collapsed toolbar at 48dp and hides the floor entirely. The annotation is class-level, so it also covers the five existing tests in `AppDetailsToolbarCardTest`. `ComposeTest`'s KDoc and `.claude/rules/testing.md` are corrected alongside, since both documented that metric as "fixed ~20px height".
- The App details height test is pinned to the variant with no back or search control: those are 32dp `IconButton`s that persist when collapsed, so any other fixture sits above the floor and would not exercise it.

Multi-pane alignment was checked on an emulator at the branch tip, where both panes' collapsed cards measure exactly 40.0dp with identical bounds; unit tests alone cannot establish that.
