### PR TITLE
General: Add German translation

### DIFF
--- a/app-common-io/src/main/res/values-de/strings.xml
+++ b/app-common-io/src/main/res/values-de/strings.xml
@@ -1,0 +1,89 @@
+<resources>
+    <!-- Delete operation progress strings -->
+    <string name="general_delete_progress_title">Elemente werden gelöscht</string>
+
+    <!-- Copy operation progress strings -->
+    <string name="general_copy_progress_title">Elemente werden kopiert</string>
+
+    <!-- Move operation progress strings -->
+    <string name="general_move_progress_title">Elemente werden verschoben</string>
+
+    <!-- Scan operation progress strings -->
+    <string name="general_scan_progress_title">Scan läuft…</string>
+
+    <!-- Path action issue strings -->
+    <string name="path_action_file_exists_title">Datei bereits vorhanden</string>
+    <string name="path_action_folder_exists_title">Ordner bereits vorhanden</string>
+    <string name="path_action_file_exists_description">Eine Datei namens \"%1$s\" ist unter \"%2$s\" bereits vorhanden.</string>
+    <string name="path_action_folder_exists_description">Ein Ordner namens \"%1$s\" ist unter \"%2$s\" bereits vorhanden.</string>
+
+    <string name="path_action_not_found_title">Datei nicht mehr vorhanden</string>
+    <string name="path_action_not_found_description">\"%1$s\" wurde gelöscht, umbenannt oder verschoben.</string>
+
+    <string name="path_action_permission_denied_title">Zugriff verweigert</string>
+    <string name="path_action_permission_denied_description">Auf \"%1$s\" unter \"%2$s\" kann wegen fehlender Berechtigungen nicht zugegriffen werden.</string>
+    <string name="path_action_permission_denied_no_mechanism_description">Auf \"%1$s\" unter \"%2$s\" kann nicht zugegriffen werden. Es ist keine Methode verfügbar, um diesen Vorgang auszuführen.</string>
+    <string name="path_action_permission_denied_readonly_description">Auf \"%1$s\" unter \"%2$s\" kann nicht zugegriffen werden. Das Dateisystem ist schreibgeschützt.</string>
+    <string name="path_action_permission_denied_not_permitted_description">Auf \"%1$s\" unter \"%2$s\" kann nicht zugegriffen werden. Das System hat den Vorgang verweigert.</string>
+
+    <string name="path_action_insufficient_space_title">Nicht genügend Speicherplatz</string>
+    <string name="path_action_insufficient_space_description">Es ist nicht genügend Speicherplatz verfügbar, um \"%1$s\" aus \"%2$s\" zu kopieren.</string>
+
+    <string name="path_action_unknown_error_title">Vorgang fehlgeschlagen</string>
+
+    <string name="path_action_trash_size_limit_title">Elemente zu groß für den Papierkorb</string>
+    <string name="path_action_trash_size_limit_description">Die Gesamtgröße (%2$s) überschreitet die Größenbegrenzung des Papierkorbs (%3$s). Betroffene Elemente: %1$d.</string>
+
+    <string name="path_action_trash_move_failed_title">Verschieben in den Papierkorb fehlgeschlagen</string>
+    <string name="path_action_trash_move_failed_description">Nicht in den Papierkorb verschobene Elemente: %1$d.</string>
+
+    <string name="path_action_trash_not_supported_title">Papierkorb nicht unterstützt</string>
+    <string name="path_action_trash_not_supported_description">Der verwendete Speicher unterstützt den Papierkorb nicht. Betroffene Elemente: %1$d.</string>
+
+    <string name="path_action_archive_password_title">Passwort erforderlich</string>
+    <string name="path_action_archive_password_description">\"%1$s\" ist verschlüsselt. Gib das Passwort ein, um den Inhalt zu lesen.</string>
+    <string name="path_action_archive_password_wrong_description">Das Passwort für \"%1$s\" war falsch. Versuche es erneut.</string>
+
+    <!-- Network storage errors -->
+    <string name="smb_error_unreachable_title">Server nicht erreichbar</string>
+    <string name="smb_error_unreachable_description">Butler konnte \"%1$s\" nicht erreichen. Prüfe, ob sich Dein Gerät im selben Netzwerk befindet und der Server eingeschaltet ist.</string>
+    <string name="smb_error_auth_title">Anmeldung fehlgeschlagen</string>
+    <string name="smb_error_auth_description">\"%1$s\" hat den Benutzernamen oder das Passwort abgelehnt.</string>
+    <string name="smb_error_share_access_denied_title">Kein Zugriff auf diese Freigabe</string>
+    <string name="smb_error_share_access_denied_description">Dieses Konto darf \"%1$s\" auf \"%2$s\" nicht verwenden. Prüfe die Freigabeberechtigungen auf dem Server.</string>
+    <string name="smb_error_share_not_found_title">Freigabe nicht gefunden</string>
+    <string name="smb_error_share_not_found_description">\"%1$s\" ist auf \"%2$s\" nicht vorhanden.</string>
+    <string name="smb_error_dialect_title">Server zu alt</string>
+    <string name="smb_error_dialect_description">\"%1$s\" bietet nur SMB1 an, das unsicher ist und nicht unterstützt wird. Aktiviere SMB2 oder höher auf dem Server.</string>
+    <string name="smb_error_credential_unavailable_title">Anmeldung erforderlich</string>
+    <string name="smb_error_credential_unavailable_description">Das gespeicherte Passwort für diesen Netzwerkspeicher kann nicht mehr gelesen werden. Gib es erneut ein, um die Verbindung wiederherzustellen.</string>
+    <!-- App install errors -->
+    <string name="app_install_error_protected_bundle_title">Geschütztes App-Bundle</string>
+    <string name="app_install_error_protected_bundle_description">\"%1$s\" ist verschlüsselt und kann nur von der App installiert werden, die es erstellt hat.</string>
+
+    <string name="app_install_error_unsupported_apk_set_title">APK-Set-Format nicht unterstützt</string>
+    <string name="app_install_error_unsupported_apk_set_description">\"%1$s\" ist ein bundletool-APK-Set. Butler kann nicht ermitteln, welche Variante für dieses Gerät geeignet ist.</string>
+
+    <string name="app_install_error_unsupported_bundle_title">Keine App zum Installieren</string>
+    <string name="app_install_error_unsupported_bundle_description">\"%1$s\" enthält keine installierbare APK.</string>
+
+    <string name="app_install_error_session_title">Installation fehlgeschlagen</string>
+    <string name="app_install_error_session_description">Das System hat die Installation abgelehnt: %1$s</string>
+
+    <string name="app_install_error_busy_title">Eine andere Installation läuft bereits</string>
+    <string name="app_install_error_busy_description">\"%1$s\" wird noch installiert. Bestätige diese Installation oder brich sie ab, bevor Du eine weitere startest.</string>
+
+    <string name="app_install_error_no_elevation_title">Keine erweiterten Zugriffsrechte</string>
+    <string name="app_install_error_no_elevation_description">Root- oder ADB-Zugriff ist derzeit nicht verfügbar.</string>
+
+    <!-- App install confirmation -->
+    <string name="app_install_confirm_pending_title">Bestätigung erforderlich</string>
+    <string name="app_install_confirm_pending_description">Android benötigt Deine Bestätigung, um die Installation von \"%1$s\" abzuschließen.</string>
+    <string name="app_install_confirm_pending_description_unnamed">Android benötigt Deine Bestätigung, um diese Installation abzuschließen.</string>
+    <string name="app_install_confirm_pending_action">Installation bestätigen</string>
+    <string name="app_install_confirm_pending_reason">Das Installationsprogramm wartet auf Deine Bestätigung</string>
+
+    <!-- Service connection errors -->
+    <string name="service_connection_lost_error_title">Dateivorgang unterbrochen</string>
+    <string name="service_connection_lost_error_message">Der Dienst für Dateivorgänge wurde unerwartet beendet. Versuche es bitte erneut.</string>
+</resources>

--- a/app-common-pkgs/src/main/res/values-de/strings.xml
+++ b/app-common-pkgs/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="pkgrepo_invalid_inventory_error_title">Ungültiges App-Inventar</string>
+    <string name="pkgrepo_invalid_inventory_error_description">Das System hat Butler eine ungültige Liste installierter Apps bereitgestellt.</string>
+</resources>

--- a/app-common/src/gplay/res/values-de/strings.xml
+++ b/app-common/src/gplay/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name_upgrade_postfix">Pro</string>
+</resources>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -1,0 +1,292 @@
+<resources>
+    <string name="app_name">Butler</string>
+    <string name="app_name_subtitle">Dateimanager der Extraklasse</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS", depending on the build). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
+
+    <string name="butler_icon_description">Butler-App-Symbol</string>
+    <string name="butler_mascot_description">Butler-Maskottchen</string>
+    <string name="butler_mascot_animation_random_description">Butler-Maskottchen mit verschiedenen Animationen</string>
+    <string name="butler_mascot_animation_wink_description">Butler-Maskottchen zwinkert</string>
+    <string name="butler_mascot_animation_greeting_description">Butler-Maskottchen winkt zur Begrüßung</string>
+    <string name="butler_mascot_animation_hatoff_description">Butler-Maskottchen zieht respektvoll den Hut</string>
+    <string name="butler_mascot_animation_drink_description">Butler-Maskottchen trinkt</string>
+    <string name="butler_mascot_animation_moustache_description">Butler-Maskottchen streicht sich über den Schnurrbart</string>
+    <string name="butler_mascot_animation_sleep_closing_description">Butler-Maskottchen schließt die Augen zum Schlafen</string>
+    <string name="butler_mascot_animation_sleep_snoring_description">Butler-Maskottchen schnarcht</string>
+    <string name="butler_mascot_animation_sleep_waking_description">Butler-Maskottchen wacht auf</string>
+    <string name="butler_mascot_animation_cameo_description">SD-Maid-Maskottchen hat einen Gastauftritt</string>
+
+    <string name="slogan_general_message_0">Zu Deinen Diensten.</string>
+    <string name="slogan_general_message_1">Alles an seinem Platz.</string>
+    <string name="slogan_general_message_2">Ordnung statt Chaos.</string>
+    <string name="slogan_general_message_3">Deine Dateien werden serviert.</string>
+    <string name="slogan_general_message_4">Deine Dateien, schön der Reihe nach.</string>
+    <string name="slogan_general_message_5">Immer gut sortiert.</string>
+    <string name="slogan_general_message_6">Dateien im Nu gefunden!</string>
+    <string name="slogan_general_message_7">Zugriff leicht gemacht.</string>
+    <string name="slogan_general_message_8">Deine Dateien lasse ich nie im Stich.</string>
+    <string name="slogan_general_message_9">Für jeden Anlass den passenden Hut.</string>
+    <string name="slogan_newyear_message_0">Wie jedes Jahr.</string>
+    <string name="slogan_xmas_message_0">Dateien werden zweimal geprüft.</string>
+    <string name="slogan_xmas_message_1">Auf der Liste der Braven.</string>
+    <string name="slogan_halloween_message_0">Buh-tler zu Deinen Diensten.</string>
+    <string name="slogan_halloween_message_1">Keine Streiche, nur Dateien.</string>
+    <string name="slogan_stpatricks_message_0">Ist heute Dein Glückstag?</string>
+    <string name="slogan_stpatricks_message_1">Auf der Suche nach Deinem Goldschatz.</string>
+    <string name="slogan_aprilfools_message_0">Kein Scherz.</string>
+    <string name="slogan_aprilfools_message_1">Ernsthaft ordentlich.</string>
+    <string name="slogan_oktoberfest_message_0">Ein Prosit auf Deine Dateien!</string>
+    <string name="slogan_oktoberfest_message_1">Dateien frisch vom Fass.</string>
+
+    <string name="general_share_action">Teilen</string>
+    <string name="general_share_single_title">%s teilen</string>
+    <plurals name="general_share_multiple_title">
+        <item quantity="one">%d Datei teilen</item>
+        <item quantity="other">%d Dateien teilen</item>
+    </plurals>
+    <string name="general_done_action">Fertig</string>
+    <string name="general_copy_action">Kopieren</string>
+    <string name="general_cut_action">Ausschneiden</string>
+    <string name="general_move_action">Verschieben</string>
+    <string name="general_paste_action">Einfügen</string>
+    <string name="general_apply_action">Anwenden</string>
+    <string name="general_open_action">Öffnen</string>
+    <string name="general_cancel_action">Abbrechen</string>
+    <string name="general_close_action">Schließen</string>
+    <string name="general_confirm_action">Bestätigen</string>
+    <string name="general_reset_action">Zurücksetzen</string>
+    <string name="general_save_action">Speichern</string>
+    <string name="general_edit_action">Bearbeiten</string>
+    <string name="general_na_label">Nicht verfügbar</string>
+    <!-- Announced by screen readers when a dialog opens -->
+    <string name="general_dialog_a11y_label">Dialog</string>
+    <string name="general_dismiss_action">Schließen</string>
+    <string name="general_read_more_action">Mehr erfahren</string>
+    <string name="general_mark_as_read_action">Als gelesen markieren</string>
+    <string name="general_back_action">Zurück</string>
+    <string name="general_navigate_up_action">Übergeordnete Ebene</string>
+    <string name="general_error_label">Fehler</string>
+    <string name="general_error_unknown_label">Unbekannter Fehler</string>
+    <string name="general_error_invalid_input_label">Ungültige Eingabe</string>
+    <string name="general_share_error_action">Fehler teilen</string>
+    <string name="general_error_report_subject">%1$s-Fehlerbericht (%2$s)</string>
+    <string name="general_error_report_consent_title">Fehlerbericht teilen?</string>
+    <string name="general_error_report_consent_message">Der Bericht enthält den Fehler und den zugehörigen Stacktrace, die letzten Protokolleinträge der App sowie Angaben zu ihrem Zustand: Dateinamen und Pfade, Suchanfragen, Paketnamen, URIs, Netzwerk- und SMB-Hostnamen, Informationen zu Deinem Gerät und Build sowie eine anonyme Installations-ID. Teile ihn nur mit Personen, denen Du vertraust.</string>
+    <string name="general_error_report_consent_confirm">Bericht teilen</string>
+    <string name="general_privacy_policy_action">Datenschutzerklärung</string>
+    <string name="general_bug_report_subject">%1$s-Fehlerbericht (%2$s)</string>
+    <string name="general_bug_report_subject_labeled">%1$s-Fehlerbericht: %2$s (%3$s)</string>
+    <string name="general_bug_report_body_what_happened_prompt">(Beschreibe hier, was passiert ist.)</string>
+    <string name="general_bug_report_body_expected_prompt">(Beschreibe, was Du stattdessen erwartet hast.)</string>
+    <string name="general_duration_input_label">Dauer</string>
+    <string name="general_size_input_label">Größe</string>
+    <string name="general_upgrade_action">Upgrade</string>
+    <string name="general_refresh_action">Aktualisieren</string>
+    <string name="general_clear_action">Leeren</string>
+    <string name="general_expand_action">Ausklappen</string>
+    <string name="general_collapse_action">Einklappen</string>
+    <string name="general_completed_label">Abgeschlossen</string>
+    <string name="general_cancelled_label">Abgebrochen</string>
+    <string name="general_searching_label">Suche läuft</string>
+    <string name="general_searching_ellipsis">Suche läuft…</string>
+    <string name="general_progress_loading">Wird geladen</string>
+    <string name="general_progress_loading_egg_0">Immer noch schneller als ein iPhone</string>
+    <string name="general_progress_loading_egg_1">Mehr RAM wird heruntergeladen</string>
+    <string name="general_progress_loading_egg_2">Restzeit: Bald™</string>
+    <string name="general_progress_loading_egg_3">Die CPU macht Kaffeepause</string>
+    <string name="general_progress_loading_egg_4">Warte auf Daten von Pepe Silvia</string>
+    <string name="general_progress_loading_egg_5">Turbo-Encabulator wird gestartet</string>
+    <string name="general_progress_loading_egg_6">Die Butter wird gereicht</string>
+    <string name="general_progress_loading_egg_7">Na, wie hältst Du Dich so?</string>
+    <string name="general_progress_loading_egg_8">Piep, bup, bop</string>
+    <string name="general_progress_loading_egg_9">Lebensentscheidungen werden gepuffert</string>
+    <string name="general_progress_loading_egg_10">Cthulhu wird beschworen</string>
+    <string name="general_progress_loading_egg_11">Alles bestens</string>
+    <string name="general_progress_loading_egg_12">Bitte warten</string>
+    <string name="general_progress_loading_egg_13">Wenigstens keine Warteschleifenmusik</string>
+    <string name="general_progress_loading_egg_14">Direkt auf die Stirn auftragen</string>
+
+    <!-- Duration formatting -->
+    <plurals name="common_duration_milliseconds_short">
+        <item quantity="one">%dms</item>
+        <item quantity="other">%dms</item>
+    </plurals>
+    <plurals name="common_duration_seconds_short">
+        <item quantity="one">%ds</item>
+        <item quantity="other">%ds</item>
+    </plurals>
+    <plurals name="common_duration_minutes_short">
+        <item quantity="one">%dmin</item>
+        <item quantity="other">%dmin</item>
+    </plurals>
+    <plurals name="common_duration_hours_short">
+        <item quantity="one">%dh</item>
+        <item quantity="other">%dh</item>
+    </plurals>
+    <plurals name="common_duration_days_short">
+        <item quantity="one">%dT</item>
+        <item quantity="other">%dT</item>
+    </plurals>
+
+    <plurals name="common_duration_seconds_full">
+        <item quantity="one">%d Sekunde</item>
+        <item quantity="other">%d Sekunden</item>
+    </plurals>
+    <plurals name="common_duration_minutes_full">
+        <item quantity="one">%d Minute</item>
+        <item quantity="other">%d Minuten</item>
+    </plurals>
+    <plurals name="common_duration_hours_full">
+        <item quantity="one">%d Stunde</item>
+        <item quantity="other">%d Stunden</item>
+    </plurals>
+    <plurals name="common_duration_days_full">
+        <item quantity="one">%d Tag</item>
+        <item quantity="other">%d Tage</item>
+    </plurals>
+
+    <string name="general_view_action">Anzeigen</string>
+    <string name="general_delete_action">Löschen</string>
+    <string name="general_show_details_action">Details anzeigen</string>
+    <string name="general_hide_details_action">Details ausblenden</string>
+
+    <string name="general_delete_confirmation_title">Löschen bestätigen</string>
+    <string name="general_delete_confirmation_message_x">\"%s\" löschen?</string>
+    <string name="general_delete_confirmation_message_selected_x_items">Auswahl löschen (Anzahl: %d)?</string>
+    <plurals name="general_delete_success_deleted_x">
+        <item quantity="one">%d Element gelöscht.</item>
+        <item quantity="other">%d Elemente gelöscht.</item>
+    </plurals>
+
+    <string name="general_create_action">Erstellen</string>
+    <string name="general_rename_action">Umbenennen</string>
+    <string name="general_retry_action">Erneut versuchen</string>
+    <string name="general_open_setup_action">Einrichtung öffnen</string>
+    <string name="general_grant_usage_stats_action">Nutzungsdatenzugriff gewähren</string>
+    <string name="general_grant_storage_permission_action">Speicherberechtigung erteilen</string>
+    <string name="general_grant_all_files_access_action">Zugriff auf alle Dateien erlauben</string>
+
+    <string name="general_result_user_cancel_msg">Du hast den Vorgang abgebrochen.</string>
+
+    <string name="general_path_label">Pfad</string>
+    <string name="general_filename_validation_error">Der Name enthält ungültige Zeichen: %1$s</string>
+
+    <string name="common_workspace_position_indicator">%1$d von %2$d: %3$s</string>
+    <string name="common_x_of_y_label">%1$d von %2$d</string>
+
+    <string name="file_type_symbolic_link">Verknüpfung</string>
+    <string name="file_type_directory">Verzeichnis</string>
+    <string name="file_type_file">Datei</string>
+    <string name="file_type_unknown">Unbekannt</string>
+
+    <!-- MIME type friendly names -->
+    <string name="common_mimetype_image">Bild</string>
+    <string name="common_mimetype_video">Video</string>
+    <string name="common_mimetype_audio">Audio</string>
+    <string name="common_mimetype_text_plain">Nur Text</string>
+    <string name="common_mimetype_text">Textdokument</string>
+    <string name="common_mimetype_pdf">PDF-Dokument</string>
+    <string name="common_mimetype_document">Dokument</string>
+    <string name="common_mimetype_archive">Archiv</string>
+    <string name="common_mimetype_apk">Android-Paket</string>
+    <string name="common_mimetype_json">JSON-Datei</string>
+    <string name="common_mimetype_xml">XML-Datei</string>
+    <string name="common_mimetype_unknown">Unbekannter Typ</string>
+
+    <string name="general_rom_type_auto_label">Automatisch (Standard)</string>
+
+    <plurals name="general_progress_items_per_second">
+        <item quantity="one">%s Element/s</item>
+        <item quantity="other">%s Elemente/s</item>
+    </plurals>
+    <plurals name="general_progress_bytes_per_second">
+        <item quantity="one">%s/s</item>
+        <item quantity="other">%s/s</item>
+    </plurals>
+
+    <string name="general_error_type_mismatch_msg">Falscher Typ: %1$s erwartet, aber %2$s erhalten.</string>
+    <string name="general_error_cant_access_msg">Zugriff auf %s nicht möglich.</string>
+    <string name="general_error_archive_not_seekable_msg">%s lässt sich nicht direkt durchsuchen: Der verwendete Speicher unterstützt nur sequenzielles Lesen, dieses Archivformat erfordert jedoch wahlfreien Zugriff.</string>
+    <string name="general_error_root_unavailable">Root-Zugriff ist nicht verfügbar.</string>
+    <string name="general_error_elevated_access_required">Dieser Vorgang erfordert erweiterte Zugriffsrechte. Konfiguriere Root oder Shizuku in der Einrichtung.</string>
+    <string name="general_error_no_compatible_app_found_msg">Keine passende App für diese Anfrage gefunden.</string>
+    <string name="general_error_ipc_deadobject_title">Verbindung zum Dienst verloren</string>
+    <string name="general_error_ipc_deadobject_description">Die Verbindung zu einem wichtigen Dienst (z. B. Magisk, Shizuku oder einem anderen Systemdienst) wurde unerwartet getrennt. Starte Dein Gerät bitte neu. Falls das Problem weiterhin auftritt, suche nach Updates oder melde Dich bei mir, damit ich es beheben kann.</string>
+
+    <string name="ui_theme_mode_dark_label">Dunkel</string>
+    <string name="ui_theme_mode_light_label">Hell</string>
+    <string name="ui_theme_mode_system_label">System</string>
+    <string name="ui_theme_style_default_label">Standard</string>
+    <string name="ui_theme_style_medium_contrast_label">Mittlerer Kontrast</string>
+    <string name="ui_theme_style_high_contrast_label">Hoher Kontrast</string>
+    <string name="ui_theme_style_materialyou_label">Material You</string>
+    <string name="ui_theme_color_green_label">Grün</string>
+    <string name="ui_theme_color_blue_label">Blau &amp; Orange</string>
+    <string name="ui_theme_color_amoled_label">AMOLED</string>
+
+    <!-- Setup module types -->
+    <string name="setup_usagestats_title">Nutzungsstatistiken</string>
+    <string name="setup_shizuku_card_title">Shizuku</string>
+    <string name="setup_root_card_title">Root</string>
+    <string name="setup_notification_title">Benachrichtigungszugriff</string>
+    <string name="setup_manage_storage_card_title">Externen Speicher verwalten</string>
+    <string name="setup_inventory_card_title">App-Inventar</string>
+
+    <!-- Common permission strings -->
+    <string name="setup_required_card_title">Einrichtung erforderlich</string>
+    <string name="setup_required_card_body">Für diesen Vorgang sind zusätzliche Einrichtungsschritte erforderlich.</string>
+    <string name="setup_required_card_setup_action">Einrichtung öffnen</string>
+
+    <!-- Open in new tabs feature -->
+    <string name="common_open_tabs_confirmation_title">Mehrere Tabs öffnen?</string>
+    <string name="common_open_tabs_confirmation_message">Dadurch werden %1$d Tabs geöffnet.</string>
+    <string name="common_open_tabs_success">%1$d Tabs geöffnet</string>
+    <string name="common_open_tabs_success_with_skipped">Tabs geöffnet: %1$d (übersprungene Elemente: %2$d)</string>
+
+    <!-- Tab close confirmation -->
+    <string name="general_tab_close_confirmation_title">Tab schließen?</string>
+    <string name="general_tab_close_confirmation_message">Möchtest Du \"%1$s\" wirklich schließen?</string>
+    <string name="general_tab_close_unsaved_title">Ungespeicherte Änderungen</string>
+    <string name="general_tab_close_unsaved_message">\"%1$s\" enthält ungespeicherte Änderungen. Schließen und Änderungen verwerfen?</string>
+    <string name="general_tab_close_unsaved_message_multiple">\"%1$s\" und weitere Tabs enthalten ungespeicherte Änderungen (%2$d zusätzlich). Schließen und Änderungen verwerfen?</string>
+    <string name="general_discard_action">Verwerfen</string>
+    <string name="general_tab_close_goto_action">Zum Tab wechseln</string>
+
+    <!-- Exit app -->
+    <string name="general_press_back_again_to_exit">Zum Beenden erneut Zurück drücken</string>
+
+    <!-- InfoBar -->
+    <plurals name="common_infobar_selected_count">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
+    <plurals name="common_folders_count">
+        <item quantity="one">%1$d Ordner</item>
+        <item quantity="other">%1$d Ordner</item>
+    </plurals>
+    <plurals name="common_files_count">
+        <item quantity="one">%1$d Datei</item>
+        <item quantity="other">%1$d Dateien</item>
+    </plurals>
+    <string name="common_select_all_folders_action">Alle Ordner auswählen</string>
+    <string name="common_select_all_files_action">Alle Dateien auswählen</string>
+    <string name="general_undo_action">Rückgängig</string>
+
+    <!-- Guided tours -->
+    <string name="tour_action_next">Weiter</string>
+    <string name="tour_action_previous">Zurück</string>
+    <string name="tour_action_cancel">Überspringen</string>
+    <string name="tour_confirm_title">Tour überspringen?</string>
+    <string name="tour_confirm_message">Du kannst die Touren jederzeit in den Einstellungen wieder aktivieren.</string>
+    <string name="tour_confirm_continue">Tour fortsetzen</string>
+    <string name="tour_confirm_dont_show_this_tour">Diese Tour nicht anzeigen</string>
+    <string name="tour_confirm_disable_all">Alle Touren deaktivieren</string>
+
+    <!-- Butler Tips -->
+    <string name="common_tip_multiple_panes">Nutze mehrere Bereiche, um Dateien nebeneinander zu vergleichen.</string>
+    <string name="common_tip_different_folders">Öffne in jedem Bereich einen anderen Ordner, um Dateien einfach zu verwalten.</string>
+    <string name="common_tip_switch_layouts">Wechsle die Anordnung der Bereiche in den Tab-Einstellungen.</string>
+    <string name="common_tip_elevated_access">Aktiviere Root oder Shizuku in der Einrichtung für erweiterte Dateivorgänge.</string>
+    <string name="common_tip_breadcrumb_home">Halte einen Abschnitt der Pfadleiste im Explorer gedrückt, um ihn als Dein Startverzeichnis festzulegen.</string>
+</resources>

--- a/app-provider-documents/src/main/res/values-de/strings.xml
+++ b/app-provider-documents/src/main/res/values-de/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- DocumentsProvider Root (Level 1) -->
+    <string name="provider_documents_root_butler_title">Butler</string>
+    <string name="provider_documents_root_butler_summary">Erweiterter Gerätezugriff</string>
+
+    <!-- Connection Types (Level 2) -->
+    <string name="provider_documents_connection_device_title">Gerät</string>
+    <string name="documents_connection_device_summary">Lokaler Gerätespeicher</string>
+
+    <!-- Storage Locations (Level 3) - Phase 1 -->
+    <string name="provider_documents_storage_root_label">Wurzeldateisystem</string>
+    <string name="provider_documents_storage_internal_label">Interner Speicher</string>
+    <string name="provider_documents_storage_sd_card_label">SD-Karte</string>
+    <string name="provider_documents_storage_saf_label">SAF-Speicherort</string>
+    <string name="provider_documents_storage_free_suffix">frei</string>
+
+    <!-- Error Messages - Phase 1 -->
+    <string name="provider_documents_error_requires_root">Zum Durchsuchen dieses Speicherorts ist Root-Zugriff erforderlich. Aktiviere ihn in den Butler-Einstellungen.</string>
+    <string name="provider_documents_error_requires_adb">Zum Durchsuchen dieses Speicherorts ist ADB-/Shizuku-Zugriff erforderlich. Aktiviere Shizuku in den Butler-Einstellungen.</string>
+    <string name="provider_documents_error_requires_storage">Zum Durchsuchen dieses Speicherorts ist eine Speicherberechtigung erforderlich. Gewähre sie in den Butler-Einstellungen.</string>
+    <string name="provider_documents_error_requires_permissions">Zum Durchsuchen dieses Speicherorts sind zusätzliche Berechtigungen erforderlich. Prüfe die Butler-Einstellungen.</string>
+    <string name="provider_documents_error_generic">Auf diesen Speicherort kann nicht zugegriffen werden. Prüfe die Zugriffsmöglichkeiten in Butler.</string>
+
+    <!-- Settings -->
+    <string name="provider_documents_settings_title">Dokumentenanbieter</string>
+    <string name="provider_documents_settings_subtitle">Integration mit anderen Apps</string>
+    <string name="provider_documents_settings_category_integration_label">Integration</string>
+    <string name="provider_documents_enabled_title">Dokumentenanbieter aktivieren</string>
+    <string name="provider_documents_enabled_desc">Anderen Apps erlauben, über die Android-Dateiauswahl auf Dateien in Butler zuzugreifen</string>
+</resources>

--- a/app-workspace-apps/src/main/res/values-de/strings.xml
+++ b/app-workspace-apps/src/main/res/values-de/strings.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Apps Workspace -->
+    <string name="apps_title">Apps</string>
+    <string name="apps_subtitle">Installierte Apps verwalten</string>
+
+    <!-- Filter Labels -->
+    <string name="apps_filter_app_type_label">App-Typ</string>
+    <string name="apps_filter_type_all">Alle</string>
+    <string name="apps_filter_type_user">Benutzer-Apps</string>
+    <string name="apps_filter_type_system">System-Apps</string>
+    <string name="apps_filter_status_label">Status</string>
+    <string name="apps_filter_status_all">Alle</string>
+    <string name="apps_filter_status_enabled">Aktiviert</string>
+    <string name="apps_filter_status_disabled">Deaktiviert</string>
+
+
+    <!-- Sort Options -->
+    <string name="apps_sort_mode_label">Sortieren nach</string>
+    <string name="apps_sort_mode_name_label">Name</string>
+    <string name="apps_sort_mode_size_label">Größe</string>
+    <string name="apps_sort_mode_install_date_label">Installationsdatum</string>
+    <string name="apps_sort_mode_update_date_label">Aktualisierungsdatum</string>
+    <string name="apps_sort_mode_package_name_label">Paketname</string>
+    <string name="apps_sort_descending_label">Absteigende Reihenfolge</string>
+    <string name="apps_sort_mode_size_slowdown_hint">Das Berechnen der App-Größen verlangsamt das Laden</string>
+
+    <!-- Actions -->
+    <string name="apps_action_launch">Starten</string>
+    <string name="apps_action_open_info">App-Info</string>
+    <string name="apps_action_disable">Deaktivieren</string>
+    <string name="apps_action_enable">Aktivieren</string>
+    <string name="apps_action_uninstall">Deinstallieren</string>
+    <string name="apps_action_clear_data">Daten löschen</string>
+    <string name="apps_action_export_apk">APK exportieren</string>
+    <string name="apps_action_browse_path">Pfad durchsuchen</string>
+    <string name="apps_action_share">Informationen teilen</string>
+    <string name="apps_action_refresh">Aktualisieren</string>
+    <string name="apps_action_sort">Sortieren</string>
+    <string name="apps_action_filter">Filtern</string>
+    <string name="apps_action_select_all">Alle auswählen</string>
+    <string name="apps_action_deselect_all">Auswahl aufheben</string>
+    <string name="apps_action_open_in_tab">In Tab öffnen</string>
+    <string name="apps_action_force_stop">Beenden erzwingen</string>
+    <string name="apps_action_view_grid">Rasteransicht</string>
+    <string name="apps_action_view_list">Listenansicht</string>
+
+    <!-- Action Descriptions -->
+    <string name="apps_action_launch_desc">App starten</string>
+    <string name="apps_action_open_info_desc">Detaillierte Systeminformationen anzeigen</string>
+    <string name="apps_action_enable_desc">Diese App aktivieren</string>
+    <string name="apps_action_disable_desc">Diese App deaktivieren</string>
+    <string name="apps_action_uninstall_desc">Diese App entfernen</string>
+    <string name="apps_action_export_apk_desc">APK-Datei im Speicher speichern</string>
+    <string name="apps_action_share_desc">App-Details als Text teilen</string>
+    <string name="apps_action_force_stop_desc">App sofort beenden</string>
+    <string name="apps_action_clear_data_desc">Alle App-Daten und Einstellungen löschen</string>
+
+    <!-- App Info Labels -->
+    <string name="apps_package_name_label">Paket</string>
+    <string name="apps_version_label">Version</string>
+    <string name="apps_size_label">Größe</string>
+    <string name="apps_size_chip_desc">App-Größe: %1$s</string>
+    <string name="apps_size_permission_hint">Für App-Größen ist Nutzungsdatenzugriff erforderlich</string>
+    <string name="apps_size_permission_body">Android meldet die Größe von App, Daten und Cache nur an Apps mit der Berechtigung für den Nutzungsdatenzugriff. Erteile sie, um die Speicheraufteilung dieser App zu sehen.</string>
+
+    <!-- App Details -->
+    <string name="apps_details_storage_locations_label">Speicherorte</string>
+    <string name="apps_path_internal_data_label">Interne Daten</string>
+    <string name="apps_path_external_data_label">Externer Speicher</string>
+    <string name="apps_path_requires_root_label">Root-Zugriff erforderlich</string>
+    <string name="apps_path_requires_shizuku_label">Shizuku erforderlich</string>
+    <string name="apps_path_requires_root_or_shizuku_label">Root-Zugriff oder Shizuku erforderlich</string>
+    <string name="apps_path_requires_access_label">Zusätzlicher Zugriff erforderlich</string>
+    <string name="apps_storage_breakdown_label">Speicheraufteilung</string>
+    <string name="apps_storage_app_label">App</string>
+
+    <!-- App Details Tabs -->
+    <string name="appdetails_tab_overview_label">Übersicht</string>
+    <string name="appdetails_tab_packageinfo_label">Paketinformationen</string>
+
+    <!-- App Details Actions -->
+    <string name="appdetails_back_action">Zurück zu Apps</string>
+    <string name="appdetails_close_action">Schließen</string>
+
+    <!-- App Details Package Info -->
+    <string name="appdetails_packageinfo_title">Paketinformationen</string>
+    <string name="appdetails_packageinfo_view_action">Paketdetails anzeigen</string>
+    <string name="appdetails_packageinfo_unavailable_msg">Die Paketdetails der App konnten nicht gelesen werden.</string>
+    <string name="appdetails_packageinfo_permissions_header">Berechtigungen (%1$d)</string>
+    <string name="appdetails_packageinfo_signing_header">Signaturzertifikate</string>
+    <string name="appdetails_packageinfo_package_label">Paket</string>
+    <string name="appdetails_packageinfo_version_label">Version</string>
+    <string name="appdetails_packageinfo_min_sdk_label">Min. SDK</string>
+    <string name="appdetails_packageinfo_target_sdk_label">Ziel-SDK</string>
+
+    <!-- Empty States -->
+    <string name="apps_empty_no_apps">Keine Apps gefunden</string>
+    <string name="apps_empty_no_apps_desc">Passe Deine Filter an</string>
+    <string name="apps_empty_loading">Apps werden geladen…</string>
+
+    <!-- Search -->
+    <string name="apps_search_hint">Apps durchsuchen</string>
+
+    <!-- Multi-select -->
+    <plurals name="apps_selected_count">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
+
+    <!-- Info Bar -->
+    <plurals name="apps_infobar_user_apps_count">
+        <item quantity="one">%d Benutzer-App</item>
+        <item quantity="other">%d Benutzer-Apps</item>
+    </plurals>
+    <plurals name="apps_infobar_system_apps_count">
+        <item quantity="one">%d System-App</item>
+        <item quantity="other">%d System-Apps</item>
+    </plurals>
+    <plurals name="apps_infobar_selected_count">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
+
+    <!-- App Details Sections -->
+    <string name="apps_details_section_actions">Aktionen</string>
+    <string name="apps_details_section_overview">Übersicht</string>
+    <string name="apps_details_section_storage">Speicher</string>
+
+    <!-- App Details Action Bar -->
+    <string name="apps_details_more_options">Weitere Optionen</string>
+
+    <!-- App Information -->
+    <string name="apps_type_label">Typ</string>
+    <string name="apps_type_system">System-App</string>
+    <string name="apps_type_user">Benutzer-App</string>
+    <string name="apps_status_label">Status</string>
+    <string name="apps_status_enabled">Aktiviert</string>
+    <string name="apps_status_disabled">Deaktiviert</string>
+    <string name="apps_installed_label">Installiert</string>
+    <string name="apps_updated_label">Zuletzt aktualisiert</string>
+    <string name="apps_target_sdk_label">Ziel-SDK</string>
+    <string name="apps_min_sdk_label">Mindest-SDK</string>
+    <string name="apps_uid_label">UID</string>
+    <string name="apps_installer_label">Installiert von</string>
+    <string name="apps_permissions_label">Berechtigungen</string>
+    <string name="apps_permissions_count">Berechtigungen: %1$d</string>
+    <string name="apps_data_size_label">Daten</string>
+    <string name="apps_cache_size_label">Cache</string>
+    <string name="apps_total_size_label">Gesamt</string>
+
+    <!-- App Tags -->
+    <string name="apps_tag_system_label">System</string>
+    <string name="apps_tag_disabled_label">Deaktiviert</string>
+    <string name="apps_tag_updated_label">Aktualisiert</string>
+    <string name="apps_tag_sideloaded_label">Manuell installiert</string>
+    <string name="apps_tag_split_label">Split-APK</string>
+    <string name="apps_tag_debug_label">Debug</string>
+    <string name="apps_tag_user_label">Benutzer %1$d</string>
+
+    <!-- Filter Tags (virtual tags for filtering) -->
+    <string name="apps_filter_tag_enabled_label">Aktiviert</string>
+    <string name="apps_filter_tag_user_app_label">Benutzer-App</string>
+    <string name="apps_filter_include_label">Muss übereinstimmen (alle ausgewählten)</string>
+    <string name="apps_filter_exclude_label">Darf nicht übereinstimmen</string>
+    <string name="apps_filter_add_action">Filter</string>
+    <string name="apps_filter_hint">Zum Einschließen tippen, zum Ausschließen erneut tippen, zum Entfernen noch einmal tippen</string>
+    <plurals name="apps_filter_count">
+        <item quantity="one">%d Filter</item>
+        <item quantity="other">%d Filter</item>
+    </plurals>
+
+    <!-- Components Section -->
+    <string name="apps_details_section_components">Komponenten</string>
+    <string name="apps_components_activities_label">Aktivitäten</string>
+    <string name="apps_components_services_label">Dienste</string>
+    <string name="apps_components_receivers_label">Broadcast-Empfänger</string>
+    <string name="apps_components_providers_label">Inhaltsanbieter</string>
+    <string name="apps_components_exported">Exportiert</string>
+    <string name="apps_components_disabled">Deaktiviert</string>
+    <string name="apps_components_empty">Keine Komponenten gefunden</string>
+    <string name="apps_components_no_matches">Keine Komponenten entsprechen „%1$s“</string>
+    <string name="apps_components_and_more">… und %d weitere</string>
+    <string name="apps_components_view_all_action">Alle Komponenten anzeigen</string>
+    <string name="apps_components_loading">Komponenten werden geladen…</string>
+    <string name="apps_components_error">Komponenten konnten nicht geladen werden</string>
+    <string name="apps_components_launch_failed">Aktivität konnte nicht gestartet werden</string>
+    <string name="apps_components_kind_activity">Aktivität</string>
+    <string name="apps_components_kind_service">Dienst</string>
+    <string name="apps_components_kind_receiver">Broadcast-Empfänger</string>
+    <string name="apps_components_kind_provider">Inhaltsanbieter</string>
+    <string name="apps_components_search_action">Komponenten durchsuchen</string>
+    <string name="apps_components_search_hint">Name oder Paket durchsuchen</string>
+    <string name="apps_components_state_label">Status</string>
+    <string name="apps_components_state_enabled">Aktiviert</string>
+    <string name="apps_components_state_disabled">Deaktiviert</string>
+    <string name="apps_components_field_type">Typ</string>
+    <string name="apps_components_field_package">Paket</string>
+    <string name="apps_components_field_permission">Berechtigung</string>
+    <string name="apps_components_field_write_permission">Schreibberechtigung</string>
+    <string name="apps_components_field_authority">Authority</string>
+    <string name="apps_components_field_process">Prozess</string>
+    <string name="apps_components_field_launch_mode">Startmodus</string>
+    <string name="apps_components_launch_action">Starten</string>
+    <string name="apps_components_copy_name_action">Komponentennamen kopieren</string>
+    <string name="apps_components_copy_package_action">Paketnamen kopieren</string>
+    <string name="apps_components_action_enable">Komponente aktivieren</string>
+    <string name="apps_components_action_disable">Komponente deaktivieren</string>
+    <string name="apps_components_action_requires_elevated">Root-Zugriff oder Shizuku erforderlich. Zum Einrichten tippen</string>
+    <string name="apps_components_confirm_enable_title">Komponenten aktivieren?</string>
+    <string name="apps_components_confirm_disable_title">Komponenten deaktivieren?</string>
+    <string name="apps_components_confirm_enable_message">Die folgenden Komponenten werden aktiviert:</string>
+    <string name="apps_components_confirm_disable_message">Die folgenden Komponenten werden deaktiviert. Dadurch funktioniert die App möglicherweise nicht mehr richtig.</string>
+    <plurals name="apps_components_selected_count">
+        <item quantity="one">%d Komponente ausgewählt</item>
+        <item quantity="other">%d Komponenten ausgewählt</item>
+    </plurals>
+
+    <!-- Generic navigation -->
+    <string name="appdetails_back_generic_action">Zurück</string>
+
+</resources>

--- a/app-workspace-bugreport/src/main/res/values-de/strings.xml
+++ b/app-workspace-bugreport/src/main/res/values-de/strings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="bugreport_workspace_title">Fehlerberichte</string>
+    <string name="bugreport_workspace_subtitle">Absturz- und Fehlerberichte</string>
+
+    <string name="bugreport_empty_title">Keine Berichte</string>
+    <string name="bugreport_empty_subtitle">Absturz- und Fehlerberichte erscheinen hier. Es wird nichts automatisch gesendet.</string>
+
+    <string name="bugreport_type_crash">Absturz</string>
+    <string name="bugreport_type_report">Bericht</string>
+    <string name="bugreport_type_recording">Aufzeichnung</string>
+
+    <string name="bugreport_record_action">Debug-Protokoll aufzeichnen</string>
+    <string name="bugreport_record_short_action">Aufzeichnen</string>
+    <string name="bugreport_stop_action">Aufzeichnung beenden</string>
+    <string name="bugreport_stop_short_action">Beenden</string>
+    <string name="bugreport_recording_ongoing_label">Aufzeichnung läuft…</string>
+
+    <string name="bugreport_recording_short_title">Aufzeichnung ist sehr kurz</string>
+    <string name="bugreport_recording_short_message">Diese Aufzeichnung ist nur wenige Sekunden lang und enthält möglicherweise keine hilfreichen Informationen. Trotzdem beenden?</string>
+    <string name="bugreport_recording_short_keep_action">Weiter aufzeichnen</string>
+
+    <string name="bugreport_rename_action">Umbenennen</string>
+    <string name="bugreport_rename_dialog_title">Bericht benennen</string>
+    <string name="bugreport_rename_name_label">Name</string>
+    <string name="bugreport_rename_name_hint">Wird in der Liste und im Namen der geteilten Datei angezeigt</string>
+
+    <string name="bugreport_share_action">Teilen</string>
+    <string name="bugreport_delete_action">Löschen</string>
+    <string name="bugreport_delete_all_action">Alle löschen</string>
+    <string name="bugreport_delete_all_confirm_title">Alle Debug-Protokolle löschen?</string>
+    <string name="bugreport_delete_all_confirm_message">Dadurch werden alle aufgezeichneten Debug-Protokollsitzungen dauerhaft gelöscht. Laufende Aufzeichnungen sind nicht betroffen.</string>
+    <string name="bugreport_delete_confirm_title">Diesen Bericht löschen?</string>
+    <string name="bugreport_delete_confirm_message">Dadurch werden dieser Bericht und sein Protokoll dauerhaft gelöscht.</string>
+    <string name="bugreport_cancel_action">Abbrechen</string>
+
+    <string name="bugreport_share_chooser_title">Fehlerbericht teilen</string>
+    <string name="bugreport_share_consent_title">Bericht teilen?</string>
+    <string name="bugreport_share_consent_message">Dieser Bericht enthält App-Protokolle, die Dateinamen, Pfade sowie App- und Geräteinformationen enthalten können. Teile ihn nur mit Personen, denen Du vertraust.</string>
+
+    <string name="bugreport_detail_back_action">Zurück</string>
+    <string name="bugreport_detail_section_error">Fehler</string>
+    <string name="bugreport_detail_section_log">Letztes Protokoll</string>
+    <string name="bugreport_detail_field_type">Typ</string>
+    <string name="bugreport_detail_field_time">Zeit</string>
+    <string name="bugreport_detail_field_app_version">App-Version</string>
+    <string name="bugreport_detail_field_device">Gerät</string>
+    <string name="bugreport_detail_field_android">Android</string>
+    <string name="bugreport_detail_field_build">Build</string>
+    <string name="bugreport_detail_field_error_class">Fehlertyp</string>
+    <string name="bugreport_detail_field_thread">Thread</string>
+    <string name="bugreport_detail_log_truncated">letzte %1$d von %2$d Zeilen</string>
+    <string name="bugreport_detail_log_count">%1$d Zeilen</string>
+    <string name="bugreport_detail_log_empty">Kein Protokoll aufgezeichnet</string>
+    <string name="bugreport_detail_log_error">Protokoll konnte nicht geladen werden</string>
+</resources>

--- a/app-workspace-developer/src/main/res/values-de/strings.xml
+++ b/app-workspace-developer/src/main/res/values-de/strings.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="developer_workspace_tab_title">Entwicklerwerkzeuge</string>
+    <string name="developer_title">Entwicklerwerkzeuge</string>
+    <string name="developer_subtitle">Entwicklungswerkzeuge</string>
+
+    <!-- Tabs -->
+    <string name="developer_tab_system">System</string>
+    <string name="developer_tab_options">Optionen</string>
+    <string name="developer_tab_workspaces">Arbeitsbereiche</string>
+    <string name="developer_tab_logs">Protokolle</string>
+    <string name="developer_tab_testdata">Testdaten</string>
+
+    <!-- Options Section -->
+    <string name="developer_options_debug_header">Debug-Optionen</string>
+    <string name="developer_options_debug_mode">Debug-Modus</string>
+    <string name="developer_options_debug_mode_desc">Ausführliche Protokollierung aktivieren</string>
+    <string name="developer_options_trace_mode">Trace-Modus</string>
+    <string name="developer_options_trace_mode_desc">Protokollierung auf Trace-Ebene aktivieren</string>
+    <string name="developer_options_floating_log">Schwebender Protokollbereich</string>
+    <string name="developer_options_floating_log_desc">Verschiebbare Protokolleinblendung auf allen Bildschirmen anzeigen</string>
+    <string name="developer_options_services_header">Diensttests</string>
+    <string name="developer_options_root_test_action">Root testen</string>
+    <string name="developer_options_root_installed_label">Installiert</string>
+    <string name="developer_options_root_available_label">Verfügbar</string>
+    <string name="developer_options_root_base_check_label">Basisprüfung</string>
+    <string name="developer_options_shizuku_test_action">Shizuku testen</string>
+    <string name="developer_options_shizuku_installed_label">Installiert</string>
+    <string name="developer_options_shizuku_granted_label">Berechtigung</string>
+    <string name="developer_options_shizuku_compatible_label">Kompatibel</string>
+    <string name="developer_options_shizuku_service_label">Dienst</string>
+    <string name="developer_options_test_running">Test läuft…</string>
+    <string name="developer_options_result_yes">Ja</string>
+    <string name="developer_options_result_no">Nein</string>
+    <string name="developer_options_result_unknown">Unbekannt</string>
+    <string name="developer_options_visibility_header">Sichtbarkeit</string>
+    <string name="developer_options_hide_mode">Entwicklermodus ausblenden</string>
+    <string name="developer_options_hide_mode_desc">Zum erneuten Aktivieren in den Einstellungen siebenmal auf die Version tippen.</string>
+    <string name="developer_options_hide_action">Ausblenden</string>
+
+    <!-- System Info Section -->
+    <string name="developer_system_device_header">Gerät</string>
+    <string name="developer_system_device_model">Modell</string>
+    <string name="developer_system_device_manufacturer">Hersteller</string>
+    <string name="developer_system_device_api">API-Level</string>
+    <string name="developer_system_build_header">Build</string>
+    <string name="developer_system_build_version">Version</string>
+    <string name="developer_system_build_code">Versionscode</string>
+    <string name="developer_system_build_flavor">Variante</string>
+    <string name="developer_system_build_type">Build-Typ</string>
+    <string name="developer_system_build_git">Git-SHA</string>
+    <string name="developer_system_memory_header">Arbeitsspeicher</string>
+    <string name="developer_system_memory_available">Verfügbar</string>
+    <string name="developer_system_memory_total">Gesamt</string>
+    <string name="developer_system_storage_header">Speicher</string>
+
+    <!-- Workspaces Section -->
+    <string name="developer_workspaces_count">%d Arbeitsbereiche</string>
+    <string name="developer_workspaces_empty">Keine Arbeitsbereiche</string>
+
+    <!-- Logs Section -->
+    <string name="developer_logs_clear">Leeren</string>
+    <string name="developer_logs_pause">Pausieren</string>
+    <string name="developer_logs_resume">Fortsetzen</string>
+    <string name="developer_logs_empty">Keine Protokolle</string>
+
+    <!-- Test Data Section -->
+    <string name="developer_testdata_target_paths_label">Zielpfade</string>
+    <string name="developer_testdata_no_paths">Keine Zielpfade ausgewählt. Füge Pfade hinzu, um Testdaten zu erzeugen.</string>
+    <string name="developer_testdata_add_path_action">Pfad hinzufügen</string>
+    <string name="developer_testdata_options_header">Erzeugungsoptionen</string>
+    <string name="developer_testdata_large_files">Große Dateien</string>
+    <string name="developer_testdata_large_files_desc">1 MB, 10 MB, 100 MB, 1 GB, 2 GB, 4 GB, 8 GB</string>
+    <string name="developer_testdata_nested_structure">Verschachtelte Struktur</string>
+    <string name="developer_testdata_nested_structure_desc">~1100 Ordner, ~1100 Dateien</string>
+    <string name="developer_testdata_text_files">Textdateien für den Editor</string>
+    <string name="developer_testdata_text_files_desc">10 KB, 100 KB, 1 MB, 10 MB, 100 MB</string>
+    <string name="developer_testdata_generate_action">Erzeugen</string>
+    <string name="developer_testdata_generating">Wird erzeugt…</string>
+    <string name="developer_testdata_history_header">Beispieleinträge im Verlauf</string>
+    <string name="developer_testdata_history_desc">Fügt etwa 25 erfundene Vorgangseinträge aus dem Zeitraum von heute bis vor 30 Tagen mit verschiedenen Arten, Ergebnissen, Ursprüngen und Pfaden hinzu. Die Einträge werden direkt in die Verlaufsdatenbank eingefügt. Erneutes Tippen ist sicher.</string>
+    <string name="developer_testdata_history_generate_action">Beispielverlauf erzeugen</string>
+    <string name="developer_testdata_progress">%1$s von %2$s</string>
+    <string name="developer_testdata_complete">Testdaten wurden erzeugt unter:</string>
+
+    <!-- Test Data Operations -->
+    <string name="developer_operation_large_files_title">Große Dateien erzeugen</string>
+    <string name="developer_operation_large_files_desc">Testdateien werden in %1$s erstellt</string>
+    <string name="developer_operation_large_files_creating">%1$s wird erstellt</string>
+
+    <string name="developer_operation_nested_title">Verschachtelte Struktur erzeugen</string>
+    <string name="developer_operation_nested_desc">Ordnerhierarchie wird in %1$s erstellt</string>
+    <string name="developer_operation_nested_starting">Verschachtelte Struktur wird gestartet…</string>
+    <string name="developer_operation_nested_creating">%1$s wird erstellt</string>
+    <string name="developer_operation_nested_files_created">%1$d Dateien erstellt</string>
+
+    <string name="developer_operation_text_files_title">Textdateien erzeugen</string>
+    <string name="developer_operation_text_files_desc">Textdateien werden in %1$s erstellt</string>
+    <string name="developer_operation_text_files_creating">%1$s wird erstellt</string>
+
+    <plurals name="developer_testdata_report_files_created">
+        <item quantity="one">%d Datei erstellt</item>
+        <item quantity="other">%d Dateien erstellt</item>
+    </plurals>
+
+    <plurals name="developer_testdata_report_dirs_created">
+        <item quantity="one">%d Verzeichnis</item>
+        <item quantity="other">%d Verzeichnisse</item>
+    </plurals>
+</resources>

--- a/app-workspace-editor/src/main/res/values-de/strings.xml
+++ b/app-workspace-editor/src/main/res/values-de/strings.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="editor_title">Editor</string>
+    <string name="editor_subtitle">Textdateien bearbeiten</string>
+    <string name="editor_settings_title">Editor-Einstellungen</string>
+    <string name="editor_settings_show_line_numbers_title">Zeilennummern anzeigen</string>
+    <string name="editor_settings_show_line_numbers_subtitle">Zeilennummern im Editor anzeigen.</string>
+    <string name="editor_settings_word_wrap_title">Zeilenumbruch</string>
+    <string name="editor_settings_word_wrap_subtitle">Lange Zeilen passend zur Bildschirmbreite umbrechen.</string>
+    <string name="editor_settings_syntax_highlighting_title">Syntaxhervorhebung</string>
+    <string name="editor_settings_syntax_highlighting_subtitle">Code in unterstützten Dateien farblich hervorheben (JavaScript, Bash, Markdown, JSON).</string>
+    <string name="editor_settings_font_size_title">Schriftgröße</string>
+    <string name="editor_settings_font_size_subtitle">Textgröße im Editor</string>
+    <string name="editor_settings_font_size_value">%1$d sp</string>
+    <string name="editor_settings_tab_size_title">Tabulatorbreite</string>
+    <string name="editor_settings_tab_size_subtitle">Anzahl der Leerzeichen, die ein Tabulator umfasst</string>
+
+    <!-- Editor tab page -->
+    <string name="editor_action_open">Öffnen</string>
+    <string name="editor_action_save">Speichern</string>
+    <string name="editor_action_save_as">Speichern unter…</string>
+    <string name="editor_action_close">Schließen</string>
+    <string name="editor_action_undo">Rückgängig</string>
+    <string name="editor_action_redo">Wiederholen</string>
+    <string name="editor_action_search">Suchen</string>
+    <string name="editor_action_go_to_line">Zu Zeile springen</string>
+    <string name="editor_action_dismiss">Ausblenden</string>
+    <string name="editor_action_previous">Zurück</string>
+    <string name="editor_action_next">Weiter</string>
+    <string name="editor_action_copy">Kopieren</string>
+    <string name="editor_action_cut">Ausschneiden</string>
+    <string name="editor_action_copy_to_butler_clipboard">In die Butler-Zwischenablage kopieren</string>
+    <string name="editor_action_cut_to_butler_clipboard">In die Butler-Zwischenablage ausschneiden</string>
+    <string name="editor_action_paste">Einfügen</string>
+    <string name="editor_action_select_all">Alles auswählen</string>
+    <string name="editor_action_delete">Löschen</string>
+
+    <!-- Save-As overwrite confirmation -->
+    <string name="editor_dialog_save_as_overwrite_title">Datei überschreiben?</string>
+    <string name="editor_dialog_save_as_overwrite_message">%1$s ist bereits vorhanden. Der aktuelle Inhalt wird ersetzt.</string>
+    <string name="editor_dialog_save_as_overwrite_action">Überschreiben</string>
+
+    <!-- Stale save-backup notice -->
+    <string name="editor_backup_banner_message">Eine Sicherung aus einem unterbrochenen Speichervorgang wurde gefunden:\n%1$s</string>
+
+    <!-- Binary file notice -->
+    <string name="editor_binary_banner_message">Das Bearbeiten als Text wird nicht unterstützt</string>
+
+    <!-- Long-lines notice -->
+    <string name="editor_long_lines_banner_title">Sehr lange Zeilen</string>
+    <string name="editor_long_lines_banner_message">Sehr lange Zeilen werden für die Anzeige gekürzt. Der vollständige Inhalt bleibt erhalten und wird gespeichert.</string>
+    <string name="editor_line_truncated_marker">⋯ +%1$d</string>
+    <string name="editor_line_leading_truncated_marker">+%1$d ⋯</string>
+    <string name="editor_line_truncated_marker_next_action">Nächsten Teil der Zeile anzeigen</string>
+    <string name="editor_line_truncated_marker_previous_action">Vorherigen Teil der Zeile anzeigen</string>
+
+    <!-- Backing-file-lost notice -->
+    <string name="editor_backing_lost_banner_title">Datei nicht mehr verfügbar</string>
+    <string name="editor_backing_lost_banner_message">Die Datei wurde möglicherweise verschoben oder gelöscht. Diese Ansicht ist schreibgeschützt. Öffne die Datei erneut oder schließe den Tab.</string>
+
+    <!-- Interrupted-save recovery notice -->
+    <string name="editor_error_save_artifacts_label">Datei nicht mehr vorhanden, Sicherung verfügbar</string>
+    <string name="editor_error_save_artifacts_description">„%1$s“ fehlt, aber bei einem unterbrochenen Speichervorgang blieb diese Datei zurück: %2$s. Dein Inhalt ist sehr wahrscheinlich noch darin enthalten.</string>
+
+    <!-- External change notice -->
+    <string name="editor_external_change_banner_title">Datei auf dem Datenträger geändert</string>
+    <string name="editor_external_change_banner_message">Eine andere App hat diese Datei geändert.</string>
+    <string name="editor_external_change_reload_action">Neu laden</string>
+    <string name="editor_external_change_keep_action">Weiter bearbeiten</string>
+    <string name="editor_error_external_change">Diese Datei wurde von einer anderen App geändert. Lade die Datei neu, um fortzufahren.</string>
+    <string name="editor_dialog_reload_confirm_title">Datei neu laden?</string>
+    <string name="editor_dialog_reload_confirm_message">Beim Neuladen werden Deine ungespeicherten Änderungen verworfen und der aktuelle Dateiinhalt vom Datenträger angezeigt.</string>
+
+    <!-- Editor info bar -->
+    <plurals name="editor_infobar_lines">
+        <item quantity="one">%1$d Zeile</item>
+        <item quantity="other">%1$d Zeilen</item>
+    </plurals>
+    <plurals name="editor_infobar_characters">
+        <item quantity="one">%1$d Zeichen</item>
+        <item quantity="other">%1$d Zeichen</item>
+    </plurals>
+
+    <string name="editor_infobar_selected_x_y">Ausgewählt: %1$s, %2$s</string>
+    <string name="editor_infobar_lines_size">%1$d Z · %2$s</string>
+
+    <!-- Editor loading states -->
+    <string name="editor_loading_file">Datei wird geladen…</string>
+    <string name="editor_saving">Wird gespeichert…</string>
+    <string name="editor_action_cancel_loading">Abbrechen</string>
+    <string name="editor_progress_opening">Datei wird geöffnet…</string>
+    <string name="editor_progress_saving">Datei wird gespeichert…</string>
+    <string name="editor_progress_building_index">Dateiindex wird erstellt…</string>
+
+    <!-- Editor UI elements -->
+    <string name="editor_error_unknown">Unbekannter Fehler</string>
+    <string name="editor_error_read_only">Diese Datei ist schreibgeschützt und kann nicht geändert werden.</string>
+    <string name="editor_error_save_integrity_label">Speichern unterbrochen</string>
+    <string name="editor_error_save_integrity">Das Speichern wurde unterbrochen und die Datei auf dem Datenträger ist möglicherweise unvollständig. Lade die Datei neu, bevor Du sie weiter bearbeitest.</string>
+    <string name="editor_error_clipboard_too_large_label">Auswahl zu groß</string>
+    <string name="editor_error_clipboard_too_large">Die Auswahl ist zu groß zum Kopieren (Limit: %1$s).</string>
+    <string name="editor_error_paste_too_large_label">Datei zu groß</string>
+    <string name="editor_error_paste_too_large">Diese Datei ist zu groß zum Einfügen (Maximum: %1$s).</string>
+    <string name="editor_error_paste_binary_label">Keine Textdatei</string>
+    <string name="editor_error_paste_binary">Der Inhalt dieser Datei kann nicht als Text eingefügt werden.</string>
+    <plurals name="editor_search_results_x_of_y">
+        <item quantity="one">%1$d von %2$d Ergebnis</item>
+        <item quantity="other">%1$d von %2$d Ergebnissen</item>
+    </plurals>
+    <string name="editor_search_results_x_of_capped">%1$d von über %2$d Ergebnissen</string>
+    <string name="editor_search_too_many_matches_label">Zu viele Treffer</string>
+    <string name="editor_search_too_many_matches">Mehr als %1$d Treffer oder zu viel übereinstimmender Text. Schränke die Suche ein, um alle zu ersetzen.</string>
+    <string name="editor_search_placeholder">Suchen…</string>
+    <string name="editor_search_previous">Vorheriges Ergebnis</string>
+    <string name="editor_search_next">Nächstes Ergebnis</string>
+    <string name="editor_search_case_sensitive_label">Groß-/Kleinschreibung beachten</string>
+    <string name="editor_search_regex_label">Regulärer Ausdruck</string>
+    <string name="editor_search_whole_word_label">Ganzes Wort</string>
+    <string name="editor_search_options_label">Suchoptionen</string>
+    <string name="editor_search_replace_label">Ersetzen</string>
+    <string name="editor_search_replace_toggle">Ersetzen ein-/ausblenden</string>
+    <string name="editor_search_replace_placeholder">Ersetzen durch…</string>
+    <string name="editor_search_replace_one_action">Ersetzen</string>
+    <string name="editor_search_replace_all_action">Alle</string>
+    <string name="editor_search_replaced_not_undoable">%1$d ersetzt (zu groß zum Rückgängigmachen)</string>
+    <plurals name="editor_search_replaced_count">
+        <item quantity="one">%1$d ersetzt</item>
+        <item quantity="other">%1$d ersetzt</item>
+    </plurals>
+
+    <!-- Editor dialogs -->
+    <string name="editor_dialog_go_to_line_title">Zu Zeile springen</string>
+    <string name="editor_dialog_go_to_line_label">Zeilennummer (1–%1$d)</string>
+    <string name="editor_dialog_action_go">Los</string>
+    <string name="editor_dialog_action_cancel">Abbrechen</string>
+    <string name="editor_dialog_close_confirm_title">Ungespeicherte Änderungen</string>
+    <string name="editor_dialog_close_confirm_message">Du hast ungespeicherte Änderungen. Möchtest Du sie verwerfen?</string>
+    <string name="editor_dialog_close_confirm_discard">Verwerfen</string>
+    <string name="editor_dialog_large_delete_confirm_title">Große Auswahl bearbeiten?</string>
+    <string name="editor_dialog_large_delete_confirm_message">Diese Auswahl ist zu groß, um die Änderung rückgängig zu machen. Trotzdem fortfahren?</string>
+    <string name="editor_dialog_large_delete_confirm_action">Fortfahren</string>
+    <string name="editor_encoding_dialog_title">Zeichenkodierung</string>
+    <string name="editor_encoding_dialog_message">Öffne die Datei mit einer anderen Zeichenkodierung erneut. Ungespeicherte Änderungen werden verworfen. Unbearbeitete Bytes bleiben beim Speichern unverändert.</string>
+    <string name="editor_infobar_read_only">Schreibgeschützt</string>
+    <string name="editor_line_ending_mixed">Gemischt</string>
+    <string name="editor_line_ending_dialog_title">Zeilenenden</string>
+    <string name="editor_line_ending_dialog_message">Alle Zeilenumbrüche konvertieren und die Datei einschließlich ungespeicherter Änderungen speichern. Der Verlauf zum Rückgängigmachen wird gelöscht.</string>
+    <string name="editor_line_ending_lf_label">LF – Unix, Android, macOS</string>
+    <string name="editor_line_ending_crlf_label">CRLF – Windows</string>
+
+    <!-- Editor File Names -->
+    <string name="editor_file_untitled">Unbenannt</string>
+
+    <!-- Editor Settings - Auto-Save -->
+    <string name="editor_settings_autosave_category">Automatisches Speichern</string>
+    <string name="editor_settings_autosave_enabled_title">Automatisches Speichern aktivieren</string>
+    <string name="editor_settings_autosave_enabled_subtitle">Änderungen nach einer gewissen Zeit ohne Eingabe automatisch speichern.</string>
+    <string name="editor_settings_autosave_interval_title">Intervall für automatisches Speichern</string>
+    <string name="editor_settings_autosave_interval_subtitle">Wartezeit nach der letzten Bearbeitung bis zum Speichern.</string>
+    <string name="editor_settings_autosave_interval_dialog_title">Intervall für automatisches Speichern</string>
+
+    <!-- Editor Settings - Clipboard -->
+    <string name="editor_settings_clipboard_category">Zwischenablage</string>
+    <string name="editor_settings_clipboard_behavior_title">Butler-Zwischenablage</string>
+    <string name="editor_settings_clipboard_behavior_subtitle">Festlegen, wie Textkopien in Butlers Zwischenablage gespeichert werden.</string>
+    <string name="editor_settings_clipboard_system_only">Nur System</string>
+    <string name="editor_settings_clipboard_system_only_desc">Nur in die Systemzwischenablage kopieren</string>
+    <string name="editor_settings_clipboard_butler_always">Immer zu Butler hinzufügen</string>
+    <string name="editor_settings_clipboard_butler_always_desc">Für das Einfügen zwischen Arbeitsbereichen auch in Butlers Zwischenablage speichern</string>
+    <string name="editor_settings_clipboard_ask">Jedes Mal fragen</string>
+    <string name="editor_settings_clipboard_ask_desc">Vor dem Hinzufügen zu Butlers Zwischenablage nachfragen</string>
+</resources>

--- a/app-workspace-explorer/src/main/res/values-de/strings.xml
+++ b/app-workspace-explorer/src/main/res/values-de/strings.xml
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Explorer -->
+    <string name="explorer_title">Explorer</string>
+    <string name="explorer_subtitle">Dateien und Verzeichnisse durchsuchen</string>
+    <string name="explorer_settings_title">Explorer-Einstellungen</string>
+    <string name="explorer_settings_file_display">Dateiansicht</string>
+    <string name="explorer_settings_filter_regex_title">Erweiterte Platzhaltersuche</string>
+    <string name="explorer_settings_filter_regex_desc">Reguläre Ausdrücke für Einschluss- und Ausschlussfilter verwenden.</string>
+    <string name="explorer_settings_navigation">Navigation</string>
+    <string name="explorer_settings_back_button_title">Navigation über die Zurück-Taste</string>
+    <string name="explorer_settings_back_button_desc">Mit der Zurück-Taste oder -Geste durch den Verlauf navigieren.</string>
+    <string name="explorer_settings_trash_category">Papierkorb</string>
+    <string name="explorer_settings_trash_enabled_title">Papierkorb aktivieren</string>
+    <string name="explorer_settings_trash_enabled_desc">Gelöschte Dateien in den Papierkorb verschieben, statt sie endgültig zu löschen</string>
+    <string name="explorer_settings_trash_auto_delete_title">Automatisch löschen nach</string>
+    <string name="explorer_settings_trash_auto_delete_desc">Elemente, die älter als %d Tage sind, automatisch löschen</string>
+    <string name="explorer_settings_trash_auto_delete_value">%d Tage</string>
+    <string name="explorer_settings_trash_max_size_title">Maximale Größe pro Speicher</string>
+    <string name="explorer_settings_trash_max_size_desc">Maximal %d MB pro Speicherort</string>
+    <string name="explorer_settings_trash_max_size_value">%d MB</string>
+    <string name="explorer_settings_trash_auto_delete_dialog_title">Zeitraum für automatisches Löschen</string>
+    <string name="explorer_settings_trash_max_size_dialog_title">Maximale Größe pro Speicher</string>
+    <string name="explorer_settings_trash_enable_dialog_title">Papierkorb aktivieren?</string>
+    <string name="explorer_settings_trash_enable_dialog_message">Anders als Desktop-Systeme hat Android keinen integrierten Papierkorb. Butler stellt über seinen Cache-Ordner einen bereit.\n\nBitte beachte:\n• Die Speicheranzeige Deines Geräts zeigt den freigegebenen Speicherplatz erst an, wenn Elemente endgültig gelöscht wurden\n• Wenn der Speicherplatz auf Deinem Gerät knapp wird, kann Android App-Caches leeren und dadurch Dateien im Papierkorb entfernen</string>
+    <string name="explorer_settings_trash_enable_action">Aktivieren</string>
+
+    <!-- File Row Content Descriptions -->
+    <string name="explorer_file_regular_content_desc">Datei</string>
+    <string name="explorer_file_symlink_content_desc">Symbolische Verknüpfung</string>
+    <string name="explorer_file_folder_content_desc">Ordner</string>
+    <string name="explorer_file_peek_content_desc">Dateiinformationen werden geladen</string>
+
+    <!-- File Row UI Strings -->
+    <string name="explorer_file_shortcut_label">Verknüpfung</string>
+    <string name="explorer_file_storage_local_label">Lokal</string>
+    <string name="explorer_file_storage_saf_label">SAF</string>
+    <string name="explorer_file_storage_saf_read_only_label">Nur Lesezugriff</string>
+    <string name="explorer_file_storage_saf_write_only_label">Nur Schreibzugriff</string>
+    <string name="explorer_file_storage_saf_no_access_label">Kein Zugriff</string>
+    <string name="explorer_file_storage_saf_uri_label">SAF-Baum-URI</string>
+    <string name="explorer_file_storage_size_format">%1$s • %2$s gesamt • %3$s frei</string>
+    <string name="explorer_file_broken_link_label">Defekte Verknüpfung</string>
+    <string name="explorer_file_items_count">%1$d Elemente</string>
+    <string name="explorer_file_empty">Leer</string>
+
+    <!-- Picker Mode -->
+    <string name="explorer_picker_select_directory_title">Ordner auswählen</string>
+    <plurals name="explorer_picker_select_directories">
+        <item quantity="one">Ordner auswählen (%d)</item>
+        <item quantity="other">Ordner auswählen (%d)</item>
+    </plurals>
+    <string name="explorer_picker_select_file_title">Datei auswählen</string>
+    <plurals name="explorer_picker_select_files">
+        <item quantity="one">Datei auswählen (%d)</item>
+        <item quantity="other">Dateien auswählen (%d)</item>
+    </plurals>
+    <plurals name="explorer_picker_select_items">
+        <item quantity="one">Element auswählen (%d)</item>
+        <item quantity="other">Elemente auswählen (%d)</item>
+    </plurals>
+    <string name="explorer_picker_select_this_folder_action">Diesen Ordner auswählen</string>
+    <plurals name="explorer_picker_select_count_action">
+        <item quantity="one">%d auswählen</item>
+        <item quantity="other">%d auswählen</item>
+    </plurals>
+    <string name="explorer_picker_save_as_title">Datei speichern</string>
+    <string name="explorer_picker_save_here_action">Hier speichern</string>
+    <string name="explorer_picker_save_as_filename_label">Dateiname</string>
+    <string name="explorer_picker_save_as_filename_hint">Dateinamen eingeben</string>
+
+    <!-- Explorer Actions -->
+    <string name="explorer_action_refresh">Aktualisieren</string>
+    <string name="explorer_action_sort">Sortieren</string>
+    <string name="explorer_action_filter">Filtern</string>
+    <string name="explorer_action_view">Ansicht</string>
+    <string name="explorer_action_create">Erstellen</string>
+    <string name="explorer_action_rename">Umbenennen</string>
+    <string name="explorer_action_copy">Kopieren</string>
+    <string name="explorer_action_cut">Ausschneiden</string>
+    <string name="explorer_action_delete">Löschen</string>
+    <string name="explorer_action_select_all">Alle auswählen</string>
+    <string name="explorer_action_deselect_all">Auswahl aufheben</string>
+    <string name="explorer_action_compress">Komprimieren</string>
+    <string name="explorer_action_extract">Entpacken</string>
+    <string name="explorer_action_add_location">Speicherort hinzufügen</string>
+    <string name="explorer_action_info">Informationen</string>
+
+    <!-- Item Info -->
+    <string name="explorer_info_title">Informationen</string>
+    <string name="explorer_info_name_label">Name</string>
+    <string name="explorer_info_path_label">Pfad</string>
+    <string name="explorer_info_type_label">Typ</string>
+    <string name="explorer_info_type_file">Datei</string>
+    <string name="explorer_info_type_directory">Verzeichnis</string>
+    <string name="explorer_info_size_label">Größe</string>
+    <string name="explorer_info_modified_label">Geändert</string>
+    <string name="explorer_info_created_label">Erstellt</string>
+    <string name="explorer_info_permissions_label">Berechtigungen</string>
+    <string name="explorer_info_owner_label">Eigentümer</string>
+    <string name="explorer_info_child_count_label">Elemente</string>
+    <string name="explorer_info_symlink_target_label">Ziel</string>
+    <string name="explorer_info_symlink_status_label">Status</string>
+    <string name="explorer_info_symlink_broken">Defekte Verknüpfung</string>
+    <string name="explorer_info_unknown">Unbekannt</string>
+
+    <!-- Trash Item Info -->
+    <string name="explorer_trash_info_deleted_label">Gelöscht</string>
+
+    <!-- SAF Info -->
+    <string name="explorer_info_saf_uri_label">URI</string>
+    <string name="explorer_info_saf_permissions_label">Berechtigungen</string>
+    <string name="explorer_info_saf_granted_label">Gewährt</string>
+    <string name="explorer_info_saf_permission_read">Lesen</string>
+    <string name="explorer_info_saf_permission_write">Schreiben</string>
+
+    <!-- Network Info -->
+    <string name="explorer_info_network_server_label">Server</string>
+    <string name="explorer_info_network_port_label">Port</string>
+    <string name="explorer_info_network_share_label">Freigabe</string>
+    <string name="explorer_info_network_folder_label">Ordner</string>
+    <string name="explorer_info_network_address_label">Adresse</string>
+    <string name="explorer_info_network_status_label">Status</string>
+    <string name="explorer_info_network_type_value">SMB</string>
+    <string name="explorer_info_network_auth_label">Anmeldung</string>
+    <string name="explorer_info_network_domain_label">Domäne</string>
+    <string name="explorer_info_network_password_label">Passwort</string>
+    <string name="explorer_info_network_password_show_action">Passwort anzeigen</string>
+    <string name="explorer_info_network_password_hide_action">Passwort ausblenden</string>
+    <string name="explorer_info_network_password_missing">Fehlt, erneut anmelden</string>
+    <string name="explorer_info_network_password_locked">Gespeichert, kann auf diesem Gerät aber nicht entsperrt werden</string>
+    <string name="explorer_info_network_added_label">Hinzugefügt</string>
+    <string name="explorer_info_network_updated_label">Aktualisiert</string>
+    <string name="explorer_info_network_last_seen_label">Zuletzt gesehen</string>
+    <string name="explorer_info_network_last_seen_never">Nie</string>
+
+    <!-- Multiple Items Info -->
+    <string name="explorer_info_selected_label">Ausgewählt</string>
+    <string name="explorer_info_files_label">Dateien</string>
+    <string name="explorer_info_directories_label">Verzeichnisse</string>
+    <string name="explorer_info_total_size_label">Gesamtgröße</string>
+
+    <!-- Device/Home View Info -->
+    <string name="explorer_info_locations_label">Speicherorte</string>
+    <string name="explorer_info_shortcuts_label">Verknüpfungen</string>
+    <string name="explorer_info_total_capacity_label">Gesamtkapazität</string>
+    <string name="explorer_info_used_space_label">Belegter Speicher</string>
+    <string name="explorer_info_free_space_label">Freier Speicher</string>
+    <string name="explorer_info_usage_label">Belegung</string>
+    <string name="explorer_info_device_storage_total_label">Gerätespeicher</string>
+    <string name="explorer_info_device_storage_used_label">Belegt</string>
+    <string name="explorer_info_device_storage_free_label">Frei</string>
+
+    <!-- Navigation -->
+    <string name="explorer_navigation_home">Start</string>
+    <string name="explorer_breadcrumb_set_as_home_action">Als Start festlegen</string>
+    <string name="explorer_breadcrumb_copy_path_action">Pfad kopieren</string>
+    <string name="explorer_breadcrumb_copy_path_confirmation">Pfad in die Zwischenablage kopiert</string>
+    <string name="explorer_navigation_device">Gerät</string>
+    <string name="explorer_navigation_network">Netzwerk</string>
+    <string name="explorer_navigation_trash">Papierkorb</string>
+    <string name="explorer_navigation_trash_desc">Gelöschte Dateien wiederherstellen</string>
+    <string name="explorer_navigation_trash_nested_desc">Im Ordner im Papierkorb</string>
+
+    <!-- Trash -->
+    <string name="explorer_trash_empty_state">Keine gelöschten Elemente</string>
+    <plurals name="explorer_trash_item_count">
+        <item quantity="one">%d Element</item>
+        <item quantity="other">%d Elemente</item>
+    </plurals>
+    <string name="explorer_trash_restore_action">Wiederherstellen</string>
+    <string name="explorer_trash_restore_selected_action">Ausgewählte wiederherstellen</string>
+    <string name="explorer_trash_delete_permanently_action">Endgültig löschen</string>
+    <string name="explorer_trash_delete_selected_action">Ausgewählte löschen</string>
+    <string name="explorer_trash_empty_trash_action">Papierkorb leeren</string>
+    <string name="explorer_trash_empty_confirm">Papierkorb leeren?</string>
+    <string name="explorer_trash_empty_message">Alle Elemente im Papierkorb werden endgültig gelöscht. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="explorer_trash_empty_confirm_action">Papierkorb leeren</string>
+    <string name="explorer_trash_restore_desc">Am ursprünglichen Speicherort wiederherstellen</string>
+    <string name="explorer_trash_item_unavailable">Element nicht verfügbar</string>
+    <string name="explorer_trash_delete_warning">Dies kann nicht rückgängig gemacht werden</string>
+    <string name="explorer_trash_disabled_warning">Papierkorb deaktiviert</string>
+
+    <!-- Nested Trash -->
+    <string name="explorer_trash_nested_loading">Inhalt des Ordners im Papierkorb wird geladen…</string>
+    <string name="explorer_trash_nested_restore_action">Am ursprünglichen Speicherort wiederherstellen</string>
+    <string name="explorer_trash_nested_delete_action">Endgültig löschen</string>
+    <string name="explorer_trash_nested_restore_conflict">Am ursprünglichen Speicherort ist bereits eine Datei vorhanden</string>
+    <string name="explorer_trash_nested_parent_missing">Übergeordnetes Element ist nicht mehr im Papierkorb vorhanden</string>
+    <string name="explorer_trash_nested_path_missing">Pfad ist nicht mehr vorhanden</string>
+    <string name="explorer_trash_error_items_not_found">Elemente nicht im Papierkorb gefunden</string>
+    <string name="explorer_trash_error_restore_failed">Elemente konnten nicht wiederhergestellt werden</string>
+    <string name="explorer_trash_error_delete_failed">Elemente konnten nicht gelöscht werden</string>
+    <string name="explorer_trash_nested_error_restore_failed">%1$s konnte nicht wiederhergestellt werden</string>
+    <string name="explorer_trash_nested_error_delete_failed">%1$s konnte nicht gelöscht werden</string>
+
+    <string name="explorer_navigation_root">Wurzelverzeichnis</string>
+    <string name="explorer_navigation_rom">System-ROM</string>
+    <string name="explorer_navigation_internal_storage">Interner öffentlicher Speicher</string>
+    <string name="explorer_navigation_external_storage">Externer öffentlicher Speicher</string>
+
+    <string name="explorer_loader_progress_directory_loading">%s wird durchsucht</string>
+    <string name="explorer_loader_progress_directory_permissions">Berechtigungen werden geprüft</string>
+    <string name="explorer_loader_progress_directory_filesystem">Dateisysteminformationen werden abgerufen</string>
+    <string name="explorer_loader_progress_directory_content">Ordnerinhalt wird geladen</string>
+    <string name="explorer_loader_progress_directory_content_details">Inhaltsdetails werden geladen</string>
+    <string name="explorer_loader_progress_directory_content_extended">Erweiterte Inhaltsdetails werden geladen</string>
+
+    <string name="explorer_loader_progress_device_loading">Gerät wird geladen</string>
+    <string name="explorer_loader_progress_device_locations">Speicherorte werden geladen</string>
+
+    <string name="explorer_loader_progress_network_loading">Netzwerkspeicher wird geladen</string>
+
+    <string name="explorer_loader_progress_home_loading">Start wird geladen</string>
+    <string name="explorer_loader_progress_trash_loading">Papierkorb wird geladen…</string>
+
+    <!-- InfoBar -->
+    <plurals name="explorer_infobar_shortcuts_count">
+        <item quantity="one">%d Verknüpfung</item>
+        <item quantity="other">%d Verknüpfungen</item>
+    </plurals>
+    <plurals name="explorer_infobar_location_count">
+        <item quantity="one">%d Speicherort</item>
+        <item quantity="other">%d Speicherorte</item>
+    </plurals>
+    <string name="explorer_infobar_storage_free">%1$s frei</string>
+    <string name="explorer_infobar_loading">Wird geladen…</string>
+
+    <!-- Dialogs -->
+    <string name="explorer_dialog_create_title">Neues Element erstellen</string>
+    <string name="explorer_dialog_rename_title">Umbenennen</string>
+    <string name="explorer_dialog_name_label">Name</string>
+    <string name="explorer_dialog_type_label">Typ</string>
+    <string name="explorer_dialog_type_folder">Ordner</string>
+    <string name="explorer_dialog_type_file">Datei</string>
+    <string name="explorer_dialog_create_text_file_title">Datei aus Text erstellen</string>
+    <string name="explorer_dialog_create_text_file_preview_label">Vorschau</string>
+    <string name="explorer_dialog_create_text_file_size_label">%1$d Zeichen</string>
+
+    <!-- Add Device Storage Dialog -->
+    <string name="explorer_add_device_storage_title">Speicherort hinzufügen</string>
+    <string name="explorer_add_device_storage_desc">Verwende das Storage Access Framework (SAF), um Butler Zugriff auf weitere Speicherorte wie USB-Laufwerke, virtuelle App-Ordner und mehr zu gewähren.</string>
+    <string name="explorer_add_device_storage_continue">Weiter</string>
+    <string name="explorer_add_device_storage_cancel">Abbrechen</string>
+    <string name="explorer_add_device_storage_suggestions_title">Apps mit Speicher</string>
+    <string name="explorer_add_device_storage_suggestion_desc_direct">Öffnet den Ordner dieser App</string>
+
+    <!-- Device Storage Actions -->
+    <string name="explorer_device_action_remove_location">Speicherort entfernen</string>
+    <string name="explorer_device_remove_confirmation_title">Speicherort entfernen?</string>
+    <plurals name="explorer_device_remove_confirmation_title_multiple">
+        <item quantity="one">%1$d Speicherort entfernen?</item>
+        <item quantity="other">%1$d Speicherorte entfernen?</item>
+    </plurals>
+    <string name="explorer_device_remove_confirmation_message">Dadurch wird Butlers Zugriff auf diesen Speicherort widerrufen. Deine Dateien werden nicht gelöscht.</string>
+
+    <!-- Network Storage -->
+    <plurals name="explorer_network_location_count">
+        <item quantity="one">%d Netzwerk-Speicherort</item>
+        <item quantity="other">%d Netzwerk-Speicherorte</item>
+    </plurals>
+    <string name="explorer_network_storage_label">Netzwerk</string>
+    <string name="explorer_network_add_location_action">Netzwerkspeicher hinzufügen</string>
+    <string name="explorer_network_edit_location_action">Netzwerkspeicher bearbeiten</string>
+    <string name="explorer_network_remove_location_action">Netzwerkspeicher entfernen</string>
+    <string name="explorer_network_sign_in_required_label">Anmeldung erforderlich</string>
+    <string name="explorer_network_status_checking_label">Wird geprüft…</string>
+    <string name="explorer_network_status_available_label">Verfügbar</string>
+    <string name="explorer_network_status_unavailable_label">Nicht verfügbar</string>
+    <string name="explorer_network_status_unavailable_since_format">Nicht verfügbar (%1$s)</string>
+    <string name="explorer_network_empty_title">Noch kein Netzwerkspeicher</string>
+    <string name="explorer_network_empty_caption">Füge eine Windows-Freigabe oder einen NAS-Ordner hinzu, um ihn hier zu durchsuchen.</string>
+    <string name="explorer_network_remove_confirmation_title">Netzwerkspeicher entfernen?</string>
+    <plurals name="explorer_network_remove_confirmation_title_multiple">
+        <item quantity="one">%1$d Netzwerkspeicher entfernen?</item>
+        <item quantity="other">%1$d Netzwerkspeicher entfernen?</item>
+    </plurals>
+    <string name="explorer_network_remove_confirmation_message">Butler vergisst die Serverdaten und das gespeicherte Passwort. Auf dem Server wird nichts gelöscht.</string>
+
+    <!-- Network Storage Form -->
+    <string name="explorer_network_form_add_title">Netzwerkspeicher hinzufügen</string>
+    <string name="explorer_network_form_edit_title">Netzwerkspeicher bearbeiten</string>
+    <string name="explorer_network_form_label_label">Name (optional)</string>
+    <string name="explorer_network_form_host_label">Serveradresse</string>
+    <string name="explorer_network_form_host_hint">nas.local oder 192.168.1.10</string>
+    <string name="explorer_network_form_port_label">Port</string>
+    <string name="explorer_network_form_share_label">Freigabe</string>
+    <string name="explorer_network_form_share_hint">medien</string>
+    <string name="explorer_network_form_base_path_label">Ordner innerhalb der Freigabe (optional)</string>
+    <string name="explorer_network_form_auth_guest">Gast</string>
+    <string name="explorer_network_form_auth_password">Benutzername und Passwort</string>
+    <string name="explorer_network_form_username_label">Benutzername</string>
+    <string name="explorer_network_form_domain_label">Domäne (optional)</string>
+    <string name="explorer_network_form_password_label">Passwort</string>
+    <string name="explorer_network_form_password_kept_hint">Leer lassen, um das gespeicherte Passwort beizubehalten</string>
+    <string name="explorer_network_form_remember_label">Passwort merken</string>
+    <string name="explorer_network_form_remember_hint">Nur auf diesem Gerät verschlüsselt gespeichert</string>
+    <string name="explorer_network_form_test_and_save_action">Testen &amp; speichern</string>
+    <string name="explorer_network_form_testing">Verbindung wird hergestellt…</string>
+    <string name="explorer_network_form_error_host_blank">Serveradresse eingeben</string>
+    <string name="explorer_network_form_error_host_not_bare">Nur die Serveradresse ohne Schema oder Pfad eingeben</string>
+    <string name="explorer_network_form_error_host_malformed">Dies ist keine gültige Serveradresse</string>
+    <string name="explorer_network_form_error_port">Port zwischen 1 und 65535 eingeben</string>
+    <string name="explorer_network_form_error_share_blank">Freigabenamen eingeben</string>
+    <string name="explorer_network_form_error_share_not_single">Nur den Freigabenamen eingeben, Unterordner gehören in das Feld darunter</string>
+    <string name="explorer_network_form_error_share_malformed">Dies ist kein gültiger Freigabename</string>
+    <string name="explorer_network_form_error_base_path">Dieser Ordnerpfad kann nicht verwendet werden</string>
+    <string name="explorer_network_form_error_username_blank">Benutzernamen eingeben</string>
+    <string name="explorer_network_form_error_password_required">Passwort erneut eingeben, um Benutzername oder Domäne zu ändern</string>
+
+    <!-- Location Naming -->
+    <string name="explorer_location_name_title">Speicherort benennen</string>
+    <string name="explorer_location_name_label">Name des Speicherorts</string>
+    <string name="explorer_location_name_hint">Leer lassen, um den Standardnamen zu verwenden</string>
+    <string name="explorer_location_rename_action">Speicherort umbenennen</string>
+
+    <!-- Empty States -->
+    <string name="explorer_empty_folder_title">Dieser Ordner ist leer</string>
+    <string name="explorer_empty_search_title">Keine Suchergebnisse</string>
+    <string name="explorer_empty_search_caption">Versuche es mit einem anderen Suchbegriff</string>
+    <string name="explorer_empty_folder_label">Leerer Ordner</string>
+    <string name="explorer_empty_filtered_title">Keine passenden Elemente</string>
+    <string name="explorer_empty_filtered_caption">Passe Deine Filter an</string>
+    <string name="explorer_path_not_found_title">Dieser Ordner ist verschwunden</string>
+    <string name="explorer_path_not_found_caption">Er wurde gelöscht, umbenannt oder an einen anderen Ort verschoben.</string>
+    <string name="explorer_path_not_found_back_action">Zurück</string>
+
+    <!-- Status Messages -->
+    <string name="explorer_loading">Wird geladen…</string>
+    <string name="explorer_file_peek_loading_text">Wird geladen…</string>
+
+    <!-- Empty Folder Captions -->
+    <string name="explorer_empty_folder_caption_1">Hier gibt es nichts zu sehen… weitergehen 🕵️</string>
+    <string name="explorer_empty_folder_caption_2">Dieser Ordner macht gerade Diät</string>
+    <string name="explorer_empty_folder_caption_3">Sogar die Dateien haben heute früher Feierabend gemacht</string>
+    <string name="explorer_empty_folder_caption_4">Folder.exe funktioniert nicht mehr</string>
+    <string name="explorer_empty_folder_caption_5">Die Dateien spielen Verstecken</string>
+    <string name="explorer_empty_folder_caption_6">404: Dateien nicht gefunden</string>
+    <string name="explorer_empty_folder_caption_7">Dieser Ordner hat Vertrauensprobleme</string>
+    <string name="explorer_empty_folder_caption_8">Die Dateien sind ohne Vorwarnung in den Urlaub gefahren</string>
+    <string name="explorer_empty_folder_caption_9">Leer wie meine Seele… aber besser organisiert</string>
+    <string name="explorer_empty_folder_caption_10">Die digitale Version von Steppenläufern</string>
+    <string name="explorer_empty_folder_caption_11">Die Dateien halten Sicherheitsabstand</string>
+    <string name="explorer_empty_folder_caption_12">Dieser Ordner lebt minimalistisch</string>
+    <string name="explorer_empty_folder_caption_13">Jemand hat vergessen, die Dateien zu füttern</string>
+    <string name="explorer_empty_folder_caption_14">Die Dateien haben das Gebäude verlassen</string>
+    <string name="explorer_empty_folder_caption_15">Leerer als das Versprechen eines Politikers</string>
+
+    <!-- Sort Options -->
+    <string name="explorer_sort_mode_label">Sortieren nach</string>
+    <string name="explorer_sort_mode_name_label">Name</string>
+    <string name="explorer_sort_mode_size_label">Größe</string>
+    <string name="explorer_sort_mode_modified_label">Änderungsdatum</string>
+    <string name="explorer_sort_mode_created_label">Erstellungsdatum</string>
+    <string name="explorer_sort_descending_label">Absteigende Reihenfolge</string>
+    <string name="explorer_sort_scope_label">Anwenden auf</string>
+    <string name="explorer_sort_scope_all_folders">Alle Ordner</string>
+    <string name="explorer_sort_scope_this_folder">Diesen Ordner</string>
+    <string name="explorer_sort_scope_this_folder_and_subfolders">Diesen Ordner und Unterordner</string>
+    <string name="explorer_sort_scope_use_default_here">Hier Standard verwenden</string>
+    <string name="explorer_sort_only_this_tab_label">Nur für diesen Tab</string>
+    <string name="explorer_sort_inherited_notice">Sortiert nach einer für %1$s gespeicherten Regel</string>
+    <string name="explorer_sort_suppressed_notice">Überschreibt die für %1$s gespeicherte Regel</string>
+    <string name="explorer_sort_tab_overrides_default_notice">Dieser Tab verwendet eine eigene Standardsortierung</string>
+    <string name="explorer_sort_tab_overrides_clear_action">Aufheben</string>
+
+    <!-- Folder Sort Rules -->
+    <string name="explorer_settings_folder_sort_rules_title">Ordnersortierregeln</string>
+    <string name="explorer_settings_folder_sort_rules_desc">Für einzelne Ordner gespeicherte Sortiereinstellungen</string>
+    <string name="explorer_settings_folder_sort_rules_clear_confirm_title">Ordnersortierregeln löschen?</string>
+    <string name="explorer_settings_folder_sort_rules_clear_confirm_message">Alle Ordner verwenden wieder die Standardsortierung. Tabs mit eigener Sortierung behalten diese bei. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="explorer_settings_folder_sort_rules_clear_confirm_action">Alle löschen</string>
+
+    <!-- Filter Options -->
+    <string name="explorer_filter_file_type_label">Dateityp</string>
+    <string name="explorer_filter_type_all">Alle</string>
+    <string name="explorer_filter_type_files">Nur Dateien</string>
+    <string name="explorer_filter_type_folders">Nur Ordner</string>
+    <string name="explorer_filter_include_label">Einschlussmuster</string>
+    <string name="explorer_filter_include_placeholder_simple">z. B. Urlaub, Bericht, IMG</string>
+    <string name="explorer_filter_include_placeholder_regex">z. B. .*\\.txt$, ^IMG_.*</string>
+    <string name="explorer_filter_exclude_label">Ausschlussmuster</string>
+    <string name="explorer_filter_exclude_placeholder_simple">z. B. tmp, cache, alt</string>
+    <string name="explorer_filter_exclude_placeholder_regex">z. B. ^\\., .*\\.tmp$, .*\\.bak$</string>
+    <string name="explorer_filter_regex_hint">💡 Reguläre Ausdrücke in den Einstellungen aktivieren</string>
+
+    <!-- Permission Messages -->
+    <string name="explorer_permission_required_title">Berechtigung erforderlich</string>
+    <string name="explorer_permission_generic_description">Butler benötigt eine zusätzliche Berechtigung, um diesen Speicherort zu durchsuchen.</string>
+    <string name="explorer_permission_setup_action">Einrichtung öffnen</string>
+    <string name="explorer_grant_access_action">Zugriff gewähren</string>
+
+    <!-- File Options -->
+    <string name="explorer_file_options_actions">Aktionen</string>
+    <string name="explorer_file_info_type_label">Typ</string>
+    <string name="explorer_file_info_size_label">Größe</string>
+    <string name="explorer_file_info_modified_label">Geändert</string>
+    <string name="explorer_file_action_install">Installieren</string>
+    <string name="explorer_file_action_install_subtitle">Diese App auf Deinem Gerät installieren</string>
+    <string name="explorer_file_action_open">Öffnen</string>
+    <string name="explorer_file_action_open_subtitle">Hier anzeigen, mit Zurück geht es zurück zu diesem Ordner</string>
+    <string name="explorer_file_action_open_in_tab">In neuem Tab öffnen</string>
+    <string name="explorer_file_action_open_in_tab_subtitle">In Butler als eigenen Tab anzeigen</string>
+    <string name="explorer_file_action_open_in_editor">Im Editor öffnen</string>
+    <string name="explorer_file_action_open_in_editor_subtitle">In einem neuen Tab bearbeiten</string>
+    <string name="explorer_file_action_open_with">Öffnen mit</string>
+    <string name="explorer_file_action_open_with_subtitle">Externe App zum Öffnen auswählen</string>
+    <string name="explorer_file_action_share">Teilen</string>
+    <string name="explorer_file_action_share_subtitle">Über installierte Apps teilen</string>
+    <string name="explorer_file_action_copy">Kopieren</string>
+    <string name="explorer_file_action_copy_subtitle">Zum Einfügen in die Zwischenablage kopieren</string>
+    <string name="explorer_file_action_cut">Ausschneiden</string>
+    <string name="explorer_file_action_cut_subtitle">Zum Einfügen in die Zwischenablage verschieben</string>
+    <string name="explorer_file_action_rename">Umbenennen</string>
+    <string name="explorer_file_action_rename_subtitle">Dateinamen ändern</string>
+    <string name="explorer_file_action_delete">Löschen</string>
+    <string name="explorer_file_action_delete_subtitle">Diese Datei endgültig löschen</string>
+
+    <string name="explorer_file_action_move_to_trash">In den Papierkorb verschieben</string>
+    <string name="explorer_file_action_move_to_trash_subtitle">Datei in den Papierkorb verschieben</string>
+    <string name="explorer_file_action_properties">Eigenschaften</string>
+    <string name="explorer_file_action_properties_subtitle">Detaillierte Dateiinformationen anzeigen</string>
+    <string name="explorer_file_action_extract">Entpacken</string>
+    <string name="explorer_file_action_extract_subtitle">Archivinhalte in einen Ordner entpacken</string>
+
+    <!-- Operations -->
+    <plurals name="explorer_operation_report_files_created">
+        <item quantity="one">%d Datei erstellt.</item>
+        <item quantity="other">%d Dateien erstellt.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_directories_created">
+        <item quantity="one">%d Verzeichnis erstellt.</item>
+        <item quantity="other">%d Verzeichnisse erstellt.</item>
+    </plurals>
+
+    <string name="explorer_operation_copy_title">Kopiervorgang</string>
+    <string name="explorer_operation_copy_description_single">\"%1$s\" von \"%2$s\" nach \"%3$s\" kopieren.</string>
+    <plurals name="explorer_operation_copy_description">
+        <item quantity="one">%1$d Element nach \"%2$s\" kopieren.</item>
+        <item quantity="other">%1$d Elemente nach \"%2$s\" kopieren.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_files_copied">
+        <item quantity="one">%d Datei kopiert.</item>
+        <item quantity="other">%d Dateien kopiert.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_directories_copied">
+        <item quantity="one">%d Verzeichnis kopiert.</item>
+        <item quantity="other">%d Verzeichnisse kopiert.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_bytes_copied">
+        <item quantity="one">%s kopiert.</item>
+        <item quantity="other">%s kopiert.</item>
+    </plurals>
+
+    <string name="explorer_operation_extract_title">Entpackvorgang</string>
+    <string name="explorer_operation_extract_description">\"%1$s\" nach \"%2$s\" entpacken.</string>
+    <string name="explorer_operation_download_copy_title">Lokaler Kopiervorgang</string>
+    <string name="explorer_operation_download_copy_description">\"%1$s\" zum lokalen Durchsuchen nach \"%2$s\" kopieren.</string>
+    <plurals name="explorer_operation_report_files_extracted">
+        <item quantity="one">%d Datei entpackt.</item>
+        <item quantity="other">%d Dateien entpackt.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_bytes_extracted">
+        <item quantity="one">%s entpackt.</item>
+        <item quantity="other">%s entpackt.</item>
+    </plurals>
+
+    <string name="explorer_operation_compress_title">Komprimiervorgang</string>
+    <plurals name="explorer_operation_compress_description">
+        <item quantity="one">%1$d Element in \"%2$s\" komprimieren.</item>
+        <item quantity="other">%1$d Elemente in \"%2$s\" komprimieren.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_files_compressed">
+        <item quantity="one">%d Datei komprimiert.</item>
+        <item quantity="other">%d Dateien komprimiert.</item>
+    </plurals>
+
+    <!-- Compress dialog -->
+    <string name="explorer_compress_dialog_title">Archiv erstellen</string>
+    <string name="explorer_compress_dialog_name_label">Archivname</string>
+    <string name="explorer_compress_dialog_format_label">Format</string>
+    <string name="explorer_compress_dialog_format_zip_hint">Lässt sich auf jedem Gerät öffnen. Kann mit einem Passwort geschützt werden.</string>
+    <string name="explorer_compress_dialog_format_targz_hint">Bei vielen Dateien kleiner. Kein Passwortschutz.</string>
+    <string name="explorer_compress_dialog_create_action">Erstellen</string>
+    <string name="explorer_compress_dialog_level_label">Komprimierungsstufe</string>
+    <string name="explorer_compress_dialog_level_fast">Schnell</string>
+    <string name="explorer_compress_dialog_level_normal">Normal</string>
+    <string name="explorer_compress_dialog_level_best">Beste</string>
+    <string name="explorer_compress_dialog_password_label">Passwort (optional)</string>
+    <string name="explorer_compress_dialog_password_confirm_label">Passwort bestätigen</string>
+    <string name="explorer_compress_dialog_password_mismatch">Passwörter stimmen nicht überein</string>
+    <string name="explorer_compress_dialog_password_weak">Schwaches Passwort</string>
+    <string name="explorer_compress_dialog_password_notice">Dateiinhalte werden verschlüsselt, Dateinamen nicht.</string>
+    <string name="explorer_compress_dialog_password_show">Passwort anzeigen</string>
+    <string name="explorer_compress_dialog_password_hide">Passwort ausblenden</string>
+    <string name="explorer_compress_dialog_overwrite_title">Archiv ersetzen?</string>
+    <string name="explorer_compress_dialog_overwrite_message">\"%1$s\" ist bereits vorhanden und wird ersetzt.</string>
+    <string name="explorer_compress_dialog_overwrite_action">Ersetzen</string>
+
+    <!-- Drop dialog (items dragged in from another pane) -->
+    <plurals name="explorer_drop_dialog_title">
+        <item quantity="one">%1$d Element ablegen?</item>
+        <item quantity="other">%1$d Elemente ablegen?</item>
+    </plurals>
+    <plurals name="explorer_drop_dialog_message">
+        <item quantity="one">%1$d Element nach \"%2$s\" kopieren oder verschieben?</item>
+        <item quantity="other">%1$d Elemente nach \"%2$s\" kopieren oder verschieben?</item>
+    </plurals>
+    <plurals name="explorer_drop_dialog_message_copy_only">
+        <item quantity="one">%1$d Element nach \"%2$s\" kopieren?</item>
+        <item quantity="other">%1$d Elemente nach \"%2$s\" kopieren?</item>
+    </plurals>
+
+    <!-- Trash drop dialog (items dragged onto the Trash view) -->
+    <string name="explorer_trash_drop_confirmation_title">In den Papierkorb verschieben?</string>
+    <plurals name="explorer_trash_drop_confirmation_message">
+        <item quantity="one">%1$d Element in den Papierkorb verschieben?</item>
+        <item quantity="other">%1$d Elemente in den Papierkorb verschieben?</item>
+    </plurals>
+
+    <string name="explorer_operation_move_title">Verschiebevorgang</string>
+    <string name="explorer_operation_move_description_single">\"%1$s\" von \"%2$s\" nach \"%3$s\" verschieben.</string>
+    <plurals name="explorer_operation_move_description">
+        <item quantity="one">%1$d Element nach \"%2$s\" verschieben.</item>
+        <item quantity="other">%1$d Elemente nach \"%2$s\" verschieben.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_files_moved">
+        <item quantity="one">%d Datei verschoben.</item>
+        <item quantity="other">%d Dateien verschoben.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_directories_moved">
+        <item quantity="one">%d Verzeichnis verschoben.</item>
+        <item quantity="other">%d Verzeichnisse verschoben.</item>
+    </plurals>
+    <plurals name="explorer_operation_report_bytes_moved">
+        <item quantity="one">%s verschoben.</item>
+        <item quantity="other">%s verschoben.</item>
+    </plurals>
+
+    <string name="explorer_operation_create_title_directory">Ordnererstellung</string>
+    <string name="explorer_operation_create_description_directory">Ordner \"%1$s\" unter \"%2$s\" erstellen</string>
+    <string name="explorer_operation_create_title_file">Dateierstellung</string>
+    <string name="explorer_operation_create_description_file">Datei \"%1$s\" unter \"%2$s\" erstellen</string>
+    <string name="explorer_operation_create_text_file_title">Textdateierstellung</string>
+    <string name="explorer_operation_create_text_file_description">\"%1$s\" aus Textausschnitt erstellen</string>
+
+    <!-- Navigation Error Messages -->
+    <string name="explorer_navigation_error_title">Navigation fehlgeschlagen</string>
+    <string name="explorer_aborted_dialog_title">Vorgang abgebrochen</string>
+    <string name="explorer_aborted_dialog_message">Das Laden wurde abgebrochen, bevor etwas angezeigt werden konnte.</string>
+    <string name="explorer_archive_unbrowsable_title">Archiv kann hier nicht durchsucht werden</string>
+    <string name="explorer_archive_unbrowsable_msg">\"%1$s\" befindet sich auf einem Speicher, der nur sequenzielles Lesen unterstützt. Das Durchsuchen eines Archivs erfordert jedoch wahlfreien Zugriff. Entpacke das Archiv hier oder lade eine lokale Kopie herunter, um es zu durchsuchen.</string>
+    <string name="explorer_archive_unbrowsable_extract_action">Archiv entpacken</string>
+    <string name="explorer_archive_unbrowsable_download_action">Lokale Kopie herunterladen</string>
+
+    <!-- SAF Location Auto-Labels -->
+    <string name="explorer_saf_location_android_data_label">Android/data (besonderer Zugriff)</string>
+    <string name="explorer_saf_location_android_obb_label">Android/obb (besonderer Zugriff)</string>
+
+    <!-- Permission Request Card Explanations -->
+    <string name="explorer_permission_saf_workaround_description">Android beschränkt den Zugriff auf diesen Ordner. Verwende die Ordnerauswahl, um Zugriff zu gewähren.</string>
+    <string name="explorer_permission_multiple_options_description">Du kannst mit der Android-Ordnerauswahl Zugriff gewähren oder Root/Shizuku einrichten, um schneller auf alle geschützten Ordner zuzugreifen.</string>
+    <string name="explorer_permission_setup_both_description">Dieser Ordner erfordert erweiterten Zugriff. Installiere und konfiguriere entweder Root oder Shizuku in der Einrichtung.</string>
+    <string name="explorer_permission_setup_shizuku_description">Dieser Ordner erfordert erweiterten Zugriff über Shizuku. Installiere den Shizuku Manager und konfiguriere ihn in der Einrichtung.</string>
+    <string name="explorer_permission_setup_root_description">Dieser Ordner erfordert Root-Zugriff. Konfiguriere Root in der Einrichtung, wenn Dein Gerät gerootet ist.</string>
+
+    <string name="explorer_permission_option_picker_title">Storage Access Framework</string>
+    <string name="explorer_permission_option_picker_description">Verwende die Android-Ordnerauswahl, um Zugriff auf diesen Ordner zu gewähren.</string>
+    <string name="explorer_permission_option_picker_action">SAF-Auswahl öffnen</string>
+
+    <string name="explorer_permission_option_setup_title">Vollzugriff</string>
+    <string name="explorer_permission_option_setup_description">Root oder Shizuku für schnelleren Zugriff auf alle geschützten Ordner konfigurieren.</string>
+    <string name="explorer_permission_option_setup_action">Konfigurieren</string>
+
+    <!-- Permission Request Card - Storage Access Option -->
+    <string name="explorer_permission_option_storage_title">Speicherzugriff</string>
+    <string name="explorer_permission_option_storage_description">Gewähre Butler die Berechtigung, auf Dateien im Speicher Deines Geräts zuzugreifen.</string>
+    <string name="explorer_permission_option_storage_action">Berechtigung gewähren</string>
+
+    <!-- Open in new tabs action -->
+    <string name="explorer_action_open_in_new_tabs">In neuen Tabs öffnen</string>
+    <string name="explorer_open_tabs_confirmation_title">@string/common_open_tabs_confirmation_title</string>
+    <string name="explorer_open_tabs_confirmation_message">@string/common_open_tabs_confirmation_message</string>
+
+    <!-- Favorite folders & files -->
+    <string name="explorer_favorites_section_title">Favoriten</string>
+    <string name="explorer_action_add_to_favorites">Zu Favoriten hinzufügen</string>
+    <string name="explorer_action_remove_from_favorites">Aus Favoriten entfernen</string>
+    <string name="explorer_favorites_unavailable_subtitle">Nicht zugänglich</string>
+    <string name="explorer_favorites_unavailable_toast">Favorit ist nicht zugänglich</string>
+    <string name="explorer_favorites_remove_action">Aus Favoriten entfernen</string>
+    <string name="explorer_favorites_added_message">%1$s zu Favoriten hinzugefügt</string>
+    <plurals name="explorer_favorites_added_multiple_message">
+        <item quantity="one">%1$d Element zu Favoriten hinzugefügt</item>
+        <item quantity="other">%1$d Elemente zu Favoriten hinzugefügt</item>
+    </plurals>
+    <string name="explorer_favorites_removed_message">%1$s aus Favoriten entfernt</string>
+    <plurals name="explorer_favorites_removed_multiple_message">
+        <item quantity="one">%1$d Element aus Favoriten entfernt</item>
+        <item quantity="other">%1$d Elemente aus Favoriten entfernt</item>
+    </plurals>
+    <plurals name="explorer_sort_tab_overrides_notice">
+        <item quantity="one">Dieser Tab überschreibt die Sortierung in %1$d Ordner</item>
+        <item quantity="other">Dieser Tab überschreibt die Sortierung in %1$d Ordnern</item>
+    </plurals>
+    <plurals name="explorer_settings_folder_sort_rules_value">
+        <item quantity="one">%1$d Ordner</item>
+        <item quantity="other">%1$d Ordner</item>
+    </plurals>
+</resources>

--- a/app-workspace-history/src/main/res/values-de/strings.xml
+++ b/app-workspace-history/src/main/res/values-de/strings.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Workspace title and subtitle (templates picker + tab) -->
+    <string name="history_workspace_title">Verlauf</string>
+    <string name="history_workspace_subtitle">Letzte Dateivorgänge</string>
+    <string name="history_workspace_title_scoped">Verlauf: %1$s</string>
+    <string name="history_workspace_title_outcome_failed">Verlauf: Fehlgeschlagen</string>
+    <string name="history_workspace_title_outcome_partial">Verlauf: Teilweise</string>
+    <string name="history_workspace_title_outcome_cancelled">Verlauf: Abgebrochen</string>
+    <string name="history_workspace_title_outcome_completed">Verlauf: Abgeschlossen</string>
+    <string name="history_workspace_title_kind_copy">Verlauf: Kopieren</string>
+    <string name="history_workspace_title_kind_move">Verlauf: Verschieben</string>
+    <string name="history_workspace_title_kind_delete">Verlauf: Löschen</string>
+    <string name="history_workspace_title_kind_create_file">Verlauf: Datei erstellen</string>
+    <string name="history_workspace_title_kind_create_folder">Verlauf: Ordner erstellen</string>
+    <string name="history_workspace_title_kind_save">Verlauf: Speichern</string>
+    <string name="history_workspace_title_kind_compress">Verlauf: Komprimieren</string>
+    <string name="history_workspace_title_kind_extract">Verlauf: Entpacken</string>
+    <string name="history_workspace_title_filtered">Verlauf (gefiltert)</string>
+    <plurals name="history_workspace_title_scoped_many">
+        <item quantity="one">Verlauf: %1$d Pfad</item>
+        <item quantity="other">Verlauf: %1$d Pfade</item>
+    </plurals>
+
+    <!-- Outcome filter chips -->
+    <string name="history_filter_outcome_all">Alle</string>
+    <string name="history_filter_outcome_completed">Abgeschlossen</string>
+    <string name="history_filter_outcome_partial">Teilweise</string>
+    <string name="history_filter_outcome_failed">Fehlgeschlagen</string>
+    <string name="history_filter_outcome_cancelled">Abgebrochen</string>
+
+    <!-- Kind filter chips -->
+    <string name="history_filter_kind_copy">Kopieren</string>
+    <string name="history_filter_kind_move">Verschieben</string>
+    <string name="history_filter_kind_delete">Löschen</string>
+    <string name="history_filter_kind_create_file">Datei erstellen</string>
+    <string name="history_filter_kind_create_folder">Ordner erstellen</string>
+    <string name="history_filter_kind_save">Speichern</string>
+    <string name="history_filter_kind_compress">Komprimieren</string>
+    <string name="history_filter_kind_extract">Entpacken</string>
+
+    <!-- Path scope chip + dialog -->
+    <string name="history_path_scope_set_action">Pfadbereich festlegen…</string>
+    <string name="history_path_scope_clear_action">Pfadbereich löschen</string>
+    <string name="history_path_scope_dialog_title">Nach Pfad filtern</string>
+    <string name="history_path_scope_dialog_description">Nur Vorgänge anzeigen, die diesen Pfad oder untergeordnete Pfade betreffen.</string>
+    <string name="history_path_scope_dialog_input_label">Pfad</string>
+    <string name="history_path_scope_dialog_pick_folder_action">Ordner auswählen…</string>
+    <string name="history_path_scope_dialog_apply_action">Anwenden</string>
+    <string name="history_path_scope_dialog_cancel_action">Abbrechen</string>
+
+    <!-- Date group headers -->
+    <string name="history_group_today">Heute</string>
+    <string name="history_group_yesterday">Gestern</string>
+    <string name="history_group_this_week">Diese Woche</string>
+    <string name="history_group_this_month">Dieser Monat</string>
+    <string name="history_group_older">Älter</string>
+
+    <!-- Entry labels (intent overrides default kind label) -->
+    <string name="history_entry_intent_rename">Umbenannt</string>
+    <string name="history_entry_intent_paste_copy">Eingefügt</string>
+    <string name="history_entry_intent_paste_move">Eingefügt (verschoben)</string>
+    <string name="history_entry_intent_drop_copy">Abgelegt (kopiert)</string>
+    <string name="history_entry_intent_drop_move">Abgelegt (verschoben)</string>
+    <string name="history_entry_kind_copy">Kopiert</string>
+    <string name="history_entry_kind_move">Verschoben</string>
+    <string name="history_entry_kind_delete">Gelöscht</string>
+    <string name="history_entry_kind_create_file">Datei erstellt</string>
+    <string name="history_entry_kind_create_folder">Ordner erstellt</string>
+    <string name="history_entry_kind_save">Gespeichert</string>
+    <string name="history_entry_kind_compress">Komprimiert</string>
+    <string name="history_entry_kind_extract">Entpackt</string>
+    <string name="history_entry_kind_restore">Wiederhergestellt</string>
+    <string name="history_entry_kind_install">Installiert</string>
+    <!-- Row headline: what happened, followed by the file or folder it happened to -->
+    <!-- Quoted so the double space survives the resource parser -->
+    <string name="history_entry_headline_format">"%1$s  %2$s"</string>
+
+    <!-- Affected paths count -->
+    <plurals name="history_entry_affected_paths">
+        <item quantity="one">%d Pfad</item>
+        <item quantity="other">%d Pfade</item>
+    </plurals>
+    <string name="history_entry_paths_truncated">Die ersten %1$d von %2$d betroffenen Pfaden</string>
+
+    <!-- Detail sheet -->
+    <string name="history_detail_label_started">Gestartet</string>
+    <string name="history_detail_label_completed">Abgeschlossen</string>
+    <string name="history_detail_label_duration">Dauer</string>
+    <string name="history_detail_label_outcome">Ergebnis</string>
+    <string name="history_detail_label_origin">Ursprung</string>
+    <string name="history_detail_label_error">Fehler</string>
+    <string name="history_detail_label_paths">Betroffene Pfade</string>
+    <string name="history_detail_label_partial_errors">Fehler pro Element</string>
+    <string name="history_detail_copy_path_action">Pfad kopieren</string>
+    <string name="history_detail_paths_empty">Keine betroffenen Pfade erfasst.</string>
+    <string name="history_detail_label_attempted_paths">Zu bearbeitende Pfade</string>
+    <string name="history_detail_paths_truncated_callout">Die ersten %1$d von %2$d betroffenen Pfaden werden angezeigt.</string>
+    <string name="history_detail_attempted_paths_truncated_callout">Die ersten %1$d von %2$d zu bearbeitenden Pfaden werden angezeigt.</string>
+    <plurals name="history_detail_partial_errors_callout">
+        <item quantity="one">%1$d Element ist bei diesem Vorgang fehlgeschlagen.</item>
+        <item quantity="other">%1$d Elemente sind bei diesem Vorgang fehlgeschlagen.</item>
+    </plurals>
+
+    <!-- Origin labels (workspace that created the operation) -->
+    <string name="history_origin_explorer">Explorer</string>
+    <string name="history_origin_searcher">Suche</string>
+    <string name="history_origin_saver">Speichern unter</string>
+    <string name="history_origin_developer">Entwicklerwerkzeuge</string>
+    <string name="history_origin_viewer">Betrachter</string>
+
+    <!-- Duration formats -->
+    <string name="history_duration_ms">%1$d ms</string>
+    <string name="history_duration_seconds">%1$.1f s</string>
+
+    <!-- Empty state -->
+    <string name="history_empty_title">Noch kein Verlauf</string>
+    <string name="history_empty_subtitle">Dateivorgänge erscheinen hier, während Du Butler verwendest.</string>
+    <string name="history_empty_filtered_title">Keine Treffer</string>
+    <string name="history_empty_filtered_subtitle">Keine Verlaufseinträge entsprechen dem aktuellen Filter.</string>
+    <string name="history_empty_filtered_reset_action">Filter zurücksetzen</string>
+
+    <!-- Toolbar -->
+    <string name="history_toolbar_reset_filter_action">Filter zurücksetzen</string>
+    <string name="history_toolbar_reset_filter_content_description">Filter zurücksetzen</string>
+    <string name="history_entry_paths_truncated_short">%1$d+</string>
+    <string name="history_entry_paths_truncated_content_description">Die ersten %1$d von %2$d betroffenen Pfaden</string>
+    <string name="history_add_filter_action">Filter hinzufügen</string>
+    <string name="history_add_filter_sheet_title">Filter hinzufügen</string>
+    <string name="history_add_filter_section_outcome">Ergebnis</string>
+    <string name="history_add_filter_section_kind">Art</string>
+    <string name="history_add_filter_section_path_scope">Pfadbereich</string>
+    <string name="history_add_filter_add_path_action">Pfad hinzufügen…</string>
+    <string name="history_path_scope_remove_action">Entfernen</string>
+    <plurals name="history_summary_total">
+        <item quantity="one">%1$d Eintrag</item>
+        <item quantity="other">%1$d Einträge</item>
+    </plurals>
+    <plurals name="history_summary_filtered">
+        <item quantity="one">%1$d von %2$d angezeigt</item>
+        <item quantity="other">%1$d von %2$d angezeigt</item>
+    </plurals>
+    <plurals name="history_group_count">
+        <item quantity="one">(%1$d)</item>
+        <item quantity="other">(%1$d)</item>
+    </plurals>
+
+    <!-- Settings -->
+    <string name="history_settings_title">Verlauf</string>
+    <string name="history_settings_save_history_title">Verlauf speichern</string>
+    <string name="history_settings_save_history_subtitle">Abgeschlossene Dateivorgänge aufzeichnen.</string>
+    <string name="history_settings_max_history_label">Maximale Verlaufseinträge</string>
+    <string name="history_settings_max_history_subtitle">Ältere Einträge werden entfernt, sobald dieses Limit überschritten wird.</string>
+    <string name="history_settings_max_history_input_label">Maximale Einträge</string>
+    <string name="history_settings_clear_history_title">Verlauf löschen</string>
+    <string name="history_settings_clear_history_subtitle">Alle gespeicherten Einträge entfernen (%1$d).</string>
+    <string name="history_clear_dialog_title">Verlauf löschen?</string>
+    <string name="history_clear_dialog_message">Alle Einträge werden aus der Datenbank für den Vorgangsverlauf entfernt. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="history_clear_confirm_action">Löschen</string>
+    <string name="history_cleared_success">Verlauf gelöscht</string>
+    <string name="history_workspace_title_kind_restore">Verlauf: Wiederherstellen</string>
+    <string name="history_filter_kind_restore">Wiederherstellen</string>
+    <string name="history_workspace_title_kind_install">Verlauf: Installieren</string>
+    <string name="history_filter_kind_install">Installieren</string>
+
+    <!-- Selection actions -->
+    <string name="history_action_select_all">Alle auswählen</string>
+    <string name="history_action_deselect_all">Auswahl aufheben</string>
+    <plurals name="history_delete_dialog_title">
+        <item quantity="one">%1$d Eintrag löschen</item>
+        <item quantity="other">%1$d Einträge löschen</item>
+    </plurals>
+    <string name="history_delete_dialog_message">Nur die Verlaufsdaten werden entfernt. Die Dateien selbst bleiben unverändert.</string>
+    <string name="history_pro_dialog_message">Das Teilen und Löschen von Verlaufseinträgen gehört zum Upgrade. Das Löschen des gesamten Verlaufs bleibt in den Verlaufseinstellungen kostenlos.</string>
+
+    <!-- Shared text -->
+    <string name="history_share_label_outcome">Ergebnis</string>
+    <string name="history_share_label_kind">Art</string>
+    <string name="history_share_label_origin">Ursprung</string>
+    <string name="history_share_label_summary">Zusammenfassung</string>
+    <string name="history_share_label_completed">Abgeschlossen</string>
+    <string name="history_share_label_duration">Dauer</string>
+    <string name="history_share_label_error">Fehler</string>
+    <string name="history_share_label_failed_items">Fehlgeschlagene Elemente</string>
+    <string name="history_share_label_paths">Betroffene Pfade (%1$d)</string>
+    <string name="history_share_paths_more">… und %1$d weitere</string>
+    <string name="history_share_truncated">… und %1$d weitere Einträge wurden nicht aufgenommen</string>
+</resources>

--- a/app-workspace-saver/src/main/res/values-de/strings.xml
+++ b/app-workspace-saver/src/main/res/values-de/strings.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="saver_workspace_title">Speichern unter</string>
+    <string name="saver_preview_label">Vorschau</string>
+    <string name="saver_loading">Wird geladen…</string>
+    <string name="saver_shared_from">Von %1$s geteilt</string>
+    <string name="saver_shared_generic">Mit Butler geteilt</string>
+    <string name="saver_destination_label">Ziel</string>
+    <string name="saver_select_destination_hint">Zielordner auswählen</string>
+    <string name="saver_filename_label">Dateiname</string>
+    <string name="saver_save_action">Speichern</string>
+    <string name="saver_saving_progress">Wird gespeichert…</string>
+    <string name="saver_success_message">Datei erfolgreich gespeichert</string>
+    <string name="saver_open_saved_action">Verzeichnis öffnen</string>
+    <string name="saver_retry_action">Erneut versuchen</string>
+    <string name="saver_save_again_action">An neuem Speicherort speichern</string>
+    <string name="saver_close_tab_action">Tab schließen</string>
+    <string name="saver_close_butler_action">Tab schließen und zurückkehren</string>
+    <string name="saver_done_action">Fertig</string>
+    <plurals name="saver_source_expired_warning">
+        <item quantity="one">Auf die Quelldatei kann nicht mehr zugegriffen werden. Bitte teile sie erneut.</item>
+        <item quantity="other">Auf %1$d Quelldateien kann nicht mehr zugegriffen werden. Bitte teile sie erneut.</item>
+    </plurals>
+    <string name="saver_error_source_expired">Auf die Quelldatei kann nicht mehr zugegriffen werden</string>
+    <string name="saver_error_permission_denied">Zugriff verweigert</string>
+    <string name="saver_error_write_failed">Datei konnte nicht gespeichert werden</string>
+    <string name="saver_error_file_exists">Datei ist bereits vorhanden</string>
+
+    <!-- Operation strings -->
+    <string name="saver_operation_title">Dateien speichern</string>
+    <plurals name="saver_operation_description">
+        <item quantity="one">%1$d Datei wird in %2$s gespeichert</item>
+        <item quantity="other">%1$d Dateien werden in %2$s gespeichert</item>
+    </plurals>
+    <plurals name="saver_workspace_title_count">
+        <item quantity="one">%1$d Datei speichern</item>
+        <item quantity="other">%1$d Dateien speichern</item>
+    </plurals>
+    <plurals name="saver_success_count">
+        <item quantity="one">%1$d Datei gespeichert</item>
+        <item quantity="other">%1$d Dateien gespeichert</item>
+    </plurals>
+    <plurals name="saver_error_count">
+        <item quantity="one">%1$d Datei konnte nicht gespeichert werden</item>
+        <item quantity="other">%1$d Dateien konnten nicht gespeichert werden</item>
+    </plurals>
+    <plurals name="saver_skipped_count">
+        <item quantity="one">%1$d Datei übersprungen</item>
+        <item quantity="other">%1$d Dateien übersprungen</item>
+    </plurals>
+    <string name="saver_partial_success">%1$d von %2$d Dateien gespeichert</string>
+</resources>

--- a/app-workspace-searcher/src/main/res/values-de/strings.xml
+++ b/app-workspace-searcher/src/main/res/values-de/strings.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="searcher_title">Suche</string>
+    <string name="searcher_subtitle">Dateien und Inhalte finden</string>
+    <!-- Tab subtitle listing the search locations, e.g. "Downloads, Photos +3" -->
+    <string name="searcher_workspace_targets_overflow">%1$s +%2$d</string>
+    <string name="searcher_settings_title">Sucheinstellungen</string>
+    <string name="searcher_settings_search_category">Suche</string>
+    <string name="searcher_settings_history">Suchverlauf</string>
+    <string name="searcher_settings_save_history_title">Suchverlauf speichern</string>
+    <string name="searcher_settings_save_history_subtitle">Vorherige Suchanfragen merken</string>
+    <string name="searcher_settings_max_history_label">Maximale Anzahl an Verlaufseinträgen</string>
+    <string name="searcher_settings_max_history_subtitle">Maximale Anzahl gespeicherter Suchanfragen</string>
+    <string name="searcher_settings_max_history_input_label">Anzahl der Einträge (1–500)</string>
+    <string name="searcher_settings_clear_history_title">Suchverlauf löschen</string>
+    <string name="searcher_settings_clear_history_subtitle">Alle gespeicherten Suchanfragen entfernen (%1$d)</string>
+    <string name="searcher_settings_search_performance">Leistung</string>
+    <string name="searcher_settings_max_results_title">Maximale Anzahl an Suchergebnissen</string>
+    <string name="searcher_settings_max_results_subtitle">Anzahl der Ergebnisse pro Suche begrenzen.</string>
+    <string name="searcher_settings_content_search_category">Inhaltssuche</string>
+    <string name="searcher_settings_include_binaries_title">Binärdateien einbeziehen</string>
+    <string name="searcher_settings_include_binaries_subtitle">Inhalte von Binärdateien durchsuchen (kann langsam sein und irrelevante Ergebnisse liefern)</string>
+
+    <!-- Searcher UI -->
+    <string name="searcher_recent_searches">Letzte Suchanfragen</string>
+    <string name="searcher_placeholder_search">Dateien und Ordner durchsuchen</string>
+    <string name="searcher_placeholder_filename">Dateiname</string>
+    <string name="searcher_placeholder_content">Inhalt</string>
+    <string name="searcher_search_error">Suchfehler</string>
+    <string name="searcher_no_paths_hint">Tippe auf +, um Suchorte hinzuzufügen</string>
+    <string name="searcher_add_path_action">Speicherort hinzufügen</string>
+    <string name="searcher_add_folder_action">Ordner…</string>
+    <string name="searcher_multipath_show_fewer_action">Weniger anzeigen</string>
+    <string name="searcher_empty_state_title">Keine Suchpfade eingerichtet</string>
+    <string name="searcher_empty_state_description">Füge Speicherorte hinzu, um Deine Dateien zu durchsuchen</string>
+    <string name="searcher_add_default_paths_action">Standardsuchpfade hinzufügen</string>
+
+    <!-- Search Options -->
+    <string name="searcher_options_action">Optionen</string>
+    <string name="searcher_option_case_sensitive_label">Groß-/Kleinschreibung beachten</string>
+    <string name="searcher_option_case_sensitive_desc">Suche mit Beachtung der Groß-/Kleinschreibung</string>
+    <string name="searcher_option_whole_word_label">Ganzes Wort</string>
+    <string name="searcher_option_whole_word_desc">Nur nach ganzen Wörtern suchen</string>
+    <string name="searcher_option_regex_label">Regulärer Ausdruck</string>
+    <string name="searcher_option_regex_desc">Mit regulärem Ausdruck suchen</string>
+    <string name="searcher_option_search_content_label">Inhalte durchsuchen</string>
+    <string name="searcher_option_search_content_desc">Dateiinhalte durchsuchen</string>
+
+    <!-- Search Templates -->
+    <string name="searcher_templates_action">Vorlagen</string>
+    <string name="searcher_templates_card_title">Schnellsuchvorlagen</string>
+    <string name="searcher_template_large_files">Große Dateien</string>
+    <string name="searcher_template_large_files_desc">Dateien über 100 MB</string>
+    <string name="searcher_template_recent_files">Kürzlich geänderte Dateien</string>
+    <string name="searcher_template_recent_files_desc">In den letzten 7 Tagen geändert</string>
+    <string name="searcher_template_old_files">Alte Dateien</string>
+    <string name="searcher_template_old_files_desc">Seit über einem Jahr nicht geändert</string>
+    <string name="searcher_template_images">Bilder</string>
+    <string name="searcher_template_images_desc">JPG, PNG, GIF, WebP, HEIC</string>
+    <string name="searcher_template_videos">Videos</string>
+    <string name="searcher_template_videos_desc">MP4, MKV, AVI, MOV, WebM</string>
+    <string name="searcher_template_audio">Audio</string>
+    <string name="searcher_template_audio_desc">MP3, WAV, FLAC, OGG, M4A</string>
+    <string name="searcher_template_documents">Dokumente</string>
+    <string name="searcher_template_documents_desc">PDF, Word, Excel, PowerPoint, TXT</string>
+    <string name="searcher_template_archives">Archive</string>
+    <string name="searcher_template_archives_desc">ZIP, RAR, 7z, TAR, GZ</string>
+    <string name="searcher_template_apks">APKs</string>
+    <string name="searcher_template_apks_desc">Android-App-Pakete</string>
+
+    <plurals name="searcher_templates_count">
+        <item quantity="one">%d Vorlage</item>
+        <item quantity="other">%d Vorlagen</item>
+    </plurals>
+
+    <!-- Search Filters -->
+    <string name="searcher_filter_action">Filter</string>
+    <string name="searcher_filter_add_action">Filter hinzufügen</string>
+    <string name="searcher_filter_title">Suchfilter</string>
+    <string name="searcher_filter_size_section">Dateigröße</string>
+    <string name="searcher_filter_size_min">Mindestgröße</string>
+    <string name="searcher_filter_size_max">Maximalgröße</string>
+    <string name="searcher_filter_date_section">Änderungsdatum</string>
+    <string name="searcher_filter_date_after">Geändert nach</string>
+    <string name="searcher_filter_date_before">Geändert vor</string>
+    <string name="searcher_filter_date_any">Beliebiger Zeitpunkt</string>
+    <string name="searcher_filter_date_24h">Letzte 24 Stunden</string>
+    <string name="searcher_filter_date_7d">Letzte 7 Tage</string>
+    <string name="searcher_filter_date_30d">Letzte 30 Tage</string>
+    <string name="searcher_filter_date_90d">Letzte 90 Tage</string>
+    <string name="searcher_filter_date_1y">Letzte 12 Monate</string>
+
+    <!-- Comparator labels -->
+    <string name="searcher_filter_comparator_greater_than">größer als</string>
+    <string name="searcher_filter_comparator_greater_or_equal">größer oder gleich</string>
+    <string name="searcher_filter_comparator_less_than">kleiner als</string>
+    <string name="searcher_filter_comparator_less_or_equal">kleiner oder gleich</string>
+    <string name="searcher_filter_comparator_equal">gleich</string>
+    <string name="searcher_filter_size_value_label">Größe</string>
+    <string name="searcher_filter_size_at_least">Mindestens</string>
+    <string name="searcher_filter_size_at_most">Höchstens</string>
+    <string name="searcher_filter_size_value_hint">z. B. 10 MB</string>
+    <string name="searcher_filter_size_format_help">Gib eine Zahl mit Einheit ein (KB, MB, GB). Eine Zahl ohne Einheit wird als MB behandelt.</string>
+    <string name="searcher_filter_size_format_error">Ungültige Größe: Verwende eine Zahl mit Einheit, z. B. 10 MB.</string>
+    <string name="searcher_filter_date_value_label">Datum</string>
+    <string name="searcher_filter_date_direction_after">Nach</string>
+    <string name="searcher_filter_date_direction_before">Vor</string>
+    <string name="searcher_filter_type_label">Typ</string>
+    <string name="searcher_filter_type_files">Dateien</string>
+    <string name="searcher_filter_type_directories">Verzeichnisse</string>
+
+    <!-- Search history actions -->
+    <string name="searcher_history_remove_action">Aus Verlauf entfernen</string>
+    <string name="searcher_history_clear_all_action">Alle löschen</string>
+    <string name="searcher_history_clear_dialog_title">Suchverlauf löschen</string>
+    <string name="searcher_history_clear_dialog_message">Der gesamte gespeicherte Suchverlauf wird gelöscht. Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="searcher_history_clear_confirm_action">Löschen</string>
+    <string name="searcher_history_cleared_success">Suchverlauf gelöscht</string>
+
+    <plurals name="searcher_history_result_count">
+        <item quantity="one">%d Ergebnis</item>
+        <item quantity="other">%d Ergebnisse</item>
+    </plurals>
+
+    <plurals name="searcher_multipath_show_more_action">
+        <item quantity="one">%d weiteren anzeigen</item>
+        <item quantity="other">%d weitere anzeigen</item>
+    </plurals>
+
+    <!-- Search progress -->
+    <string name="searcher_progress_action_searching">Suche läuft:</string>
+    <string name="searcher_progress_action_searched">Durchsucht:</string>
+    <string name="searcher_progress_status_completed_with_errors">Mit Fehlern abgeschlossen</string>
+    <string name="searcher_result_limit_reached">Ergebnislimit erreicht</string>
+    <!-- Banner: some individual items inside a searched location could not be read (e.g. permission denied) -->
+    <string name="searcher_progress_items_partial">Einige Elemente konnten nicht vollständig durchsucht werden</string>
+    <string name="searcher_progress_clear_action">Ausblenden</string>
+
+    <plurals name="searcher_progress_failed_count">
+        <item quantity="one">%d fehlgeschlagen</item>
+        <item quantity="other">%d fehlgeschlagen</item>
+    </plurals>
+
+    <plurals name="searcher_progress_items_inaccessible_count">
+        <item quantity="one">Auf %d Element konnte nicht zugegriffen werden</item>
+        <item quantity="other">Auf %d Elemente konnte nicht zugegriffen werden</item>
+    </plurals>
+
+    <plurals name="searcher_progress_inaccessible_more">
+        <item quantity="one">…und %d weiteres</item>
+        <item quantity="other">…und %d weitere</item>
+    </plurals>
+
+    <!-- Access-errors detail sheet (opened from the "N items couldn't be accessed" line) -->
+    <string name="searcher_access_sheet_body_unlockable">Android schützt diese Speicherorte. Mit zusätzlichem Zugriff kann Butler sie durchsuchen.</string>
+    <string name="searcher_access_sheet_body_protected">Android schützt diese Speicherorte. Auf diesem Gerät kann kein Zugriff gewährt werden.</string>
+    <string name="searcher_access_sheet_unlock_action">Zugriff freigeben</string>
+
+    <plurals name="searcher_progress_locations_count">
+        <item quantity="one">%d Speicherort</item>
+        <item quantity="other">%d Speicherorte</item>
+    </plurals>
+
+    <plurals name="searcher_progress_items_scanned_count">
+        <item quantity="one">%d durchsucht</item>
+        <item quantity="other">%d durchsucht</item>
+    </plurals>
+
+    <plurals name="searcher_progress_results_found_count">
+        <item quantity="one">%d gefunden</item>
+        <item quantity="other">%d gefunden</item>
+    </plurals>
+
+    <!-- Match context -->
+    <string name="searcher_match_context_label">Trefferkontext</string>
+    <string name="searcher_match_line_label">Zeile %1$d: %2$s</string>
+
+    <!-- Action strings -->
+    <string name="searcher_action_open">Öffnen</string>
+    <string name="searcher_action_open_in_tab">In neuem Tab öffnen</string>
+    <string name="searcher_action_open_with">Öffnen mit</string>
+    <string name="searcher_action_open_in_editor">Im Editor öffnen</string>
+    <string name="searcher_action_open_in_explorer">Im Explorer öffnen</string>
+    <string name="searcher_action_install">Installieren</string>
+    <string name="searcher_action_copy">Kopieren</string>
+    <string name="searcher_action_cut">Ausschneiden</string>
+    <string name="searcher_action_delete">Löschen</string>
+    <string name="searcher_action_copy_path">Pfad kopieren</string>
+    <string name="searcher_action_properties">Eigenschaften</string>
+    <string name="searcher_action_select_all">Alle auswählen</string>
+    <string name="searcher_action_deselect_all">Auswahl aufheben</string>
+    <string name="searcher_action_open_in_new_tabs">In neuen Tabs öffnen</string>
+    <string name="searcher_action_sort">Sortieren</string>
+    <string name="searcher_action_view">Ansicht</string>
+
+    <!-- Sort options -->
+    <string name="searcher_sort_mode_label">Sortieren nach</string>
+    <string name="searcher_sort_mode_name_label">Name</string>
+    <string name="searcher_sort_mode_size_label">Größe</string>
+    <string name="searcher_sort_mode_modified_label">Änderungsdatum</string>
+    <string name="searcher_sort_mode_created_label">Erstellungsdatum</string>
+    <string name="searcher_sort_mode_path_label">Pfad</string>
+    <string name="searcher_sort_descending_label">Absteigende Reihenfolge</string>
+
+    <!-- Permission setup -->
+    <string name="searcher_setup_required_body">Für die Suche an einigen Speicherorten ist eine zusätzliche Einrichtung erforderlich.</string>
+</resources>

--- a/app-workspace-templates/src/main/res/values-de/strings.xml
+++ b/app-workspace-templates/src/main/res/values-de/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="workspace_templates_tab_title">Neu</string>
+    <string name="workspace_templates_choose_title">Neuer Tab</string>
+    <string name="workspace_templates_choose_subtitle">Wähle einen Tab-Typ aus. Wie kann ich helfen?</string>
+    <string name="workspace_templates_name_tab_action">Diesen Tab benennen</string>
+
+    <!-- Guided tour -->
+    <string name="tour_templates_picker_title">Werkzeug auswählen</string>
+    <string name="tour_templates_picker_body">Das ist die Tab-Auswahl. Wähle aus, wofür dieser Tab dienen soll. Deine Auswahl macht aus diesem Tab das entsprechende Werkzeug.</string>
+    <string name="tour_templates_butler_button_title">Hier sind Deine Tabs</string>
+    <string name="tour_templates_butler_button_body">Tippe auf die Butler-Schaltfläche, um das Tab-Menü zu öffnen: Erstelle einen neuen Tab, schließe den aktuellen oder öffne die vollständige Tab-Verwaltung. Halte die Schaltfläche gedrückt, um direkt zur Tab-Verwaltung zu springen.</string>
+</resources>

--- a/app-workspace-viewer/src/main/res/values-de/strings.xml
+++ b/app-workspace-viewer/src/main/res/values-de/strings.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Toolbar and image -->
+    <string name="viewer_open_with_action">Öffnen mit</string>
+    <string name="viewer_image_content_description">Bild %1$s</string>
+    <string name="viewer_toolbar_folder_label">Ordner</string>
+    <string name="viewer_back_action">Zurück</string>
+
+    <!-- Action bar -->
+    <string name="viewer_previous_file_action">Vorherige Datei</string>
+    <string name="viewer_next_file_action">Nächste Datei</string>
+    <string name="viewer_open_location_action">Speicherort öffnen</string>
+    <string name="viewer_clipboard_copied">%1$s kopiert. Füge das Element in einem Explorer-Tab ein.</string>
+    <string name="viewer_clipboard_cut">%1$s ausgeschnitten. Füge das Element in einem Explorer-Tab ein, um es zu verschieben.</string>
+    <string name="viewer_share_failed_label">Diese Datei konnte nicht geteilt werden</string>
+    <string name="viewer_share_failed_description">%1$s kann nicht an eine andere App übergeben werden. Das passiert bei Dateien, die Root- oder ADB-Zugriff benötigen, und bei Dateien, die nicht mehr vorhanden sind.</string>
+
+    <!-- File info card -->
+    <string name="viewer_info_size_label">Größe</string>
+    <string name="viewer_info_modified_label">Geändert</string>
+    <string name="viewer_info_created_label">Erstellt</string>
+    <string name="viewer_info_format_label">Format</string>
+    <string name="viewer_info_dimensions_label">Abmessungen</string>
+    <string name="viewer_info_dimensions_value">%1$d × %2$d</string>
+    <string name="viewer_info_permissions_label">Berechtigungen</string>
+    <string name="viewer_info_permissions_value">%1$s (%2$s)</string>
+    <string name="viewer_info_owner_label">Eigentümer</string>
+    <string name="viewer_info_caption_label">Geteilte Nachricht</string>
+    <string name="viewer_info_owner_value">%1$s / %2$s</string>
+    <string name="viewer_info_expand_action">Alle Details anzeigen</string>
+    <string name="viewer_info_collapse_action">Details ausblenden</string>
+
+    <!-- PDF preview -->
+    <string name="viewer_pdf_preview_hint_single">Vorschau · 1 Seite</string>
+    <string name="viewer_pdf_page_indicator">Seite %1$d von %2$d</string>
+    <string name="viewer_pdf_page_previous">Vorherige Seite</string>
+    <string name="viewer_pdf_page_next">Nächste Seite</string>
+    <string name="viewer_pdf_page_error">Seite %1$d konnte nicht angezeigt werden.</string>
+    <string name="viewer_pdf_page_content_description">PDF-Vorschau von %1$s, Seite %2$d von %3$d</string>
+
+    <!-- Unsupported file -->
+    <string name="viewer_unsupported_title">Dieser Dateityp wird noch nicht unterstützt</string>
+
+    <!-- Archive -->
+    <string name="viewer_archive_title">Dies ist ein Archiv</string>
+    <string name="viewer_browse_archive_action">Inhalt durchsuchen</string>
+    <string name="viewer_archive_needs_copy_msg">Speichere eine Kopie auf Deinem Gerät. Danach kann Butler den Inhalt durchsuchen.</string>
+    <string name="viewer_archive_nested_msg">Dieses Archiv befindet sich in einem anderen Archiv. Entpacke es zuerst, um seinen Inhalt zu durchsuchen.</string>
+
+    <!-- APK file -->
+    <string name="viewer_apk_version_label">Version</string>
+    <string name="viewer_apk_min_sdk_label">Min. SDK</string>
+    <string name="viewer_apk_target_sdk_label">Ziel-SDK</string>
+    <string name="viewer_apk_installed_label">Installiert</string>
+    <string name="viewer_apk_not_installed_value">Nicht installiert</string>
+    <string name="viewer_apk_installed_unknown_value">Prüfung fehlgeschlagen</string>
+    <string name="viewer_apk_installed_older_hint">Älter als diese Datei</string>
+    <string name="viewer_apk_installed_newer_hint">Neuer als diese Datei</string>
+    <string name="viewer_apk_permissions_header">Berechtigungen (%1$d)</string>
+    <string name="viewer_apk_signing_header">Signaturzertifikate</string>
+
+    <!-- App install -->
+    <string name="viewer_install_action">Installieren</string>
+    <string name="viewer_bundle_format_label">Bundle-Format</string>
+    <string name="viewer_bundle_splits_label">Enthaltene APKs</string>
+    <string name="viewer_bundle_expansion_files_hint">Enthält Erweiterungsdateien, die nach der Installation der App abgelegt werden.</string>
+    <string name="viewer_bundle_expansion_needs_elevation_warning">Zum Ablegen von Erweiterungsdateien ist Root- oder ADB-Zugriff erforderlich. Ohne diesen Zugriff wird die App installiert, aber ihre Erweiterungsdateien werden nicht abgelegt.</string>
+
+    <!-- APK icon -->
+    <string name="viewer_apk_icon_content_description">App-Symbol von %1$s</string>
+    <string name="viewer_apk_icon_show_action">Symbol anzeigen</string>
+    <string name="viewer_apk_icon_save_action">Symbol speichern</string>
+    <string name="viewer_apk_icon_dimensions">%1$d × %2$d</string>
+    <string name="viewer_apk_icon_saved">Symbol als %1$s gespeichert</string>
+    <string name="viewer_apk_icon_overwrite_title">Datei ersetzen?</string>
+    <string name="viewer_apk_icon_overwrite_message">%1$s ist bereits in diesem Ordner vorhanden. Beim Speichern des Symbols wird die Datei ersetzt.</string>
+    <string name="viewer_apk_icon_overwrite_confirm">Ersetzen</string>
+
+    <!-- External change notice -->
+    <string name="viewer_external_change_title">Datei geändert</string>
+    <string name="viewer_external_change_message">Diese Datei wurde auf dem Gerät geändert. Aktualisiere die Ansicht, um die Datei erneut zu laden.</string>
+    <string name="viewer_external_change_gone_title">Datei nicht mehr vorhanden</string>
+    <string name="viewer_external_change_gone_message">Diese Datei wurde gelöscht oder ist nicht mehr erreichbar.</string>
+
+    <!-- Errors -->
+    <string name="viewer_error_title">Diese Datei kann nicht angezeigt werden</string>
+    <string name="viewer_error_not_a_file_label">Keine Datei</string>
+    <string name="viewer_error_not_a_file_description">%1$s ist keine reguläre Datei.</string>
+    <string name="viewer_error_broken_symlink_label">Defekte Verknüpfung</string>
+    <string name="viewer_error_broken_symlink_description">%1$s verweist auf ein Ziel, das nicht mehr existiert.</string>
+    <string name="viewer_error_undecodable_label">Beschädigtes Bild</string>
+    <string name="viewer_error_undecodable_description">%1$s konnte nicht dekodiert werden. Die Datei ist möglicherweise unvollständig oder beschädigt.</string>
+    <string name="viewer_error_file_gone_label">Datei nicht gefunden</string>
+    <string name="viewer_error_file_gone_description">%1$s ist nicht mehr vorhanden. Die Datei wurde möglicherweise verschoben, umbenannt oder gelöscht.</string>
+    <string name="viewer_error_empty_file_label">Leere Datei</string>
+    <string name="viewer_error_empty_file_description">%1$s ist leer und enthält nichts, was angezeigt werden kann.</string>
+    <string name="viewer_error_apk_unreadable_label">Nicht lesbare APK</string>
+    <string name="viewer_error_apk_unreadable_description">%1$s konnte nicht als Android-App-Paket verarbeitet werden.</string>
+    <string name="viewer_error_icon_unavailable_label">Kein Symbol</string>
+    <string name="viewer_error_icon_unavailable_description">Das App-Symbol von %1$s konnte nicht gelesen werden.</string>
+    <string name="viewer_error_icon_target_notfile_label">Name bereits vergeben</string>
+    <string name="viewer_error_icon_target_notfile_description">%1$s ist hier bereits vorhanden und keine reguläre Datei. Das Element kann daher nicht ersetzt werden.</string>
+    <string name="viewer_error_icon_target_appeared_label">Datei neu erstellt</string>
+    <string name="viewer_error_icon_target_appeared_description">%1$s wurde erstellt, während Du den Speicherort ausgewählt hast. Es wurde nichts überschrieben. Versuche es erneut.</string>
+    <string name="viewer_error_content_unreadable_label">Diese Datei kann nicht gelesen werden</string>
+    <string name="viewer_error_content_unreadable_description">Die App, die %1$s geteilt hat, erlaubt Butler nicht mehr, die Datei zu lesen. Teile sie von dieser App aus erneut.</string>
+    <string name="viewer_save_copy_action">Kopie speichern…</string>
+    <string name="viewer_open_in_editor_action">Im Editor öffnen</string>
+    <string name="viewer_text_truncated_bytes">Die Vorschau ist auf die ersten %1$s dieser Datei begrenzt.</string>
+    <string name="viewer_text_truncated_lines">Die Vorschau ist auf die ersten %1$s Zeilen dieser Datei begrenzt.</string>
+    <string name="viewer_text_truncated_width">Lange Zeilen werden in dieser Vorschau gekürzt.</string>
+    <string name="viewer_text_unreadable_label">Diese Datei konnte nicht gelesen werden</string>
+</resources>

--- a/app-workspace/src/main/res/values-de/strings.xml
+++ b/app-workspace/src/main/res/values-de/strings.xml
@@ -1,0 +1,441 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Clipboard -->
+    <string name="clipboard_header_title">Zwischenablage</string>
+    <string name="clipboard_clear_all">Alles leeren</string>
+    <string name="clipboard_paste">Einfügen</string>
+    <string name="clipboard_open_in_explorer">Im Explorer öffnen</string>
+    <string name="clipboard_copy">Kopieren</string>
+    <string name="clipboard_cut">Ausschneiden</string>
+    <string name="clipboard_origin">Ursprung: %s</string>
+    <plurals name="clipboard_paths_title_copy">
+        <item quantity="one">%d Element kopieren</item>
+        <item quantity="other">%d Elemente kopieren</item>
+    </plurals>
+    <plurals name="clipboard_paths_description_copy">
+        <item quantity="one">%d Element aus %s</item>
+        <item quantity="other">%d Elemente aus %s</item>
+    </plurals>
+    <plurals name="clipboard_paths_title_cut">
+        <item quantity="one">%d Element ausschneiden</item>
+        <item quantity="other">%d Elemente ausschneiden</item>
+    </plurals>
+    <plurals name="clipboard_paths_description_cut">
+        <item quantity="one">%d Element aus %s</item>
+        <item quantity="other">%d Elemente aus %s</item>
+    </plurals>
+    <plurals name="clipboard_paths_locations">
+        <item quantity="one">%d Speicherort</item>
+        <item quantity="other">%d Speicherorte</item>
+    </plurals>
+    <plurals name="clipboard_paths_description_copy_multi">
+        <item quantity="one">%1$d Element aus %2$s</item>
+        <item quantity="other">%1$d Elemente aus %2$s</item>
+    </plurals>
+    <plurals name="clipboard_paths_description_cut_multi">
+        <item quantity="one">%1$d Element aus %2$s</item>
+        <item quantity="other">%1$d Elemente aus %2$s</item>
+    </plurals>
+    <string name="clipboard_text_title">Textausschnitt</string>
+    <plurals name="clipboard_text_description">
+        <item quantity="one">%1$d Zeichen</item>
+        <item quantity="other">%1$d Zeichen</item>
+    </plurals>
+    <string name="clipboard_text_paste_as_file">Als Datei einfügen</string>
+    <string name="clipboard_text_info_characters">Zeichen</string>
+    <string name="clipboard_text_info_lines">Zeilen</string>
+    <string name="clipboard_text_info_content">Inhalt</string>
+
+    <!-- Clipboard Info Dialog -->
+    <string name="clipboard_info_overview">Übersicht</string>
+    <string name="clipboard_info_operation">Vorgang</string>
+    <string name="clipboard_info_items">Elemente</string>
+    <string name="clipboard_info_source">Quelle</string>
+    <string name="clipboard_info_sources">Quellen</string>
+    <string name="clipboard_info_workspace">Arbeitsbereich</string>
+    <string name="clipboard_info_workspace_closed">Geschlossen</string>
+    <string name="clipboard_info_time">Zeitpunkt</string>
+    <string name="clipboard_info_items_with_count">Elemente (%1$d)</string>
+    <string name="clipboard_info_actions">Aktionen</string>
+    <string name="clipboard_info_go_to_source">Zur Quelle wechseln</string>
+    <string name="clipboard_info_go_to_first_source">Zur ersten Quelle wechseln</string>
+    <string name="clipboard_info_remove">Aus Zwischenablage entfernen</string>
+
+    <!-- Clipboard Settings -->
+    <string name="clipboard_settings_title">Zwischenablage</string>
+    <string name="clipboard_settings_remove_on_paste_title">Beim Einfügen entfernen</string>
+    <string name="clipboard_settings_remove_on_paste_desc">Kopierte Elemente nach dem Einfügen aus der Zwischenablage entfernen</string>
+    <string name="clipboard_settings_max_items_title">Maximale Anzahl an Elementen</string>
+    <string name="clipboard_settings_max_items_desc">Maximale Anzahl an Elementen in der Zwischenablage</string>
+
+    <string name="workspace_explorer_label">Explorer</string>
+    <string name="workspace_searcher_label">Suche</string>
+    <string name="workspace_editor_label">Editor</string>
+    <string name="workspace_templates_label">Vorlagen</string>
+    <string name="workspace_apps_label">Apps</string>
+    <string name="workspace_appdetails_label">App-Details</string>
+    <string name="workspace_saver_label">Speichern unter</string>
+    <string name="workspace_developer_label">Entwicklerwerkzeuge</string>
+    <string name="workspace_history_label">Verlauf</string>
+    <string name="workspace_bugreport_label">Fehlerberichte</string>
+    <string name="workspace_viewer_label">Betrachter</string>
+
+    <!-- Searcher media search targets -->
+    <string name="workspace_searcher_target_photos">Fotos</string>
+    <string name="workspace_searcher_target_videos">Videos</string>
+    <string name="workspace_searcher_target_music">Musik</string>
+    <string name="workspace_searcher_target_downloads">Downloads</string>
+
+    <!-- Workspace UI Actions -->
+    <string name="workspace_expand_more_action">Mehr</string>
+    <string name="workspace_expand_less_action">Weniger</string>
+
+    <!-- Workspace Button Menu -->
+    <string name="workspace_button_menu_new_workspace_format">Neu: %1$s</string>
+    <string name="workspace_button_menu_new_tab_action">Neuer Tab</string>
+    <string name="workspace_button_menu_category_recent">Zuletzt</string>
+    <string name="workspace_button_menu_category_other">Weitere</string>
+    <string name="workspace_button_menu_category_current_tab">Dieser Tab</string>
+    <string name="workspace_button_menu_manager_action">Tab-Verwaltung</string>
+    <string name="workspace_button_menu_close_current_action">Aktuellen Tab schließen</string>
+    <plurals name="workspace_button_menu_close_current_stack_action">
+        <item quantity="one">Aktuellen Tab schließen (%d Arbeitsbereich)</item>
+        <item quantity="other">Aktuellen Tab schließen (%d Arbeitsbereiche)</item>
+    </plurals>
+    <string name="workspace_button_menu_settings_action">Einstellungen</string>
+
+    <!-- Workspace Manager Actions -->
+    <string name="workspace_manager_close_all_title">Alle Tabs schließen?</string>
+    <string name="workspace_manager_close_all_message">Dadurch werden alle offenen Tabs geschlossen (%1$d %2$s). Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="workspace_manager_close_all_message_singular">Tab</string>
+    <string name="workspace_manager_close_all_message_plural">Tabs</string>
+    <string name="workspace_manager_close_all_action">Alle schließen</string>
+    <string name="workspace_manager_close_all_unsaved_warning">Einige Tabs enthalten ungespeicherte Änderungen, die dabei verloren gehen.</string>
+    <string name="workspace_manager_close_all_unsaved_action">Alle verwerfen</string>
+    <string name="workspace_manager_close_selected_title">Ausgewählte Tabs schließen?</string>
+    <string name="workspace_manager_close_selected_message">Dadurch werden die ausgewählten Tabs geschlossen (%1$d %2$s). Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="workspace_manager_close_selected_action">Ausgewählte schließen</string>
+    <string name="workspace_manager_close_selected_unsaved_warning">Einige ausgewählte Tabs enthalten ungespeicherte Änderungen, die dabei verloren gehen.</string>
+    <string name="workspace_manager_close_selected_unsaved_action">Ausgewählte verwerfen</string>
+    <string name="workspace_manager_pause_partial_title">Tabs pausieren?</string>
+    <string name="workspace_manager_pause_partial_message">%1$d von %2$d ausgewählten Tabs können pausiert werden. Die übrigen werden verwendet, enthalten ungespeicherte Änderungen oder sind gerade geöffnet.</string>
+    <string name="workspace_manager_pause_partial_action">%1$d pausieren</string>
+    <string name="workspace_fab_close_all">Alle Tabs schließen</string>
+    <string name="general_cancel_action">Abbrechen</string>
+
+    <!-- Operations -->
+    <string name="operations_header_title">Vorgänge</string>
+    <string name="operations_clear_completed">Abgeschlossene entfernen</string>
+    <string name="operations_state_queued">In Warteschlange</string>
+    <string name="operations_state_running">Wird ausgeführt</string>
+    <string name="operations_state_waiting">Wartet auf Eingabe</string>
+    <string name="operations_state_successful">Erfolgreich</string>
+    <string name="operations_state_failed">Fehlgeschlagen</string>
+    <string name="operations_state_cancelled">Abgebrochen</string>
+    <string name="operations_cancel_operation">Vorgang abbrechen</string>
+    <string name="operations_cancel_dialog_title">Vorgang abbrechen?</string>
+    <string name="operations_cancel_dialog_message">Möchtest Du diesen Vorgang wirklich abbrechen?</string>
+    <string name="operations_cancel_dialog_warning">Beim Abbrechen können Dateien in einem inkonsistenten Zustand zurückbleiben.</string>
+    <string name="operations_details_started_at">Gestartet</string>
+    <string name="operations_details_completed_at">Abgeschlossen</string>
+    <string name="operations_details_duration">Dauer</string>
+    <string name="operations_details_duration_not_started">Nicht gestartet</string>
+    <string name="operations_details_progress">Fortschritt</string>
+    <string name="operations_details_error">Fehlerdetails</string>
+    <string name="operations_details_actions">Aktionen</string>
+    <string name="operations_details_overview">Übersicht</string>
+    <string name="operations_details_handle_issue">Problem bearbeiten</string>
+    <string name="operations_details_show_in_history_action">Im Verlauf anzeigen</string>
+    <string name="operations_details_status">Status</string>
+    <string name="operations_details_result">Ergebnis</string>
+    <string name="operations_details_destination_folder">Zielordner</string>
+    <string name="operations_details_destination_path">Zielpfad</string>
+    <string name="operations_details_affected_paths_with_count">Betroffene Pfade (%d)</string>
+    <string name="operations_details_section_expand">%1$s ausklappen</string>
+    <string name="operations_details_section_collapse">%1$s einklappen</string>
+    <string name="workspace_operations_performance_graph_label">Leistungsdiagramm</string>
+
+    <!-- Delete Confirmation Dialog -->
+    <string name="workspace_dialog_delete_title_single">Element löschen?</string>
+    <plurals name="workspace_dialog_delete_title_multiple">
+        <item quantity="one">%1$d Element löschen?</item>
+        <item quantity="other">%1$d Elemente löschen?</item>
+    </plurals>
+    <string name="workspace_dialog_delete_message_single">Dieses Element wird endgültig gelöscht:</string>
+    <string name="workspace_dialog_delete_message_multiple">Diese Elemente werden endgültig gelöscht:</string>
+    <string name="workspace_dialog_delete_more_items">… weitere Elemente: %1$d</string>
+    <string name="workspace_dialog_delete_warning">Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="workspace_dialog_delete_permanently_action">Endgültig löschen</string>
+    <string name="workspace_dialog_delete_permanently_toggle">Stattdessen endgültig löschen</string>
+    <string name="workspace_dialog_delete_partial_trash_notice">Einige Elemente können nicht in den Papierkorb verschoben werden und werden gesondert behandelt.</string>
+
+    <!-- Trash Dialog -->
+    <string name="workspace_dialog_trash_title_single">In den Papierkorb verschieben?</string>
+    <plurals name="workspace_dialog_trash_title_multiple">
+        <item quantity="one">%1$d Element in den Papierkorb verschieben?</item>
+        <item quantity="other">%1$d Elemente in den Papierkorb verschieben?</item>
+    </plurals>
+    <string name="workspace_dialog_trash_message_single">Dieses Element wird in den Papierkorb verschoben:</string>
+    <string name="workspace_dialog_trash_message_multiple">Diese Elemente werden in den Papierkorb verschoben:</string>
+    <string name="workspace_dialog_trash_hint">Danach im Papierkorb zu finden</string>
+    <string name="workspace_dialog_move_to_trash_action">Verschieben</string>
+
+    <!-- Action Bar -->
+    <plurals name="workspace_selection_count">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
+    <string name="workspace_action_more">Weitere Aktionen</string>
+
+    <!-- Delete Operation (shared across workspaces) -->
+    <string name="workspace_operation_delete_title">Löschvorgang</string>
+    <string name="workspace_operation_delete_description_single">\"%1$s\" aus \"%2$s\" löschen.</string>
+    <plurals name="workspace_operation_delete_description">
+        <item quantity="one">%1$d Element aus \"%2$s\" löschen.</item>
+        <item quantity="other">%1$d Elemente aus \"%2$s\" löschen.</item>
+    </plurals>
+
+    <!-- App Install Operation (shared across workspaces) -->
+    <string name="workspace_operation_install_title">App-Installation</string>
+    <string name="workspace_operation_install_description">\"%1$s\" installieren.</string>
+    <string name="workspace_operation_install_progress_inspecting">Paket wird gelesen…</string>
+    <string name="workspace_operation_install_progress_extracting">Wird entpackt…</string>
+    <string name="workspace_operation_install_progress_writing">Dateien werden an das Installationsprogramm übergeben…</string>
+    <string name="workspace_operation_install_progress_committing">Installation wird abgeschlossen…</string>
+    <string name="workspace_operation_install_progress_placing_obb">Erweiterungsdateien werden abgelegt…</string>
+    <string name="workspace_operation_install_summary_success">%1$s wurde installiert.</string>
+    <string name="workspace_operation_install_summary_success_partial">%1$s wurde installiert, aber die Erweiterungsdateien konnten nicht abgelegt werden.</string>
+    <string name="workspace_install_unknown_sources_required">Butler benötigt die Berechtigung zum Installieren von Apps. Erteile sie in den gerade geöffneten Einstellungen und versuche es dann erneut.</string>
+    <string name="workspace_install_obb_failed">Die App wurde installiert, aber die Erweiterungsdateien konnten nicht abgelegt werden: %1$s</string>
+
+    <!-- Delete Operation Reports -->
+    <plurals name="workspace_operation_report_files_deleted">
+        <item quantity="one">%1$d Datei gelöscht.</item>
+        <item quantity="other">%1$d Dateien gelöscht.</item>
+    </plurals>
+    <plurals name="workspace_operation_report_directories_deleted">
+        <item quantity="one">%1$d Verzeichnis gelöscht.</item>
+        <item quantity="other">%1$d Verzeichnisse gelöscht.</item>
+    </plurals>
+    <plurals name="workspace_operation_report_skipped_items">
+        <item quantity="one">%1$d Element übersprungen.</item>
+        <item quantity="other">%1$d Elemente übersprungen.</item>
+    </plurals>
+    <plurals name="workspace_operation_report_bytes_freed">
+        <item quantity="one">%1$s freigegeben.</item>
+        <item quantity="other">%1$s freigegeben.</item>
+    </plurals>
+
+    <!-- Trash Operation Reports -->
+    <string name="workspace_operation_progress_moving_to_trash">Wird in den Papierkorb verschoben…</string>
+    <plurals name="workspace_operation_report_files_trashed">
+        <item quantity="one">%1$d Datei in den Papierkorb verschoben.</item>
+        <item quantity="other">%1$d Dateien in den Papierkorb verschoben.</item>
+    </plurals>
+    <plurals name="workspace_operation_report_directories_trashed">
+        <item quantity="one">%1$d Verzeichnis in den Papierkorb verschoben.</item>
+        <item quantity="other">%1$d Verzeichnisse in den Papierkorb verschoben.</item>
+    </plurals>
+
+    <string name="workspace_operation_progress_bytes_speed_freed">%1$s/s freigegeben.</string>
+    <string name="workspace_operation_progress_bytes_freed">%1$s freigegeben.</string>
+    <string name="workspace_operation_progress_time_remaining">%1$s verbleibend.</string>
+
+    <!-- File Info Dialog (shared across workspaces) -->
+    <string name="workspace_file_info_title">Informationen</string>
+    <string name="workspace_file_info_name_label">Name</string>
+    <string name="workspace_file_info_path_label">Pfad</string>
+    <string name="workspace_file_info_type_label">Typ</string>
+    <string name="workspace_file_info_type_file">Datei</string>
+    <string name="workspace_file_info_type_directory">Verzeichnis</string>
+    <string name="workspace_file_info_type_symlink">Symbolische Verknüpfung</string>
+    <string name="workspace_file_info_type_unknown">Unbekannt</string>
+    <string name="workspace_file_info_size_label">Größe</string>
+    <string name="workspace_file_info_modified_label">Geändert</string>
+    <string name="workspace_file_info_created_label">Erstellt</string>
+    <string name="workspace_file_info_permissions_label">Berechtigungen</string>
+    <string name="workspace_file_info_owner_label">Eigentümer</string>
+    <string name="workspace_file_info_child_count_label">Elemente</string>
+    <string name="workspace_file_info_symlink_target_label">Ziel</string>
+    <string name="workspace_file_info_unknown">Unbekannt</string>
+    <string name="workspace_file_info_copy_action">In Zwischenablage kopieren</string>
+
+    <!-- Multiple Items Info Dialog -->
+    <string name="workspace_file_info_selected_label">Ausgewählt</string>
+    <string name="workspace_file_info_files_label">Dateien</string>
+    <string name="workspace_file_info_directories_label">Verzeichnisse</string>
+    <string name="workspace_file_info_total_size_label">Gesamtgröße</string>
+
+    <!-- Performance Graph -->
+    <string name="workspace_operation_performance_unavailable_not_started">Dieser Vorgang wurde noch nicht gestartet.</string>
+    <string name="workspace_operation_performance_unavailable_collecting">Leistungsdaten werden gesammelt…</string>
+    <string name="workspace_operation_performance_unavailable_insufficient">Für diesen Vorgang liegen nicht genügend Leistungsdaten für ein Diagramm vor.</string>
+    <string name="workspace_operation_performance_unavailable_not_available">Für diesen Vorgang sind keine Leistungsdaten verfügbar.</string>
+    <string name="workspace_operation_performance_unit_bytes">B/s</string>
+    <string name="workspace_operation_performance_unit_kilobytes">kB/s</string>
+    <string name="workspace_operation_performance_unit_megabytes">MB/s</string>
+    <string name="workspace_operation_performance_unit_gigabytes">GB/s</string>
+    <string name="workspace_operation_performance_unit_items">Elemente/s</string>
+
+    <!-- Error Display (shared across workspaces) -->
+    <string name="workspace_error_show_details_action">Technische Details anzeigen</string>
+    <string name="workspace_error_hide_details_action">Technische Details ausblenden</string>
+
+    <!-- Workspace State Components -->
+    <string name="workspace_initializing_title">Tab wird initialisiert</string>
+    <string name="workspace_error_subtitle">Ein unerwarteter Fehler ist aufgetreten</string>
+    <string name="workspace_close_tab_action">Tab schließen</string>
+    <string name="workspace_paused_body">Dieser Tab ist pausiert, um Arbeitsspeicher und Akku zu sparen. Setze ihn fort, um weiterzumachen.</string>
+    <string name="workspace_paused_error_body">Dieser Tab konnte nicht fortgesetzt werden.</string>
+    <string name="workspace_paused_resume_action">Fortsetzen</string>
+    <string name="workspace_paused_label">Pausiert</string>
+    <string name="workspace_paused_content_label">Tab-Inhalt</string>
+
+    <!-- Issue Resolution (conflict handling) -->
+    <string name="workspace_issue_collision_existing_file_label">Vorhandene Datei</string>
+    <string name="workspace_issue_collision_existing_folder_label">Vorhandener Ordner</string>
+    <string name="workspace_issue_collision_new_file">Neue Datei</string>
+    <string name="workspace_issue_collision_new_folder">Neuer Ordner</string>
+    <string name="workspace_issue_collision_overwrite">Ersetzen</string>
+    <string name="workspace_issue_collision_merge">Zusammenführen</string>
+    <string name="workspace_issue_common_source_file">Quelldatei</string>
+    <string name="workspace_issue_common_destination_file">Ziel</string>
+    <string name="workspace_issue_common_skip">Überspringen</string>
+    <string name="workspace_issue_common_rename">Umbenennen</string>
+    <string name="workspace_issue_common_rename_new">Quelle umbenennen</string>
+    <string name="workspace_issue_common_rename_existing">Ziel umbenennen</string>
+    <string name="workspace_issue_common_cancel">Abbrechen</string>
+    <string name="workspace_issue_common_delete_permanently">Endgültig löschen</string>
+    <string name="workspace_issue_archive_password_label">Passwort</string>
+    <string name="workspace_issue_archive_password_unlock">Entsperren</string>
+    <string name="workspace_issue_trash_move_failed_items_label">Fehlgeschlagene Elemente</string>
+    <string name="workspace_issue_trash_move_failed_more_items">… weitere Elemente: %1$d</string>
+    <string name="workspace_issue_trash_not_supported_items_label">Betroffene Elemente</string>
+    <string name="workspace_issue_trash_not_supported_more_items">… weitere Elemente: %1$d</string>
+    <string name="workspace_issue_apply_all">Auf alle verbleibenden Probleme anwenden</string>
+    <string name="workspace_issue_rename_new_name">Neuer Name</string>
+    <string name="workspace_issue_rename_dialog_title_new">Neue Datei umbenennen</string>
+    <string name="workspace_issue_rename_dialog_title_existing">Vorhandene Datei umbenennen</string>
+    <string name="workspace_issue_type_folder">Ordner</string>
+
+    <!-- Open in New Tabs Confirmation Dialog -->
+    <string name="workspace_open_tabs_confirmation_title">Mehrere Tabs öffnen?</string>
+    <string name="workspace_open_tabs_confirmation_message">Dadurch werden %1$d Tabs geöffnet.</string>
+
+    <!-- Open with (hand a file to another app) -->
+    <string name="workspace_open_with_chooser_title">Öffnen mit</string>
+    <string name="workspace_open_with_no_app_label">Keine andere App gefunden</string>
+    <string name="workspace_open_with_no_app_description">Keine andere installierte App kann %1$s öffnen.</string>
+
+    <!-- Workspace Banner Feedback -->
+    <plurals name="workspace_banner_opened_tabs">
+        <item quantity="one">%1$d Tab geöffnet</item>
+        <item quantity="other">%1$d Tabs geöffnet</item>
+    </plurals>
+
+    <!-- Workspace > Settings-->
+    <string name="workspace_settings_title">Tabs</string>
+    <string name="workspace_settings_navigation">Navigation</string>
+    <string name="workspace_settings_swipe_gestures_title">Wischgesten</string>
+    <string name="workspace_settings_swipe_gestures_desc">Wische nach links oder rechts, um zwischen Tabs zu wechseln.</string>
+    <string name="workspace_settings_ondemand_creation_title">Tabs automatisch erstellen</string>
+    <string name="workspace_settings_ondemand_creation_desc">Automatisch einen neuen Tab erstellen, wenn Du über den letzten Tab hinauswischst.</string>
+    <string name="workspace_settings_live_preview_title">Live-Vorschau</string>
+    <string name="workspace_settings_live_preview_desc">Live-Inhalte der Tabs in der Tab-Verwaltung anzeigen.</string>
+    <string name="workspace_settings_other">Sonstiges</string>
+    <string name="workspace_settings_layout_title">Anordnung</string>
+    <string name="workspace_settings_layout_mode_portrait_title">Anordnung im Hochformat</string>
+    <string name="workspace_settings_layout_mode_portrait_desc">Wähle die Tab-Anordnung im Hochformat.</string>
+    <string name="workspace_settings_layout_mode_landscape_title">Anordnung im Querformat</string>
+    <string name="workspace_settings_layout_mode_landscape_desc">Wähle die Tab-Anordnung im Querformat.</string>
+    <string name="workspace_settings_layout_mode_auto">Automatisch</string>
+    <string name="workspace_settings_layout_mode_auto_desc">Anordnung automatisch an die Bildschirmgröße anpassen.</string>
+    <string name="workspace_settings_layout_mode_single">Ein Bereich</string>
+    <string name="workspace_settings_layout_mode_single_desc">Ein Tab-Bereich füllt den gesamten Bildschirm.</string>
+    <string name="workspace_settings_layout_mode_dual_vertical">Zwei nebeneinander</string>
+    <string name="workspace_settings_layout_mode_dual_vertical_desc">Zwei Bereiche nebeneinander (links/rechts).</string>
+    <string name="workspace_settings_layout_mode_dual_horizontal">Zwei übereinander</string>
+    <string name="workspace_settings_layout_mode_dual_horizontal_desc">Zwei Bereiche übereinander (oben/unten).</string>
+    <string name="workspace_settings_layout_mode_triple_sidebar_left">Drei Bereiche, links groß</string>
+    <string name="workspace_settings_layout_mode_triple_sidebar_left_desc">Ein großer Bereich links, zwei kleinere Bereiche übereinander rechts.</string>
+    <string name="workspace_settings_layout_mode_triple_sidebar_right">Drei Bereiche, rechts groß</string>
+    <string name="workspace_settings_layout_mode_triple_sidebar_right_desc">Zwei kleinere Bereiche übereinander links, ein großer Bereich rechts.</string>
+    <string name="workspace_settings_layout_mode_quad_grid">Vier im Raster</string>
+    <string name="workspace_settings_layout_mode_quad_grid_desc">Vier Bereiche in einem 2×2-Raster.</string>
+
+    <string name="workspace_settings_pane_click_to_focus_title">Zum Fokussieren klicken</string>
+    <string name="workspace_settings_pane_click_to_focus_desc">Der erste Klick auf einen nicht fokussierten Bereich fokussiert ihn nur. Nicht fokussierte Bereiche reagieren auch nicht auf den Mauszeiger. Deaktiviere diese Option, um direkt mit ihnen zu interagieren.</string>
+
+    <!-- Session -->
+    <string name="workspace_settings_session_title">Sitzung</string>
+    <string name="workspace_settings_session_restore_title">Tabs beim Start wiederherstellen</string>
+    <string name="workspace_settings_session_restore_desc">Zuvor geöffnete Tabs beim Start der App automatisch wiederherstellen.</string>
+    <string name="workspace_settings_autopause_title">Inaktive Tabs pausieren</string>
+    <string name="workspace_settings_autopause_desc">Tabs, die Du eine Weile nicht angesehen hast, werden pausiert, um Arbeitsspeicher und Akku zu sparen. Beim Öffnen wird der jeweilige Tab fortgesetzt.</string>
+    <string name="workspace_settings_autopause_delay_title">Pausieren nach</string>
+    <string name="workspace_settings_autopause_delay_desc">Wie lange ein Tab nicht sichtbar sein darf, bevor er pausiert wird.</string>
+    <string name="workspace_settings_undoclose_title">Schließen von Tabs rückgängig machen</string>
+    <string name="workspace_settings_undoclose_desc">Nach dem Schließen eines Tabs kannst Du ihn einige Sekunden lang wiederherstellen.</string>
+    <string name="workspace_settings_session_data_title">Sitzungsdaten</string>
+    <plurals name="workspace_settings_session_data_desc">
+        <item quantity="one">%1$d Tab • %2$s</item>
+        <item quantity="other">%1$d Tabs • %2$s</item>
+    </plurals>
+
+    <!-- Undo close -->
+    <string name="workspace_closed_undo_message">\"%1$s\" geschlossen</string>
+
+    <!-- Session Restoration Error -->
+    <string name="workspace_session_restoration_error_title">Sitzung konnte nicht wiederhergestellt werden</string>
+    <string name="workspace_session_restoration_error_description">Deine vorherige Tab-Sitzung konnte nicht wiederhergestellt werden. Möglicherweise liegt das an einem Fehler, der in einem zukünftigen Update behoben wird.\n\nDu kannst die gespeicherte Sitzung löschen, um Butler weiter zu verwenden, oder auf ein Update warten.</string>
+    <string name="workspace_session_restoration_error_clear_action">Sitzung löschen</string>
+    <string name="workspace_session_restoration_error_report_action">Problem melden</string>
+    <string name="workspace_session_restoration_error_confirm_title">Sitzung löschen?</string>
+    <string name="workspace_session_restoration_error_confirm_description">Dadurch wird Deine gespeicherte Tab-Sitzung endgültig gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.</string>
+
+    <!-- Rename tab -->
+    <string name="workspace_rename_dialog_title">Tab umbenennen</string>
+    <string name="workspace_rename_name_label">Eigener Name</string>
+    <string name="workspace_rename_name_hint">Leer lassen, um den automatischen Namen zu verwenden</string>
+
+    <!-- Workspace Limit -->
+    <string name="workspace_limit_reached_title">Tab-Limit erreicht</string>
+    <string name="workspace_limit_reached_message">In der kostenlosen Version kannst Du bis zu %1$d Tabs gleichzeitig öffnen. Mit Butler Pro sind unbegrenzt viele Tabs möglich!</string>
+    <string name="workspace_limit_pick_tabs_message">Deine kostenlose Version erlaubt %1$d offene Tabs. Wähle die Tabs aus, die Du nicht mehr brauchst, und schließe sie, um Platz zu schaffen.</string>
+    <string name="workspace_limit_no_slot_hint">Durch das Schließen von Tabs wird gerade kein Platz frei.</string>
+    <plurals name="workspace_limit_close_selected_action">
+        <item quantity="one">%d Tab schließen</item>
+        <item quantity="other">%d Tabs schließen</item>
+    </plurals>
+    <plurals name="workspace_limit_selection_hint">
+        <item quantity="one">Wähle mindestens %d Tab zum Schließen aus.</item>
+        <item quantity="other">Wähle mindestens %d Tabs zum Schließen aus.</item>
+    </plurals>
+    <string name="workspace_limit_tab_opened">%1$s geöffnet</string>
+    <string name="workspace_limit_blocker_unsaved">Ungespeicherte Änderungen</string>
+    <string name="workspace_limit_blocker_busy">Gerade beschäftigt</string>
+    <string name="workspace_limit_blocker_attention">Wartet auf Dich</string>
+    <string name="workspace_limit_blocker_loading">Wird noch geladen</string>
+    <string name="workspace_limit_blocker_awaiting_result">Schließe zuerst die offene Auswahl ab</string>
+    <string name="workspace_limit_blocker_unavailable">Kann gerade nicht geschlossen werden</string>
+    <string name="workspace_limit_stacked_content_desc">Beim Schließen dieses Tabs werden auch die darauf gestapelten Inhalte geschlossen</string>
+    <string name="workspace_limit_pro_description">Öffne so viele Tabs, wie Du möchtest.</string>
+
+    <!-- Drag and drop -->
+    <plurals name="workspace_drag_decoration_items">
+        <item quantity="one">%1$d Element</item>
+        <item quantity="other">%1$d Elemente</item>
+    </plurals>
+    <string name="workspace_drag_decoration_breakdown">%1$s, %2$s</string>
+
+    <!-- Restore operation -->
+    <string name="workspace_operation_restore_title">Wiederherstellung aus dem Papierkorb</string>
+    <plurals name="workspace_operation_restore_description">
+        <item quantity="one">%d Element aus dem Papierkorb wiederherstellen.</item>
+        <item quantity="other">%d Elemente aus dem Papierkorb wiederherstellen.</item>
+    </plurals>
+    <plurals name="workspace_operation_restore_summary">
+        <item quantity="one">%d Element wiederhergestellt</item>
+        <item quantity="other">%d Elemente wiederhergestellt</item>
+    </plurals>
+</resources>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="upgrade_feature_requires_pro">Erfordert Butler FOSS</string>
+
+    <string name="upgrade_prompt_title">Upgrade für Butler</string>
+    <string name="upgrade_prompt_body">Schalte zusätzliche Funktionen frei und unterstütze die weitere Entwicklung!</string>
+    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
+
+    <string name="upgrade_screen_title">Upgrade für Butler</string>
+    <string name="upgrade_screen_preamble">Butler enthält keine Werbung und verkauft keine Nutzerdaten. Die weitere Entwicklung ist nur durch Dich möglich.</string>
+    <string name="upgrade_screen_how_title">So kannst Du helfen</string>
+    <string name="upgrade_screen_how_body">Unterstütze die Entwicklung als Förderer! Tippe auf die Schaltfläche unten, um alle zusätzlichen Funktionen zu aktivieren und mein GitHub-Sponsors-Profil zu öffnen.</string>
+
+    <string name="upgrade_screen_sponsor_action">Entwicklung unterstützen</string>
+    <string name="upgrade_screen_sponsor_action_hint">Die Alternative sind Werbung, Analysen und Google Play 🙁.</string>
+    <string name="upgrade_screen_thanks_toast">Danke für Deine Unterstützung der Open-Source-Entwicklung ❤️</string>
+    <string name="upgrade_screen_sponsor_too_fast">Schon zurück? Deine Unterstützung hält Butler am Leben. Nimm Dir bitte einen Moment Zeit für die Sponsorenseite.</string>
+
+    <string name="upgrade_screen_status_free_title">Du nutzt die kostenlose Version</string>
+    <string name="upgrade_screen_status_free_body">Butler FOSS ist vollständig quelloffen. Unterstütze die Entwicklung, um die zusätzlichen Funktionen freizuschalten.</string>
+    <string name="upgrade_screen_status_free_action">Upgrade-Optionen ansehen</string>
+    <string name="upgrade_screen_status_upgraded_title">Du unterstützt Butler</string>
+    <string name="upgrade_screen_status_upgraded_body">Danke für Deine Unterstützung der Open-Source-Entwicklung ❤️ Alle zusätzlichen Funktionen sind freigeschaltet.</string>
+    <string name="upgrade_screen_supporter_since">Unterstützt seit %s</string>
+    <string name="upgrade_screen_recurring_title">Dauerhaft unterstützen</string>
+    <string name="upgrade_screen_recurring_body">Butler wird in meiner Freizeit entwickelt. Eine regelmäßige Spende hilft dabei, das Projekt am Leben zu halten.</string>
+    <string name="upgrade_screen_recurring_action">Regelmäßig unterstützen</string>
+
+    <string name="upgrade_benefits_title">Vorteile des Upgrades</string>
+    <!-- Lines starting with "•" (or "-") render as checkmarked feature rows; lines without a marker
+         render as plain footnote text. Keep the markers. -->
+    <string name="upgrade_screen_benefits_body">• Unbegrenzte Tabs und Vorgänge\n• Design und Bedienung anpassen\n• Zusätzliche Optionen und Funktionen für jedes Werkzeug\n• Frühzeitiger Zugriff auf neue Funktionen\n• Ein motivierter Entwickler 🧙\nund mehr…</string>
+</resources>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="upgrade_feature_requires_pro">Erfordert Butler Pro</string>
+
+    <string name="upgrade_prompt_title">Upgrade für Butler</string>
+    <string name="upgrade_prompt_body">Butler Pro bietet bessere Ergebnisse, mehr Funktionen und Optionen für erfahrene Nutzer.</string>
+    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
+
+    <!-- %1$s is the full brand name ("Butler Pro"), composed from the app name plus the upgrade
+         postfix. Translate the sentence around it and keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s holen</string>
+    <string name="upgrade_screen_preamble">Butler enthält keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von Dir finanziert ❤️.</string>
+
+    <string name="upgrade_screen_how_title">Optionen</string>
+    <string name="upgrade_screen_subscription_trial_action">Kostenlosen 14-Tage-Test starten</string>
+    <string name="upgrade_screen_subscription_action">Abonnieren</string>
+    <string name="upgrade_screen_iap_action">Einmalkauf</string>
+    <string name="upgrade_screen_restore_purchase_action">Kauf wiederherstellen</string>
+    <string name="upgrade_screen_restore_banner_title">Pro bereits gekauft?</string>
+    <string name="upgrade_screen_restore_banner_body">Anscheinend hattest Du auf diesem Gerät schon einmal ein Upgrade auf Pro. Stelle Deinen Kauf wieder her, um Pro erneut freizuschalten.</string>
+    <string name="upgrade_screen_restore_checked_message">Butler hat gerade bei Google Play nachgesehen, aber für das von Google Play für diese App verwendete Konto konnte kein Pro-Kauf bestätigt werden.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Die Prüfung durch Google Play wurde nicht rechtzeitig abgeschlossen. Dein Kaufstatus ist daher weiterhin unbekannt. An Deinem Konto wurde nichts geändert.</string>
+    <string name="upgrade_screen_restore_contact_hint">Kommst Du weiterhin nicht weiter? Melde Dich über die E-Mail-Adresse, mit der Du den Kauf getätigt hast, und gib Deine Google-Play-Bestellnummer an.</string>
+    <string name="upgrade_screen_contact_support_action">Support kontaktieren</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Die Synchronisierung mit dem Play Store kann etwas dauern. Starte das Gerät neu, leere den Cache von Google Play oder warte einfach ab.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play verwirren. Melde Dich von anderen Konten ab oder installiere die App über die Google-Play-Website. Dadurch wird sie einem bestimmten Konto zugeordnet.</string>
+    <string name="upgrade_screen_restore_success_message">Dein Kauf wurde wiederhergestellt ❤️</string>
+    <string name="upgrade_screen_restore_status_title">Status stimmt nicht?</string>
+    <string name="upgrade_screen_restore_status_body">Wenn Du Pro bereits gekauft hast, es aber nicht angezeigt wird, stelle Deinen Kauf wieder her.</string>
+
+    <string name="upgrade_screen_offers_or">oder</string>
+
+    <string name="upgrade_screen_offers_title">Upgrade-Optionen</string>
+    <string name="upgrade_screen_offers_body">Beide Optionen schalten genau dieselben Pro-Funktionen frei. Wähle das Preismodell, das zu Dir passt.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preise nicht verfügbar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Butler konnte die Upgrade-Optionen nicht von Google Play laden. Das ist oft nur vorübergehend. Versuche es gleich noch einmal.</string>
+    <string name="upgrade_screen_subscription_offer_title">Jahresabo</string>
+    <string name="upgrade_screen_subscription_offer_body">Beginnt mit einem kostenlosen 14-Tage-Test und wird danach einmal jährlich abgerechnet. Jederzeit kündbar.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Wird einmal jährlich abgerechnet. Jederzeit kündbar.</string>
+    <string name="upgrade_screen_iap_offer_title">Einmal kaufen</string>
+    <string name="upgrade_screen_iap_offer_body">Einmal zahlen, dauerhaft behalten. Kein Abo.</string>
+    <string name="upgrade_screen_restore_body">Beim Wiederherstellen prüft Google Play die Käufe dieser App für das aktuelle Konto erneut.</string>
+
+    <string name="upgrade_screen_owned_hero_title">Du hast Butler Pro!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Danke für Deinen Einmalkauf. Damit bist Du dauerhaft versorgt ❤️</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Danke für Dein Abo ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Einmalkauf</string>
+    <string name="upgrade_screen_owned_iap_body">Du besitzt das dauerhafte Pro-Upgrade.</string>
+    <string name="upgrade_screen_owned_sub_title">Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Dein Abo ist aktiv und verlängert sich automatisch.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Dein Abo ist aktiv, wird aber nicht verlängert. Pro bleibt bis zum Ende des aktuellen Zeitraums aktiv.</string>
+    <string name="upgrade_screen_owned_both_renewing_warning">Du besitzt den Einmalkauf, aber Dein Abo wird weiterhin verlängert. Kündige es bei Google Play, damit Du nicht doppelt zahlst.</string>
+    <string name="upgrade_screen_manage_subscription_action">Abo verwalten</string>
+
+    <string name="upgrade_screen_switch_locked_note">Kündige zuerst die Verlängerung über \"Abo verwalten\", sonst würdest Du für beides bezahlen.</string>
+    <string name="upgrade_screen_switch_purchase_note">Dein Abo wird nicht verlängert. Du kannst den Einmalkauf jetzt bedenkenlos abschließen.</string>
+
+    <string name="upgrade_screen_sub_still_renewing_title">Abo noch aktiv</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Dein Abo ist weiterhin zur Verlängerung vorgesehen. Kündige zuerst die Verlängerung bei Google Play, damit Du nicht für beides bezahlst, und schließe danach den Einmalkauf ab.</string>
+    <string name="upgrade_screen_purchase_check_failed_title">Überprüfung fehlgeschlagen</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Butler konnte Deinen Kaufstatus nicht über Google Play bestätigen. Der Kauf wurde deshalb abgebrochen, damit Du nicht doppelt belastet wirst. Versuche es gleich noch einmal.</string>
+
+    <string name="upgrade_screen_pending_card_title">Zahlung ausstehend</string>
+    <string name="upgrade_screen_pending_card_body">Google Play verarbeitet Deine Zahlung noch. Pro wird automatisch freigeschaltet, sobald die Zahlung abgeschlossen ist. Bei manchen Zahlungsmethoden kann das etwas dauern. Du musst nichts weiter tun.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play hat einen Kauf mit ausstehender Zahlung gefunden und verarbeitet ihn noch. Pro wird automatisch freigeschaltet, sobald die Zahlung abgeschlossen ist.</string>
+
+    <string name="upgrade_screen_grace_title">Kauf wird bestätigt</string>
+    <string name="upgrade_screen_grace_body_short">Google Play braucht einen Moment, um Deinen Pro-Status zu bestätigen. Du hast weiterhin vollen Zugriff.</string>
+    <string name="upgrade_screen_grace_body">Google Play hat Deinen Pro-Status noch nicht erneut bestätigt. Du hast vorerst weiterhin Zugriff. Falls Dir das falsch vorkommt, versuche Deinen Kauf wiederherzustellen.</string>
+
+    <string name="upgrades_gplay_already_owned_error_title">Bereits gekauft?</string>
+    <string name="upgrades_gplay_already_owned_error_description">Laut Google Play besitzt Du dieses Upgrade bereits, es konnte aber nicht automatisch wiederhergestellt werden. Stelle sicher, dass Du mit dem Google-Konto des ursprünglichen Kaufs angemeldet bist, und versuche dann \"Kauf wiederherstellen\".</string>
+    <string name="upgrades_gplay_unavailable_error_title">Google Play ist nicht verfügbar</string>
+    <string name="upgrades_gplay_unavailable_error_description">Butler kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und aktuell? Bist Du in Deinem Google-Konto angemeldet? Leere den Cache der Google-Play-App und starte Dein Gerät neu.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play konnte nicht geöffnet werden. Möglicherweise fehlt es, ist deaktiviert oder auf diesem Gerät eingeschränkt.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem mit Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Bei der Kommunikation mit Google Play ist etwas schiefgelaufen. Versuche es später erneut oder starte Dein Gerät neu.\n\nDetails: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google-Play-Fehler</string>
+    <string name="upgrades_gplay_internal_error_description">Bei Google Play ist ein interner Fehler aufgetreten. Versuche Folgendes:\n\n• Starte Dein Gerät neu\n• Leere den Cache des Google Play Store\n• Versuche es später erneut</string>
+    <string name="upgrades_gplay_network_error_title">Verbindungsfehler</string>
+    <string name="upgrades_gplay_network_error_description">Butler konnte Google Play nicht erreichen. Prüfe Deine Internetverbindung und versuche es erneut.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Angebot nicht verfügbar</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play bietet diese Upgrade-Option für Dein Konto derzeit nicht an. Versuche es später erneut oder prüfe den Google Play Store.</string>
+    <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest Du das richtige Konto?</string>
+
+    <string name="upgrade_benefits_title">Vorteile des Upgrades</string>
+    <!-- Lines starting with "•" (or "-") render as checkmarked feature rows; lines without a marker
+         render as plain footnote text. Keep the markers. -->
+    <string name="upgrade_screen_benefits_body">• Unbegrenzte Tabs und Vorgänge\n• Design und Bedienung anpassen\n• Zusätzliche Optionen und Funktionen für jedes Werkzeug\n• Frühzeitiger Zugriff auf neue Funktionen\n• Ein motivierter Entwickler 🧙\nund mehr…</string>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,504 @@
+<resources>
+    <string name="onboarding_welcome_title">Willkommen bei Butler</string>
+    <string name="onboarding_welcome_message">Tabs für Dateien.\nDurchsuchen, suchen und bearbeiten – alles gleichzeitig.</string>
+    <string name="onboarding_welcome_subtitle">Quelloffen. Werbefrei. Kein Tracking.\nDer Dateimanager, den Du verdienst.</string>
+    <string name="onboarding_welcome_action">Jetzt erkunden</string>
+    <string name="onboarding_beta_title">Gestalte die Zukunft</string>
+    <string name="onboarding_beta_message">Dies ist eine Beta- bzw. Testversion. Fahre mit Humor und einem guten Backup-Plan fort. Bitte melde alle Probleme, auf die Du stößt.</string>
+    <string name="onboarding_beta_action">Ich fürchte nichts</string>
+    <string name="onboarding_beta_feature_early_access_title">Frühzeitiger Zugriff</string>
+    <string name="onboarding_beta_feature_early_access_description">Probiere die neuesten Funktionen vor allen anderen aus.</string>
+    <string name="onboarding_beta_feature_influence_title">Direkter Einfluss</string>
+    <string name="onboarding_beta_feature_influence_description">Dein Feedback gestaltet die Entwicklung von Butler.</string>
+    <string name="onboarding_beta_feature_feedback_title">Von der Community geprägt</string>
+    <string name="onboarding_beta_feature_feedback_description">Werde Teil einer Community erfahrener Nutzer, die Butler verbessern.</string>
+    <string name="onboarding_privacy_title">Datenschutz &amp; Daten</string>
+    <string name="onboarding_privacy_message">Butler enthält keine Werbung und verkauft keine Nutzerdaten. Deine Privatsphäre ist mir wichtig.</string>
+    <string name="onboarding_privacy_read_action">Datenschutzerklärung lesen</string>
+    <string name="onboarding_privacy_action">Akzeptieren</string>
+    <string name="onboarding_skip_action">Überspringen</string>
+    <string name="onboarding_progress_step">%1$d von %2$d</string>
+
+    <string name="onboarding_workspaces_title">Mit Tabs arbeiten</string>
+    <string name="onboarding_workspaces_message">Öffne mehrere Tabs und wechsle zwischen ihnen, genau wie in Deinem Webbrowser.</string>
+    <string name="onboarding_workspaces_action">Weiter</string>
+    <string name="onboarding_workspaces_hint">Mehrere Tabs gleichzeitig geöffnet lassen.</string>
+    <string name="onboarding_workspaces_explorer_title">Explorer</string>
+    <string name="onboarding_workspaces_explorer_description">Dateien durchsuchen.</string>
+    <string name="onboarding_workspaces_searcher_title">Suche</string>
+    <string name="onboarding_workspaces_searcher_description">Dinge finden.</string>
+    <string name="onboarding_workspaces_editor_title">Editor</string>
+    <string name="onboarding_workspaces_editor_description">Dateien bearbeiten.</string>
+    <string name="onboarding_workspaces_templates_title">Vorlagen</string>
+    <string name="onboarding_workspaces_templates_description">Deine Einrichtung speichern.</string>
+    <string name="onboarding_workspaces_apps_description">Deine Apps verwalten.</string>
+
+    <!-- Explorer Shortcuts -->
+    <string name="shortcut_explorer_new_short">Neuer Explorer</string>
+    <string name="shortcut_explorer_new_long">Neuen Explorer-Tab erstellen</string>
+
+    <!-- Shortcuts Settings -->
+    <string name="shortcuts_settings_title">Verknüpfungen</string>
+    <string name="shortcuts_settings_subtitle">Verknüpfungen im App-Launcher einrichten</string>
+    <string name="shortcuts_settings_enabled_title">Verknüpfungen aktivieren</string>
+    <string name="shortcuts_settings_enabled_subtitle">Häufig verwendete Elemente im App-Launcher anzeigen</string>
+    <string name="shortcuts_settings_auto_remember_title">Besuchte Pfade merken</string>
+    <string name="shortcuts_settings_auto_remember_subtitle">Häufig besuchte Pfade automatisch als Verknüpfungen hinzufügen</string>
+    <string name="shortcuts_settings_last_accessed_title">Zuletzt aufgerufen</string>
+    <string name="shortcuts_settings_max_count_title">Maximale Anzahl Verknüpfungen</string>
+    <string name="shortcuts_settings_max_count_subtitle">Derzeit werden %d Verknüpfungen angezeigt</string>
+    <string name="shortcuts_settings_min_access_title">Mindestanzahl der Zugriffe</string>
+    <string name="shortcuts_settings_min_access_subtitle">Vor dem Anzeigen sind %d Zugriffe erforderlich</string>
+    <string name="shortcuts_settings_current_title">Aktuelle Verknüpfungen</string>
+    <string name="shortcuts_settings_current_subtitle">%d Verknüpfungen erfasst</string>
+    <string name="shortcuts_settings_clear_title">Verknüpfungsverlauf leeren</string>
+    <string name="shortcuts_settings_clear_subtitle">Alle erfassten Verknüpfungen entfernen</string>
+    <string name="shortcuts_settings_clear_confirm_title">Verknüpfungsverlauf leeren?</string>
+    <string name="shortcuts_settings_clear_confirm_message">Dadurch werden alle erfassten Verknüpfungen entfernt. Lesezeichen bleiben erhalten.</string>
+    <string name="shortcuts_settings_cleared_message">Verknüpfungsverlauf geleert</string>
+    <string name="shortcuts_settings_max_dialog_title">Maximale Anzahl Verknüpfungen</string>
+    <string name="shortcuts_settings_max_dialog_message">Anzahl der Verknüpfungen im App-Launcher (1–4)</string>
+    <string name="shortcuts_settings_min_dialog_title">Mindestanzahl der Zugriffe</string>
+    <string name="shortcuts_settings_min_dialog_message">Wie oft ein Pfad aufgerufen werden muss, bevor er als Verknüpfung erscheint (1–10)</string>
+
+    <string name="setup_usagestats_title">Nutzungsstatistiken</string>
+    <string name="setup_shizuku_card_title">Shizuku</string>
+    <string name="setup_root_card_title">Root</string>
+    <string name="setup_notification_title">Benachrichtigungszugriff</string>
+    <string name="setup_manage_storage_card_title">Externen Speicher verwalten</string>
+    <string name="setup_inventory_card_title">App-Inventar</string>
+
+    <string name="setup_title">Berechtigungen einrichten</string>
+    <string name="setup_settings_description">App-Berechtigungen und Funktionen einrichten.</string>
+    <string name="setup_help_description">Hilfe</string>
+
+    <string name="setup_root_description">Ermöglicht für die erweiterte Dateiverwaltung den Zugriff auf Systemdateien und geschützte Verzeichnisse. Schaltet das volle Potenzial von Butler frei, einschließlich Zugriff auf App-Daten und Systemänderungen. Das Gerät muss gerootet sein.</string>
+    <string name="setup_shizuku_description">Eine Alternative zu Root, die privilegierte Dateivorgänge über eine sichere API ermöglicht. Gewährt ohne klassischen Root-Zugriff Zugriff auf eingeschränkte Verzeichnisse. Die Shizuku-App muss installiert sein und ausgeführt werden.</string>
+    <string name="setup_notification_description">Zeigt Aktualisierungen zu Dateivorgängen, Hintergrundaufgaben und Übertragungsfortschritten. So erfährst Du, wenn Vorgänge abgeschlossen sind oder Fehler auftreten.</string>
+    <string name="setup_usagestats_description">Analysiert die Speichernutzung von Apps, um große Dateien zu finden und Speicherplatz effektiv zu verwalten. Alle Daten bleiben auf Deinem Gerät und werden niemals übertragen.</string>
+    <string name="setup_storage_description">Vollständiger Zugriff auf den gesamten Gerätespeicher für schnelle Dateivorgänge und Stapelverarbeitung. Ermöglicht eine umfassende Dateiverwaltung ohne wiederholte Berechtigungsabfragen.</string>
+    <string name="setup_inventory_description">Zeigt alle installierten Apps für Funktionen wie APK-Extraktion und Speicheranalyse. Unter Android 11 und neuer erforderlich, um die vollständige App-Liste anzuzeigen.</string>
+
+    <string name="setup_grant_access_label">Zugriff gewähren</string>
+    <string name="setup_access_granted_label">Zugriff gewährt</string>
+    <string name="setup_use_root_label">Root verwenden, falls verfügbar</string>
+    <string name="setup_use_shizuku_label">Shizuku verwenden, falls verfügbar</string>
+
+    <string name="setup_status_checking">Wird geprüft…</string>
+    <string name="setup_status_completed">Eingerichtet</string>
+    <string name="setup_status_required">Erforderlich</string>
+    <string name="setup_status_optional">Optional</string>
+    <string name="setup_status_connected">Verbunden</string>
+    <string name="setup_status_not_connected">Nicht verbunden</string>
+    <string name="setup_status_not_installed">Nicht installiert</string>
+    <string name="setup_status_connecting">Verbindung wird hergestellt…</string>
+    <string name="setup_status_connection_failed">Verbindung fehlgeschlagen</string>
+    <string name="setup_status_unavailable">Nicht verfügbar</string>
+
+    <!-- Debug Log -->
+    <string name="debug_notification_channel_label">Debug-Benachrichtigungen</string>
+    <string name="debug_log_consent_title">Debug-Protokoll</string>
+    <string name="debug_log_consent_explanation">Diese Funktion zeichnet alle Aktivitäten der App in einer teilbaren Datei auf. Die erzeugte Datei enthält vertrauliche Informationen (z. B. Dateinamen und installierte Apps). Teile sie nur mit vertrauenswürdigen Personen (z. B. einem Entwickler, der ein Problem untersucht).</string>
+    <string name="debug_log_recording_progress">Debug-Protokoll wird aufgezeichnet</string>
+    <string name="debug_log_record_action">Aufzeichnen</string>
+    <string name="debug_log_record_full_action">Debug-Protokoll aufzeichnen</string>
+    <string name="debug_log_stop_action">Aufzeichnung beenden</string>
+    <string name="debug_log_screen_title">Debug-Protokollaufzeichnung</string>
+    <string name="debug_log_screen_sensitive_information_message">Die erzeugte Datei enthält vertrauliche Informationen (z. B. Dateinamen und installierte Apps). Teile sie nur mit vertrauenswürdigen Personen.</string>
+    <string name="debug_log_screen_session_path_label">Pfad der Debug-Sitzung</string>
+    <string name="debug_log_screen_log_files_label">Protokolldateien</string>
+    <string name="debug_log_screen_log_files_ready">Protokolldateien bereit (ZIP: %1$s)</string>
+    <string name="debug_log_screen_discard_action">Verwerfen</string>
+    <string name="debug_log_file_label">Aufgezeichnete Protokolldatei</string>
+    <string name="debug_banner_label">AUFZ.</string>
+    <string name="debug_banner_label_expanded">Protokolldatei wird aufgezeichnet</string>
+    <string name="debug_banner_stop_action">Beenden</string>
+    <string name="debug_banner_view_action">Anzeigen</string>
+    <string name="debug_banner_explanation">App-Aktivitäten werden aufgezeichnet. Beende die Aufzeichnung, sobald Du fertig bist, und teile das Protokoll anschließend mit Deinem Fehlerbericht.</string>
+    <string name="debug_log_short_recording_title">Aufzeichnung ist sehr kurz</string>
+    <string name="debug_log_short_recording_message">Debug-Protokolle erfassen, was während der aktiven Aufzeichnung geschieht. Starte die Aufzeichnung, reproduziere das Problem und beende sie anschließend. Diese Aufzeichnung enthält möglicherweise keine hilfreichen Informationen.</string>
+    <string name="debug_log_short_recording_keep_action">Weiter aufzeichnen</string>
+
+    <string name="debug_logview_screen_title">Protokollbetrachter</string>
+    <string name="debug_logview_pause_action">Pausieren (Anzeige einfrieren)</string>
+    <string name="debug_logview_resume_action">Fortsetzen</string>
+    <string name="debug_logview_copy_action">Protokoll kopieren</string>
+    <string name="debug_logview_collapse_action">Einklappen</string>
+    <string name="debug_logview_close_action">Protokollbereich schließen</string>
+    <string name="debug_logview_resize_action">Größe ändern</string>
+    <string name="debug_logview_more_action">Weitere Optionen</string>
+    <string name="debug_logview_level_action">Protokollierungsstufe</string>
+    <string name="debug_logview_clear_action">Puffer leeren</string>
+    <string name="debug_logview_search_action">Suchen</string>
+    <string name="debug_logview_search_clear_action">Suche leeren</string>
+    <string name="debug_logview_search_close_action">Suche schließen</string>
+    <string name="debug_logview_search_prev_action">Vorheriger Treffer</string>
+    <string name="debug_logview_search_next_action">Nächster Treffer</string>
+    <string name="debug_logview_jump_to_bottom_action">Zum neuesten Eintrag springen</string>
+    <string name="debug_logview_paused_msg">Pausiert – Anzeige eingefroren</string>
+    <string name="debug_logview_paused_new_msg">Pausiert – seitdem %1$d neue Zeile(n)</string>
+    <string name="debug_logview_copied_msg">Protokoll in die Zwischenablage kopiert</string>
+    <string name="debug_logview_copied_truncated_msg">Letzte %1$d Zeilen in die Zwischenablage kopiert</string>
+    <string name="debug_logview_share_label">Protokoll teilen</string>
+
+    <string name="settings_label">Einstellungen</string>
+    <string name="settings_category_tools_label">Werkzeuge</string>
+    <string name="settings_category_other_label">Sonstiges</string>
+    <string name="settings_category_integration_label">Integration</string>
+    <string name="general_settings_label">Allgemein</string>
+    <string name="general_settings_desc">Allgemeine Anpassungen, die sich auf die gesamte App auswirken.</string>
+    <string name="settings_category_ui_label">Benutzeroberfläche</string>
+    <string name="ui_theme_mode_setting_label">Designmodus</string>
+    <string name="ui_theme_mode_setting_explanation">Der zum Gestalten der App verwendete Modus (z. B. Tag oder Nacht).</string>
+    <string name="ui_theme_style_setting_label">Designstil</string>
+    <string name="ui_theme_style_setting_explanation">Der zum Gestalten der App verwendete Farbstil.</string>
+    <string name="ui_theme_color_setting_label">Designfarbe</string>
+    <string name="ui_theme_color_setting_explanation">Die zum Gestalten der App verwendete Farbpalette.</string>
+    <string name="ui_theme_color_setting_disabled_materialyou">Die Farben werden von Material You anhand Deines Hintergrundbilds bereitgestellt</string>
+    <string name="ui_theme_color_value_system">Systemfarben</string>
+    <string name="ui_language_override_label">App-Sprache</string>
+    <string name="ui_language_override_desc">Wähle für Butler unabhängig von der Standardsprache Deines Systems eine andere Sprache aus.</string>
+    <string name="ui_display_cutout_avoid_setting_title">Displayaussparung vermeiden</string>
+    <string name="ui_display_cutout_avoid_setting_description">Hält die Benutzeroberfläche von der Kameraaussparung frei. Schalte dies aus, um mehr vom Bildschirm zu nutzen. Teile der Oberfläche können dann jedoch hinter der Aussparung liegen.</string>
+
+    <string name="previews_settings_title">Vorschauen</string>
+    <string name="previews_settings_subtitle">Zwischenspeicher für Bildvorschauen verwalten.</string>
+
+    <string name="tour_settings_reset_title">Einführungstouren zurücksetzen</string>
+    <string name="tour_settings_reset_subtitle">Einführungstouren erneut anzeigen, auch wenn Du sie übersprungen oder deaktiviert hast.</string>
+    <string name="tour_settings_reset_done">Einführungstouren wurden zurückgesetzt.</string>
+
+    <string name="storage_settings_title">Speicher</string>
+    <string name="storage_settings_subtitle">Zwischenspeicher, Speicher und Papierkorb von Butler verwalten.</string>
+    <string name="storage_category_previews_label">Vorschauen</string>
+    <string name="storage_previews_disk_cache_title">Datenträgercache</string>
+    <string name="storage_previews_memory_cache_title">Arbeitsspeichercache</string>
+    <string name="storage_previews_max_size_title">Maximale Cache-Größe</string>
+    <string name="storage_clear_disk_confirm_title">Datenträgercache leeren?</string>
+    <string name="storage_clear_disk_confirm_message">Dadurch werden alle zwischengespeicherten Vorschaubilder entfernt. Sie werden bei Bedarf neu erzeugt.</string>
+    <string name="storage_clear_memory_confirm_title">Arbeitsspeichercache leeren?</string>
+    <string name="storage_clear_memory_confirm_message">Dadurch werden zwischengespeicherte Vorschaubilder aus dem Arbeitsspeicher entfernt. Sie werden bei Bedarf neu erzeugt.</string>
+    <string name="storage_clear_all_confirm_title">Alle Caches leeren?</string>
+    <string name="storage_clear_all_confirm_message">Dadurch werden der Datenträger- und der Arbeitsspeichercache für Vorschaubilder geleert.</string>
+    <string name="storage_clear_all_previews_action">Alle Vorschaucaches leeren</string>
+    <string name="storage_clear_all_subtitle">Alle Vorschaucaches entfernen</string>
+    <string name="storage_cache_cleared_message">Cache geleert</string>
+    <string name="storage_size_50mb">50 MB</string>
+    <string name="storage_size_250mb">250 MB</string>
+    <string name="storage_size_512mb">512 MB</string>
+    <string name="storage_size_1gb">1 GB</string>
+
+    <string name="updater_check_enabled_setting_title">Nach Updates suchen</string>
+    <string name="updater_check_enabled_setting_description">Butler erlauben, online nach einer neuen Version zu suchen.</string>
+    <string name="motd_check_enabled_setting_title">Nach Ankündigungen suchen</string>
+    <string name="motd_check_enabled_setting_description">Butler erlauben, wichtige Nachrichten des Entwicklers abzurufen.</string>
+    <string name="motd_card_header">Ankündigung</string>
+
+    <string name="confirm_exit_setting_title">Beenden bestätigen</string>
+    <string name="confirm_exit_setting_description">Beim Beenden der App einen Bestätigungsdialog anzeigen.</string>
+    <string name="confirm_exit_dialog_title">Butler beenden</string>
+    <string name="confirm_exit_dialog_message">Dadurch wird die App geschlossen und Du kehrst zum Startbildschirm zurück.</string>
+    <string name="confirm_exit_dialog_exit">Beenden</string>
+    <string name="confirm_exit_dialog_cancel">Abbrechen</string>
+    <string name="confirm_exit_dialog_dont_ask_again">Nicht erneut fragen</string>
+
+    <string name="settings_support_category_help_label">Hilfe erhalten</string>
+    <string name="settings_support_label">Support</string>
+    <string name="settings_support_description">Dokumentation lesen, Probleme melden, mit anderen chatten oder Debug-Protokolle aufzeichnen.</string>
+    <string name="settings_support_wiki_label">Dokumentation</string>
+    <string name="settings_support_wiki_description">Erfahre, wie Du Butler effektiv verwendest.</string>
+    <string name="settings_support_issue_tracker_description">Eine öffentliche Problemverwaltung für Fehlerberichte und Funktionswünsche.</string>
+    <string name="settings_support_issue_tracker_label">Problemverwaltung</string>
+    <string name="settings_support_debuglog_label">Debug-Protokoll</string>
+    <string name="settings_support_debuglog_desc">Alle Aktivitäten der App in einer teilbaren Textdatei aufzeichnen.</string>
+    <string name="settings_support_debuglog_recording_desc">Debug-Informationen werden gerade aufgezeichnet. Tippe hier, um die Aufzeichnung zu beenden.</string>
+    <string name="settings_support_debuglog_path">Protokollpfad: %1$s</string>
+    <string name="settings_support_bugreports_label">Fehlerberichte</string>
+    <string name="settings_support_bugreports_desc">Absturzberichte anzeigen, Debug-Protokolle aufzeichnen und mit mir teilen.</string>
+    <string name="support_contact_report_type_crash">Absturzbericht</string>
+    <string name="support_contact_report_type_reported">Fehlerbericht</string>
+    <string name="support_contact_report_type_recording">Aufzeichnung</string>
+    <string name="settings_support_discord_label">Discord</string>
+    <string name="settings_support_discord_description">Ein Ort zum Austauschen und Fragenstellen.</string>
+
+    <string name="settings_acknowledgements_label">Danksagungen</string>
+    <string name="settings_acknowledgements_description">Mitwirkende, Lizenzen und besonderer Dank.</string>
+    <string name="settings_acks_translation_header">Übersetzung</string>
+    <string name="settings_acks_translators_title">Übersetzer</string>
+    <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
+    <string name="settings_acks_translate_title">Butler übersetzen</string>
+    <string name="settings_acks_translate_desc">Hilf dabei, Butler in Deine Sprache zu übersetzen.</string>
+
+    <string name="settings_acks_thanks_header">Dank</string>
+    <string name="settings_acks_crowdin_title">crowdin.com</string>
+    <string name="settings_acks_crowdin_desc">Für die Unterstützung bei der Übersetzung von Open-Source-Projekten.</string>
+    <string name="settings_acks_maxpatchs_title">Max Patchs</string>
+    <string name="settings_acks_maxpatchs_desc">Danke für das App-Symbol, die Maskottchen-Entwürfe und die Animationen.</string>
+    <string name="settings_licenses_label">Lizenzen</string>
+
+    <!-- Workspace Status Card -->
+    <string name="workspace_status_tab_singular">Tab</string>
+    <string name="workspace_status_tab_plural">Tabs</string>
+    <string name="workspace_status_operation_singular">Vorgang</string>
+    <string name="workspace_status_operation_plural">Vorgänge</string>
+    <string name="workspace_status_attention_label">Achtung</string>
+    <string name="workspace_status_unsaved_label">Ungespeichert</string>
+    <string name="workspace_status_filter_tabs_desc">Alle Tabs anzeigen</string>
+    <string name="workspace_status_filter_operations_desc">Nach Tabs mit Vorgängen filtern</string>
+    <string name="workspace_status_filter_attention_desc">Nach Tabs filtern, die Aufmerksamkeit erfordern</string>
+    <string name="workspace_status_filter_paused_desc">Nach pausierten Tabs filtern</string>
+    <string name="workspace_status_filter_unsaved_desc">Nach Tabs mit ungespeicherten Änderungen filtern</string>
+
+    <!-- Acknowledgements -->
+    <string name="acknowledgement_android_title">Android</string>
+    <string name="acknowledgement_android_subtitle">Android Open Source Project (APACHE 2.0)</string>
+    <string name="acknowledgement_kotlin_title">Kotlin</string>
+    <string name="acknowledgement_kotlin_subtitle">Die Programmiersprache Kotlin. (APACHE 2.0)</string>
+    <string name="acknowledgement_dagger_title">Dagger</string>
+    <string name="acknowledgement_dagger_subtitle">Ein schneller Abhängigkeitsinjektor für Android und Java. (APACHE 2.0)</string>
+    <string name="acknowledgement_librootjava_title">libRootJava</string>
+    <string name="acknowledgement_librootjava_subtitle">Java- und Kotlin-Code als Root ausführen! (APACHE 2.0)</string>
+    <string name="acknowledgement_librootkotlinx_title">librootkotlinx</string>
+    <string name="acknowledgement_librootkotlinx_subtitle">Root-Kotlin-JVM-Code einfach mit Coroutinen ausführen. (APACHE 2.0)</string>
+    <string name="acknowledgement_shizuku_title">Shizuku</string>
+    <string name="acknowledgement_shizuku_subtitle">System-APIs über einen mit app_process gestarteten Java-Prozess direkt mit ADB- oder Root-Berechtigungen aus normalen Apps verwenden. (APACHE 2.0)</string>
+    <string name="acknowledgement_material_design_icons_title">Material Design Icons</string>
+    <string name="acknowledgement_material_design_icons_subtitle">materialdesignicons.com (SIL Open Font License 1.1 / Attribution 4.0 International)</string>
+    <string name="acknowledgement_lottie_title">Lottie</string>
+    <string name="acknowledgement_lottie_subtitle">Lottie von Airbnb für Android. (APACHE 2.0)</string>
+    <string name="acknowledgement_android_robot_title">Android</string>
+    <string name="acknowledgement_android_robot_subtitle">Der Android-Roboter wurde aus von Google erstellten und freigegebenen Werken vervielfältigt oder verändert und wird gemäß den Bedingungen der Creative Commons Attribution License 3.0 verwendet.</string>
+    <string name="acknowledgement_jetpack_compose_title">Jetpack Compose</string>
+    <string name="acknowledgement_jetpack_compose_subtitle">Das moderne Android-Werkzeugpaket zum Erstellen nativer Benutzeroberflächen. (APACHE 2.0)</string>
+    <string name="acknowledgement_jetpack_libraries_title">Jetpack-Bibliotheken</string>
+    <string name="acknowledgement_jetpack_libraries_subtitle">Room, WorkManager, DataStore, Navigation und weitere AndroidX-Bibliotheken. (APACHE 2.0)</string>
+    <string name="acknowledgement_kotlin_extensions_title">Kotlin-Erweiterungen</string>
+    <string name="acknowledgement_kotlin_extensions_subtitle">Bibliotheken für Coroutinen und Serialisierung. (APACHE 2.0)</string>
+    <string name="acknowledgement_coil_title">Coil</string>
+    <string name="acknowledgement_coil_subtitle">Eine auf Kotlin-Coroutinen basierende Bildladebibliothek. (APACHE 2.0)</string>
+    <string name="acknowledgement_smbj_title">SMBJ</string>
+    <string name="acknowledgement_smbj_subtitle">SMB2- und SMB3-Clientbibliothek für die Kommunikation mit Netzwerkfreigaben. (APACHE 2.0)</string>
+    <string name="acknowledgement_square_libraries_title">Square-Bibliotheken</string>
+    <string name="acknowledgement_square_libraries_subtitle">Die Netzwerkbibliotheken Retrofit, OkHttp und OkIO. (APACHE 2.0)</string>
+    <string name="acknowledgement_accompanist_title">Accompanist</string>
+    <string name="acknowledgement_accompanist_subtitle">Hilfswerkzeuge für Jetpack Compose. (APACHE 2.0)</string>
+    <string name="acknowledgement_reorderable_title">Reorderable</string>
+    <string name="acknowledgement_reorderable_subtitle">Drag-and-drop für LazyColumn in Compose. (APACHE 2.0)</string>
+    <string name="acknowledgement_semver_title">SemVer</string>
+    <string name="acknowledgement_semver_subtitle">Bibliothek für semantische Versionierung in Kotlin. (MIT License)</string>
+    <string name="acknowledgement_vico_title">Vico</string>
+    <string name="acknowledgement_vico_subtitle">Diagramme und Graphen für Jetpack Compose. (APACHE 2.0)</string>
+
+    <string name="settings_privacy_policy_label">Datenschutzerklärung</string>
+    <string name="settings_privacy_policy_desc">Verantwortungsvoller Umgang mit Daten.</string>
+
+
+    <string name="changelog_label">Änderungsprotokoll</string>
+
+    <!-- Upgrade Status -->
+    <string name="settings_upgrade_status_label">Butler-Upgrade-Status</string>
+    <string name="upgrade_status_free">Status: Kostenlos</string>
+    <string name="upgrade_status_pro">Status: Pro</string>
+    <string name="upgrade_status_foss">Status: FOSS</string>
+
+    <string name="storage_area_sdcard_label">SD-Karte</string>
+    <string name="storage_area_public_label">Öffentlicher Speicher</string>
+    <string name="storage_area_public_app_data_label">Öffentliche App-Daten</string>
+
+    <!-- Workspace -->
+    <!-- Workspace > Manager -->
+    <string name="workspace_manager_title">Tab-Verwaltung</string>
+    <string name="workspace_manager_empty_title">Keine Tabs</string>
+    <string name="workspace_manager_empty_subtitle">Erstelle Deinen ersten Tab, um loszulegen</string>
+
+    <!-- Workspace > Empty Content-->
+    <string name="workspace_empty_create_action">Tab erstellen</string>
+    <string name="workspace_empty_create_hint">Parallel arbeiten: Erstelle einen Tab und verwandle ihn in ein Werkzeug Deiner Wahl.</string>
+    <string name="workspace_empty_settings_action">Einstellungen öffnen</string>
+    <string name="workspace_empty_settings_hint">Passe Butler nach Deinen Wünschen an. Lege fest, wie sich die Werkzeuge verhalten.</string>
+    <string name="workspace_classic_empty_tabs_closed">Keine offenen Tabs. Bereit, wenn Du es bist.</string>
+    <string name="workspace_classic_empty_tip">Tipp: Tippe auf „Tab erstellen“ und wähle ein Werkzeug aus: Explorer, Suche, Editor und mehr.</string>
+
+    <!-- Workspace > Guided tour -->
+    <string name="tour_first_tab_title">Mit einem Tab beginnen</string>
+    <string name="tour_first_tab_body">Butler arbeitet wie ein Browser mit Tabs: Jeder Tab ist ein eigenes Werkzeug, etwa Explorer, Suche oder Editor. Erstelle Deinen ersten Tab.</string>
+    <string name="tour_manager_fab_title">Schnellzugriffe</string>
+    <string name="tour_manager_fab_body">Tippe hier, um schnell auf Deine meistgenutzten Werkzeuge zuzugreifen oder alle Tabs auf einmal zu schließen.</string>
+    <string name="tour_manager_reorder_title">Tabs neu anordnen</string>
+    <string name="tour_manager_reorder_body">Halte die Titelleiste eines Tabs gedrückt und ziehe ihn an die gewünschte Position. In dieser Reihenfolge erscheinen Deine Tabs auch überall sonst.</string>
+    <string name="tour_manager_select_title">Mit mehreren Tabs arbeiten</string>
+    <string name="tour_manager_select_body">Halte die Vorschau eines Tabs gedrückt, um Tabs auszuwählen. Tippe dann auf die übrigen Tabs, um alle gemeinsam zu schließen oder zu pausieren.</string>
+    <string name="tour_manager_new_tab_title">Neuen Tab beginnen</string>
+    <string name="tour_manager_new_tab_body">Tippe auf diese Karte, um ein beliebiges Werkzeug für einen neuen Tab auszuwählen.</string>
+
+    <string name="workspace_creating_placeholder">Tab wird erstellt…</string>
+    <string name="workspace_ondemand_swipe_title">Wischen, um neuen Tab zu erstellen</string>
+
+    <!-- Adaptive Workspace -->
+    <string name="workspace_adaptive_pane_ready">Bereich %1$d ist bereit für Inhalte</string>
+    <string name="workspace_adaptive_add_action">Tab hinzufügen</string>
+
+    <string name="workspace_badge_tip_title">Tipp: Anzeigen auf der Tab-Schaltfläche</string>
+    <string name="workspace_badge_open_workspaces">Anzahl geöffneter Tabs</string>
+    <string name="workspace_badge_active_operations">Aktive Vorgänge (Dateikopien, Suchen usw.)</string>
+    <string name="workspace_badge_attention_items">Elemente, die Aufmerksamkeit erfordern (fehlgeschlagene oder wartende Vorgänge, nicht erreichbare Dateien)</string>
+
+    <!-- Workspace Manager Actions -->
+    <string name="workspace_manager_dismiss_content_desc">Schließen</string>
+    <string name="workspace_manager_close_all_title">Alle Tabs schließen?</string>
+    <string name="workspace_manager_close_all_message">Dadurch werden alle offenen Tabs geschlossen (%1$d %2$s). Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="workspace_manager_close_all_message_singular">Tab</string>
+    <string name="workspace_manager_close_all_message_plural">Tabs</string>
+    <string name="workspace_manager_close_all_action">Alle schließen</string>
+    <string name="workspace_manager_selection_count">%1$d ausgewählt</string>
+    <string name="workspace_manager_selection_select_all">Alle auswählen</string>
+    <string name="workspace_manager_selection_pause_action">Ausgewählte pausieren</string>
+    <string name="workspace_manager_selection_close_action">Ausgewählte schließen</string>
+    <string name="workspace_manager_selection_cancel_content_desc">Auswahlmodus verlassen</string>
+    <string name="workspace_manager_selection_clear_content_desc">Auswahl aufheben</string>
+    <string name="workspace_manager_select_all_tabs_desc">Alle Tabs auswählen</string>
+    <string name="workspace_manager_new_tab_card_title">Neuer Tab</string>
+    <string name="workspace_row_select_content_desc">Tab auswählen</string>
+    <string name="general_cancel_action">Abbrechen</string>
+
+    <!-- Workspace Manager FAB -->
+    <string name="workspace_fab_quick_shortcuts">Schnellzugriffe</string>
+    <string name="workspace_fab_close_shortcuts">Schnellzugriffe schließen</string>
+    <string name="workspace_fab_close_all">Alle Tabs schließen</string>
+
+    <!-- Workspace Navigation Rail -->
+    <string name="workspace_pane_assign_action">Bereich %1$d zuweisen</string>
+    <string name="workspace_pane_close_action">Schließen</string>
+    <string name="workspace_pane_unassign_action">Aus Bereich entfernen</string>
+    <string name="workspace_dragging_description">Wird gezogen</string>
+    <string name="workspace_pane_current_description">In Bereich %1$d</string>
+    <string name="workspace_add_tab_description">Tab hinzufügen</string>
+
+    <!-- Workspace Manager Row -->
+    <string name="workspace_row_close_content_desc">Tab schließen</string>
+    <string name="workspace_row_more_options_content_desc">Weitere Optionen</string>
+    <string name="workspace_row_pause_action">Pausieren</string>
+    <string name="workspace_row_resume_action">Fortsetzen</string>
+    <string name="workspace_row_stacked_content_desc">Auf diesem Tab gestapelt</string>
+    <string name="workspace_row_unsaved_content_desc">Ungespeicherte Änderungen</string>
+
+    <!-- Settings Index -->
+    <string name="workspace_settings_subtitle">Tab-Verhalten einrichten.</string>
+    <string name="explorer_settings_subtitle">Verhalten des Dateimanagers einrichten.</string>
+    <string name="searcher_settings_subtitle">Suchverhalten einrichten.</string>
+    <string name="editor_settings_subtitle">Verhalten des Texteditors einrichten.</string>
+    <string name="history_settings_subtitle">Aufbewahrung und Löschung des Vorgangsverlaufs.</string>
+    <string name="clipboard_settings_subtitle">Verhalten der Zwischenablage einrichten.</string>
+
+    <!-- Saver Share Target -->
+    <string name="saver_share_label">Speichern unter…</string>
+
+    <!-- Single-file Share Target -->
+    <string name="share_receive_label">In Butler öffnen</string>
+
+    <!-- Editor Share Target -->
+    <string name="editor_share_label">Text bearbeiten</string>
+
+    <!-- Open with: a file another app handed to Butler -->
+    <string name="external_open_unknown_file_title">Unbenannte Datei</string>
+    <string name="external_open_action_view">Anzeigen</string>
+    <string name="external_open_action_edit">Als Text bearbeiten</string>
+    <string name="external_open_action_show_in_explorer">Im Explorer anzeigen</string>
+    <string name="external_open_action_save">Speichern unter…</string>
+    <string name="external_open_failed_label">Datei konnte nicht geöffnet werden</string>
+    <string name="external_open_failed_description">Butler konnte „%1$s“ nicht öffnen.</string>
+
+    <!-- Developer Mode -->
+    <string name="settings_developer_mode_unlock_title">Entwicklermodus aktivieren?</string>
+    <string name="settings_developer_mode_unlock_message">Dadurch werden erweiterte Diagnosewerkzeuge für Fehlersuche und Tests freigeschaltet.</string>
+    <string name="settings_developer_mode_unlock_action">Aktivieren</string>
+    <plurals name="settings_developer_mode_countdown">
+        <item quantity="one">Noch %d Schritt bis zum Entwicklermodus</item>
+        <item quantity="other">Noch %d Schritte bis zum Entwicklermodus</item>
+    </plurals>
+
+    <!-- Support: Contact Form -->
+    <string name="support_contact_label">Entwickler kontaktieren</string>
+    <string name="support_contact_description">Fülle ein Formular aus, um mir eine E-Mail zu senden.</string>
+    <string name="support_contact_no_email_app">Keine E-Mail-App gefunden</string>
+    <string name="support_contact_category_label">Kategorie</string>
+    <string name="support_contact_category_question">Frage</string>
+    <string name="support_contact_category_feature">Funktionswunsch</string>
+    <string name="support_contact_category_bug">Fehlerbericht</string>
+    <string name="support_contact_workspace_label">Betroffener Bereich</string>
+    <string name="support_contact_workspace_general">Allgemein</string>
+    <string name="support_contact_workspace_explorer">Explorer</string>
+    <string name="support_contact_workspace_searcher">Suche</string>
+    <string name="support_contact_workspace_editor">Editor</string>
+    <string name="support_contact_description_label">Beschreibung</string>
+    <string name="support_contact_description_question_hint">Beschreibe Deine Frage ausführlich. Bitte sei konkret (mindestens 20 Wörter).</string>
+    <string name="support_contact_description_feature_hint">Beschreibe die gewünschte Funktion. Bitte sei konkret (mindestens 20 Wörter).</string>
+    <string name="support_contact_description_bug_hint">Beschreibe, was passiert ist und wie sich das Problem reproduzieren lässt. Bitte sei konkret (mindestens 20 Wörter).</string>
+    <string name="support_contact_expected_label">Erwartetes Verhalten</string>
+    <string name="support_contact_expected_hint">Beschreibe, was Deiner Erwartung nach hätte passieren sollen (mindestens 10 Wörter).</string>
+    <string name="support_contact_word_count">Mindestens %1$d Wörter</string>
+    <string name="support_contact_debuglog_label">Debug-Protokoll</string>
+    <string name="support_contact_debuglog_empty">Keine Debug-Protokolle gefunden. Zeichne zuerst eines auf.</string>
+    <string name="support_contact_debuglog_picker_hint">Vorhandenes Debug-Protokoll anhängen oder ein neues aufzeichnen.</string>
+    <string name="support_contact_send_action">E-Mail-App öffnen</string>
+    <string name="support_contact_welcome">Ich lese jede Nachricht selbst und versuche, so gut wie möglich zu antworten. Da ich allein daran arbeite, kann es etwas dauern. Danke für Deine Geduld.</string>
+    <string name="support_contact_footer">Deine Nachricht wird per E-Mail gesendet. Geräte- und Einrichtungsinformationen werden automatisch angehängt. Du kannst der E-Mail Screenshots oder ein Video hinzufügen.\n\nEinige Teile der E-Mail sind auf Englisch, damit ich sie leicht verstehen kann.</string>
+
+    <!-- Support: Debug Log Storage -->
+    <string name="support_debuglog_storage_label">Debug-Protokollspeicher</string>
+    <string name="support_debuglog_storage_description">%1$d Protokollsitzungen, %2$s</string>
+    <string name="support_debuglog_storage_empty">Keine Debug-Protokolle gespeichert</string>
+    <string name="support_debuglog_delete_action">Alle Debug-Protokolle löschen</string>
+    <string name="support_debuglog_delete_description">Alle aufgezeichneten Debug-Protokolldateien entfernen</string>
+    <string name="support_debuglog_delete_confirm_title">Alle Debug-Protokolle löschen?</string>
+    <string name="support_debuglog_delete_confirm_message">Dadurch werden alle aufgezeichneten Debug-Protokollsitzungen dauerhaft gelöscht. Laufende Aufzeichnungen sind nicht betroffen.</string>
+
+    <!-- Support: Debug Log Actions -->
+    <string name="settings_support_debuglog_stop_action">Aufzeichnung beenden</string>
+    <string name="settings_support_debuglog_record_action">Debug-Protokoll aufzeichnen</string>
+
+    <!-- Support: Debug Sessions Bottom Sheet -->
+    <string name="support_debuglog_sessions_label">Debug-Protokollsitzungen</string>
+    <string name="support_debuglog_sessions_desc">Aufgezeichnete Debug-Protokollsitzungen verwalten</string>
+    <string name="support_debuglog_sessions_empty">Keine Debug-Protokollsitzungen</string>
+    <string name="support_debuglog_session_recording">Aufzeichnung läuft…</string>
+    <string name="support_debuglog_session_compressing">Wird komprimiert…</string>
+    <string name="support_debuglog_session_failed_empty_log">Fehlgeschlagen: leeres Protokoll</string>
+    <string name="support_debuglog_session_failed_missing_log">Fehlgeschlagen: Protokoll fehlt</string>
+    <string name="support_debuglog_session_failed_corrupt_zip">Fehlgeschlagen: beschädigtes Archiv</string>
+    <string name="support_debuglog_session_failed_zip_failed">Fehlgeschlagen: Komprimierungsfehler</string>
+    <string name="support_debuglog_session_delete_title">Debug-Sitzung löschen?</string>
+    <string name="support_debuglog_session_delete_message">Dadurch wird diese Debug-Protokollsitzung dauerhaft gelöscht.</string>
+    <string name="support_debuglog_clear_action">Alle löschen</string>
+    <string name="support_debuglog_clear_confirm_message">Alle gespeicherten Debug-Protokollsitzungen löschen?</string>
+
+    <!-- Debug Log Screen -->
+    <string name="debug_log_share_subject">Butler-Debug-Protokoll – %1$s</string>
+    <string name="debug_log_screen_subtitle">Debug-Informationen für die Fehlersuche exportieren</string>
+    <string name="debug_log_screen_sensitive_information_title">Vertrauliche Informationen</string>
+
+    <!-- Support: Contact Form -->
+    <string name="support_contact_sent_title">Hast Du die Nachricht gesendet?</string>
+    <string name="support_contact_sent_message">Wenn die Nachricht gesendet wurde, wird das angehängte Debug-Protokoll gelöscht, um Speicherplatz freizugeben. Andernfalls kannst Du es behalten und es später erneut versuchen.</string>
+    <string name="support_contact_debuglog_zip_error">Debug-Protokollanhang konnte nicht vorbereitet werden</string>
+
+    <!-- Background file operations: progress & attention notifications -->
+    <string name="ops_notification_channel_progress_name">Fortschritt der Dateivorgänge</string>
+    <string name="ops_notification_channel_progress_desc">Laufender Fortschritt bei Kopier-, Verschiebe- und Löschvorgängen</string>
+    <string name="ops_notification_channel_attention_name">Warnungen zu Dateivorgängen</string>
+    <string name="ops_notification_channel_attention_desc">Vorgänge, die Deine Aufmerksamkeit erfordern oder fehlgeschlagen sind</string>
+    <plurals name="ops_notification_summary_title">
+        <item quantity="one">%1$d Dateivorgang läuft</item>
+        <item quantity="other">%1$d Dateivorgänge laufen</item>
+    </plurals>
+    <string name="ops_notification_state_queued">In Warteschlange…</string>
+    <string name="ops_notification_state_attention_title">Aktion erforderlich</string>
+    <string name="ops_notification_state_attention_text">Ein Konflikt erfordert Deine Aufmerksamkeit. Tippe hier, um ihn zu lösen.</string>
+    <string name="ops_notification_result_failed_title">Vorgang fehlgeschlagen</string>
+
+    <!-- Review prompt -->
+    <string name="review_app_body">Möchtest Du Butler bewerten? ❤️</string>
+    <string name="review_app_dismiss_action">Vielleicht später</string>
+    <string name="review_app_review_action">Bewerten</string>
+
+</resources>


### PR DESCRIPTION
## What changed

Add German throughout the app, using friendly, capitalized Du, Dir, Dich, and Dein. Short actions use their UI context, including Ansicht for the layout choice and Anzeigen for viewing a file.

## Technical Context

- Add 19 `values-de/strings.xml` files alongside the English module and flavor sources, covering 2,213 strings and 110 plurals.
- Preserve resource names, formatting placeholders, and German singular/plural forms; non-translatable resources remain inherited.
- Spot-checked onboarding, Explorer, settings, tab selection, and file-action dialogs on a Pixel 7 emulator running Android 16 in German.
