### PR TITLE
Explorer: Fix folder rows never showing item counts and permissions

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/BrowsingEngine.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/engine/BrowsingEngine.kt
@@ -552,7 +552,8 @@ class BrowsingEngine @AssistedInject constructor(
  * [previous] are the same variant in practice - a mismatch just skips the carry-over.
  */
 internal fun ExplorerLocation.retainContentFrom(previous: ExplorerLocation): ExplorerLocation {
-    if (!isLoading || previous.items == null || hasOwnListing) return this
+    if (!isLoading || previous.items == null) return this
+    if (hasOwnListing) return retainExtendedDataFrom(previous)
     return when (this) {
         is ExplorerLocation.Home -> (previous as? ExplorerLocation.Home)
             ?.let { copy(items = it.items, info = it.info) }
@@ -591,6 +592,21 @@ internal fun ExplorerLocation.withoutProgress(): ExplorerLocation = when (this) 
  */
 private val ExplorerLocation.hasOwnListing: Boolean
     get() = items?.none { it is ExplorerItem.Peek } == true
+
+/**
+ * A reload's first listing carries only the basic lookups; child counts, ownership and permissions
+ * arrive with the extended pass. A row whose lookup did not change keeps its previous row until
+ * then, so a refresh does not blank those fields for the length of the extended pass.
+ */
+private fun ExplorerLocation.retainExtendedDataFrom(previous: ExplorerLocation): ExplorerLocation {
+    if (this !is ExplorerLocation.Directory || previous !is ExplorerLocation.Directory) return this
+    val previousLookups = previous.items.orEmpty().filterIsInstance<ExplorerItem.Lookup>().associateBy { it.id }
+    val retained = items.orEmpty().map { item ->
+        if (item !is ExplorerItem.Lookup) return@map item
+        previousLookups[item.id]?.takeIf { it.lookup == item.lookup } ?: item
+    }
+    return copy(items = retained)
+}
 
 /**
  * Recomputes the directory file/folder counts from the given items so the stat-bar stays in sync

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -2277,24 +2277,14 @@ internal fun ExplorerDialogState.withLiveNetworkItem(items: List<ExplorerItem>?)
 /**
  * Whether two listings would render the same, i.e. whether the newer one can be dropped.
  *
- * Lookups are compared by id and type, which lets a phase transition (Peek to Lookup) through while
- * filtering same-phase duplicates. A storage row instead carries its whole presentation - name,
- * status, address - in its own fields, so those are compared in full: by id alone a renamed or
- * re-probed location would keep rendering its old row.
+ * Rows are compared in full. Every variant is a data class, so this drops an exact re-emission and
+ * lets everything else through: a phase transition (Peek to Lookup), a renamed or re-probed storage
+ * row, and the extended pass that fills in a lookup's child count, ownership and permissions after
+ * the first listing was already published.
  *
  * Top-level for the same reason as `applyFavoritePriority`: unit-testable without VM scaffolding.
  */
-internal fun List<ExplorerItem>?.hasSameItemsAs(other: List<ExplorerItem>?): Boolean {
-    if (this === other) return true
-    if (this == null || other == null) return false
-    if (size != other.size) return false
-    return zip(other).all { (a, b) ->
-        when {
-            a is ExplorerItem.Storage || b is ExplorerItem.Storage -> a == b
-            else -> a.id == b.id && a::class == b::class
-        }
-    }
-}
+internal fun List<ExplorerItem>?.hasSameItemsAs(other: List<ExplorerItem>?): Boolean = this == other
 
 /**
  * Waits for the tab to actually be SHOWING [location]: a settled [ExplorerWorkspace.State] whose

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/BrowsingEngineTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/engine/BrowsingEngineTest.kt
@@ -185,11 +185,35 @@ class BrowsingEngineTest : BaseTest() {
         }
 
         @Test
-        fun `a reload publishes its own listing as soon as it has one`() {
+        fun `a reload replaces rows its listing no longer contains`() {
             val previous = loaded(entry("a"), entry("b"))
             val reloaded = loading(listOf(entry("c")))
 
             reloaded.retainContentFrom(previous) shouldBe reloaded
+        }
+
+        @Test
+        fun `a reload keeps the extended data of rows whose lookup did not change`() {
+            val previous = loaded(entry("a").copy(childCount = 3), entry("b").copy(childCount = 0))
+            val reloaded = loading(listOf(entry("a"), entry("b")))
+
+            reloaded.retainContentFrom(previous).items shouldBe previous.items
+        }
+
+        @Test
+        fun `a reload replaces a row whose lookup changed`() {
+            val previous = loaded(entry("a").copy(childCount = 3))
+            val changed = entry("a").copy(
+                lookup = LocalPathLookup(
+                    lookedUp = path.child("a"),
+                    fileType = FileType.DIRECTORY,
+                    size = 42L,
+                    modifiedAt = null,
+                ),
+            )
+            val reloaded = loading(listOf(changed))
+
+            reloaded.retainContentFrom(previous).items shouldBe listOf(changed)
         }
 
         @Test

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerItemListChangeTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerItemListChangeTest.kt
@@ -3,6 +3,10 @@ package eu.darken.butler.explorer.ui.explorer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Lan
 import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.files.smb.credentials.SmbCredentialStore
 import eu.darken.butler.common.files.smb.location.SmbLocation
 import eu.darken.butler.explorer.core.ExplorerNavigation
@@ -46,17 +50,50 @@ class ExplorerItemListChangeTest : BaseTest() {
         )
     }
 
+    /** Real lookups, not the preview mocks: those are anonymous objects and never equal each other. */
+    private fun file(name: String, modifiedAt: Instant? = null) = ExplorerItem.RegularFile(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath.build("/home/user/$name"),
+            fileType = FileType.FILE,
+            size = 4_096L,
+            modifiedAt = modifiedAt,
+        ),
+        mimeType = MimeInfo("text/plain"),
+    )
+
+    private fun directory(name: String, childCount: Int? = null) = ExplorerItem.RegularDirectory(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath.build("/home/user/$name"),
+            fileType = FileType.DIRECTORY,
+            size = 0L,
+            modifiedAt = null,
+        ),
+        childCount = childCount,
+    )
+
     @Test
-    fun `a re-listing that produced the same lookups again is dropped`() {
-        val old = listOf(MockDataProvider.createMockRegularFile("readme.txt"))
-        val new = listOf(
-            MockDataProvider.createMockRegularFile(
-                name = "readme.txt",
-                modifiedAt = Instant.parse("2024-01-01T00:00:00Z"),
-            ),
-        )
+    fun `an identical re-listing is dropped`() {
+        val old = listOf(file("readme.txt"))
+        val new = listOf(file("readme.txt"))
 
         old.hasSameItemsAs(new) shouldBe true
+    }
+
+    @Test
+    fun `a re-listing with changed lookup data gets through`() {
+        val old = listOf(file("readme.txt"))
+        val new = listOf(file("readme.txt", modifiedAt = Instant.parse("2024-01-01T00:00:00Z")))
+
+        old.hasSameItemsAs(new) shouldBe false
+    }
+
+    /** The extended pass republishes the same ids with the child count filled in. */
+    @Test
+    fun `a directory whose child count arrived gets through`() {
+        val old = listOf(directory("Documents"))
+        val new = listOf(directory("Documents", childCount = 5))
+
+        old.hasSameItemsAs(new) shouldBe false
     }
 
     @Test
@@ -83,7 +120,7 @@ class ExplorerItemListChangeTest : BaseTest() {
         old.hasSameItemsAs(new) shouldBe false
     }
 
-    /** Storage rows take the full-equality branch, not the id-and-type one that would match here. */
+    /** Same id and type, so only field equality can see the new name. */
     @Test
     fun `a renamed SAF location gets through`() {
         val old = listOf(MockDataProvider.createMockStorageSAF(name = "SD Card", id = "saf-sdcard"))


### PR DESCRIPTION
## What changed

Folder rows in the Explorer stopped showing their item count in January, and on storage where it applies they also lost their ownership and permission details. Both show again. A pull-to-refresh no longer blanks those details for the length of the reload.

## Technical Context

- Root cause: the listing pipeline dedupes re-emissions through `hasSameItemsAs`, which compared lookup rows by id and runtime class only. `DirectoryLocationLoader` publishes a directory twice (basic lookups, then the extended pass with `childCount`, ownership, permissions, writability), and the second publish was judged identical and dropped. The `Modified` incremental hint was swallowed the same way. Introduced in e243d84b0; 4fd64c375 fixed the same symptom for storage rows only.
- Fix: rows now compare in full. Every `ExplorerItem` variant and all four `APathLookup` implementations are data classes, so an exact re-emission still dedupes and any changed field passes. A directory load makes at most three passes through the gate; metadata is attached in batch, so nothing re-emits per item.
- Making the basic pass visible again exposed a refresh flicker, so `retainContentFrom` now keeps the previous row for every lookup whose `APathLookup` is unchanged until the extended pass republishes. `withExtendedData` stores the extended fields on the item and leaves the basic lookup in place, which is what makes that equality match. `retainExtendedDataFrom` and its two tests in `BrowsingEngineTest` are the part worth a close read.
- Left as is: rows carrying a `CaString` (Shortcut, Storage, Trash) never compare equal, so a Home or Device reload always re-sorts a handful of rows. Storage rows have done that since August; the cost is negligible.
- Pre-existing and not addressed here: keyboard focus is a numeric index, so any re-sort under an unchanged count moves focus to whichever row now sits at that index. That already happens on every fresh load's peek-to-lookup re-sort; this change adds one more trigger (a `Modified` hint while sorting by date).
