### PR TITLE
Workspace: Stop finished operations from piling up in memory

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerWorkspace.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerWorkspace.kt
@@ -46,7 +46,6 @@ import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.core.operations.awaitCompletion
 import eu.darken.butler.workspace.core.operations.operationsForWorkspace
-import eu.darken.butler.workspace.core.operations.submitAndGet
 import eu.darken.butler.workspace.core.operations.withOnlyStateChanges
 import eu.darken.butler.workspace.core.stateInWorkspace
 import eu.darken.butler.workspace.core.tracker.PathAccessTracker
@@ -578,7 +577,7 @@ class ExplorerWorkspace @AssistedInject constructor(
     suspend fun execute(command: ExplorerCommand): Operation.State.Completed {
         log(tag) { "execute(): $command" }
         val executable = createOperation(command)
-        val managed = operationsManager.submitAndGet(executable)
+        val managed = operationsManager.submitManaged(executable)
         log(tag) { "execute(): Submitted ${managed.id}, awaiting completion" }
         val completed = managed.awaitCompletion()
         log(tag) { "execute(): ${managed.id} completed" }

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/SaverWorkspace.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/SaverWorkspace.kt
@@ -45,12 +45,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -115,21 +115,16 @@ class SaverWorkspace @AssistedInject constructor(
     // Serializes the check-and-set below so a rapid double-tap can't submit two operations.
     private val saveMutex = Mutex()
 
-    private val _currentOperationId = MutableStateFlow<Operation.Id?>(null)
-    val currentOperation: Flow<ManagedOperation?> = _currentOperationId
-        .flatMapLatest { opId ->
-            if (opId == null) {
+    // The operation itself, not its id looked up in OperationsManager.operations: a finished
+    // operation is evicted from that list once retention is over its cap, and the save it belongs to
+    // would stop being reportable the moment it succeeded.
+    private val _currentOperation = MutableStateFlow<ManagedOperation?>(null)
+    val currentOperation: Flow<ManagedOperation?> = _currentOperation
+        .flatMapLatest { managedOp ->
+            if (managedOp == null) {
                 flowOf(null)
             } else {
-                operationsManager.operations
-                    .map { ops -> ops.find { it.id == opId } }
-                    .flatMapLatest { managedOp ->
-                        if (managedOp == null) {
-                            flowOf(null)
-                        } else {
-                            managedOp.state.map { managedOp }
-                        }
-                    }
+                managedOp.state.map { managedOp }
             }
         }
 
@@ -400,14 +395,20 @@ class SaverWorkspace @AssistedInject constructor(
             ),
         )
 
-        val operationId = operationsManager.submit(operation)
-        _currentOperationId.value = operationId
+        val managed = operationsManager.submitManaged(operation)
+        _currentOperation.value = managed
 
-        // Observe operation state
-        operationsManager.operations
-            .map { ops -> ops.find { it.id == operationId } }
-            .filterNotNull()
-            .flatMapLatest { it.state }
+        // Observe operation state on the handle itself. Finding it in OperationsManager.operations
+        // instead would never resolve for a save that finished and was evicted before this collector
+        // first ran, leaving the save stuck in Saving and every later save rejected.
+        managed.state
+            // Completed is terminal, and every save starts its own collector, so without this a tab
+            // saving repeatedly keeps one collector per save alive and holds each finished
+            // operation's report for as long as the tab is open, out of reach of retention.
+            .transformWhile { state ->
+                emit(state)
+                state !is Operation.State.Completed
+            }
             .onEach { state ->
                 when (state) {
                     is SaveFilesOperation.State.Active -> {
@@ -438,7 +439,7 @@ class SaverWorkspace @AssistedInject constructor(
 
     fun resetSaveState() {
         _saveState.value = SaveState.Idle
-        _currentOperationId.value = null
+        _currentOperation.value = null
     }
 
     fun resolveConflict(operationId: Operation.Id, resolution: PathActionIssue.Resolution) {

--- a/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/SaverWorkspacePausableTest.kt
+++ b/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/SaverWorkspacePausableTest.kt
@@ -9,6 +9,7 @@ import eu.darken.butler.workspace.contracts.saver.SaverArguments
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.IssueHandler
 import eu.darken.butler.workspace.core.operations.ManagedOperation
+import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationsManager
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -17,6 +18,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlin.time.Instant
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -48,8 +50,12 @@ class SaverWorkspacePausableTest {
             dispatcherProvider = TestDispatcherProvider(),
             contentUriHelper = mockk<ContentUriHelper> { every { extractInfo(any()) } returns sourceInfo },
             operationsManager = mockk<OperationsManager> {
-                coEvery { submit(any()) } returns eu.darken.butler.workspace.core.operations.Operation.Id()
-                every { operations } returns MutableStateFlow<List<ManagedOperation>>(emptyList())
+                coEvery { submitManaged(any()) } returns mockk<ManagedOperation> {
+                    every { id } returns Operation.Id()
+                    every { state } returns MutableStateFlow(
+                        Operation.State.Queued(startedAt = Instant.fromEpochSeconds(0))
+                    )
+                }
             },
             issueHandler = mockk<IssueHandler>(relaxed = true),
             saveFilesOperationFactory = mockk<SaveFilesOperation.Factory> {

--- a/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/SaverWorkspaceSaveIdempotencyTest.kt
+++ b/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/SaverWorkspaceSaveIdempotencyTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlin.time.Instant
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -34,8 +35,12 @@ import testhelpers.coroutine.TestDispatcherProvider
 class SaverWorkspaceSaveIdempotencyTest {
 
     private val operationsManager = mockk<OperationsManager> {
-        coEvery { submit(any()) } returns Operation.Id()
-        every { operations } returns MutableStateFlow<List<ManagedOperation>>(emptyList())
+        coEvery { submitManaged(any()) } returns mockk<ManagedOperation> {
+            every { id } returns Operation.Id()
+            every { state } returns MutableStateFlow(
+                Operation.State.Queued(startedAt = Instant.fromEpochSeconds(0))
+            )
+        }
     }
 
     private fun makeWorkspace(): SaverWorkspace {
@@ -79,7 +84,7 @@ class SaverWorkspaceSaveIdempotencyTest {
         first.join()
         second.join()
 
-        coVerify(exactly = 1) { operationsManager.submit(any()) }
+        coVerify(exactly = 1) { operationsManager.submitManaged(any()) }
     }
 
     @Test
@@ -90,6 +95,6 @@ class SaverWorkspaceSaveIdempotencyTest {
         // The first save left state in Saving (no operation completion emitted), so this is dropped.
         workspace.save()
 
-        coVerify(exactly = 1) { operationsManager.submit(any()) }
+        coVerify(exactly = 1) { operationsManager.submitManaged(any()) }
     }
 }

--- a/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/SaverWorkspaceUnsavedTest.kt
+++ b/app-workspace-saver/src/test/java/eu/darken/butler/saver/core/SaverWorkspaceUnsavedTest.kt
@@ -62,8 +62,7 @@ class SaverWorkspaceUnsavedTest {
             dispatcherProvider = TestDispatcherProvider(),
             contentUriHelper = mockk<ContentUriHelper> { every { extractInfo(any()) } returns sourceInfo },
             operationsManager = mockk<OperationsManager> {
-                coEvery { submit(any()) } returns operationId
-                every { operations } returns MutableStateFlow(listOf(managed))
+                coEvery { submitManaged(any()) } returns managed
             },
             issueHandler = mockk<IssueHandler>(relaxed = true),
             saveFilesOperationFactory = mockk<SaveFilesOperation.Factory> {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/ManagedOperation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/ManagedOperation.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
@@ -43,6 +44,15 @@ class ManagedOperation(
     val state: StateFlow<Operation.State> = _state
 
     val metadata: Operation.Metadata = operation.metadata
+
+    private val completionEmitted = AtomicBoolean(false)
+
+    /**
+     * Claims the right to emit this operation's completion snapshot, granting it to the first caller
+     * only. Kept here rather than in a manager-side id set so the claim is released with the
+     * operation it is about instead of outliving it for the process' lifetime.
+     */
+    fun claimCompletionEmission(): Boolean = completionEmitted.compareAndSet(false, true)
 
     val canCancel: Boolean
         get() = when (state.value) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsExtensions.kt
@@ -2,20 +2,7 @@ package eu.darken.butler.workspace.core.operations
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-
-/**
- * Submits an operation and returns the ManagedOperation for observation.
- */
-suspend fun OperationsManager.submitAndGet(operation: Operation): ManagedOperation {
-    val id = submit(operation)
-    return operations
-        .map { ops -> ops.find { it.id == id } }
-        .filterNotNull()
-        .first()
-}
 
 /**
  * Suspends until the operation completes (success or failure).

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsManager.kt
@@ -20,7 +20,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -40,7 +42,10 @@ class OperationsManager @Inject constructor(
     private val _operations = MutableStateFlow<List<ManagedOperation>>(emptyList())
     val operations: Flow<List<ManagedOperation>> = _operations.asStateFlow()
     private val mutex = Mutex()
-    private val stateObservers = mutableMapOf<Operation.Id, Job>()
+    // Concurrent: entries are removed by each observer's own completion callback, which runs off the
+    // mutex once that observer's operation is done. internal (module-scoped) so a test can assert an
+    // observer is released with its operation — the codebase uses no @VisibleForTesting.
+    internal val stateObservers = ConcurrentHashMap<Operation.Id, Job>()
 
     /**
      * Side-channel emitting exactly one [CompletedOperationSnapshot] per operation when it reaches
@@ -48,21 +53,25 @@ class OperationsManager @Inject constructor(
      *
      * Race-free contract: when [removeWorkspace] cancels in-flight ops, it synthesizes a cancellation
      * snapshot BEFORE cancelling the per-op state observer (otherwise the asynchronous cancellation
-     * Completed state would arrive after the observer is gone). Dedup is enforced by [emittedCompletions]
-     * so the eventual real Completed (if it sneaks past) is suppressed.
+     * Completed state would arrive after the observer is gone). Dedup is enforced by
+     * [ManagedOperation.claimCompletionEmission] so the eventual real Completed (if it sneaks past)
+     * is suppressed.
      */
     private val _completedOperations = MutableSharedFlow<CompletedOperationSnapshot>(
         extraBufferCapacity = 64,
     )
     val completedOperations: SharedFlow<CompletedOperationSnapshot> = _completedOperations.asSharedFlow()
 
-    /**
-     * Operation IDs whose Completed snapshot has been emitted. Concurrent because writers come from
-     * both `opsScope` (state observers) and the main mutex (synthesis path).
-     */
-    private val emittedCompletions: MutableSet<Operation.Id> = ConcurrentHashMap.newKeySet()
+    suspend fun submit(operation: Operation): Operation.Id = submitManaged(operation).id
 
-    suspend fun submit(operation: Operation): Operation.Id = mutex.withLock {
+    /**
+     * [submit], but handing back the [ManagedOperation] itself.
+     *
+     * Submitting and then looking the operation up in [operations] races retention instead: an
+     * operation that finishes before the caller looks can be evicted first, and the lookup then waits
+     * for an entry that is never coming back.
+     */
+    suspend fun submitManaged(operation: Operation): ManagedOperation = mutex.withLock {
         val id = Operation.Id()
         log(TAG, INFO) { "submit(): New operation $id" }
 
@@ -74,9 +83,16 @@ class OperationsManager @Inject constructor(
         log(TAG) { "submit(): $id -> $managed" }
 
         val stateObserver = managed.state
+            // Completed is terminal, so there is nothing left to observe once one passes through.
+            // Without this the observer keeps collecting a StateFlow that never completes, and every
+            // finished operation leaves a live collector behind for the rest of the process' life.
+            .transformWhile { state ->
+                emit(state)
+                state !is Operation.State.Completed
+            }
             .onEach { state ->
-                // Side-channel: emit Completed snapshot exactly once per op (concurrent dedup set)
-                if (state is Operation.State.Completed && emittedCompletions.add(id)) {
+                // Side-channel: emit Completed snapshot exactly once per op
+                if (state is Operation.State.Completed && managed.claimCompletionEmission()) {
                     _completedOperations.emit(
                         CompletedOperationSnapshot(
                             id = id,
@@ -90,18 +106,22 @@ class OperationsManager @Inject constructor(
             .distinctUntilChanged()
             .onEach {
                 log(TAG, VERBOSE) { "submit(): State type changed for $id, triggering operations update" }
-                _operations.update { currentList -> currentList.toList() }
+                _operations.update { it.pruneTerminal() }
             }
+            // Runs on a natural finish and on cancellation alike, so this is the single owner of the
+            // map entry. Nothing suspending in here: under cancellation that throws instead of
+            // cleaning up.
+            .onCompletion { stateObservers.remove(id) }
             .launchIn(opsScope)
 
         stateObservers[id] = stateObserver
-        _operations.update { it + managed }
+        _operations.update { (it + managed).pruneTerminal() }
 
         log(TAG, VERBOSE) { "submit(): Starting $id" }
         managed.start()
         log(TAG) { "submit(): Started $id" }
 
-        id
+        managed
     }
 
     suspend fun cancel(id: Operation.Id) = mutex.withLock {
@@ -117,8 +137,7 @@ class OperationsManager @Inject constructor(
     suspend fun remove(id: Operation.Id) = mutex.withLock {
         log(TAG, INFO) { "remove(): Remove $id" }
 
-        stateObservers[id]?.cancel()
-        stateObservers.remove(id)
+        stateObservers.remove(id)?.cancel()
 
         _operations.update { ops ->
             val target = ops.find { it.id == id }
@@ -131,17 +150,12 @@ class OperationsManager @Inject constructor(
     suspend fun clearCompleted() = mutex.withLock {
         log(TAG, INFO) { "clearCompleted(): Clearing completed" }
         // Completed ops were already emitted via their state observers, no synthesis needed.
-        _operations.update { ops ->
-            ops.filter { op ->
-                val isCompleted = op.state.value is Operation.State.Completed
-                if (isCompleted) {
-                    log(TAG, VERBOSE) { "clearCompleted(): Clearing $op" }
-                    stateObservers[op.id]?.cancel()
-                    stateObservers.remove(op.id)
-                }
-                !isCompleted
-            }
-        }
+        val completed = _operations.value.filter { it.state.value is Operation.State.Completed }
+        completed.forEach { log(TAG, VERBOSE) { "clearCompleted(): Clearing $it" } }
+        _operations.update { ops -> ops - completed.toSet() }
+        // Outside the update lambda: that lambda is a CAS that can be retried, and cancelling from
+        // inside it would run once per attempt.
+        completed.forEach { stateObservers.remove(it.id)?.cancel() }
     }
 
     suspend fun removeWorkspace(id: Workspace.Id) {
@@ -153,13 +167,13 @@ class OperationsManager @Inject constructor(
             log(TAG) { "removeWorkspace(): Removing ${fromWorkspace.size} operations" }
 
             // Synthesize cancellation snapshots BEFORE cancelling — closes the observer race window.
-            // If an op already completed naturally, its observer already emitted; emittedCompletions.add
-            // returns false and we skip. If an op is still in-flight, the eventual real Completed is
-            // suppressed because we claimed the id first.
+            // If an op already completed naturally, its observer already emitted; the claim fails and
+            // we skip. If an op is still in-flight, the eventual real Completed is suppressed because
+            // we claimed the emission first.
             val toEmit = fromWorkspace.mapNotNull { managed ->
                 if (managed.state.value is Operation.State.Completed) {
                     null
-                } else if (emittedCompletions.add(managed.id)) {
+                } else if (managed.claimCompletionEmission()) {
                     buildCancellationSnapshot(managed, reason = "Workspace removed")
                 } else {
                     null
@@ -169,10 +183,9 @@ class OperationsManager @Inject constructor(
             fromWorkspace.forEach {
                 log(TAG, VERBOSE) { "removeWorkspace(): Cancelling $it" }
                 it.cancel()
-                stateObservers[it.id]?.cancel()
-                stateObservers.remove(it.id)
+                stateObservers.remove(it.id)?.cancel()
             }
-            _operations.update { ops -> ops - fromWorkspace }
+            _operations.update { ops -> ops - fromWorkspace.toSet() }
 
             toEmit
         }
@@ -199,7 +212,41 @@ class OperationsManager @Inject constructor(
         )
     }
 
+    /**
+     * Keeps every unfinished operation plus the [MAX_RETAINED_TERMINAL] most recently finished ones,
+     * dropping the rest. Returns the receiver unchanged when nothing is over the limit, so a prune
+     * that evicts nothing stays conflated away by [_operations].
+     *
+     * A finished operation is a receipt the user may dismiss, and nothing makes them, so uncapped they
+     * pile up for the process' lifetime together with whatever their report holds. The bound is
+     * deliberately independent of the workspace an operation came from: workspace close is not what
+     * has to make this terminate.
+     */
+    private fun List<ManagedOperation>.pruneTerminal(): List<ManagedOperation> {
+        // One state read per operation: this runs inside a CAS lambda that may be retried, and an
+        // operation whose state changed between the count and the sort would evict the wrong entry.
+        val finished = mapNotNull { op ->
+            (op.state.value as? Operation.State.Completed)?.let { op to it.completedAt }
+        }
+        if (finished.size <= MAX_RETAINED_TERMINAL) return this
+
+        val evicted = finished
+            .sortedByDescending { (_, completedAt) -> completedAt }
+            .drop(MAX_RETAINED_TERMINAL)
+            .map { (op, _) -> op }
+            .toSet()
+        evicted.forEach { log(TAG, VERBOSE) { "pruneTerminal(): Evicting $it" } }
+        // Their observers ended with their operation, so there is no job left here to cancel.
+        return filter { it !in evicted }
+    }
+
     companion object {
         private val TAG = logTag("Workspace", "Operations", "Manager")
+
+        /**
+         * Finished operations kept in memory for the operations bar. The global Operation History
+         * persists them separately and with its own cap.
+         */
+        internal const val MAX_RETAINED_TERMINAL = 50
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationsManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationsManagerTest.kt
@@ -1,0 +1,175 @@
+package eu.darken.butler.workspace.core.operations
+
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.workspace.core.Workspace
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+/**
+ * Nothing obliges the user to dismiss a finished operation, so retention cannot be left to them:
+ * these pin that finished operations and the observers watching them are released on their own.
+ */
+class OperationsManagerTest : BaseTest() {
+
+    private val workspaceId = Workspace.Id()
+    private val epoch = Clock.System.now()
+
+    private fun create() = OperationsManager(TestDispatcherProvider())
+
+    /** Emits nothing until told to, so an operation stays unfinished for as long as a test needs. */
+    private class FakeOperation(workspaceId: Workspace.Id) : Operation {
+        // replay = 1: the collector subscribes when the manager starts the operation, a test finishes
+        // it afterwards, and nothing should hinge on which of the two the dispatcher runs first.
+        private val states = MutableSharedFlow<Operation.State>(replay = 1)
+
+        override val metadata: Operation.Metadata = mockk<Operation.Metadata>().apply {
+            every { origin } returns Operation.Metadata.Origin.Explorer(workspaceId)
+        }
+
+        override fun perform(operationContext: Operation.Context): Flow<Operation.State> = states
+
+        suspend fun finish(at: Instant) = states.emit(
+            object : Operation.State.Completed {
+                override val startedAt: Instant = at
+                override val completedAt: Instant = at
+                override val summary = "done".toCaString()
+                override val report: Operation.Report? = null
+                override val error: Throwable? = null
+            }
+        )
+    }
+
+    private fun TestScope.recordCompletions(manager: OperationsManager): List<CompletedOperationSnapshot> {
+        val seen = mutableListOf<CompletedOperationSnapshot>()
+        backgroundScope.launch { manager.completedOperations.collect { seen.add(it) } }
+        runCurrent()
+        return seen
+    }
+
+    @Test
+    fun `a finished operation releases its state observer`() = runTest {
+        val manager = create()
+        val operation = FakeOperation(workspaceId)
+
+        val managed = manager.submitManaged(operation)
+        manager.stateObservers.keys shouldContainExactly setOf(managed.id)
+
+        operation.finish(epoch)
+        runCurrent()
+
+        manager.stateObservers.keys.shouldBeEmpty()
+    }
+
+    @Test
+    fun `an unfinished operation keeps its state observer`() = runTest {
+        val manager = create()
+
+        val managed = manager.submitManaged(FakeOperation(workspaceId))
+        runCurrent()
+
+        manager.stateObservers.keys shouldContainExactly setOf(managed.id)
+    }
+
+    @Test
+    fun `finished operations beyond the cap are evicted oldest first`() = runTest {
+        val manager = create()
+        val overflow = 5
+        val total = OperationsManager.MAX_RETAINED_TERMINAL + overflow
+
+        val submitted = (0 until total).map {
+            val operation = FakeOperation(workspaceId)
+            manager.submitManaged(operation) to operation
+        }
+        // Finished in reverse submission order, so the last submitted carry the oldest completedAt.
+        // Evicting the last five submitted is right only if completedAt decides; evicting by
+        // submission order would take the first five instead.
+        submitted.reversed().forEachIndexed { index, (_, operation) ->
+            operation.finish(epoch + index.seconds)
+            runCurrent()
+        }
+
+        manager.operations.first().map { it.id } shouldContainExactly
+            submitted.take(OperationsManager.MAX_RETAINED_TERMINAL).map { (managed, _) -> managed.id }
+    }
+
+    @Test
+    fun `unfinished operations are never evicted`() = runTest {
+        val manager = create()
+
+        val unfinished = manager.submitManaged(FakeOperation(workspaceId)).id
+        repeat(OperationsManager.MAX_RETAINED_TERMINAL + 5) { index ->
+            val operation = FakeOperation(workspaceId)
+            manager.submitManaged(operation)
+            operation.finish(epoch + index.seconds)
+            runCurrent()
+        }
+
+        val remaining = manager.operations.first()
+        remaining.first().id shouldBe unfinished
+        remaining.size shouldBe OperationsManager.MAX_RETAINED_TERMINAL + 1
+    }
+
+    @Test
+    fun `eviction does not cost an operation its completion snapshot`() = runTest {
+        val manager = create()
+        val seen = recordCompletions(manager)
+        val submitted = OperationsManager.MAX_RETAINED_TERMINAL + 5
+
+        repeat(submitted) { index ->
+            val operation = FakeOperation(workspaceId)
+            manager.submitManaged(operation)
+            operation.finish(epoch + index.seconds)
+            runCurrent()
+        }
+
+        seen.size shouldBe submitted
+        manager.operations.first().size shouldBe OperationsManager.MAX_RETAINED_TERMINAL
+    }
+
+    @Test
+    fun `a workspace removal emits one completion and takes the operation's claim`() = runTest {
+        val manager = create()
+        val seen = recordCompletions(manager)
+        val operation = FakeOperation(workspaceId)
+
+        val managed = manager.submitManaged(operation)
+        manager.removeWorkspace(workspaceId)
+        runCurrent()
+
+        seen.size shouldBe 1
+        seen.single().state.error.shouldBeInstanceOf<CancellationException>()
+        // The synthesis took the operation's one claim, which is what suppresses the real Completed
+        // if it still reaches an observer that has not finished cancelling yet.
+        managed.claimCompletionEmission() shouldBe false
+    }
+
+    @Test
+    fun `an operation grants its completion claim once`() = runTest {
+        val managed = ManagedOperation(
+            id = Operation.Id(),
+            operation = FakeOperation(workspaceId),
+            parentScope = backgroundScope,
+        )
+
+        managed.claimCompletionEmission() shouldBe true
+        managed.claimCompletionEmission() shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

Finished file operations, the receipts that show up in the operations bar, used to stay in memory for as long as the app was running. They only went away if you dismissed one, tapped "Clear completed", or closed the tab that started it. A long session therefore kept building up memory it never gave back, and every finished operation still held the full list of paths it had touched.

Butler now keeps the 50 most recently finished operations and drops the older ones by itself. Operations that are still running are never dropped.

## Technical Context

- `OperationsManager._operations` had no cap and no eviction, and every removal path needed either a user action or a workspace close. Finished operations accumulated along with their reports (`Report.affectedPaths` can list every path a recursive operation touched), and each one also left a live collector behind, because the per-operation state observer collects a `StateFlow` that never completes.
- The cap is global and count-based (50, oldest first by `completedAt`), deliberately not keyed on the workspace an operation came from: a separate in-flight design change may stop workspace close deleting terminal receipts, so close must not be the thing that bounds growth. The tradeoff is that one busy tab can evict a quiet tab's finished rows, since the bar renders per-workspace while the cap is app-wide.
- The completion-dedup id set is gone. Dedup is now a claim on `ManagedOperation` itself, so it is released with the operation rather than living for the whole process.
- Submitting an operation and then looking it up in the operations list races eviction, so `submitManaged()` returns the handle directly and Explorer and Saver use it. Without that, an operation finishing before its collector attached left `filterNotNull()` suspended forever, which pinned the Saver UI in `Saving` and made it reject every later save. `SaverWorkspace`'s `_currentOperation` rework is the part of the diff that deserves the closest look.
- `SaverWorkspace` now also ends its per-save state collector at the terminal state. Each save started its own collector, so a tab saving repeatedly held every finished operation's report for the tab's lifetime, out of reach of the new cap.
