### PR TITLE
Workspace: Add a single-pane layout with the tab rail

### DIFF
--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsToolbarCard.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/elements/AppsToolbarCard.kt
@@ -60,7 +60,7 @@ fun AppsToolbarCard(
 
     CutoutCard(
         modifier = modifier.fillMaxWidth(),
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsToolbarCard.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsToolbarCard.kt
@@ -116,7 +116,7 @@ fun AppDetailsToolbarCard(
         // overlays get it too - the tab underneath stays swipeable and the manager renders the
         // overlay as the face of its owning tab's card, so the switcher is neither unreachable nor
         // meaningless there.
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     buttonSize = if (isCollapsed) WorkspaceButtonDefaults.sizeCompact else WorkspaceButtonDefaults.sizeDefault,

--- a/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
+++ b/app-workspace-bugreport/src/main/java/eu/darken/butler/bugreport/ui/BugReportWorkspacePage.kt
@@ -318,7 +318,7 @@ private fun BugReportToolbarCard(
 
     CutoutCard(
         modifier = Modifier.fillMaxWidth(),
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspacePage.kt
@@ -189,7 +189,7 @@ fun DeveloperWorkspacePage(
                 .fillMaxWidth()
                 .padding(top = statusBarInset + 12.dp, bottom = 12.dp)
                 .padding(horizontal = 16.dp),
-            cutoutContent = if (design.isSingle) {
+            cutoutContent = if (!design.hasNavigationRail) {
                 {
                     WorkspaceButton(
                         buttonSize = WorkspaceButtonDefaults.sizeCompact,

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorToolbarCard.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/ui/editor/elements/EditorToolbarCard.kt
@@ -92,7 +92,7 @@ fun EditorToolbarCard(
         modifier = modifier
             .fillMaxWidth()
             .requiredHeightIn(min = minHeight),
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerToolbarCard.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerToolbarCard.kt
@@ -97,7 +97,7 @@ fun ExplorerToolbarCard(
             .fillMaxWidth()
             .requiredHeightIn(min = minHeight),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-        cutoutContent = if (design.isSingle && pickerSelection == null) {
+        cutoutContent = if (!design.hasNavigationRail && pickerSelection == null) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryToolbarCard.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryToolbarCard.kt
@@ -69,7 +69,7 @@ fun HistoryToolbarCard(
 
     CutoutCard(
         modifier = modifier.fillMaxWidth(),
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverHeader.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverHeader.kt
@@ -80,7 +80,7 @@ internal fun SaverHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             // Single-pane only: the navigation rail already carries one on every other layout.
-            if (design.isSingle) {
+            if (!design.hasNavigationRail) {
                 WorkspaceButton(currentWorkspaceId = workspaceId)
             }
         }

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/SearcherWorkspacePage.kt
@@ -202,7 +202,7 @@ fun SearcherWorkspacePage(
 
     // Dragging results to another pane needs a second pane to drop them on. The payload comes from
     // the state this composition already holds, so a drag can't lose items to an in-flight update.
-    val dragsToOtherPanes = !design.isSingle
+    val dragsToOtherPanes = design.maxPanes > 1
 
     // Handle back button for selection mode - clear selection first
     WorkspaceBackHandler(enabled = currentState.selectionState.isSelectionMode) {

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchToolbarCard.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/ui/search/elements/SearchToolbarCard.kt
@@ -71,7 +71,7 @@ fun SearchToolbarCard(
 
     CutoutCard(
         modifier = modifier.fillMaxWidth(),
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspacePage.kt
@@ -169,18 +169,18 @@ fun TemplatesWorkspacePage(
             horizontalAlignment = Alignment.Start,
             contentPadding = PaddingValues(
                 top = statusBarInset + 16.dp,
-                // The floating settings card only exists in single-pane; without it we just
-                // reserve the nav bar inset instead of the (stale) measured card height.
-                bottom = if (design.isSingle) settingsCardHeight + 16.dp else navBarInset + 16.dp,
+                // The floating settings card only exists without the navigation rail; without it
+                // we just reserve the nav bar inset instead of the (stale) measured card height.
+                bottom = if (!design.hasNavigationRail) settingsCardHeight + 16.dp else navBarInset + 16.dp,
             ),
         ) {
             item {
                 Column(modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)) {
                     Row(
-                        // The floating Butler button overlays this row's trailing edge in
-                        // single-pane; without the reserve, a long custom title pushes the pencil
-                        // underneath it.
-                        modifier = Modifier.padding(end = if (design.isSingle) 40.dp else 0.dp),
+                        // The floating Butler button overlays this row's trailing edge when no
+                        // rail is composed; without the reserve, a long custom title pushes the
+                        // pencil underneath it.
+                        modifier = Modifier.padding(end = if (!design.hasNavigationRail) 40.dp else 0.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
@@ -235,9 +235,8 @@ fun TemplatesWorkspacePage(
         }
 
         // Floating settings card with gradient fades.
-        // Single-pane only: every multi-pane layout renders the navigation rail, which
-        // already exposes a Butler/settings button, so this card would be redundant there.
-        if (design.isSingle) {
+        // Only without the navigation rail, which already exposes a Butler/settings button.
+        if (!design.hasNavigationRail) {
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -309,7 +308,7 @@ fun TemplatesWorkspacePage(
             }
         }
 
-        if (design.isSingle) {
+        if (!design.hasNavigationRail) {
             WorkspaceButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
+++ b/app-workspace-templates/src/test/java/eu/darken/butler/templates/ui/TemplatesWorkspacePageTest.kt
@@ -128,13 +128,14 @@ class TemplatesWorkspacePageTest : ComposeTest() {
         navigated shouldBe true
     }
 
-    // The card visibility gate is `design.isSingle`; assert it holds for every layout so the
-    // representative compose check above transitively covers all non-single layouts.
+    // The card visibility gate is `!design.hasNavigationRail`, which `WorkspaceDesignTest` covers
+    // per design; asserted here for the one single-pane layout that composes a rail anyway.
     @Test
-    fun `only the single layout counts as single-pane`() {
-        WorkspaceDesign.Layout.entries.forEach { layout ->
-            WorkspaceDesign(layout = layout).isSingle shouldBe (layout == WorkspaceDesign.Layout.SINGLE)
-        }
+    fun `a single pane with the rail hides the settings card`() {
+        setPage(WorkspaceDesign(layout = WorkspaceDesign.Layout.SINGLE, hasNavigationRail = true))
+        composeTestRule
+            .onNodeWithTag(TemplatesWorkspacePageDefaults.SETTINGS_CARD_TEST_TAG)
+            .assertDoesNotExist()
     }
 
     @Test

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCard.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerToolbarCard.kt
@@ -66,7 +66,7 @@ fun ViewerToolbarCard(
 
     CutoutCard(
         modifier = modifier.fillMaxWidth(),
-        cutoutContent = if (design.isSingle) {
+        cutoutContent = if (!design.hasNavigationRail) {
             {
                 WorkspaceButton(
                     currentWorkspaceId = workspaceId,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceRemote.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceRemote.kt
@@ -15,6 +15,9 @@ interface WorkspaceRemote {
      */
     suspend fun emitEvent(event: WorkspaceEvent)
 
+    /** The current infos, read from the repository itself rather than from a possibly stale [state] snapshot. */
+    suspend fun peekInfos(): List<Workspace.Info>
+
     data class State(
         val infos: List<Workspace.Info> = emptyList(),
         val portraitPanelMode: WorkspacePanelMode = WorkspacePanelMode.AUTO,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/layout/WorkspacePanelMode.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/layout/WorkspacePanelMode.kt
@@ -11,6 +11,9 @@ enum class WorkspacePanelMode {
     @SerialName("SINGLE")
     SINGLE,
 
+    @SerialName("SINGLE_RAIL")
+    SINGLE_RAIL,
+
     @SerialName("DUAL_VERTICAL")
     DUAL_VERTICAL,
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
@@ -601,11 +601,18 @@ class WorkspacePageManager @Inject constructor(
      * Atomically sets both focus and selections during session restoration.
      * Unlike calling setFocusedWorkspace() + setSelectedWorkspaces() separately,
      * this avoids the auto-focus side effect in setSelectedWorkspaces().
+     * A focused tab restored onto an index the current layout does not render is placed like after a shrink.
      */
-    fun applyRestoredUIState(
+    suspend fun applyRestoredUIState(
         focusedId: Workspace.Id?,
         selectedWorkspaces: Map<Int, Workspace.Id>,
     ) {
+        // The restored tab can still be missing from the replayed snapshot, as in
+        // handleWorkspaceSelection; a null focus has nothing to wait for.
+        val infos = workspaceRemote.state.first { state ->
+            focusedId == null || state.infos.any { it.id == focusedId }
+        }.infos
+
         _state.update { currentState ->
             val updatedAccessTimes = if (focusedId != null) {
                 currentState.workspaceAccessTimes + (focusedId to Clock.System.now())
@@ -616,7 +623,7 @@ class WorkspacePageManager @Inject constructor(
                 focusedWorkspaceId = focusedId,
                 selectedWorkspaces = selectedWorkspaces,
                 workspaceAccessTimes = updatedAccessTimes,
-            )
+            ).withFocusRendered(infos)
         }
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
@@ -370,12 +370,16 @@ class WorkspacePageManager @Inject constructor(
 
     suspend fun setPaneCount(count: Int) {
         log(TAG) { "Setting pane count to $count" }
+        val firstReport = !paneCountReported
         paneCountReported = true
 
         val oldPaneCount = _state.getAndUpdate { it.copy(currentPaneCount = count) }.currentPaneCount
+        // A repeat report of the same layout changes nothing, and a tab the user detached stays
+        // detached; only the first report and real count changes place the focused tab.
+        if (count == oldPaneCount && !firstReport) return
         if (count > oldPaneCount) autoFillGrownPanes(count, oldPaneCount)
 
-        // Every report makes the layout's pane set authoritative, equal counts included: this is
+        // The first report and every count change make the layout's pane set authoritative: this is
         // where a focused tab left on an unrendered index, by a shrink or by a restore that landed
         // before the first report, gets placed.
         val infos = workspaceRemote.peekInfos()

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
@@ -73,6 +73,7 @@ class WorkspacePageManager @Inject constructor(
 
     private val _state = MutableStateFlow(State())
     val state: StateFlow<State> = _state.asStateFlow()
+    private var paneCountReported = false
 
     private val _selectionEvents = MutableSharedFlow<Workspace.Id>()
     val selectionEvents = _selectionEvents.asSharedFlow()
@@ -369,18 +370,19 @@ class WorkspacePageManager @Inject constructor(
 
     suspend fun setPaneCount(count: Int) {
         log(TAG) { "Setting pane count to $count" }
+        paneCountReported = true
 
         val oldPaneCount = _state.getAndUpdate { it.copy(currentPaneCount = count) }.currentPaneCount
-        if (count == oldPaneCount) return
+        if (count > oldPaneCount) autoFillGrownPanes(count, oldPaneCount)
 
-        if (count < oldPaneCount) {
-            // The assignments survive the shrink, so a focused tab can end up on an index the
-            // narrower layout no longer draws.
-            val infos = workspaceRemote.state.first().infos
-            _state.update { it.withFocusRendered(infos) }
-            return
-        }
+        // Every report makes the layout's pane set authoritative, equal counts included: this is
+        // where a focused tab left on an unrendered index, by a shrink or by a restore that landed
+        // before the first report, gets placed.
+        val infos = workspaceRemote.peekInfos()
+        _state.update { it.withFocusRendered(infos) }
+    }
 
+    private suspend fun autoFillGrownPanes(count: Int, oldPaneCount: Int) {
         log(TAG) { "Pane count increased from $oldPaneCount to $count, checking for empty panes to fill" }
 
         // Only pay for the workspace list when a pane might need filling - growing back into
@@ -520,8 +522,8 @@ class WorkspacePageManager @Inject constructor(
 
     /**
      * A focused tab parked on an index the layout does not render is open but invisible.
-     * This moves it into an empty rendered pane, or moves focus to a rendered occupant when none of
-     * them is empty.
+     * This moves it into an empty rendered pane; with one pane it swaps it in; otherwise focus moves
+     * to a rendered occupant.
      */
     private fun State.withFocusRendered(infos: List<Workspace.Info>): State {
         val focused = focusedWorkspaceId ?: return this
@@ -540,6 +542,18 @@ class WorkspacePageManager @Inject constructor(
                     (emptyRenderedSlot to focusedRoot),
             )
         } else {
+            if (currentPaneCount == 1) {
+                // One pane shows exactly one tab, so the focused tab takes it and the occupant moves to
+                // the index the focused tab held, keeping the arrangement for the next grow.
+                val occupant = selectedWorkspaces.getValue(0)
+                val focusedIndex = selectedWorkspaces.entries.firstOrNull { it.value == focusedRoot }?.key
+                log(TAG) { "withFocusRendered: swapping $focusedRoot into the single pane, parking $occupant at $focusedIndex" }
+                return copy(
+                    selectedWorkspaces = selectedWorkspaces.filterValues { it != focusedRoot && it != occupant } +
+                        (0 to focusedRoot) +
+                        listOfNotNull(focusedIndex?.let { it to occupant }),
+                )
+            }
             // Same rule as unassignWorkspace: the lowest rendered pane, never a retained index.
             val newFocus = selectedWorkspaces.filterKeys { it in renderedSlots }.minByOrNull { it.key }?.value
                 ?: return this
@@ -607,11 +621,7 @@ class WorkspacePageManager @Inject constructor(
         focusedId: Workspace.Id?,
         selectedWorkspaces: Map<Int, Workspace.Id>,
     ) {
-        // The restored tab can still be missing from the replayed snapshot, as in
-        // handleWorkspaceSelection; a null focus has nothing to wait for.
-        val infos = workspaceRemote.state.first { state ->
-            focusedId == null || state.infos.any { it.id == focusedId }
-        }.infos
+        val infos = workspaceRemote.peekInfos()
 
         _state.update { currentState ->
             val updatedAccessTimes = if (focusedId != null) {
@@ -623,7 +633,10 @@ class WorkspacePageManager @Inject constructor(
                 focusedWorkspaceId = focusedId,
                 selectedWorkspaces = selectedWorkspaces,
                 workspaceAccessTimes = updatedAccessTimes,
-            ).withFocusRendered(infos)
+            ).let {
+                // A restore that lands before the layout has reported its pane count is placed by that report instead.
+                if (paneCountReported) it.withFocusRendered(infos) else it
+            }
         }
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
@@ -371,7 +371,15 @@ class WorkspacePageManager @Inject constructor(
         log(TAG) { "Setting pane count to $count" }
 
         val oldPaneCount = _state.getAndUpdate { it.copy(currentPaneCount = count) }.currentPaneCount
-        if (count <= oldPaneCount) return
+        if (count == oldPaneCount) return
+
+        if (count < oldPaneCount) {
+            // The assignments survive the shrink, so a focused tab can end up on an index the
+            // narrower layout no longer draws.
+            val infos = workspaceRemote.state.first().infos
+            _state.update { it.withFocusRendered(infos) }
+            return
+        }
 
         log(TAG) { "Pane count increased from $oldPaneCount to $count, checking for empty panes to fill" }
 
@@ -507,6 +515,36 @@ class WorkspacePageManager @Inject constructor(
             }
 
             currentState.copy(selectedWorkspaces = remaining, focusedWorkspaceId = newFocus)
+        }
+    }
+
+    /**
+     * A focused tab parked on an index the layout does not render is open but invisible.
+     * This moves it into an empty rendered pane, or moves focus to a rendered occupant when none of
+     * them is empty.
+     */
+    private fun State.withFocusRendered(infos: List<Workspace.Info>): State {
+        val focused = focusedWorkspaceId ?: return this
+        // A dangling or cyclic child belongs to no tab, so there is nothing to place - the UI falls
+        // back on its own.
+        val focusedRoot = WorkspaceStacks(infos).rootOf(focused)?.id ?: return this
+
+        val renderedSlots = 0 until currentPaneCount
+        if (selectedWorkspaces.any { (index, id) -> index in renderedSlots && id == focusedRoot }) return this
+
+        val emptyRenderedSlot = renderedSlots.firstOrNull { !selectedWorkspaces.containsKey(it) }
+        return if (emptyRenderedSlot != null) {
+            log(TAG) { "withFocusRendered: moving $focusedRoot into rendered pane $emptyRenderedSlot" }
+            copy(
+                selectedWorkspaces = selectedWorkspaces.filterValues { it != focusedRoot } +
+                    (emptyRenderedSlot to focusedRoot),
+            )
+        } else {
+            // Same rule as unassignWorkspace: the lowest rendered pane, never a retained index.
+            val newFocus = selectedWorkspaces.filterKeys { it in renderedSlots }.minByOrNull { it.key }?.value
+                ?: return this
+            log(TAG) { "withFocusRendered: $focusedRoot has no rendered pane, focusing $newFocus instead" }
+            copy(focusedWorkspaceId = newFocus)
         }
     }
 
@@ -790,19 +828,14 @@ class WorkspacePageManager @Inject constructor(
 
             val newFocus = if (needsRefocus) nextWorkspace?.id else state.focusedWorkspaceId
 
-            // Ensure we have a selection if we have a focus
-            val finalSelections = if (newFocus != null && newSelections.isEmpty()) {
-                mapOf(0 to newFocus)
-            } else {
-                newSelections
-            }
+            log(TAG) { "handleWorkspaceClosed.update: newFocus=$newFocus, newSelections=$newSelections" }
 
-            log(TAG) { "handleWorkspaceClosed.update: newFocus=$newFocus, finalSelections=$finalSelections" }
-
+            // The close can leave a rendered pane empty while the focused tab sits on a retained
+            // index, so the focus is placed into a pane the layout actually draws.
             state.copy(
-                selectedWorkspaces = finalSelections,
+                selectedWorkspaces = newSelections,
                 focusedWorkspaceId = newFocus,
-            )
+            ).withFocusRendered(repoSnapshot.infos)
         }
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
@@ -30,6 +30,30 @@ object WorkspacePanelIcons {
             }
         }.build()
 
+    val SingleRail: ImageVector
+        get() = ImageVector.Builder(
+            name = "LayoutSingleRail",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 4f)
+                lineTo(20f, 4f)
+                lineTo(20f, 15f)
+                lineTo(4f, 15f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 17f)
+                lineTo(20f, 17f)
+                lineTo(20f, 20f)
+                lineTo(4f, 20f)
+                close()
+            }
+        }.build()
+
     val DualVertical: ImageVector
         get() = ImageVector.Builder(
             name = "LayoutDualVertical",

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelModeExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelModeExtensions.kt
@@ -12,6 +12,7 @@ fun WorkspacePanelMode.label(): String {
     return when (this) {
         WorkspacePanelMode.AUTO -> stringResource(R.string.workspace_settings_layout_mode_auto)
         WorkspacePanelMode.SINGLE -> stringResource(R.string.workspace_settings_layout_mode_single)
+        WorkspacePanelMode.SINGLE_RAIL -> stringResource(R.string.workspace_settings_layout_mode_single_rail)
         WorkspacePanelMode.DUAL_VERTICAL -> stringResource(R.string.workspace_settings_layout_mode_dual_vertical)
         WorkspacePanelMode.DUAL_HORIZONTAL -> stringResource(R.string.workspace_settings_layout_mode_dual_horizontal)
         WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> stringResource(R.string.workspace_settings_layout_mode_triple_sidebar_left)
@@ -25,6 +26,7 @@ fun WorkspacePanelMode.description(): String {
     return when (this) {
         WorkspacePanelMode.AUTO -> stringResource(R.string.workspace_settings_layout_mode_auto_desc)
         WorkspacePanelMode.SINGLE -> stringResource(R.string.workspace_settings_layout_mode_single_desc)
+        WorkspacePanelMode.SINGLE_RAIL -> stringResource(R.string.workspace_settings_layout_mode_single_rail_desc)
         WorkspacePanelMode.DUAL_VERTICAL -> stringResource(R.string.workspace_settings_layout_mode_dual_vertical_desc)
         WorkspacePanelMode.DUAL_HORIZONTAL -> stringResource(R.string.workspace_settings_layout_mode_dual_horizontal_desc)
         WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> stringResource(R.string.workspace_settings_layout_mode_triple_sidebar_left_desc)
@@ -36,6 +38,7 @@ fun WorkspacePanelMode.description(): String {
 fun WorkspacePanelMode.icon(): ImageVector = when (this) {
     WorkspacePanelMode.AUTO -> WorkspacePanelIcons.Auto
     WorkspacePanelMode.SINGLE -> WorkspacePanelIcons.Single
+    WorkspacePanelMode.SINGLE_RAIL -> WorkspacePanelIcons.SingleRail
     WorkspacePanelMode.DUAL_VERTICAL -> WorkspacePanelIcons.DualVertical
     WorkspacePanelMode.DUAL_HORIZONTAL -> WorkspacePanelIcons.DualHorizontal
     WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> WorkspacePanelIcons.TripleSidebarLeft

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesign.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesign.kt
@@ -4,10 +4,19 @@ data class WorkspaceDesign(
     val layout: Layout = Layout.SINGLE,
     val paneEdges: PaneEdges = PaneEdges.All,
     val railPlacement: RailPlacement = RailPlacement.START,
+    /**
+     * Whether the window composes the navigation rail. Always true for multi-pane layouts, a single
+     * pane opts into it via the single-with-rail panel mode. Chrome a page supplies only when there
+     * is no rail gates on this, never on the layout.
+     */
+    val hasNavigationRail: Boolean = layout != Layout.SINGLE,
 ) {
 
-    val isSingle: Boolean
-        get() = layout == Layout.SINGLE
+    init {
+        require(hasNavigationRail || layout == Layout.SINGLE) {
+            "Multi-pane layouts always compose the navigation rail: $layout"
+        }
+    }
 
     val maxPanes = when (layout) {
         Layout.SINGLE -> 1
@@ -131,7 +140,7 @@ data class WorkspaceDesign(
 
     /**
      * Which window edge the navigation rail occupies. A property of the window rather than of the
-     * layout: a single-pane window carries one too, even though it composes no rail.
+     * layout: a single-pane window carries one too, even when it composes no rail.
      */
     enum class RailPlacement {
         START,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -246,6 +246,7 @@ fun WorkspaceSettingsScreen(
             availableModes = listOf(
                 WorkspacePanelMode.AUTO,
                 WorkspacePanelMode.SINGLE,
+                WorkspacePanelMode.SINGLE_RAIL,
                 WorkspacePanelMode.DUAL_VERTICAL,
                 WorkspacePanelMode.DUAL_HORIZONTAL,
             ),
@@ -264,6 +265,7 @@ fun WorkspaceSettingsScreen(
             availableModes = listOf(
                 WorkspacePanelMode.AUTO,
                 WorkspacePanelMode.SINGLE,
+                WorkspacePanelMode.SINGLE_RAIL,
                 WorkspacePanelMode.DUAL_VERTICAL,
                 WorkspacePanelMode.DUAL_HORIZONTAL,
                 WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/PathGoneContent.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/PathGoneContent.kt
@@ -158,7 +158,7 @@ fun PathGoneContent(
             }
         }
 
-        if (design.isSingle && LocalWorkspaceButtonProvider.current != null) {
+        if (!design.hasNavigationRail && LocalWorkspaceButtonProvider.current != null) {
             WorkspaceButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/WorkspaceErrorContent.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/WorkspaceErrorContent.kt
@@ -233,7 +233,7 @@ fun WorkspaceErrorContent(
             }
         }
 
-        if (design.isSingle && LocalWorkspaceButtonProvider.current != null) {
+        if (!design.hasNavigationRail && LocalWorkspaceButtonProvider.current != null) {
             WorkspaceButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/WorkspaceInitializingContent.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/WorkspaceInitializingContent.kt
@@ -78,7 +78,7 @@ fun WorkspaceInitializingContent(
             }
         }
 
-        if (design.isSingle && LocalWorkspaceButtonProvider.current != null) {
+        if (!design.hasNavigationRail && LocalWorkspaceButtonProvider.current != null) {
             WorkspaceButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/WorkspacePausedContent.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/states/WorkspacePausedContent.kt
@@ -180,7 +180,7 @@ fun WorkspacePausedContent(
             }
         }
 
-        if (design.isSingle && LocalWorkspaceButtonProvider.current != null) {
+        if (!design.hasNavigationRail && LocalWorkspaceButtonProvider.current != null) {
             WorkspaceButton(
                 modifier = Modifier
                     .align(Alignment.TopEnd)

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -352,6 +352,8 @@
     <string name="workspace_settings_layout_mode_auto_desc">Automatically adapt layout based on screen size.</string>
     <string name="workspace_settings_layout_mode_single">Single</string>
     <string name="workspace_settings_layout_mode_single_desc">One tab pane takes the full screen.</string>
+    <string name="workspace_settings_layout_mode_single_rail">Single with tab rail</string>
+    <string name="workspace_settings_layout_mode_single_rail_desc">One tab pane plus the tab rail of the multi-pane layouts. Switch tabs from the rail instead of by swiping; the rail takes a strip of the screen.</string>
     <string name="workspace_settings_layout_mode_dual_vertical">Dual vertical</string>
     <string name="workspace_settings_layout_mode_dual_vertical_desc">Two panes side-by-side (left/right).</string>
     <string name="workspace_settings_layout_mode_dual_horizontal">Dual horizontal</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
@@ -14,16 +14,16 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -49,6 +49,7 @@ class WorkspacePageManagerTest : BaseTest() {
         workspaceRemote = mockk {
             every { state } returns stateFlow
             every { events } returns eventsFlow
+            coEvery { peekInfos() } answers { stateFlow.value.infos }
         }
 
         testScope = TestScope(UnconfinedTestDispatcher())
@@ -1397,29 +1398,72 @@ class WorkspacePageManagerTest : BaseTest() {
         after.focusedWorkspaceId shouldBe tab
     }
 
-    /** The repository publishes a restored tab a beat after creating it; the restore must wait for it. */
+    /** The repository holds a restored tab before its state flow has published it. */
     @Test
-    fun `restoring a focused tab before the repository publishes it still places it`() = runTest {
+    fun `restoring a focused tab the state flow has not published yet still places it`() = runTest {
         val tab = Workspace.Id()
 
         stateFlow.value = WorkspaceRemote.State(infos = emptyList())
         pageManager.setPaneCount(1)
+        coEvery { workspaceRemote.peekInfos() } returns listOf(createWorkspaceInfo(id = tab))
 
-        // Undispatched so the restore reaches its wait before the tab is published.
-        val restore = launch(start = CoroutineStart.UNDISPATCHED) {
-            pageManager.applyRestoredUIState(tab, mapOf(1 to tab))
-        }
-        stateFlow.value = WorkspaceRemote.State(infos = listOf(createWorkspaceInfo(id = tab)))
-        restore.join()
+        pageManager.applyRestoredUIState(tab, mapOf(1 to tab))
 
         val after = pageManager.state.value
         after.selectedWorkspaces shouldBe mapOf(0 to tab)
         after.focusedWorkspaceId shouldBe tab
     }
 
-    /** With the sole pane occupied there is nowhere to move the focused tab to, so focus moves. */
+    /** A tab closed while the session was still restoring must not stall the restore. */
     @Test
-    fun `shrinking to one pane refocuses to the rendered occupant`() = runTest {
+    fun `restoring a focused tab that was closed meanwhile does not wait for it`() = runTest {
+        val tab = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(infos = emptyList())
+        pageManager.setPaneCount(1)
+
+        withTimeout(1_000) { pageManager.applyRestoredUIState(tab, mapOf(1 to tab)) }
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(1 to tab)
+        after.focusedWorkspaceId shouldBe tab
+    }
+
+    /** Restore can land before the screen reports its pane count; the report, not the restore, places focus. */
+    @Test
+    fun `a restore before the pane count is reported keeps a two-pane arrangement`() = runTest {
+        val paneOne = Workspace.Id()
+        val paneTwo = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(createWorkspaceInfo(id = paneOne), createWorkspaceInfo(id = paneTwo)),
+        )
+
+        pageManager.applyRestoredUIState(paneTwo, mapOf(0 to paneOne, 1 to paneTwo))
+        pageManager.setPaneCount(2)
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to paneOne, 1 to paneTwo)
+        after.focusedWorkspaceId shouldBe paneTwo
+    }
+
+    @Test
+    fun `a restore before the pane count is reported is placed when a one-pane layout reports`() = runTest {
+        val tab = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(infos = listOf(createWorkspaceInfo(id = tab)))
+
+        pageManager.applyRestoredUIState(tab, mapOf(1 to tab))
+        pageManager.setPaneCount(1)
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to tab)
+        after.focusedWorkspaceId shouldBe tab
+    }
+
+    /** One pane shows exactly one tab, so the focused tab takes it; the occupant keeps a place for the next grow. */
+    @Test
+    fun `shrinking to one pane brings the focused tab into the pane and parks the occupant`() = runTest {
         val paneOne = Workspace.Id()
         val paneTwo = Workspace.Id()
 
@@ -1432,10 +1476,8 @@ class WorkspacePageManagerTest : BaseTest() {
         pageManager.setPaneCount(1)
 
         val after = pageManager.state.value
-        after.visiblePaneAssignments shouldBe mapOf(0 to paneOne)
-        after.focusedWorkspaceId shouldBe paneOne
-        // The arrangement a wider layout left behind is still retained.
-        after.selectedWorkspaces[1] shouldBe paneTwo
+        after.selectedWorkspaces shouldBe mapOf(0 to paneTwo, 1 to paneOne)
+        after.focusedWorkspaceId shouldBe paneTwo
     }
 
     /** Closing the occupant of the only pane must not leave that pane empty while a tab is left. */
@@ -1524,16 +1566,11 @@ class WorkspacePageManagerTest : BaseTest() {
         )
         stateFlow.value = WorkspaceRemote.State(infos = infos)
 
-        // The restore itself reads this flow, so only the outermost collection performs the write.
-        var restored = false
         every { workspaceRemote.state } returns flow {
-            if (!restored) {
-                restored = true
-                pageManager.applyRestoredUIState(
-                    focusedId = restoredA,
-                    selectedWorkspaces = mapOf(0 to restoredA, 1 to restoredB),
-                )
-            }
+            pageManager.applyRestoredUIState(
+                focusedId = restoredA,
+                selectedWorkspaces = mapOf(0 to restoredA, 1 to restoredB),
+            )
             emit(WorkspaceRemote.State(infos = infos))
         }
 
@@ -1551,12 +1588,8 @@ class WorkspacePageManagerTest : BaseTest() {
         val infos = listOf(createWorkspaceInfo(id = placed), createWorkspaceInfo(id = candidate))
         stateFlow.value = WorkspaceRemote.State(infos = infos)
 
-        var restored = false
         every { workspaceRemote.state } returns flow {
-            if (!restored) {
-                restored = true
-                pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
-            }
+            pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
             emit(WorkspaceRemote.State(infos = infos))
         }
 
@@ -1574,12 +1607,8 @@ class WorkspacePageManagerTest : BaseTest() {
         val infos = listOf(createWorkspaceInfo(id = placed), createWorkspaceInfo(id = candidate))
         stateFlow.value = WorkspaceRemote.State(infos = infos)
 
-        var restored = false
         every { workspaceRemote.state } returns flow {
-            if (!restored) {
-                restored = true
-                pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
-            }
+            pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
             emit(WorkspaceRemote.State(infos = infos))
         }
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
@@ -1461,6 +1461,27 @@ class WorkspacePageManagerTest : BaseTest() {
         after.focusedWorkspaceId shouldBe tab
     }
 
+    /** A repeat report of the same layout changes nothing; a tab the user detached stays detached. */
+    @Test
+    fun `a repeated pane count report leaves detached panes empty`() = runTest {
+        val first = Workspace.Id()
+        val second = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(createWorkspaceInfo(id = first), createWorkspaceInfo(id = second)),
+        )
+        pageManager.setPaneCount(2)
+        pageManager.applyRestoredUIState(first, mapOf(0 to first, 1 to second))
+        pageManager.unassignWorkspace(second)
+        pageManager.unassignWorkspace(first)
+
+        pageManager.setPaneCount(2)
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe emptyMap()
+        after.focusedWorkspaceId shouldBe first
+    }
+
     /** One pane shows exactly one tab, so the focused tab takes it; the occupant keeps a place for the next grow. */
     @Test
     fun `shrinking to one pane brings the focused tab into the pane and parks the occupant`() = runTest {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
@@ -1361,6 +1361,89 @@ class WorkspacePageManagerTest : BaseTest() {
         after.selectedWorkspaces[3] shouldBe otherHidden
     }
 
+    /**
+     * A layout shrink keeps the assignments so growing back restores them, which can leave the
+     * focused tab parked on an index no pane draws - open, but invisible.
+     */
+    @Test
+    fun `shrinking to one pane moves a focused retained tab into the empty pane`() = runTest {
+        val retained = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(infos = listOf(createWorkspaceInfo(id = retained)))
+        pageManager.setPaneCount(2)
+        pageManager.applyRestoredUIState(retained, mapOf(1 to retained))
+
+        pageManager.setPaneCount(1)
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to retained)
+        after.focusedWorkspaceId shouldBe retained
+    }
+
+    /** With the sole pane occupied there is nowhere to move the focused tab to, so focus moves. */
+    @Test
+    fun `shrinking to one pane refocuses to the rendered occupant`() = runTest {
+        val paneOne = Workspace.Id()
+        val paneTwo = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(createWorkspaceInfo(id = paneOne), createWorkspaceInfo(id = paneTwo)),
+        )
+        pageManager.setPaneCount(2)
+        pageManager.applyRestoredUIState(paneTwo, mapOf(0 to paneOne, 1 to paneTwo))
+
+        pageManager.setPaneCount(1)
+
+        val after = pageManager.state.value
+        after.visiblePaneAssignments shouldBe mapOf(0 to paneOne)
+        after.focusedWorkspaceId shouldBe paneOne
+        // The arrangement a wider layout left behind is still retained.
+        after.selectedWorkspaces[1] shouldBe paneTwo
+    }
+
+    /** Closing the occupant of the only pane must not leave that pane empty while a tab is left. */
+    @Test
+    fun `closing the only pane's occupant brings a retained tab into the pane`() = runTest {
+        val visible = Workspace.Id()
+        val retained = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(createWorkspaceInfo(id = visible), createWorkspaceInfo(id = retained)),
+        )
+        pageManager.setPaneCount(1)
+        pageManager.applyRestoredUIState(visible, mapOf(0 to visible, 1 to retained))
+
+        eventsFlow.emit(WorkspaceEvent.Closed(workspaceId = visible, callerWorkspaceId = null))
+        testScope.testScheduler.advanceUntilIdle()
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to retained)
+        after.focusedWorkspaceId shouldBe retained
+    }
+
+    /** A focus that belongs to no tab has no pane to be placed in; the UI's fallback owns it. */
+    @Test
+    fun `a dangling focus is left alone by the shrink`() = runTest {
+        val visibleTab = Workspace.Id()
+        val orphan = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(
+            infos = listOf(
+                createWorkspaceInfo(id = visibleTab),
+                createWorkspaceInfo(id = orphan, callerWorkspaceId = Workspace.Id()),
+            )
+        )
+        pageManager.setPaneCount(2)
+        pageManager.handleWorkspaceSelection(visibleTab)
+        pageManager.handleWorkspaceSelection(orphan)
+        val before = pageManager.state.value.selectedWorkspaces.toMap()
+
+        pageManager.setPaneCount(1)
+
+        pageManager.state.value.selectedWorkspaces shouldBe before
+        pageManager.state.value.focusedWorkspaceId shouldBe orphan
+    }
+
     /** A workspace already in a rendered pane is only focused - no reshuffling. */
     @Test
     fun `selecting a visible workspace does not move it`() = runTest {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspacePageManagerTest.kt
@@ -16,9 +16,11 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -1380,6 +1382,41 @@ class WorkspacePageManagerTest : BaseTest() {
         after.focusedWorkspaceId shouldBe retained
     }
 
+    /** A session saved in a wider layout can park the focused tab on an index the current layout does not draw. */
+    @Test
+    fun `restoring a focused tab on an unrendered index moves it into the empty pane`() = runTest {
+        val tab = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(infos = listOf(createWorkspaceInfo(id = tab)))
+        pageManager.setPaneCount(1)
+
+        pageManager.applyRestoredUIState(tab, mapOf(1 to tab))
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to tab)
+        after.focusedWorkspaceId shouldBe tab
+    }
+
+    /** The repository publishes a restored tab a beat after creating it; the restore must wait for it. */
+    @Test
+    fun `restoring a focused tab before the repository publishes it still places it`() = runTest {
+        val tab = Workspace.Id()
+
+        stateFlow.value = WorkspaceRemote.State(infos = emptyList())
+        pageManager.setPaneCount(1)
+
+        // Undispatched so the restore reaches its wait before the tab is published.
+        val restore = launch(start = CoroutineStart.UNDISPATCHED) {
+            pageManager.applyRestoredUIState(tab, mapOf(1 to tab))
+        }
+        stateFlow.value = WorkspaceRemote.State(infos = listOf(createWorkspaceInfo(id = tab)))
+        restore.join()
+
+        val after = pageManager.state.value
+        after.selectedWorkspaces shouldBe mapOf(0 to tab)
+        after.focusedWorkspaceId shouldBe tab
+    }
+
     /** With the sole pane occupied there is nowhere to move the focused tab to, so focus moves. */
     @Test
     fun `shrinking to one pane refocuses to the rendered occupant`() = runTest {
@@ -1487,11 +1524,16 @@ class WorkspacePageManagerTest : BaseTest() {
         )
         stateFlow.value = WorkspaceRemote.State(infos = infos)
 
+        // The restore itself reads this flow, so only the outermost collection performs the write.
+        var restored = false
         every { workspaceRemote.state } returns flow {
-            pageManager.applyRestoredUIState(
-                focusedId = restoredA,
-                selectedWorkspaces = mapOf(0 to restoredA, 1 to restoredB),
-            )
+            if (!restored) {
+                restored = true
+                pageManager.applyRestoredUIState(
+                    focusedId = restoredA,
+                    selectedWorkspaces = mapOf(0 to restoredA, 1 to restoredB),
+                )
+            }
             emit(WorkspaceRemote.State(infos = infos))
         }
 
@@ -1509,8 +1551,12 @@ class WorkspacePageManagerTest : BaseTest() {
         val infos = listOf(createWorkspaceInfo(id = placed), createWorkspaceInfo(id = candidate))
         stateFlow.value = WorkspaceRemote.State(infos = infos)
 
+        var restored = false
         every { workspaceRemote.state } returns flow {
-            pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
+            if (!restored) {
+                restored = true
+                pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
+            }
             emit(WorkspaceRemote.State(infos = infos))
         }
 
@@ -1528,8 +1574,12 @@ class WorkspacePageManagerTest : BaseTest() {
         val infos = listOf(createWorkspaceInfo(id = placed), createWorkspaceInfo(id = candidate))
         stateFlow.value = WorkspaceRemote.State(infos = infos)
 
+        var restored = false
         every { workspaceRemote.state } returns flow {
-            pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
+            if (!restored) {
+                restored = true
+                pageManager.applyRestoredUIState(focusedId = placed, selectedWorkspaces = mapOf(0 to placed))
+            }
             emit(WorkspaceRemote.State(infos = infos))
         }
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspaceUndoPlacementTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/WorkspaceUndoPlacementTest.kt
@@ -15,6 +15,7 @@ import eu.darken.butler.workspace.ui.restore.WorkspaceViewPrefs
 import eu.darken.butler.workspace.ui.scroll.WorkspaceScrollPosition
 import eu.darken.butler.workspace.ui.scroll.WorkspaceScrollPositions
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -56,6 +57,7 @@ class WorkspaceUndoPlacementTest : BaseTest() {
         workspaceRemote = mockk {
             every { state } returns stateFlow
             every { events } returns eventsFlow
+            coEvery { peekInfos() } answers { stateFlow.value.infos }
         }
         testScope = TestScope(UnconfinedTestDispatcher())
         stash = ClosedWorkspaceStash(testScope)

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesignTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesignTest.kt
@@ -113,4 +113,21 @@ class WorkspaceDesignTest : BaseTest() {
             edges(top = true, bottom = false, start = false, end = false)
         design.withoutEdges(start = true).layout shouldBe Layout.QUAD_GRID
     }
+
+    @Test
+    fun `the rail follows the layout unless a single pane opts in`() {
+        Layout.entries.forEach { layout ->
+            withClue(layout) {
+                WorkspaceDesign(layout = layout).hasNavigationRail shouldBe (layout != Layout.SINGLE)
+            }
+        }
+        WorkspaceDesign(layout = Layout.SINGLE, hasNavigationRail = true).hasNavigationRail shouldBe true
+    }
+
+    @Test
+    fun `a multi-pane layout cannot drop the rail`() {
+        shouldThrow<IllegalArgumentException> {
+            WorkspaceDesign(layout = Layout.DUAL_VERTICAL, hasNavigationRail = false)
+        }
+    }
 }

--- a/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/butler/screenshots/ScreenshotContent.kt
@@ -202,6 +202,7 @@ internal fun ScreenshotPaneFrame(
             workspaces = workspaces,
             selected = selected,
             focusedId = panes.firstOrNull()?.id,
+            focusedRootId = panes.firstOrNull()?.id,
             dividerPositions = dividerPositions,
             onDividerPositionsChange = {},
             showPaneNumbers = false,

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -448,7 +448,7 @@ class WorkspaceRepo @Inject constructor(
      *
      * [lock] is NOT reentrant, so this must not be called from a path that already holds it.
      */
-    suspend fun peekInfos(): List<Workspace.Info> = lock.withLock {
+    override suspend fun peekInfos(): List<Workspace.Info> = lock.withLock {
         val titles = _customTitles.value
         _workspaces.value.map { it.info.value.withCustomTitle(titles) }
     }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/AdaptiveWorkspaceLayout.kt
@@ -45,6 +45,8 @@ fun AdaptiveWorkspaceLayout(
     /** Only the assignments this layout renders. Anything showing a pane number reads this. */
     visibleSelected: Map<Int, WorkspacePaneInfo> = selected,
     focusedId: Workspace.Id?,
+    /** The tab owning [focusedId], null when focus resolves to no tab. */
+    focusedRootId: Workspace.Id?,
     dividerPositions: DividerPositions,
     onDividerPositionsChange: (DividerPositions) -> Unit,
     showPaneNumbers: Boolean,
@@ -83,6 +85,14 @@ fun AdaptiveWorkspaceLayout(
                 focusedId = focusedId,
                 onTabAction = { workspaceActionHandler?.executeWorkspaceAction(it) },
                 onPaneAssignment = { workspaceId, paneIndex ->
+                    // One pane has nothing to swap with, so the entry is selected into it the way
+                    // the tab manager selects into a one-pane layout.
+                    if (design.maxPanes == 1) {
+                        onScreenAction(WorkspaceScreenAction.Select(workspaceId))
+                        onPaneMenuToggle(false)
+                        return@WorkspaceNavigationRail
+                    }
+
                     // Create new selection with the workspace at the specified pane index
                     val currentSelection = selected.toMutableMap()
 
@@ -142,6 +152,7 @@ fun AdaptiveWorkspaceLayout(
                     railThickness = railThickness,
                     selected = selected,
                     focusedId = focusedId,
+                    focusedRootId = focusedRootId,
                     dividerPositions = dividerPositions,
                     onDividerPositionsChange = onDividerPositionsChange,
                     showPaneNumbers = showPaneNumbers,
@@ -171,6 +182,7 @@ fun AdaptiveWorkspaceLayout(
                     railThickness = railThickness,
                     selected = selected,
                     focusedId = focusedId,
+                    focusedRootId = focusedRootId,
                     dividerPositions = dividerPositions,
                     onDividerPositionsChange = onDividerPositionsChange,
                     showPaneNumbers = showPaneNumbers,
@@ -205,6 +217,8 @@ private fun PaneArea(
     railThickness: Dp,
     selected: Map<Int, WorkspacePaneInfo>,
     focusedId: Workspace.Id?,
+    /** The tab owning [focusedId], null when focus resolves to no tab. */
+    focusedRootId: Workspace.Id?,
     dividerPositions: DividerPositions,
     onDividerPositionsChange: (DividerPositions) -> Unit,
     showPaneNumbers: Boolean,
@@ -260,6 +274,12 @@ private fun PaneArea(
                         val focusSuppressed = isOverlayVisible || fullScreenModalVisible
                         val paneIsFocused = !focusSuppressed &&
                             (focusedId == info.id || chain.any { it.id == focusedId })
+                        // Widened for presses only, as the classic pager does for its resting page:
+                        // with a single pane nobody else can hold focus, so while focus resolves to
+                        // no tab the pane must not consume the first press to request one. Back
+                        // below stays tied to focus actually held.
+                        val paneAcceptsPresses = paneIsFocused ||
+                            (design.maxPanes == 1 && !focusSuppressed && focusedRootId == null)
                         // Deepest layer is the active one; global focus can sit on a covered
                         // ancestor (launchPicker never moves it).
                         val activeId = (chain.lastOrNull()?.id ?: info.id).takeIf { paneIsFocused }
@@ -270,7 +290,8 @@ private fun PaneArea(
                             // Any occupant counts as focusing the pane, and every layer requests
                             // focus for the tab: a Focus() for a modal is silently dropped,
                             // which would leave another pane active.
-                            paneFocused = paneIsFocused,
+                            paneFocused = paneAcceptsPresses,
+                            backActive = paneIsFocused,
                             clickToFocus = clickToFocus,
                             onRequestPaneFocus = {
                                 onScreenAction(WorkspaceScreenAction.Focus(info.id))

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceModalDialog.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceModalDialog.kt
@@ -177,7 +177,7 @@ fun WorkspaceModalContent(
                     // The state placeholders offer a tab-manager button on single-pane layouts, which
                     // is meaningless inside a modal window: it would open the manager behind the
                     // dialog. Suppressed by taking the provider away instead of by faking
-                    // design.isSingle, which would perturb layout and insets.
+                    // design.hasNavigationRail, which would perturb layout and insets.
                     CompositionLocalProvider(LocalWorkspaceButtonProvider provides null) {
                         WorkspaceMapper(
                             info = workspace.asPaneInfo(),

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -128,7 +128,7 @@ fun WorkspaceScreen(
     // gates BOTH layouts: an empty pane next to an occupied one is not "no tabs yet".
     val firstTabTourEligible = !state.isRestoring && state.tabWorkspaces.isEmpty()
     // With zero tabs every pane is empty, so the first one is always the one to tag - no scan needed.
-    val firstTabTourPaneNumber: Int? = if (!firstTabTourEligible || design.isSingle) null else 1
+    val firstTabTourPaneNumber: Int? = if (!firstTabTourEligible || !design.hasNavigationRail) null else 1
 
     // Both empty-state surfaces scroll vertically, so on a short viewport the create/add-tab card
     // starts below the fold with no bounds to anchor on. The tour's prepareTarget brings it in
@@ -150,7 +150,7 @@ fun WorkspaceScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Main workspace content
-        if (!design.isSingle) {
+        if (design.hasNavigationRail) {
             AdaptiveWorkspaceLayout(
                 design = design,
                 workspaces = state.tabWorkspaces,
@@ -557,7 +557,7 @@ fun WorkspacesScreenHost(
         closedFeedback?.let { feedback ->
             // Only while the manager is down: the overlay covers the rail, and a bar offset over a
             // full-width grid would look misplaced.
-            val railVisible = design?.isSingle == false && !pageManagerState.isManagerOverlayVisible
+            val railVisible = design?.hasNavigationRail == true && !pageManagerState.isManagerOverlayVisible
             val bottomRailVisible = railVisible && design.railPlacement == WorkspaceDesign.RailPlacement.BOTTOM
             WorkspaceClosedUndoBarHost(
                 feedback = feedback,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -157,6 +157,7 @@ fun WorkspaceScreen(
                 selected = state.selected,
                 visibleSelected = state.visibleSelected,
                 focusedId = state.focused,
+                focusedRootId = state.focusedRootId,
                 dividerPositions = dividerPositions,
                 onDividerPositionsChange = { newPositions ->
                     dividerPositions = newPositions
@@ -164,8 +165,10 @@ fun WorkspaceScreen(
                 showPaneNumbers = showPaneNumbers,
                 showPaneOverlay = showPaneOverlay,
                 onPaneMenuToggle = { isOpen ->
-                    showPaneOverlay = isOpen
-                    showPaneNumbers = isOpen
+                    // One pane offers nothing to pick, so it gets neither the scrim nor a number.
+                    val show = isOpen && design.maxPanes > 1
+                    showPaneOverlay = show
+                    showPaneNumbers = show
                 },
                 onScreenAction = onScreenAction,
                 managerDialogStates = managerDialogStates,
@@ -281,9 +284,9 @@ fun WorkspaceScreen(
  * Shared by the screen and its host: the host draws chrome outside every pane (the close-undo bar)
  * and has to know where the rail is.
  *
- * The placement follows the window, not the layout: a portrait window that ends up single-pane also
- * says BOTTOM even though it composes no rail. Everything reading it therefore gates on the rail
- * being visible rather than on the placement alone.
+ * The placement follows the window, not the layout: a portrait window that ends up single-pane
+ * without the rail also says BOTTOM. Everything reading it therefore gates on the rail being visible
+ * rather than on the placement alone.
  */
 @Composable
 fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
@@ -300,6 +303,7 @@ fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
     val effectivePaneLayout = when (effectivePanelMode) {
         WorkspacePanelMode.AUTO -> windowSizeInfo.recommendedLayout
         WorkspacePanelMode.SINGLE -> WorkspaceDesign.Layout.SINGLE
+        WorkspacePanelMode.SINGLE_RAIL -> WorkspaceDesign.Layout.SINGLE
         WorkspacePanelMode.DUAL_VERTICAL -> WorkspaceDesign.Layout.DUAL_VERTICAL
         WorkspacePanelMode.DUAL_HORIZONTAL -> WorkspaceDesign.Layout.DUAL_HORIZONTAL
         WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT
@@ -314,6 +318,8 @@ fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
         } else {
             WorkspaceDesign.RailPlacement.BOTTOM
         },
+        hasNavigationRail = effectivePaneLayout != WorkspaceDesign.Layout.SINGLE ||
+            effectivePanelMode == WorkspacePanelMode.SINGLE_RAIL,
     )
 }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.twotone.Looks4
 import androidx.compose.material.icons.twotone.LooksOne
 import androidx.compose.material.icons.twotone.LooksTwo
 import androidx.compose.material.icons.twotone.RemoveCircleOutline
+import androidx.compose.material.icons.twotone.Visibility
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -340,8 +341,8 @@ fun WorkspaceNavigationRail(
         placement = placement,
         onRailThicknessChanged = onRailThicknessChanged,
     ) { listModifier ->
-        // Unconditional: the rail exists once per screen, and only in multi-pane - where the
-        // Templates page renders no Butler button of its own.
+        // Unconditional: the rail exists once per screen and is that screen's Butler button;
+        // pages composed beside it supply none of their own.
         WorkspaceButton(
             modifier = when (placement) {
                 RailPlacement.START -> Modifier.padding(vertical = RailSectionPadding)
@@ -834,7 +835,8 @@ private fun DraggableWorkspaceRailItem(
  *
  * [currentPaneIndex] is what decides whether the entry can be detached, so it has to come from the
  * assignments the layout renders - an entry parked on a pane this layout does not have shows no pane
- * number either, and offering to remove it from one would name a pane the user cannot see.
+ * number either, and offering to remove it from one would name a pane the user cannot see. At one
+ * pane detaching is never offered, since it would leave the only pane empty.
  */
 @Composable
 internal fun WorkspaceRailItemMenu(
@@ -855,13 +857,22 @@ internal fun WorkspaceRailItemMenu(
     ) {
         repeat(maxPanes) { paneIndex ->
             DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_pane_assign_action, paneIndex + 1)) },
+                text = {
+                    Text(
+                        if (maxPanes == 1) {
+                            stringResource(R.string.workspace_pane_show_action)
+                        } else {
+                            stringResource(R.string.workspace_pane_assign_action, paneIndex + 1)
+                        },
+                    )
+                },
                 leadingIcon = {
                     Icon(
-                        imageVector = when (paneIndex) {
-                            0 -> Icons.TwoTone.LooksOne
-                            1 -> Icons.TwoTone.LooksTwo
-                            2 -> Icons.TwoTone.Looks3
+                        imageVector = when {
+                            maxPanes == 1 -> Icons.TwoTone.Visibility
+                            paneIndex == 0 -> Icons.TwoTone.LooksOne
+                            paneIndex == 1 -> Icons.TwoTone.LooksTwo
+                            paneIndex == 2 -> Icons.TwoTone.Looks3
                             else -> Icons.TwoTone.Looks4
                         },
                         contentDescription = null,
@@ -873,7 +884,7 @@ internal fun WorkspaceRailItemMenu(
                 },
             )
         }
-        if (currentPaneIndex != null) {
+        if (currentPaneIndex != null && maxPanes > 1) {
             DropdownMenuItem(
                 modifier = Modifier.testTag(WorkspaceNavigationRailDefaults.UNASSIGN_TEST_TAG),
                 text = { Text(stringResource(R.string.workspace_pane_unassign_action)) },

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/layouts/SinglePaneLayout.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/layouts/SinglePaneLayout.kt
@@ -31,7 +31,7 @@ internal fun SinglePaneLayout(
     val ws1 = selected[0]
     WorkspacePaneWrapper(
         modifier = Modifier.fillMaxSize(),
-        isFocused = focusedTabId == ws1,
+        isFocused = focusedTabId == ws1?.id,
         showFocusBorder = false, // Single pane doesn't need focus border
         onFocus = { ws1?.let { onTabFocus(it.id) } },
         paneNumber = if (showPaneNumbers) 1 else null,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,6 +368,7 @@
 
     <!-- Workspace Navigation Rail -->
     <string name="workspace_pane_assign_action">Assign to pane %1$d</string>
+    <string name="workspace_pane_show_action">Show</string>
     <string name="workspace_pane_close_action">Close</string>
     <string name="workspace_pane_unassign_action">Remove from pane</string>
     <string name="workspace_dragging_description">Dragging</string>

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerOverlayBackDispatchTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/ManagerOverlayBackDispatchTest.kt
@@ -111,6 +111,7 @@ class ManagerOverlayBackDispatchTest : ComposeTest() {
                             workspaces = state.tabWorkspaces,
                             selected = mapOf(0 to tabInfo.asPaneInfo()),
                             focusedId = tabId,
+                            focusedRootId = tabId,
                             dividerPositions = DividerPositions(),
                             onDividerPositionsChange = {},
                             showPaneNumbers = false,

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailSinglePaneTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailSinglePaneTest.kt
@@ -1,0 +1,202 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceNavigationRailDefaults
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+
+/**
+ * The single-with-rail panel mode: one pane, rendered through the adaptive layout so the rail is
+ * composed beside it and follows the window's placement rule like any multi-pane layout does.
+ *
+ * The plain single mode is asserted alongside it, because that one still routes to the classic
+ * pager and must keep composing no rail at all.
+ */
+class WorkspaceRailSinglePaneTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val firstTab = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "Explorer".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    private val secondTab = Workspace.Info(
+        id = Workspace.Id(),
+        type = Workspace.Type.EXPLORER,
+        title = "Downloads".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    /** The real page instantiates Hilt ViewModels; this one only marks out the pane's bounds. */
+    private object PaneMarkerHost : WorkspacePageHostEntry {
+        @Composable
+        override fun Content(id: Workspace.Id, design: WorkspaceDesign) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(PANE_TAG),
+            )
+        }
+
+        @Composable
+        override fun Overlays(id: Workspace.Id, design: WorkspaceDesign) = Unit
+    }
+
+    private fun state(mode: WorkspacePanelMode) = WorkspacesViewModel.State(
+        state = WorkspaceRemote.State(
+            infos = listOf(firstTab, secondTab),
+            portraitPanelMode = mode,
+            landscapePanelMode = mode,
+        ),
+        focusedWorkspace = firstTab.id,
+        selectedWorkspaces = mapOf(0 to firstTab.id),
+        visiblePaneSelections = mapOf(0 to firstTab.id),
+        isUpgraded = true,
+        swipeGesturesEnabled = false,
+        onDemandWorkspaceCreation = false,
+        currentPaneCount = 1,
+    )
+
+    private fun setScreen(
+        mode: WorkspacePanelMode = WorkspacePanelMode.SINGLE_RAIL,
+        onScreenAction: (WorkspaceScreenAction) -> Unit = {},
+    ) {
+        // The Butler button's mascot animates on an endless loop, which never lets the clock idle.
+        // Nothing asserted here needs frames.
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalWorkspacePageHosts provides mapOf(Workspace.Type.EXPLORER to PaneMarkerHost),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(ROOT_TAG),
+                    ) {
+                        WorkspaceScreen(
+                            state = state(mode),
+                            managerDialogStates = emptyMap(),
+                            onScreenAction = onScreenAction,
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun assertTheSolePaneHasHeight() {
+        val panes = composeTestRule.onAllNodesWithTag(PANE_TAG, useUnmergedTree = true)
+        panes.assertCountEquals(1)
+        val bounds = panes[0].getUnclippedBoundsInRoot()
+        (bounds.bottom - bounds.top > 0.dp) shouldBe true
+    }
+
+    @Test
+    @Config(qualifiers = "w720dp-h1280dp-port")
+    fun `a portrait window puts the rail along the bottom edge`() {
+        setScreen()
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val rail = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+
+        rail.bottom shouldBe root.bottom
+        rail.left shouldBe root.left
+        rail.right shouldBe root.right
+        (rail.top > root.top) shouldBe true
+
+        assertTheSolePaneHasHeight()
+    }
+
+    @Test
+    @Config(qualifiers = "w1280dp-h720dp-land")
+    fun `a landscape window keeps the rail on the start edge`() {
+        setScreen()
+
+        val root = composeTestRule.onNodeWithTag(ROOT_TAG).getUnclippedBoundsInRoot()
+        val rail = composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+
+        rail.left shouldBe root.left
+        rail.top shouldBe root.top
+        rail.bottom shouldBe root.bottom
+        (rail.right < root.right) shouldBe true
+
+        assertTheSolePaneHasHeight()
+    }
+
+    @Test
+    @Config(qualifiers = "w720dp-h1280dp-port")
+    fun `the plain single mode still composes no rail`() {
+        setScreen(mode = WorkspacePanelMode.SINGLE)
+
+        composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .assertDoesNotExist()
+    }
+
+    /**
+     * With one pane there is nothing to swap the entry against, so the menu's single assign item
+     * selects the tab into the pane instead of rearranging assignments around it.
+     */
+    @Test
+    @Config(qualifiers = "w720dp-h1280dp-port")
+    fun `Show selects the entry into the only pane`() {
+        val actions = mutableListOf<WorkspaceScreenAction>()
+        setScreen(onScreenAction = { actions.add(it) })
+        // The reveal scroll holds the list's scroll mutex until its first frame; a touch on a
+        // scrolling list starts a drag instead of a click.
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithTag(WorkspaceNavigationRailDefaults.ITEM_TEST_TAG)[1]
+            .performClick()
+        // The clock is parked, so a state change needs a frame before it has recomposed.
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.workspace_pane_show_action))
+            .performClick()
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+
+        actions shouldContain WorkspaceScreenAction.Select(secondTab.id)
+        actions.none { it is WorkspaceScreenAction.SelectMultiple } shouldBe true
+    }
+
+    companion object {
+        private const val ROOT_TAG = "rail.single.root"
+        private const val PANE_TAG = "rail.single.pane"
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceScreenTourEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceScreenTourEligibilityTest.kt
@@ -215,6 +215,15 @@ class WorkspaceScreenTourEligibilityTest : ComposeTest() {
         prepareJob.cancel()
     }
 
+    /** The single-with-rail layout renders through the adaptive route, which tags its own panes. */
+    @Test
+    fun `the create-tab anchor exists in the single-with-rail layout`() {
+        val harness = setScreen(state(panelMode = WorkspacePanelMode.SINGLE_RAIL))
+
+        harness.tourAccess.started shouldBe listOf(FirstTabTour.id)
+        harness.registry.has(FirstTabTour.CREATE_TAB_TARGET) shouldBe true
+    }
+
     @Test
     fun `the create-tab anchor survives a single to dual layout change`() {
         // A layout-specific target id would strand a running tour on rotation or a panel-mode

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/AdaptivePaneFocusFallbackTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/AdaptivePaneFocusFallbackTest.kt
@@ -1,0 +1,272 @@
+package eu.darken.butler.workspace.ui.workspaces.adaptive
+
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.down
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.up
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
+import eu.darken.butler.workspace.ui.LocalWorkspacePagerVisibility
+import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.WorkspaceVisibilityTracker
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
+import eu.darken.butler.workspace.ui.workspaces.AdaptiveWorkspaceLayout
+import eu.darken.butler.workspace.ui.workspaces.asPaneInfo
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The single-with-rail layout while focus resolves to no tab at all.
+ *
+ * That state is reachable and nothing repairs it on its own - after a pane-local modal closes, after
+ * picker-driven tab creation, after a session restore - and the pane boundary swallows every press
+ * to request a focus that never arrives, leaving the visible pane tap-dead. With only one pane
+ * nobody else can hold focus, so the pane accepts presses, while Back stays tied to focus that is
+ * actually held: no pane may arm a back handler while nothing is focused.
+ */
+class AdaptivePaneFocusFallbackTest : ComposeTest() {
+
+    private val tabA = Workspace.Id()
+
+    private val infoA = Workspace.Info(
+        id = tabA,
+        type = Workspace.Type.EXPLORER,
+        title = "Tab ${tabA.shortTag}".toCaString(),
+        lifecycleState = Workspace.LifecycleState.Ready,
+    )
+
+    /**
+     * Stands in for a workspace page: clickable content plus a back handler of its own, which is
+     * what every real page installs. Both are what the two questions here are asked of.
+     */
+    private class RecordingHost : WorkspacePageHostEntry {
+        val clicks = mutableMapOf<Workspace.Id, Int>()
+        val backPresses = mutableMapOf<Workspace.Id, Int>()
+
+        @Composable
+        override fun Content(id: Workspace.Id, design: WorkspaceDesign) {
+            WorkspaceBackHandler(enabled = true) { backPresses[id] = (backPresses[id] ?: 0) + 1 }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(tagFor(id))
+                    .clickable { clicks[id] = (clicks[id] ?: 0) + 1 },
+            )
+        }
+
+        @Composable
+        override fun Overlays(id: Workspace.Id, design: WorkspaceDesign) = Unit
+
+        companion object {
+            fun tagFor(id: Workspace.Id) = "page-${id.shortTag}"
+        }
+    }
+
+    @Composable
+    private fun Container(
+        focusedId: Workspace.Id?,
+        focusedRootId: Workspace.Id?,
+        host: RecordingHost,
+        onReachedAppRoot: () -> Unit = {},
+    ) {
+        PreviewWrapper {
+            CompositionLocalProvider(
+                LocalWorkspacePageHosts provides mapOf(Workspace.Type.EXPLORER to host),
+                LocalWorkspacePagerVisibility provides WorkspaceVisibilityTracker(),
+            ) {
+                // Stands in for MainActivity's press-back-again-to-exit prompt: registered above
+                // everything else, so it only runs once nothing in the workspace tree consumed the
+                // press.
+                BackHandler(enabled = true) { onReachedAppRoot() }
+
+                AdaptiveWorkspaceLayout(
+                    design = WorkspaceDesign(
+                        layout = WorkspaceDesign.Layout.SINGLE,
+                        hasNavigationRail = true,
+                    ),
+                    workspaces = listOf(infoA),
+                    selected = mapOf(0 to infoA.asPaneInfo()),
+                    focusedId = focusedId,
+                    focusedRootId = focusedRootId,
+                    dividerPositions = DividerPositions(),
+                    onDividerPositionsChange = {},
+                    showPaneNumbers = false,
+                    showPaneOverlay = false,
+                    onPaneMenuToggle = {},
+                    onScreenAction = {},
+                    managerDialogStates = emptyMap(),
+                    bannerStates = emptyMap(),
+                    onDismissBanner = {},
+                    clickToFocus = true,
+                    onShareError = { _, _ -> },
+                )
+            }
+        }
+    }
+
+    /** The rail's mascot animates on an endless loop, which never lets the clock idle. */
+    private fun parkTheClock() {
+        composeTestRule.mainClock.autoAdvance = false
+    }
+
+    private fun pressThePage() {
+        // Pressed near the corner rather than via performClick(), which targets the node's centre.
+        composeTestRule.onNodeWithTag(RecordingHost.tagFor(tabA)).performTouchInput {
+            down(Offset(5f, 5f))
+            up()
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * Nothing is focused, so no pane can claim the press for itself - and the request the boundary
+     * makes instead is dropped on the floor here, exactly as it is in production while the state
+     * that produced this focus keeps being republished.
+     */
+    @Test
+    fun `a press reaches the sole pane while focus names no tab`() {
+        val host = RecordingHost()
+        parkTheClock()
+
+        composeTestRule.setContent {
+            Container(focusedId = null, focusedRootId = null, host = host)
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(RecordingHost.tagFor(tabA)).assertIsDisplayed()
+
+        pressThePage()
+
+        composeTestRule.runOnIdle { host.clicks[tabA] shouldBe 1 }
+    }
+
+    /**
+     * The other reachable shape of the same state: focus names a workspace whose caller chain does
+     * not resolve, so it belongs to no tab and no pane can be focused by it either.
+     */
+    @Test
+    fun `a press reaches the sole pane while focus names a dangling child`() {
+        val host = RecordingHost()
+        parkTheClock()
+
+        composeTestRule.setContent {
+            Container(focusedId = Workspace.Id(), focusedRootId = null, host = host)
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(RecordingHost.tagFor(tabA)).assertIsDisplayed()
+
+        pressThePage()
+
+        composeTestRule.runOnIdle { host.clicks[tabA] shouldBe 1 }
+    }
+
+    /**
+     * The other half of the split: accepting presses must not arm anything Back can reach. A page
+     * that answered Back here would navigate or close a workspace that nothing has focused, so the
+     * press belongs to the app root.
+     */
+    @Test
+    fun `back is not dispatched into the sole pane while focus names no tab`() {
+        val host = RecordingHost()
+        var reachedAppRoot = 0
+        var dispatcher: OnBackPressedDispatcher? = null
+        parkTheClock()
+
+        composeTestRule.setContent {
+            dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+            Container(
+                focusedId = null,
+                focusedRootId = null,
+                host = host,
+                onReachedAppRoot = { reachedAppRoot++ },
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(RecordingHost.tagFor(tabA)).assertIsDisplayed()
+
+        composeTestRule.runOnIdle { dispatcher!!.onBackPressed() }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            (host.backPresses[tabA] ?: 0) shouldBe 0
+            reachedAppRoot shouldBe 1
+        }
+    }
+
+    /**
+     * Control for the press tests: the very same press on the very same page is accepted once focus
+     * really is on its tab, so "the press arrived" there is about the focus state and not about the
+     * press location happening to land on something that always accepts.
+     */
+    @Test
+    fun `a press reaches the sole pane once focus names its tab`() {
+        val host = RecordingHost()
+        parkTheClock()
+
+        composeTestRule.setContent {
+            Container(focusedId = tabA, focusedRootId = tabA, host = host)
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(RecordingHost.tagFor(tabA)).assertIsDisplayed()
+
+        pressThePage()
+
+        composeTestRule.runOnIdle { host.clicks[tabA] shouldBe 1 }
+    }
+
+    /**
+     * Control for the Back test: the very same page's handler does answer Back once focus really is
+     * on its tab, so "nothing answered" there is about the focus state and not about the page never
+     * having registered a handler.
+     */
+    @Test
+    fun `back reaches the sole pane once focus names its tab`() {
+        val host = RecordingHost()
+        var reachedAppRoot = 0
+        var dispatcher: OnBackPressedDispatcher? = null
+        var focused by mutableStateOf<Workspace.Id?>(null)
+        parkTheClock()
+
+        composeTestRule.setContent {
+            dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+            Container(
+                focusedId = focused,
+                focusedRootId = focused,
+                host = host,
+                onReachedAppRoot = { reachedAppRoot++ },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle { focused = tabA }
+        // The clock is parked, so a state change needs a frame before it has recomposed.
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle { dispatcher!!.onBackPressed() }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            host.backPresses[tabA] shouldBe 1
+            reachedAppRoot shouldBe 0
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailItemMenuTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceRailItemMenuTest.kt
@@ -24,15 +24,15 @@ class WorkspaceRailItemMenuTest : ComposeTest() {
 
     private val calls = mutableListOf<String>()
 
-    private fun renderMenu(currentPaneIndex: Int?) {
+    private fun renderMenu(currentPaneIndex: Int?, maxPanes: Int = 2) {
         composeTestRule.setContent {
             PreviewWrapper {
                 WorkspaceRailItemMenu(
                     expanded = true,
-                    maxPanes = 2,
+                    maxPanes = maxPanes,
                     currentPaneIndex = currentPaneIndex,
                     onDismiss = { calls.add("dismiss") },
-                    onAssign = { calls.add("assign") },
+                    onAssign = { calls.add("assign:$it") },
                     onUnassign = { calls.add("unassign") },
                     onRename = { calls.add("rename") },
                     onClose = { calls.add("close") },
@@ -47,6 +47,8 @@ class WorkspaceRailItemMenuTest : ComposeTest() {
     )
 
     private val closeLabel get() = context.getString(R.string.workspace_pane_close_action)
+
+    private val showLabel get() = context.getString(R.string.workspace_pane_show_action)
 
     @Test
     fun `an entry in a pane can be removed from it`() {
@@ -87,6 +89,32 @@ class WorkspaceRailItemMenuTest : ComposeTest() {
         composeTestRule.onNodeWithText(assignLabel(1)).assertExists()
         composeTestRule.onNodeWithText(assignLabel(2)).assertExists()
         composeTestRule.onNodeWithText(closeLabel).assertExists()
+    }
+
+    /** One pane names no pane number, so the entry that puts a tab in it just says what it does. */
+    @Test
+    fun `at one pane the assign entry reads Show`() {
+        renderMenu(currentPaneIndex = 0, maxPanes = 1)
+
+        composeTestRule.onNodeWithText(showLabel).assertExists()
+        composeTestRule.onNodeWithText(assignLabel(1)).assertDoesNotExist()
+    }
+
+    /** Detaching the sole pane's occupant would leave the layout with nothing to render. */
+    @Test
+    fun `at one pane an entry cannot be removed from its pane`() {
+        renderMenu(currentPaneIndex = 0, maxPanes = 1)
+
+        composeTestRule.onNodeWithTag(UNASSIGN_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `Show dismisses the menu then assigns the pane`() {
+        renderMenu(currentPaneIndex = null, maxPanes = 1)
+
+        composeTestRule.onNodeWithText(showLabel).performClick()
+
+        calls shouldBe listOf("dismiss", "assign:0")
     }
 
     companion object {


### PR DESCRIPTION
## What changed

A new layout mode, "Single with tab rail", is available in Settings under Tabs for both portrait and landscape. It shows one pane like the plain Single layout, but keeps the tab rail from the multi-pane layouts on screen: at the bottom in portrait, along the start edge in landscape. Tabs are switched from the rail (tap an entry, then "Show") instead of by swiping; the rail entry menu at one pane offers Show, Rename and Close, and no longer dims the pane while open. The mode is opt-in and never chosen by Auto.

Alongside it, two placement rules changed for every layout, because the new mode exposed them: after a layout shrinks to one pane (rotation from a two-pane landscape, or a session saved in a wider layout), the tab the user was working in is the one shown, and a tab detached with "Remove from pane" stays detached when the layout re-reports itself (returning from Settings, rotation).

Refs #83

## Technical Context

- `WorkspaceDesign.isSingle` is gone; `hasNavigationRail` (default `layout != SINGLE`, required true for multi-pane) is what the 21 chrome/routing sites gate on, so a page composed beside the rail never adds its own Butler button. The Searcher drag site uses `maxPanes > 1` instead.
- The page manager places a focused tab that sits on a pane index the current layout does not render: into an empty rendered pane, by swapping it into the pane at one pane, otherwise by moving focus to a rendered occupant. Applied on the first pane-count report, on real count changes, after a close, and on session restore once a count has been reported.
- Session restore reads the repository's current workspaces through the new `WorkspaceRemote.peekInfos()` rather than the replayed state snapshot, which can predate a just-created tab; an earlier attempt that waited on the flow could hang if the tab was closed mid-restore.
- The sole pane accepts presses while focus resolves to no tab (the classic pager's resting-page rule), while Back stays tied to focus actually held.
- The rail's "+" button is untouched here; its one-pane behaviour comes from #161. Review focus: `WorkspacePageManager.withFocusRendered` and `setPaneCount`, and the ten one-token toolbar conversions.
