### PR TITLE
IO: Fix files not opening in storage provided by other apps

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFDocFile.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFDocFile.kt
@@ -167,6 +167,19 @@ data class SAFDocFile(
         val lastModified: Instant,
     )
 
+    data class ChildEntry(
+        val docFile: SAFDocFile,
+        /** The display name the cursor carried, null when the provider left the column empty. */
+        val name: String?,
+        val lookupData: LookupData,
+    )
+
+    /** [partial] = the provider flagged this listing as still loading or errored; entries may be missing. */
+    data class ChildListing(
+        val entries: List<ChildEntry>,
+        val partial: Boolean,
+    )
+
     fun getLookupData(): LookupData = resolver.query(
         uri,
         arrayOf(
@@ -267,10 +280,10 @@ data class SAFDocFile(
      * Instead of N+1 queries (1 for listing, N for metadata), this uses just 1 query.
      * For 10,000 files, this reduces ~10,001 queries to 1 query.
      *
-     * @return List of pairs containing the file and its lookup data
+     * @return the children with their handles, display names and metadata
      */
     @SuppressLint("Recycle")
-    fun listFilesWithLookupData(): List<Pair<SAFDocFile, LookupData>> {
+    fun listFilesWithLookupData(): ChildListing {
         val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(uri, DocumentsContract.getDocumentId(uri))
 
         val results = resolver.query(
@@ -279,17 +292,19 @@ data class SAFDocFile(
                 DocumentsContract.Document.COLUMN_DOCUMENT_ID,
                 DocumentsContract.Document.COLUMN_MIME_TYPE,
                 DocumentsContract.Document.COLUMN_SIZE,
-                DocumentsContract.Document.COLUMN_LAST_MODIFIED
+                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
             ),
             null,
             null,
             null
         )?.useQuietly { cursor ->
-            cursor.asSequence().map {
+            val entries = cursor.asSequence().map {
                 val documentId = it.getString(0)
                 val mimeType = it.getString(1)
                 val size = if (!it.isNull(2)) it.getLong(2) else 0L
                 val lastModifiedMs = if (!it.isNull(3)) it.getLong(3) else 0L
+                val displayName = if (!it.isNull(4)) it.getString(4) else null
 
                 val fileUri = DocumentsContract.buildDocumentUriUsingTree(uri, documentId)
                 val docFile = SAFDocFile(context, resolver, fileUri)
@@ -303,8 +318,16 @@ data class SAFDocFile(
                     lastModified = Instant.fromEpochMilliseconds(lastModifiedMs)
                 )
 
-                docFile to lookupData
+                ChildEntry(docFile = docFile, name = displayName, lookupData = lookupData)
             }.toList()
+
+            // Read inside the block, the cursor is closed on exit.
+            val extras = cursor.extras
+            ChildListing(
+                entries = entries,
+                partial = extras.getBoolean(DocumentsContract.EXTRA_LOADING, false) ||
+                    extras.getString(DocumentsContract.EXTRA_ERROR) != null,
+            )
         }
 
         requireNotNull(results) { "Unable to list files for $uri" }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
@@ -155,6 +155,9 @@ class SAFFileSystemOps @Inject constructor(
     /** Invalidate a path and all cached descendants (stale after directory move/delete). */
     private fun invalidateSubtree(path: SAFPath) {
         invalidatePath(path)
+        // The parent's listing holds this path's handle under the parent's key, so dropping only
+        // the path's own keys would leave it resolvable through the listing.
+        path.parent?.let { childrenCache.remove(it) }
         val isDescendant = { candidate: SAFPath ->
             candidate.treeRootUri == path.treeRootUri &&
                 candidate.segments.size > path.segments.size &&
@@ -221,7 +224,10 @@ class SAFFileSystemOps @Inject constructor(
         byPath.forEach { (childPath, entries) ->
             if (entries.size > 1) {
                 log(TAG, WARN) { "cacheChildren(): $parentPath lists '${childPath.name}' ${entries.size} times" }
-                invalidatePath(childPath)
+                // Descendants were resolved through a name that is now ambiguous; their handles
+                // cannot stand. Runs before childrenCache[parentPath] is written below, which the
+                // subtree invalidation would otherwise delete.
+                invalidateSubtree(childPath)
                 duplicated.add(childPath)
                 return@forEach
             }
@@ -245,7 +251,9 @@ class SAFFileSystemOps @Inject constructor(
         val cacheEntry = ChildrenEntry(
             resolved = resolved,
             duplicated = duplicated,
-            partial = listing.partial,
+            // A row we could not name is indexed under a URI-derived fallback, so this listing
+            // cannot prove any name absent.
+            partial = listing.partial || listing.entries.any { it.name == null },
             cachedAt = now,
         )
         childrenCache[parentPath] = cacheEntry

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
@@ -13,6 +13,7 @@ import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.errors.PathAlreadyExistsException
+import eu.darken.butler.common.files.errors.PathNotFoundException
 import eu.darken.butler.common.files.errors.ReadException
 import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.metadata.FileSystem
@@ -112,6 +113,24 @@ class SAFFileSystemOps @Inject constructor(
         }
     )
 
+    private data class ChildrenEntry(
+        /** Child paths the listing carried exactly once, to the handle the provider returned. */
+        val resolved: Map<SAFPath, SAFDocFile>,
+        /** Child paths the listing carried more than once. */
+        val duplicated: Set<SAFPath>,
+        /** The provider flagged the listing as still loading or errored. */
+        val partial: Boolean,
+        val cachedAt: Instant,
+    )
+
+    private val childrenCache = java.util.Collections.synchronizedMap(
+        object : LinkedHashMap<SAFPath, ChildrenEntry>(INITIAL_CHILDREN_CACHE_SIZE, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<SAFPath, ChildrenEntry>?): Boolean {
+                return size > MAX_CHILDREN_CACHE_PARENTS
+            }
+        }
+    )
+
     // Attribute operation support cache (null = unknown, true = supported, false = not supported)
     @Volatile private var supportsSetModifiedAt: Boolean? = null
     @Volatile private var supportsSetPermissions: Boolean? = null
@@ -124,11 +143,13 @@ class SAFFileSystemOps @Inject constructor(
     private fun cacheCreated(path: SAFPath, docFile: SAFDocFile) {
         docFileCache[path] = CacheEntry(docFile, Clock.System.now())
         lookupCache.remove(path)
+        path.parent?.let { childrenCache.remove(it) }
     }
 
     private fun invalidatePath(path: SAFPath) {
         docFileCache.remove(path)
         lookupCache.remove(path)
+        childrenCache.remove(path)
     }
 
     /** Invalidate a path and all cached descendants (stale after directory move/delete). */
@@ -141,38 +162,176 @@ class SAFFileSystemOps @Inject constructor(
         }
         synchronized(docFileCache) { docFileCache.keys.removeAll { isDescendant(it) } }
         synchronized(lookupCache) { lookupCache.keys.removeAll { isDescendant(it) } }
+        synchronized(childrenCache) { childrenCache.keys.removeAll { isDescendant(it) } }
     }
 
     /** Drop the cached lookup of a path's parent (child count/mtime changed). */
     private fun invalidateParentLookup(path: SAFPath) {
-        path.parent?.let { lookupCache.remove(it) }
+        path.parent?.let {
+            lookupCache.remove(it)
+            childrenCache.remove(it)
+        }
     }
 
-    private fun SAFPath.resolveDocFile(): SAFDocFile {
+    /** Fresh cache entry for this path, or null; an expired entry is evicted on the way. */
+    private fun SAFPath.cachedDocFile(now: Instant): SAFDocFile? {
+        val cached = docFileCache[this] ?: return null
+
+        val age = now - cached.cachedAt
+        if (age < CACHE_TTL) {
+            if (Bugs.isTrace) log(TAG, VERBOSE) { "resolveDocFile() $this -> ${cached.docFile} (cached)" }
+            return cached.docFile
+        }
+
+        // Expired entry
+        docFileCache.remove(this)
+        return null
+    }
+
+    /**
+     * Lists [parentDocFile] once, records the listing under [parentPath], and returns it.
+     *
+     * @return every child in provider order (duplicates included) plus the recorded listing
+     */
+    private suspend fun cacheChildren(
+        parentPath: SAFPath,
+        parentDocFile: SAFDocFile,
+        now: Instant,
+    ): Pair<List<SAFPath>, ChildrenEntry> {
+        // Batch query: files + metadata in one go
+        val listing = parentDocFile.listFilesWithLookupData()
+
+        val childPaths = mutableListOf<SAFPath>()
+        val byPath = mutableMapOf<SAFPath, MutableList<SAFDocFile.ChildEntry>>()
+
+        listing.entries.forEachIndexed { index, entry ->
+            if (index % 50 == 0) currentCoroutineContext().ensureActive()
+
+            val name = entry.name ?: entry.docFile.uri.pathSegments.last().split('/').last()
+            val childPath = parentPath.child(name)
+            childPaths.add(childPath)
+            byPath.getOrPut(childPath) { mutableListOf() }.add(entry)
+        }
+
+        // Grouped before publishing: publishing per row would let the last of two same-named
+        // documents win, hiding an ambiguity that resolution has to refuse to answer.
+        val resolved = mutableMapOf<SAFPath, SAFDocFile>()
+        val duplicated = mutableSetOf<SAFPath>()
+
+        byPath.forEach { (childPath, entries) ->
+            if (entries.size > 1) {
+                log(TAG, WARN) { "cacheChildren(): $parentPath lists '${childPath.name}' ${entries.size} times" }
+                invalidatePath(childPath)
+                duplicated.add(childPath)
+                return@forEach
+            }
+
+            val entry = entries.single()
+            resolved[childPath] = entry.docFile
+
+            // Populate lookup cache with batch-queried metadata (basic only - no extended)
+            val lookup = SAFPathLookup(
+                lookedUp = childPath,
+                fileType = entry.lookupData.fileType,
+                size = entry.lookupData.size,
+                modifiedAt = entry.lookupData.lastModified,
+                ownership = null, // Not available in batch listing
+                permissions = null, // Not available in batch listing
+                createdAt = null, // SAF doesn't support creation time
+            )
+            lookupCache[childPath] = LookupCacheEntry(lookup, now)
+        }
+
+        val cacheEntry = ChildrenEntry(
+            resolved = resolved,
+            duplicated = duplicated,
+            partial = listing.partial,
+            cachedAt = now,
+        )
+        childrenCache[parentPath] = cacheEntry
+
+        return childPaths to cacheEntry
+    }
+
+    private suspend fun SAFPath.resolveDocFile(): SAFDocFile =
+        resolveDocFileOrNull() ?: throw PathNotFoundException(this)
+
+    /**
+     * Null ONLY when a complete, unambiguous parent listing proves this path absent - the one answer
+     * that may authorize a create, a delete-returns-false or an [Existence.ABSENT].
+     *
+     * A listing that cannot answer - flagged as loading/errored, or carrying the name more than once -
+     * raises instead, so a transient provider hiccup never reads as absence.
+     *
+     * Document ids are opaque by contract, so only [EXTERNAL_STORAGE_AUTHORITY] keeps the zero-query
+     * synthesized resolution; every other authority walks the granted tree through the handles the
+     * provider itself handed out.
+     */
+    private suspend fun SAFPath.resolveDocFileOrNull(): SAFDocFile? {
         val now = Clock.System.now()
 
-        // Check cache first
-        val cached = docFileCache[this]
-        if (cached != null) {
-            val age = now - cached.cachedAt
-            if (age < CACHE_TTL) {
-                if (Bugs.isTrace) log(TAG, VERBOSE) { "resolveDocFile() $this -> ${cached.docFile} (cached)" }
-                return cached.docFile
-            } else {
-                // Expired entry
-                docFileCache.remove(this)
+        cachedDocFile(now)?.let { return it }
+
+        if (treeRootUri.authority == EXTERNAL_STORAGE_AUTHORITY) {
+            val docFile = locationManager.getDocFileFor(this)
+            if (Bugs.isTrace) log(TAG, VERBOSE) { "resolveDocFile() $this -> $docFile" }
+            if (docFile != null) docFileCache[this] = CacheEntry(docFile, now)
+            return docFile ?: throw MissingUriPermissionException(path = this)
+        }
+
+        val match = locationManager.findPermissionFor(this) ?: throw MissingUriPermissionException(path = this)
+        val rootPath = SAFPath.build(match.location.treeUri)
+        val missing = match.missingSegments
+        fun key(i: Int) = if (i == 0) rootPath else rootPath.child(*missing.take(i).toTypedArray())
+
+        val cachedAncestor = (missing.size - 1 downTo 1).firstNotNullOfOrNull { i ->
+            key(i).cachedDocFile(now)?.let { i to it }
+        }
+        val start = cachedAncestor?.first ?: 0
+        var current = cachedAncestor?.second ?: run {
+            val root = locationManager.getDocFileFor(rootPath) ?: throw MissingUriPermissionException(path = this)
+            docFileCache[rootPath] = CacheEntry(root, now)
+            root
+        }
+
+        for (j in start until missing.size) {
+            val parentPath = key(j)
+            val wanted = key(j + 1)
+
+            val listing = childrenCache[parentPath]?.takeIf { now - it.cachedAt < CACHE_TTL }
+                ?: run {
+                    childrenCache.remove(parentPath)
+                    cacheChildren(parentPath, current, now).second
+                }
+
+            if (wanted in listing.duplicated) {
+                throw ReadException(
+                    "Provider listed more than one child named '${missing[j]}' under $parentPath",
+                    this,
+                )
             }
+
+            val child = listing.resolved[wanted]
+            if (child != null) {
+                current = child
+                docFileCache[wanted] = CacheEntry(child, now)
+                continue
+            }
+
+            if (listing.partial) {
+                throw ReadException(
+                    "Provider listing of $parentPath was incomplete; cannot prove '${missing[j]}' absent",
+                    this,
+                )
+            }
+
+            // An absent path is never cached, so a document another app creates is found on the next miss.
+            return null
         }
 
-        // Cache miss or expired - fetch fresh
-        val docFile = locationManager.getDocFileFor(this)
-        if (Bugs.isTrace) log(TAG, VERBOSE) { "resolveDocFile() $this -> $docFile" }
-
-        if (docFile != null) {
-            docFileCache[this] = CacheEntry(docFile, now)
-        }
-
-        return docFile ?: throw MissingUriPermissionException(path = this)
+        if (Bugs.isTrace) log(TAG, VERBOSE) { "resolveDocFile() $this -> $current" }
+        docFileCache[this] = CacheEntry(current, now)
+        return current
     }
 
     private fun SAFDocFile.performLookup(path: SAFPath, options: LookupOptions): SAFPathLookup {
@@ -273,32 +432,7 @@ class SAFFileSystemOps @Inject constructor(
         val docFile = path.resolveDocFile()
         log(TAG, VERBOSE) { "listFiles($path) -> $docFile" }
 
-        val now = Clock.System.now()
-
-        // Use batch query to get files + metadata in one query
-        val filesWithMetadata = docFile.listFilesWithLookupData()
-
-        // Map to SAFPath and populate lookup cache
-        filesWithMetadata.mapIndexed { index, (file, lookupData) ->
-            if (index % 50 == 0) currentCoroutineContext().ensureActive()
-
-            val name = file.name ?: file.uri.pathSegments.last().split('/').last()
-            val childPath = path.child(name)
-
-            // Populate lookup cache with batch-queried metadata (basic only - no extended)
-            val lookup = SAFPathLookup(
-                lookedUp = childPath,
-                fileType = lookupData.fileType,
-                size = lookupData.size,
-                modifiedAt = lookupData.lastModified,
-                ownership = null, // Not available in batch listing
-                permissions = null, // Not available in batch listing
-                createdAt = null, // SAF doesn't support creation time
-            )
-            lookupCache[childPath] = LookupCacheEntry(lookup, now)
-
-            childPath
-        }
+        cacheChildren(path, docFile, Clock.System.now()).first
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
@@ -307,9 +441,11 @@ class SAFFileSystemOps @Inject constructor(
     }
 
     override suspend fun exists(path: SAFPath): Boolean = try {
-        val docFile = path.resolveDocFile()
+        val docFile = path.resolveDocFileOrNull()
         log(TAG, VERBOSE) { "exists(): $path -> $docFile" }
-        docFile.exists
+        docFile?.exists ?: false
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         throw ReadException(path = path, cause = e)
     }
@@ -318,20 +454,22 @@ class SAFFileSystemOps @Inject constructor(
      * Uses [SAFDocFile.existsStrict], which addresses the provider through a client: no client means
      * nobody was asked, while [SAFDocFile.exists] cannot tell that from a document that is gone.
      */
-    override suspend fun existsStrict(path: SAFPath): Existence = try {
-        val docFile = path.resolveDocFile()
-        if (docFile.existsStrict()) Existence.PRESENT else Existence.ABSENT
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        log(TAG, WARN) { "existsStrict($path) could not be answered: ${e.asLog()}" }
-        Existence.UNKNOWN
+    override suspend fun existsStrict(path: SAFPath): Existence {
+        return try {
+            val docFile = path.resolveDocFileOrNull() ?: return Existence.ABSENT
+            if (docFile.existsStrict()) Existence.PRESENT else Existence.ABSENT
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "existsStrict($path) could not be answered: ${e.asLog()}" }
+            Existence.UNKNOWN
+        }
     }
 
     override suspend fun delete(path: SAFPath, recursive: Boolean): Boolean {
         return try {
             log(TAG, VERBOSE) { "delete(recursive=$recursive): $path" }
-            val docFile = path.resolveDocFile()
+            val docFile = path.resolveDocFileOrNull() ?: return false
 
             if (!docFile.exists) {
                 return false
@@ -500,16 +638,13 @@ class SAFFileSystemOps @Inject constructor(
         // If parent is tree root (no segments), it always exists
         if (parentPath.segments.isEmpty()) return
 
-        // Try to resolve the parent DocFile
-        val parentDocFile = try {
-            parentPath.resolveDocFile()
-        } catch (e: MissingUriPermissionException) {
-            // Permission issue - can't proceed
-            throw e
-        } catch (e: Exception) {
-            // Parent might not exist
+        // Only proven absence may authorize a create here; anything the provider couldn't answer
+        // (permission, dead provider, ambiguous listing, cancellation) propagates.
+        val parentDocFile = parentPath.resolveDocFileOrNull()
+
+        if (parentDocFile == null || !parentDocFile.exists) {
             if (!createParents) {
-                throw WriteException("Parent directory does not exist: $parentPath", path, e)
+                throw WriteException("Parent directory does not exist: $parentPath", path)
             }
 
             // Recursively ensure the parent's parent exists
@@ -520,18 +655,7 @@ class SAFFileSystemOps @Inject constructor(
             return
         }
 
-        // Parent DocFile resolved - check if it exists
-        if (!parentDocFile.exists) {
-            if (!createParents) {
-                throw WriteException("Parent directory does not exist: $parentPath", path)
-            }
-
-            // Recursively ensure the parent's parent exists
-            ensureParentExists(parentPath, createParents = true)
-
-            // Now create this missing parent directory
-            createMissingParentDir(parentPath)
-        } else if (!parentDocFile.isDirectory) {
+        if (!parentDocFile.isDirectory) {
             // Parent exists but is not a directory - this is an error
             throw WriteException("Parent exists but is not a directory: $parentPath", path)
         }
@@ -563,9 +687,9 @@ class SAFFileSystemOps @Inject constructor(
 
             ensureParentExists(path, createParents)
 
-            val docFile = path.resolveDocFile()
+            val docFile = path.resolveDocFileOrNull()
 
-            if (docFile.existsStrict()) {
+            if (docFile != null && docFile.existsStrict()) {
                 if (docFile.isDirectory) return // Already exists - idempotent
 
                 throw PathAlreadyExistsException(
@@ -596,8 +720,8 @@ class SAFFileSystemOps @Inject constructor(
 
             ensureParentExists(path, createParents)
 
-            val docFile = path.resolveDocFile()
-            if (docFile.existsStrict()) throw PathAlreadyExistsException(path = path)
+            val docFile = path.resolveDocFileOrNull()
+            if (docFile != null && docFile.existsStrict()) throw PathAlreadyExistsException(path = path)
 
             val created = createDocumentFile("application/octet-stream", path)
             cacheCreated(path, created)
@@ -623,26 +747,27 @@ class SAFFileSystemOps @Inject constructor(
         // DocumentsProvider operates in a different permission context than direct file access.
         contentResolver.openInputStream(docFile.uri)
             ?: throw IOException("Couldn't open input stream for $path")
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         log(TAG, WARN) { "openInputStream($path) failed: ${e.asLog()}" }
         throw ReadException(path = path, cause = e)
     }
 
     override suspend fun openOutputStream(path: SAFPath, append: Boolean): OutputStream = try {
-        var docFile = path.resolveDocFile()
-        log(TAG, VERBOSE) { "openOutputStream(append=$append): $path -> $docFile" }
+        val existing = path.resolveDocFileOrNull()?.takeIf { it.existsStrict() }
+        log(TAG, VERBOSE) { "openOutputStream(append=$append): $path -> $existing" }
 
         // Match Local's create-on-write semantics (StandardOpenOption.CREATE, both modes).
         // The parent must already exist — createDocumentFile enforces that.
-        val created = if (!docFile.existsStrict()) {
-            docFile = createDocumentFile("application/octet-stream", path)
-            cacheCreated(path, docFile)
+        val created = existing == null
+        val docFile = existing ?: createDocumentFile("application/octet-stream", path).also {
+            cacheCreated(path, it)
             invalidateParentLookup(path)
-            true
-        } else {
+        }
+        if (!created) {
             // Size/mtime become stale once the caller writes
             lookupCache.remove(path)
-            false
         }
 
         val mode = if (append) "wa" else "w"
@@ -686,6 +811,8 @@ class SAFFileSystemOps @Inject constructor(
 
             val pfd = openPFD(path, if (readWrite) FileMode.READ_WRITE else FileMode.READ)
             pfd.toFileHandle(readWrite)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "file($path, readWrite=$readWrite) failed: ${e.asLog()}" }
             throw ReadException(path = path, cause = e)
@@ -713,6 +840,8 @@ class SAFFileSystemOps @Inject constructor(
             }
 
             success
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "setModifiedAt($path, $modifiedAt) failed: $e" }
             supportsSetModifiedAt = false
@@ -741,6 +870,8 @@ class SAFFileSystemOps @Inject constructor(
             }
 
             success
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "setPermissions($path, $permissions) failed: ${e.asLog()}" }
             supportsSetPermissions = false
@@ -769,6 +900,8 @@ class SAFFileSystemOps @Inject constructor(
             }
 
             success
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "setOwnership($path, $ownership) failed: ${e.asLog()}" }
             supportsSetOwnership = false
@@ -843,7 +976,7 @@ class SAFFileSystemOps @Inject constructor(
         }
 
         // renameDocument/moveDocument may collide or silently auto-suffix on an existing destination
-        if (destination.resolveDocFile().existsStrict()) {
+        if (destination.resolveDocFileOrNull()?.existsStrict() == true) {
             return MoveOutcome.NotSupported("Destination already exists: $destination")
         }
 
@@ -920,6 +1053,8 @@ class SAFFileSystemOps @Inject constructor(
         val docFile = path.resolveDocFile()
         log(TAG, VERBOSE) { "canRead(): $path -> $docFile" }
         docFile.readable
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         log(TAG, WARN) { "canRead($path): $e" }
         false
@@ -929,12 +1064,14 @@ class SAFFileSystemOps @Inject constructor(
         val docFile = path.resolveDocFile()
         log(TAG, VERBOSE) { "canWrite(): $path -> $docFile" }
         docFile.writable
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         log(TAG, WARN) { "canWrite($path): $e" }
         false
     }
 
-    fun openPFD(path: SAFPath, mode: FileMode): ParcelFileDescriptor {
+    suspend fun openPFD(path: SAFPath, mode: FileMode): ParcelFileDescriptor {
         return path.resolveDocFile().openPFD(mode)
     }
 
@@ -944,6 +1081,8 @@ class SAFFileSystemOps @Inject constructor(
 
             val pfd = openPFD(path, FileMode.READ)
             pfd.use { android.system.Os.fstatvfs(it.fileDescriptor) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "getFileSystem($path) failed: ${e.asLog()}" }
             null
@@ -996,6 +1135,10 @@ class SAFFileSystemOps @Inject constructor(
 
         private const val INITIAL_CACHE_SIZE = 16
         private const val MAX_CACHE_SIZE = 1000
+        private const val INITIAL_CHILDREN_CACHE_SIZE = 4
+        private const val MAX_CHILDREN_CACHE_PARENTS = 4
         private val CACHE_TTL = 10.seconds
+
+        private const val EXTERNAL_STORAGE_AUTHORITY = "com.android.externalstorage.documents"
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFDocFileTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFDocFileTest.kt
@@ -8,8 +8,10 @@ import android.content.pm.PackageManager
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
+import android.os.Bundle
 import android.os.RemoteException
 import android.provider.DocumentsContract
+import eu.darken.butler.common.files.metadata.FileType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -20,6 +22,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import java.io.IOException
+import kotlin.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [29])
@@ -97,6 +100,64 @@ class SAFDocFileTest : BaseTest() {
 //            fileUri
 //        ).toString() shouldBe "SAFDocFile(uri=$fileUri)"
 //    }
+
+    // ============ CHILD LISTING ============
+
+    private val listedUri: Uri get() = Uri.parse("content://auth.ority/tree/7/document/7")
+
+    private val listedChildrenUri: Uri
+        get() = DocumentsContract.buildChildDocumentsUriUsingTree(listedUri, DocumentsContract.getDocumentId(listedUri))
+
+    private fun childrenCursor(vararg rows: Array<Any?>): MatrixCursor = MatrixCursor(
+        arrayOf(
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+            DocumentsContract.Document.COLUMN_MIME_TYPE,
+            DocumentsContract.Document.COLUMN_SIZE,
+            DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+        )
+    ).apply { rows.forEach { addRow(it) } }
+
+    private fun listChildren(cursor: Cursor): SAFDocFile.ChildListing {
+        every { contentResolver.query(listedChildrenUri, any(), any(), any(), any()) } returns cursor
+        return SAFDocFile(context, contentResolver, listedUri).listFilesWithLookupData()
+    }
+
+    @Test
+    fun `listFilesWithLookupData returns the display name column`() {
+        val listing = listChildren(
+            childrenCursor(
+                arrayOf<Any?>("42", "text/plain", 12L, 34L, "a.txt"),
+                arrayOf<Any?>("43", DocumentsContract.Document.MIME_TYPE_DIR, 0L, 0L, null),
+            )
+        )
+
+        listing.entries[0].name shouldBe "a.txt"
+        listing.entries[0].lookupData shouldBe SAFDocFile.LookupData(
+            fileType = FileType.FILE,
+            size = 12L,
+            lastModified = Instant.fromEpochMilliseconds(34L),
+        )
+        listing.entries[0].docFile.uri shouldBe DocumentsContract.buildDocumentUriUsingTree(listedUri, "42")
+
+        listing.entries[1].name shouldBe null
+        listing.entries[1].lookupData.fileType shouldBe FileType.DIRECTORY
+    }
+
+    @Test
+    fun `listFilesWithLookupData reports a loading or errored cursor as partial`() {
+        val row = arrayOf<Any?>("42", "text/plain", 0L, 0L, "a.txt")
+
+        listChildren(childrenCursor(row)).partial shouldBe false
+
+        listChildren(
+            childrenCursor(row).apply { extras = Bundle().apply { putBoolean(DocumentsContract.EXTRA_LOADING, true) } }
+        ).partial shouldBe true
+
+        listChildren(
+            childrenCursor(row).apply { extras = Bundle().apply { putString(DocumentsContract.EXTRA_ERROR, "boom") } }
+        ).partial shouldBe true
+    }
 
     // Helper to create cursor with MIME type
     private fun createMimeCursor(mimeType: String?): Cursor {

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.common.files.saf
 
 import android.content.ContentProviderClient
 import android.content.ContentResolver
+import android.content.Context
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
@@ -77,9 +78,6 @@ class SAFFileSystemOpsTest : BaseTest() {
             contentResolver = mockContentResolver,
             locationManager = mockLocationManager
         )
-
-        // Contract mutators are simulated against the opaque fixture; URI helpers keep real behavior
-        mockkStatic(DocumentsContract::class)
     }
 
     @After
@@ -271,6 +269,7 @@ class SAFFileSystemOpsTest : BaseTest() {
     private val opaqueDocs = mutableMapOf<String, OpaqueDoc>()
     private val opaqueChildren = mutableMapOf<String, MutableList<OpaqueDoc>>()
     private val opaqueListingExtras = mutableMapOf<String, Bundle>()
+    private val opaqueContext: Context = mockk(relaxed = true)
     private val queriedProjections = mutableListOf<List<String>>()
     private var onChildrenQuery: (() -> Unit)? = null
 
@@ -353,11 +352,21 @@ class SAFFileSystemOpsTest : BaseTest() {
         every { mockLocationManager.getDocFileFor(any()) } answers {
             val path = firstArg<SAFPath>()
             SAFDocFile(
-                mockk(relaxed = true),
+                opaqueContext,
                 mockContentResolver,
                 SAFDocFile.buildTreeUri(Uri.parse(OPAQUE_TREE), path.segments),
             )
         }
+    }
+
+    /**
+     * Simulates the contract mutators against the opaque fixture, for the tests that create or delete.
+     *
+     * Only those: while [DocumentsContract] is static-mocked, a call to it nested inside a `verify`
+     * block records a matcher instead of returning a URI, which silently truncates expected URIs.
+     */
+    private fun useContractMutators() {
+        mockkStatic(DocumentsContract::class)
 
         every { DocumentsContract.createDocument(any(), any(), any(), any()) } answers {
             val id = "created${opaqueDocs.size}"
@@ -390,22 +399,18 @@ class SAFFileSystemOpsTest : BaseTest() {
         useOpaqueProvider()
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
         val child = opaqueRoot.child("a.txt")
+        val handleUri = opaqueDocUri("42")
+        val synthesizedUri = SAFDocFile.buildTreeUri(Uri.parse(OPAQUE_TREE), listOf("a.txt"))
+        val rootChildrenUri = opaqueChildrenUri(OPAQUE_ROOT_ID)
 
         fileSystemOps.listFiles(opaqueRoot) shouldBe listOf(child)
         // Extended lookups bypass the lookup cache, so this really re-resolves the document
         fileSystemOps.lookup(child, LookupOptions(fetchOwnership = true)).fileType shouldBe FileType.FILE
 
-        verify { mockContentResolver.query(opaqueDocUri("42"), any(), any(), any(), any()) }
-        verify(exactly = 0) {
-            mockContentResolver.query(
-                SAFDocFile.buildTreeUri(Uri.parse(OPAQUE_TREE), listOf("a.txt")),
-                any(), any(), any(), any(),
-            )
-        }
+        verify { mockContentResolver.query(handleUri, any(), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.query(synthesizedUri, any(), any(), any(), any()) }
         verify(exactly = 0) { mockLocationManager.getDocFileFor(child) }
-        verify(exactly = 1) {
-            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
-        }
+        verify(exactly = 1) { mockContentResolver.query(rootChildrenUri, any(), any(), any(), any()) }
     }
 
     @Test
@@ -413,13 +418,13 @@ class SAFFileSystemOpsTest : BaseTest() {
         useOpaqueProvider()
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
         val child = opaqueRoot.child("a.txt")
+        val rootChildrenUri = opaqueChildrenUri(OPAQUE_ROOT_ID)
+        val handleUri = opaqueDocUri("42")
 
         fileSystemOps.exists(child) shouldBe true
 
-        verify(exactly = 1) {
-            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
-        }
-        verify { mockContentResolver.query(opaqueDocUri("42"), any(), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(rootChildrenUri, any(), any(), any(), any()) }
+        verify { mockContentResolver.query(handleUri, any(), any(), any(), any()) }
         verify { mockLocationManager.getDocFileFor(opaqueRoot) }
         verify(exactly = 0) { mockLocationManager.getDocFileFor(child) }
     }
@@ -429,14 +434,14 @@ class SAFFileSystemOpsTest : BaseTest() {
         useOpaqueProvider()
         registerOpaqueDir()
         val dir = opaqueRoot.child("dir")
+        val dirChildrenUri = opaqueChildrenUri("42")
+        val rootChildrenUri = opaqueChildrenUri(OPAQUE_ROOT_ID)
 
         fileSystemOps.exists(dir) shouldBe true
         fileSystemOps.lookup(dir.child("a.txt"), LookupOptions()).fileType shouldBe FileType.FILE
 
-        verify(exactly = 1) { mockContentResolver.query(opaqueChildrenUri("42"), any(), any(), any(), any()) }
-        verify(exactly = 1) {
-            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
-        }
+        verify(exactly = 1) { mockContentResolver.query(dirChildrenUri, any(), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(rootChildrenUri, any(), any(), any(), any()) }
     }
 
     @Test
@@ -461,6 +466,7 @@ class SAFFileSystemOpsTest : BaseTest() {
     @Test
     fun `duplicate display names are inconclusive, not absent`() = runTest {
         useOpaqueProvider()
+        useContractMutators()
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "dup.txt")
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "dup.txt")
         val dup = opaqueRoot.child("dup.txt")
@@ -479,18 +485,21 @@ class SAFFileSystemOpsTest : BaseTest() {
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "dup.txt")
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "dup.txt")
         val dup = opaqueRoot.child("dup.txt")
+        val firstCandidateUri = opaqueDocUri("42")
+        val secondCandidateUri = opaqueDocUri("43")
 
         fileSystemOps.listFiles(opaqueRoot) shouldBe listOf(dup, dup)
         shouldThrow<ReadException> { fileSystemOps.exists(dup) }
         shouldThrow<ReadException> { fileSystemOps.exists(dup) }
 
         // Neither of the two candidates may be picked as "the" document
-        verify(exactly = 0) { mockContentResolver.query(opaqueDocUri("42"), any(), any(), any(), any()) }
-        verify(exactly = 0) { mockContentResolver.query(opaqueDocUri("43"), any(), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.query(firstCandidateUri, any(), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.query(secondCandidateUri, any(), any(), any(), any()) }
     }
 
     private suspend fun assertPartialListingIsInconclusive(extras: Bundle) {
         useOpaqueProvider()
+        useContractMutators()
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
         opaqueListingExtras[OPAQUE_ROOT_ID] = extras
         val later = opaqueRoot.child("later.txt")
@@ -553,38 +562,41 @@ class SAFFileSystemOpsTest : BaseTest() {
         useOpaqueProvider()
         val names = (0 until 1001).map { "child$it.txt" }
         names.forEachIndexed { index, name -> addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "d$index", name = name) }
+        // Counted at the fixture: matching 1000+ recorded calls with verify exhausts the heap
+        var listings = 0
+        onChildrenQuery = { listings++ }
 
         names.forEach { fileSystemOps.exists(opaqueRoot.child(it)) shouldBe true }
 
-        verify(exactly = 1) {
-            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
-        }
+        listings shouldBe 1
     }
 
     @Test
     fun `a changed directory is re-listed`() = runTest {
         useOpaqueProvider()
+        useContractMutators()
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
         addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "b.txt")
+        val rootChildrenUri = opaqueChildrenUri(OPAQUE_ROOT_ID)
 
         fileSystemOps.exists(opaqueRoot.child("a.txt")) shouldBe true
         fileSystemOps.delete(opaqueRoot.child("a.txt"), recursive = false) shouldBe true
         fileSystemOps.exists(opaqueRoot.child("b.txt")) shouldBe true
 
-        verify(exactly = 2) {
-            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
-        }
+        verify(exactly = 2) { mockContentResolver.query(rootChildrenUri, any(), any(), any(), any()) }
     }
 
     @Test
     fun `deleting a directory drops its stored listing`() = runTest {
         useOpaqueProvider()
+        useContractMutators()
         registerOpaqueDir()
         val dir = opaqueRoot.child("dir")
+        val dirChildrenUri = opaqueChildrenUri("42")
 
         fileSystemOps.listFiles(dir) shouldBe listOf(dir.child("a.txt"))
         fileSystemOps.exists(dir.child("a.txt")) shouldBe true
-        verify(exactly = 1) { mockContentResolver.query(opaqueChildrenUri("42"), any(), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(dirChildrenUri, any(), any(), any(), any()) }
 
         fileSystemOps.delete(dir, recursive = true) shouldBe true
         // Another app puts the tree back; the stored listing must not be what answers for it
@@ -592,7 +604,7 @@ class SAFFileSystemOpsTest : BaseTest() {
         fileSystemOps.exists(dir.child("a.txt")) shouldBe true
 
         // listFiles, the recursive delete walk, and the re-resolve after invalidation
-        verify(exactly = 3) { mockContentResolver.query(opaqueChildrenUri("42"), any(), any(), any(), any()) }
+        verify(exactly = 3) { mockContentResolver.query(dirChildrenUri, any(), any(), any(), any()) }
     }
 
     @Test
@@ -624,6 +636,7 @@ class SAFFileSystemOpsTest : BaseTest() {
     @Test
     fun `createFile on a foreign provider creates under the parent's real handle`() = runTest {
         useOpaqueProvider()
+        useContractMutators()
         addOpaqueChild(
             parentId = OPAQUE_ROOT_ID,
             id = "42",
@@ -631,10 +644,11 @@ class SAFFileSystemOpsTest : BaseTest() {
             mime = DocumentsContract.Document.MIME_TYPE_DIR,
         )
         val target = opaqueRoot.child("dir").child("new.txt")
+        val parentHandleUri = opaqueDocUri("42")
 
         fileSystemOps.createFile(target, createParents = false)
 
-        verify { DocumentsContract.createDocument(any(), opaqueDocUri("42"), any(), "new.txt") }
+        verify { DocumentsContract.createDocument(any(), parentHandleUri, any(), "new.txt") }
     }
 
     companion object {

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
@@ -264,7 +264,7 @@ class SAFFileSystemOpsTest : BaseTest() {
      * A document of a provider whose ids are opaque: "42" is not derivable from a display name, so
      * resolution that synthesizes an id from the tree id plus display names never finds it.
      */
-    private data class OpaqueDoc(val id: String, val name: String, val mime: String)
+    private data class OpaqueDoc(val id: String, val name: String?, val mime: String)
 
     private val opaqueDocs = mutableMapOf<String, OpaqueDoc>()
     private val opaqueChildren = mutableMapOf<String, MutableList<OpaqueDoc>>()
@@ -282,7 +282,7 @@ class SAFFileSystemOpsTest : BaseTest() {
     private fun opaqueChildrenUri(id: String): Uri =
         DocumentsContract.buildChildDocumentsUriUsingTree(opaqueRootDocUri, id)
 
-    private fun addOpaqueChild(parentId: String, id: String, name: String, mime: String = "text/plain") {
+    private fun addOpaqueChild(parentId: String, id: String, name: String?, mime: String = "text/plain") {
         val doc = OpaqueDoc(id = id, name = name, mime = mime)
         opaqueDocs[id] = doc
         opaqueChildren.getOrPut(parentId) { mutableListOf() }.add(doc)
@@ -381,6 +381,22 @@ class SAFFileSystemOpsTest : BaseTest() {
         every { DocumentsContract.deleteDocument(any(), any()) } answers {
             val id = DocumentsContract.getDocumentId(secondArg<Uri>())
             (opaqueDocs[id] != null).also { removeOpaqueDoc(id) }
+        }
+    }
+
+    /**
+     * Routes [SAFDocFile.existsStrict] at the same in-memory documents the resolver serves.
+     *
+     * Without it the relaxed resolver hands back a relaxed [ContentProviderClient] whose cursor
+     * reports no row, so every strict existence probe answers "gone".
+     */
+    private fun useStrictExistence() {
+        every { mockContentResolver.acquireUnstableContentProviderClient(any<Uri>()) } answers {
+            mockk<ContentProviderClient>(relaxed = true).also { client ->
+                every { client.query(any(), any(), any(), any(), any()) } answers {
+                    mockContentResolver.query(firstArg(), secondArg(), thirdArg(), arg(3), arg(4))
+                }
+            }
         }
     }
 
@@ -649,6 +665,66 @@ class SAFFileSystemOpsTest : BaseTest() {
         fileSystemOps.createFile(target, createParents = false)
 
         verify { DocumentsContract.createDocument(any(), parentHandleUri, any(), "new.txt") }
+    }
+
+    @Test
+    fun `a failed move leaves no handle behind in the parent's stored listing`() = runTest {
+        useOpaqueProvider()
+        useStrictExistence()
+        mockkStatic(DocumentsContract::class)
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        val source = opaqueRoot.child("a.txt")
+        val destination = opaqueRoot.child("b.txt")
+        every { DocumentsContract.renameDocument(any(), any(), any()) } throws RuntimeException("provider blew up")
+
+        // Populates the root listing, which is where the source's handle also lives
+        fileSystemOps.exists(source) shouldBe true
+
+        val failure = shouldThrow<WriteException> { fileSystemOps.move(source, destination) }
+        // Pins where the move died: anything earlier would mean the fixture, not the rename, refused
+        failure.cause?.message shouldBe "provider blew up"
+
+        // The failure may have had side effects, so the source must be genuinely uncached now
+        var listings = 0
+        onChildrenQuery = { listings++ }
+        fileSystemOps.exists(source) shouldBe true
+
+        listings shouldBe 1
+    }
+
+    @Test
+    fun `a name turning ambiguous drops the descendants resolved under it`() = runTest {
+        useOpaqueProvider()
+        useStrictExistence()
+        registerOpaqueDir()
+        val dir = opaqueRoot.child("dir")
+        val file = dir.child("a.txt")
+
+        fileSystemOps.existsStrict(file) shouldBe Existence.PRESENT
+
+        // A second document of the same name appears; the parent is re-listed
+        addOpaqueChild(
+            parentId = OPAQUE_ROOT_ID,
+            id = "44",
+            name = "dir",
+            mime = DocumentsContract.Document.MIME_TYPE_DIR,
+        )
+        fileSystemOps.listFiles(opaqueRoot) shouldBe listOf(dir, dir)
+
+        fileSystemOps.existsStrict(dir) shouldBe Existence.UNKNOWN
+        // The descendant was resolved through the now-ambiguous 'dir'; its handle cannot stand
+        fileSystemOps.existsStrict(file) shouldBe Existence.UNKNOWN
+    }
+
+    @Test
+    fun `a row without a display name cannot prove another name absent`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        // The provider left COLUMN_DISPLAY_NAME empty, so this document's name is unknown to us
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = null)
+        val unindexable = opaqueRoot.child("secret.txt")
+
+        fileSystemOps.existsStrict(unindexable) shouldBe Existence.UNKNOWN
     }
 
     companion object {

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
@@ -5,29 +5,45 @@ import android.content.ContentResolver
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
+import android.os.Bundle
 import android.os.RemoteException
 import android.provider.DocumentsContract
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.darken.butler.common.SafUri
 import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.errors.ReadException
+import eu.darken.butler.common.files.errors.WriteException
 import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.files.permissions.PermissionErrorClassifier
+import eu.darken.butler.common.files.saf.location.SAFLocation
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
+import eu.darken.butler.common.files.saf.location.SAFLocationMatch
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.EmptyApp
+import kotlin.time.Instant
 
 /**
  * Tests for SAFFileSystemOps using Robolectric.
@@ -61,6 +77,14 @@ class SAFFileSystemOpsTest : BaseTest() {
             contentResolver = mockContentResolver,
             locationManager = mockLocationManager
         )
+
+        // Contract mutators are simulated against the opaque fixture; URI helpers keep real behavior
+        mockkStatic(DocumentsContract::class)
+    }
+
+    @After
+    fun teardown() {
+        unmockkStatic(DocumentsContract::class)
     }
 
     // ============ FALLBACKTOUNKNOWN BEHAVIOR TESTS ============
@@ -236,8 +260,388 @@ class SAFFileSystemOpsTest : BaseTest() {
         PermissionErrorClassifier.isPermissionError(error) shouldBe true
     }
 
+    // ============ FOREIGN PROVIDER RESOLUTION TESTS ============
+
+    /**
+     * A document of a provider whose ids are opaque: "42" is not derivable from a display name, so
+     * resolution that synthesizes an id from the tree id plus display names never finds it.
+     */
+    private data class OpaqueDoc(val id: String, val name: String, val mime: String)
+
+    private val opaqueDocs = mutableMapOf<String, OpaqueDoc>()
+    private val opaqueChildren = mutableMapOf<String, MutableList<OpaqueDoc>>()
+    private val opaqueListingExtras = mutableMapOf<String, Bundle>()
+    private val queriedProjections = mutableListOf<List<String>>()
+    private var onChildrenQuery: (() -> Unit)? = null
+
+    private val opaqueRoot: SAFPath get() = SAFPath.build(OPAQUE_TREE)
+
+    private val opaqueRootDocUri: Uri get() = SAFDocFile.buildTreeUri(Uri.parse(OPAQUE_TREE), emptyList())
+
+    private fun opaqueDocUri(id: String): Uri = DocumentsContract.buildDocumentUriUsingTree(opaqueRootDocUri, id)
+
+    private fun opaqueChildrenUri(id: String): Uri =
+        DocumentsContract.buildChildDocumentsUriUsingTree(opaqueRootDocUri, id)
+
+    private fun addOpaqueChild(parentId: String, id: String, name: String, mime: String = "text/plain") {
+        val doc = OpaqueDoc(id = id, name = name, mime = mime)
+        opaqueDocs[id] = doc
+        opaqueChildren.getOrPut(parentId) { mutableListOf() }.add(doc)
+    }
+
+    private fun removeOpaqueDoc(id: String) {
+        opaqueDocs.remove(id)
+        opaqueChildren.remove(id)
+        opaqueChildren.values.forEach { siblings -> siblings.removeAll { it.id == id } }
+    }
+
+    private fun rowFor(projection: Array<String>, doc: OpaqueDoc): Array<Any?> = projection.map { column ->
+        when (column) {
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID -> doc.id
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME -> doc.name
+            DocumentsContract.Document.COLUMN_MIME_TYPE -> doc.mime
+            DocumentsContract.Document.COLUMN_SIZE -> 0L
+            DocumentsContract.Document.COLUMN_LAST_MODIFIED -> 0L
+            DocumentsContract.Document.COLUMN_FLAGS -> 0
+            else -> null
+        }
+    }.toTypedArray()
+
+    /**
+     * Points the resolver and the location manager at an in-memory provider with opaque ids.
+     *
+     * The tree document id and the root document id agree, as they do on a real provider:
+     * `getDocFileFor` builds the root URI through [SAFDocFile.buildTreeUri], which reads the tree
+     * document id, and a fixture where the two differ would mock that relationship away.
+     */
+    private fun useOpaqueProvider() {
+        opaqueDocs[OPAQUE_ROOT_ID] = OpaqueDoc(OPAQUE_ROOT_ID, "opaque", DocumentsContract.Document.MIME_TYPE_DIR)
+
+        every { mockContentResolver.query(any(), any(), any(), any(), any()) } answers {
+            val uri = firstArg<Uri>()
+            val projection = secondArg<Array<String>>()
+            queriedProjections.add(projection.toList())
+
+            val cursor: Cursor? = if (uri.lastPathSegment == "children") {
+                onChildrenQuery?.invoke()
+                val parentId = DocumentsContract.getDocumentId(uri)
+                MatrixCursor(projection).apply {
+                    opaqueChildren[parentId].orEmpty().forEach { addRow(rowFor(projection, it)) }
+                    opaqueListingExtras[parentId]?.let { extras = it }
+                }
+            } else {
+                opaqueDocs[DocumentsContract.getDocumentId(uri)]
+                    ?.let { doc -> MatrixCursor(projection).apply { addRow(rowFor(projection, doc)) } }
+            }
+            cursor
+        }
+        // fstat() is best-effort for extended lookups; deny it rather than leave it to a relaxed mock
+        every { mockContentResolver.openFileDescriptor(any(), any()) } returns null
+
+        val location = SAFLocation(
+            id = "opaque",
+            treeUri = SafUri.parse(OPAQUE_TREE),
+            path = opaqueRoot,
+            hasReadPermission = true,
+            hasWritePermission = true,
+            grantedAt = Instant.fromEpochMilliseconds(0),
+        )
+        every { mockLocationManager.findPermissionFor(any()) } answers {
+            SAFLocationMatch(location = location, missingSegments = firstArg<SAFPath>().segments)
+        }
+        // Synthesized resolution stays available, so the tests prove it is not what gets used.
+        every { mockLocationManager.getDocFileFor(any()) } answers {
+            val path = firstArg<SAFPath>()
+            SAFDocFile(
+                mockk(relaxed = true),
+                mockContentResolver,
+                SAFDocFile.buildTreeUri(Uri.parse(OPAQUE_TREE), path.segments),
+            )
+        }
+
+        every { DocumentsContract.createDocument(any(), any(), any(), any()) } answers {
+            val id = "created${opaqueDocs.size}"
+            addOpaqueChild(
+                parentId = DocumentsContract.getDocumentId(secondArg<Uri>()),
+                id = id,
+                name = arg<String>(3),
+                mime = thirdArg<String>(),
+            )
+            opaqueDocUri(id)
+        }
+        every { DocumentsContract.deleteDocument(any(), any()) } answers {
+            val id = DocumentsContract.getDocumentId(secondArg<Uri>())
+            (opaqueDocs[id] != null).also { removeOpaqueDoc(id) }
+        }
+    }
+
+    private fun registerOpaqueDir() {
+        addOpaqueChild(
+            parentId = OPAQUE_ROOT_ID,
+            id = "42",
+            name = "dir",
+            mime = DocumentsContract.Document.MIME_TYPE_DIR,
+        )
+        addOpaqueChild(parentId = "42", id = "43", name = "a.txt")
+    }
+
+    @Test
+    fun `a listed child resolves through the provider's handle, not a synthesized one`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        val child = opaqueRoot.child("a.txt")
+
+        fileSystemOps.listFiles(opaqueRoot) shouldBe listOf(child)
+        // Extended lookups bypass the lookup cache, so this really re-resolves the document
+        fileSystemOps.lookup(child, LookupOptions(fetchOwnership = true)).fileType shouldBe FileType.FILE
+
+        verify { mockContentResolver.query(opaqueDocUri("42"), any(), any(), any(), any()) }
+        verify(exactly = 0) {
+            mockContentResolver.query(
+                SAFDocFile.buildTreeUri(Uri.parse(OPAQUE_TREE), listOf("a.txt")),
+                any(), any(), any(), any(),
+            )
+        }
+        verify(exactly = 0) { mockLocationManager.getDocFileFor(child) }
+        verify(exactly = 1) {
+            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `foreign provider cache miss resolves by listing the parent`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        val child = opaqueRoot.child("a.txt")
+
+        fileSystemOps.exists(child) shouldBe true
+
+        verify(exactly = 1) {
+            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
+        }
+        verify { mockContentResolver.query(opaqueDocUri("42"), any(), any(), any(), any()) }
+        verify { mockLocationManager.getDocFileFor(opaqueRoot) }
+        verify(exactly = 0) { mockLocationManager.getDocFileFor(child) }
+    }
+
+    @Test
+    fun `foreign provider resolves a new descendant from a cached ancestor`() = runTest {
+        useOpaqueProvider()
+        registerOpaqueDir()
+        val dir = opaqueRoot.child("dir")
+
+        fileSystemOps.exists(dir) shouldBe true
+        fileSystemOps.lookup(dir.child("a.txt"), LookupOptions()).fileType shouldBe FileType.FILE
+
+        verify(exactly = 1) { mockContentResolver.query(opaqueChildrenUri("42"), any(), any(), any(), any()) }
+        verify(exactly = 1) {
+            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `foreign provider reports an unlisted child as absent`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        val missing = opaqueRoot.child("nope.txt")
+
+        fileSystemOps.exists(missing) shouldBe false
+        fileSystemOps.existsStrict(missing) shouldBe Existence.ABSENT
+        fileSystemOps.lookup(missing, LookupOptions(fallbackToUnknown = true)).fileType shouldBe FileType.UNKNOWN
+        shouldThrow<ReadException> { fileSystemOps.lookup(missing, LookupOptions()) }
+
+        verify(exactly = 0) {
+            mockContentResolver.query(
+                match<Uri> { it.toString().contains("nope.txt") },
+                any(), any(), any(), any(),
+            )
+        }
+    }
+
+    @Test
+    fun `duplicate display names are inconclusive, not absent`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "dup.txt")
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "dup.txt")
+        val dup = opaqueRoot.child("dup.txt")
+
+        shouldThrow<ReadException> { fileSystemOps.exists(dup) }
+        shouldThrow<ReadException> { fileSystemOps.lookup(dup, LookupOptions()) }
+        fileSystemOps.existsStrict(dup) shouldBe Existence.UNKNOWN
+        shouldThrow<WriteException> { fileSystemOps.createFile(dup, createParents = false) }
+
+        verify(exactly = 0) { DocumentsContract.createDocument(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a duplicate name stays inconclusive on the next access`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "dup.txt")
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "dup.txt")
+        val dup = opaqueRoot.child("dup.txt")
+
+        fileSystemOps.listFiles(opaqueRoot) shouldBe listOf(dup, dup)
+        shouldThrow<ReadException> { fileSystemOps.exists(dup) }
+        shouldThrow<ReadException> { fileSystemOps.exists(dup) }
+
+        // Neither of the two candidates may be picked as "the" document
+        verify(exactly = 0) { mockContentResolver.query(opaqueDocUri("42"), any(), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.query(opaqueDocUri("43"), any(), any(), any(), any()) }
+    }
+
+    private suspend fun assertPartialListingIsInconclusive(extras: Bundle) {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        opaqueListingExtras[OPAQUE_ROOT_ID] = extras
+        val later = opaqueRoot.child("later.txt")
+
+        fileSystemOps.existsStrict(later) shouldBe Existence.UNKNOWN
+        shouldThrow<ReadException> { fileSystemOps.exists(later) }
+        shouldThrow<WriteException> { fileSystemOps.createFile(later, createParents = false) }
+
+        verify(exactly = 0) { DocumentsContract.createDocument(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a listing the provider is still loading is inconclusive, not absent`() = runTest {
+        assertPartialListingIsInconclusive(Bundle().apply { putBoolean(DocumentsContract.EXTRA_LOADING, true) })
+    }
+
+    @Test
+    fun `a listing the provider flagged as errored is inconclusive, not absent`() = runTest {
+        assertPartialListingIsInconclusive(Bundle().apply { putString(DocumentsContract.EXTRA_ERROR, "boom") })
+    }
+
+    @Test
+    fun `externalstorage keeps synthesized resolution`() = runTest {
+        val child = SAFPath.build(testTreeUri, "a.txt")
+        val docUri = SAFDocFile.buildTreeUri(Uri.parse(testTreeUri), listOf("a.txt"))
+        every { mockLocationManager.getDocFileFor(child) } returns
+            SAFDocFile(mockk(relaxed = true), mockContentResolver, docUri)
+        every { mockContentResolver.query(docUri, any(), any(), any(), any()) } answers {
+            val projection = secondArg<Array<String>>()
+            MatrixCursor(projection).apply { addRow(rowFor(projection, OpaqueDoc("a.txt", "a.txt", "text/plain"))) }
+        }
+
+        fileSystemOps.lookup(child, LookupOptions()).fileType shouldBe FileType.FILE
+
+        verify { mockLocationManager.getDocFileFor(child) }
+        verify(exactly = 0) { mockLocationManager.findPermissionFor(any()) }
+        verify(exactly = 0) {
+            mockContentResolver.query(
+                match<Uri> { it.lastPathSegment == "children" },
+                any(), any(), any(), any(),
+            )
+        }
+    }
+
+    @Test
+    fun `listFiles takes display names from the batch listing`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "b.txt")
+
+        fileSystemOps.listFiles(opaqueRoot) shouldBe
+            listOf(opaqueRoot.child("a.txt"), opaqueRoot.child("b.txt"))
+
+        // The per-child display-name getter is the one that queries this projection alone
+        queriedProjections.none { it == listOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME) } shouldBe true
+    }
+
+    @Test
+    fun `a directory larger than the doc-file cache costs one listing, not one per child`() = runTest {
+        useOpaqueProvider()
+        val names = (0 until 1001).map { "child$it.txt" }
+        names.forEachIndexed { index, name -> addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "d$index", name = name) }
+
+        names.forEach { fileSystemOps.exists(opaqueRoot.child(it)) shouldBe true }
+
+        verify(exactly = 1) {
+            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `a changed directory is re-listed`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "43", name = "b.txt")
+
+        fileSystemOps.exists(opaqueRoot.child("a.txt")) shouldBe true
+        fileSystemOps.delete(opaqueRoot.child("a.txt"), recursive = false) shouldBe true
+        fileSystemOps.exists(opaqueRoot.child("b.txt")) shouldBe true
+
+        verify(exactly = 2) {
+            mockContentResolver.query(opaqueChildrenUri(OPAQUE_ROOT_ID), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `deleting a directory drops its stored listing`() = runTest {
+        useOpaqueProvider()
+        registerOpaqueDir()
+        val dir = opaqueRoot.child("dir")
+
+        fileSystemOps.listFiles(dir) shouldBe listOf(dir.child("a.txt"))
+        fileSystemOps.exists(dir.child("a.txt")) shouldBe true
+        verify(exactly = 1) { mockContentResolver.query(opaqueChildrenUri("42"), any(), any(), any(), any()) }
+
+        fileSystemOps.delete(dir, recursive = true) shouldBe true
+        // Another app puts the tree back; the stored listing must not be what answers for it
+        registerOpaqueDir()
+        fileSystemOps.exists(dir.child("a.txt")) shouldBe true
+
+        // listFiles, the recursive delete walk, and the re-resolve after invalidation
+        verify(exactly = 3) { mockContentResolver.query(opaqueChildrenUri("42"), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a cancelled resolution cancels the caller`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        val child = opaqueRoot.child("a.txt")
+
+        val readScope = CoroutineScope(Job() + Dispatchers.Unconfined)
+        onChildrenQuery = { readScope.cancel() }
+        var readable: Boolean? = null
+        readScope.launch { readable = fileSystemOps.canRead(child) }.join()
+        // canRead swallows Exception; a cancellation must not surface as "not readable"
+        readable shouldBe null
+
+        val fileScope = CoroutineScope(Job() + Dispatchers.Unconfined)
+        onChildrenQuery = { fileScope.cancel() }
+        var failure: Throwable? = null
+        fileScope.launch {
+            try {
+                fileSystemOps.file(child, readWrite = false)
+            } catch (e: Throwable) {
+                failure = e
+            }
+        }.join()
+        (failure is CancellationException) shouldBe true
+    }
+
+    @Test
+    fun `createFile on a foreign provider creates under the parent's real handle`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(
+            parentId = OPAQUE_ROOT_ID,
+            id = "42",
+            name = "dir",
+            mime = DocumentsContract.Document.MIME_TYPE_DIR,
+        )
+        val target = opaqueRoot.child("dir").child("new.txt")
+
+        fileSystemOps.createFile(target, createParents = false)
+
+        verify { DocumentsContract.createDocument(any(), opaqueDocUri("42"), any(), "new.txt") }
+    }
+
     companion object {
         private val PROBE_URI: Uri = Uri.parse("content://com.android.externalstorage.documents/document/probe")
         private val PROBE_PROJECTION = arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+
+        private const val OPAQUE_TREE = "content://com.example.opaque/tree/7"
+        private const val OPAQUE_ROOT_ID = "7"
     }
 }


### PR DESCRIPTION
## What changed

Storage that you add from another app (a cloud client, a file server app, Termux, anything that exposes folders through Android's storage picker) could list a folder's contents and then fail on everything else. Opening, editing, copying or deleting a file inside it would not work, even though the file was plainly visible in the listing.

Butler now uses the file identity the storage app itself hands out, instead of guessing one from the file's name. Storage on your device is unaffected and takes the same path it always did.

A folder from one of those apps is also read once and reused for the files inside it, so browsing a large folder no longer re-reads it for every file.

## Technical Context

- Root cause: `listFiles` received each child carrying the provider's real document URI, kept only the display name, and dropped the handle. Every later access rebuilt a document ID by concatenating display names onto the tree document ID. `COLUMN_DOCUMENT_ID` is opaque by contract, so a provider whose IDs are not path-shaped listed fine and then failed on every child. Two other call paths in this file already kept provider handles for exactly this reason; the read path was the last one that did not.
- Resolution now returns one of three answers, and the distinction is load-bearing: a handle, a proven absence (`null`), or "cannot tell" (a `ReadException`). Only proven absence may authorize creating a file, reporting a delete as a no-op, or `Existence.ABSENT`. Without that split, a provider returning a partial listing (`EXTRA_LOADING`) or a duplicate display name would read as "the file is not there", which is enough to create a duplicate or silently skip a delete.
- The listing is cached once per parent rather than once per child. Per-child caching was the original design and was rejected during review: `docFileCache` holds 1000 entries, so a folder above that size evicts its own entries before the listing returns, and the Explorer's metadata pass requests `fetchCreatedAt` without `fetchSize`/`fetchModifiedAt`, which makes `lookupCache` ineligible and sends every child through resolution individually.
- `com.android.externalstorage.documents` keeps its previous zero-query synthesized resolution, gated by authority. `SAFFileSystemOpsWriteTest` and `SAFPathMoveStrategyTest` are unchanged and still pass, which is what pins that path as untouched.
- Worth close review: `invalidateSubtree` now also drops the parent's listing. That is not incidental tidying. The new cache is the first one storing a path's handle under its parent's key, so subtree invalidation alone left a failed move able to resurrect the old source handle.
- `resolveDocFile` became `suspend`, which cascades to `openPFD`. Ten functions in this class caught `Exception` without rethrowing `CancellationException` and would have started swallowing cancellations; `canRead`/`canWrite` are the sharp end, since a cancelled open would have surfaced as "Permission denied" instead.
