### PR TITLE
Apps: Fix app actions failing silently and not updating the screen

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/pkgs/pkgops/PkgOps.kt
@@ -399,10 +399,13 @@ class PkgOps @Inject constructor(
         } catch (e: Exception) {
             if (e is ElevatedAccessUnavailableException) {
                 log(TAG, DEBUG) { "uninstall(...): $mode unavailable for $id" }
-            } else {
-                log(TAG, WARN) { "uninstall($id, mode=$mode) failed: $e" }
+                // No cause text: this branch is consumed by the caller's cause-walk, not rendered.
+                throw PkgOpsException(message = "uninstall($id, $mode) failed", cause = e)
             }
-            throw PkgOpsException(message = "uninstall($id, $mode) failed", cause = e)
+            log(TAG, WARN) { "uninstall($id, mode=$mode) failed: $e" }
+            // The cause's text carries the shell's reason and only survives here: what the user is
+            // shown renders the top-level message and nothing from the cause chain.
+            throw PkgOpsException(message = "uninstall($id, $mode) failed: ${e.message}", cause = e)
         }
     }
 
@@ -429,10 +432,13 @@ class PkgOps @Inject constructor(
         } catch (e: Exception) {
             if (e is ElevatedAccessUnavailableException) {
                 log(TAG, DEBUG) { "clearData(...): $mode unavailable for $id" }
-            } else {
-                log(TAG, WARN) { "clearData($id, mode=$mode) failed: $e" }
+                // No cause text: this branch is consumed by the caller's cause-walk, not rendered.
+                throw PkgOpsException(message = "clearData($id, $mode) failed", cause = e)
             }
-            throw PkgOpsException(message = "clearData($id, $mode) failed", cause = e)
+            log(TAG, WARN) { "clearData($id, mode=$mode) failed: $e" }
+            // The cause's text carries the shell's reason and only survives here: what the user is
+            // shown renders the top-level message and nothing from the cause chain.
+            throw PkgOpsException(message = "clearData($id, $mode) failed: ${e.message}", cause = e)
         }
     }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/pkgs/pkgops/ipc/PkgOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/pkgs/pkgops/ipc/PkgOpsHost.kt
@@ -173,15 +173,17 @@ class PkgOpsHost @Inject constructor(
 
     override fun uninstallPackage(packageName: String, handleId: Int): Boolean = try {
         log(TAG, VERBOSE) { "uninstallPackage($packageName, $handleId)..." }
+        val cmd = "pm uninstall --user $handleId $packageName"
         val result = runBlocking {
             sharedShell.useRes {
-                FlowCmd("pm uninstall --user $handleId $packageName").execute(it)
+                FlowCmd(cmd).execute(it)
             }
         }
         if (result.exitCode != FlowProcess.ExitCode.OK) {
             log(TAG, WARN) { "uninstallPackage($packageName, $handleId) failed: output=${result.output}, errors=${result.errors}" }
+            throw IllegalStateException(shellFailure(cmd, result))
         }
-        result.exitCode == FlowProcess.ExitCode.OK
+        true
     } catch (e: Exception) {
         log(TAG, ERROR) { "uninstallPackage($packageName, $handleId) failed: ${e.asLog()}" }
         throw e.wrapToPropagate()
@@ -189,19 +191,26 @@ class PkgOpsHost @Inject constructor(
 
     override fun clearData(packageName: String, handleId: Int): Boolean = try {
         log(TAG, VERBOSE) { "clearData($packageName, $handleId)..." }
+        val cmd = "pm clear --user $handleId $packageName"
         val result = runBlocking {
             sharedShell.useRes {
-                FlowCmd("pm clear --user $handleId $packageName").execute(it)
+                FlowCmd(cmd).execute(it)
             }
         }
         if (result.exitCode != FlowProcess.ExitCode.OK) {
             log(TAG, WARN) { "clearData($packageName, $handleId) failed: output=${result.output}, errors=${result.errors}" }
+            throw IllegalStateException(shellFailure(cmd, result))
         }
-        result.exitCode == FlowProcess.ExitCode.OK
+        true
     } catch (e: Exception) {
         log(TAG, ERROR) { "clearData($packageName, $handleId) failed: ${e.asLog()}" }
         throw e.wrapToPropagate()
     }
+
+    // `pm` reports why it refused on stdout/stderr, not through the exit code, so the text has to
+    // travel with the exception - it is what the user gets to see.
+    private fun shellFailure(cmd: String, result: FlowCmd.Result): String =
+        "`$cmd` failed (exitCode=${result.exitCode}): output=${result.output}, errors=${result.errors}"
 
     companion object {
         val TAG = logTag("Pkg", "Ops", "Service", "Host", Bugs.processTag)

--- a/app-common-io/src/test/java/eu/darken/butler/common/pkgs/pkgops/PkgOpsErrorMessageTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/pkgs/pkgops/PkgOpsErrorMessageTest.kt
@@ -6,6 +6,7 @@ import eu.darken.butler.common.adb.AdbManager
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.common.root.RootManager
+import eu.darken.butler.common.root.service.RootServiceClient
 import eu.darken.butler.common.user.UserHandle2
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -38,15 +39,20 @@ class PkgOpsErrorMessageTest : BaseTest() {
 
     private lateinit var rootManager: RootManager
     private lateinit var adbManager: AdbManager
+    private lateinit var rootServiceClient: RootServiceClient
     private lateinit var pkgOps: PkgOps
 
     @Before
     fun setup() {
         rootManager = mockk()
         adbManager = mockk()
+        // Held as its own reference: stubbing through `rootManager.serviceClient.get()` would make
+        // mockk re-stub the chain with a fresh strict child mock, which then fails on the first
+        // resource call the lease makes.
+        rootServiceClient = mockk(relaxed = true)
         every { rootManager.useRoot } returns flowOf(false)
         every { adbManager.useAdb } returns flowOf(false)
-        every { rootManager.serviceClient } returns mockk(relaxed = true)
+        every { rootManager.serviceClient } returns rootServiceClient
         every { adbManager.serviceClient } returns mockk(relaxed = true)
 
         pkgOps = PkgOps(
@@ -66,7 +72,7 @@ class PkgOpsErrorMessageTest : BaseTest() {
     /** Same simulation the gateway tests use: the client's resource lease is what fails. */
     private fun failElevatedAccessWith(message: String) {
         every { rootManager.useRoot } returns flowOf(true)
-        coEvery { rootManager.serviceClient.get() } throws IllegalStateException(message)
+        coEvery { rootServiceClient.get() } throws IllegalStateException(message)
     }
 
     @Test

--- a/app-common-io/src/test/java/eu/darken/butler/common/pkgs/pkgops/PkgOpsErrorMessageTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/pkgs/pkgops/PkgOpsErrorMessageTest.kt
@@ -1,0 +1,108 @@
+package eu.darken.butler.common.pkgs.pkgops
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.darken.butler.common.ElevatedAccessUnavailableException
+import eu.darken.butler.common.adb.AdbManager
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.features.InstallId
+import eu.darken.butler.common.root.RootManager
+import eu.darken.butler.common.user.UserHandle2
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.EmptyApp
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+/**
+ * The shell's reason for refusing an uninstall or a data wipe only reaches the user if it survives
+ * into the [PkgOpsException]'s own message: what renders an error reads the top-level message and
+ * nothing from the cause chain.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29], application = EmptyApp::class)
+class PkgOpsErrorMessageTest : BaseTest() {
+
+    private val installId = InstallId(Pkg.Id("com.example.app"), UserHandle2(0))
+
+    private lateinit var rootManager: RootManager
+    private lateinit var adbManager: AdbManager
+    private lateinit var pkgOps: PkgOps
+
+    @Before
+    fun setup() {
+        rootManager = mockk()
+        adbManager = mockk()
+        every { rootManager.useRoot } returns flowOf(false)
+        every { adbManager.useAdb } returns flowOf(false)
+        every { rootManager.serviceClient } returns mockk(relaxed = true)
+        every { adbManager.serviceClient } returns mockk(relaxed = true)
+
+        pkgOps = PkgOps(
+            appScope = TestScope(),
+            dispatcherProvider = TestDispatcherProvider(),
+            context = mockk(relaxed = true),
+            ipcFunnel = mockk(relaxed = true),
+            rootManager = rootManager,
+            adbManager = adbManager,
+            usageStatsManager = mockk(relaxed = true),
+            storageStatsManager = mockk(relaxed = true),
+            userManager2 = mockk(relaxed = true),
+            localFileMaterializer = mockk(relaxed = true),
+        )
+    }
+
+    /** Same simulation the gateway tests use: the client's resource lease is what fails. */
+    private fun failElevatedAccessWith(message: String) {
+        every { rootManager.useRoot } returns flowOf(true)
+        coEvery { rootManager.serviceClient.get() } throws IllegalStateException(message)
+    }
+
+    @Test
+    fun `a refused uninstall carries the reason`() = runTest2 {
+        failElevatedAccessWith("`pm uninstall --user 0 com.example.app` failed: DELETE_FAILED_INTERNAL_ERROR")
+
+        val thrown = shouldThrow<PkgOpsException> { pkgOps.uninstall(installId) }
+
+        thrown.message!! shouldContain "DELETE_FAILED_INTERNAL_ERROR"
+    }
+
+    @Test
+    fun `a refused clear data carries the reason`() = runTest2 {
+        failElevatedAccessWith("`pm clear --user 0 com.example.app` failed: Permission Denial")
+
+        val thrown = shouldThrow<PkgOpsException> { pkgOps.clearData(installId) }
+
+        thrown.message!! shouldContain "Permission Denial"
+    }
+
+    @Test
+    fun `missing elevated access stays a bare message for the cause-walk`() = runTest2 {
+        val thrown = shouldThrow<PkgOpsException> { pkgOps.uninstall(installId) }
+
+        thrown.message!! shouldNotContain "unavailable"
+        // The fallback to Android's own uninstall dialog hinges on finding this in the chain.
+        generateSequence<Throwable>(thrown) { it.cause }
+            .filterIsInstance<ElevatedAccessUnavailableException>()
+            .firstOrNull()
+            .shouldNotBeNull()
+    }
+
+    @Test
+    fun `missing elevated access stays a bare message for clear data too`() = runTest2 {
+        val thrown = shouldThrow<PkgOpsException> { pkgOps.clearData(installId) }
+
+        thrown.message!! shouldNotContain "unavailable"
+    }
+}

--- a/app-common-io/src/test/java/eu/darken/butler/common/pkgs/pkgops/ipc/PkgOpsHostShellFailureTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/pkgs/pkgops/ipc/PkgOpsHostShellFailureTest.kt
@@ -1,0 +1,105 @@
+package eu.darken.butler.common.pkgs.pkgops.ipc
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.shell.SharedShell
+import eu.darken.flowshell.core.cmd.FlowCmd
+import eu.darken.flowshell.core.cmd.FlowCmdShell
+import eu.darken.flowshell.core.process.FlowProcess
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+
+/**
+ * `pm uninstall` and `pm clear` answer a refusal with a non-OK exit code and an explanation on
+ * stdout/stderr. Returning false for that would lose both.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PkgOpsHostShellFailureTest : BaseTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val session = mockk<FlowCmdShell.Session>()
+    private val executed = slot<FlowCmd>()
+
+    private fun createHost(result: FlowCmd.Result): PkgOpsHost {
+        coEvery { session.execute(capture(executed)) } returns result
+        val sharedShell = mockk<SharedShell>()
+        coEvery { sharedShell.useRes<FlowCmd.Result>(any()) } coAnswers {
+            firstArg<suspend (FlowCmdShell.Session) -> FlowCmd.Result>().invoke(session)
+        }
+        return PkgOpsHost(
+            context = context,
+            libcoreTool = mockk(relaxed = true),
+            sharedShell = sharedShell,
+            processScanner = mockk(relaxed = true),
+        )
+    }
+
+    private fun result(
+        exitCode: FlowProcess.ExitCode,
+        output: List<String> = emptyList(),
+        errors: List<String> = emptyList(),
+    ) = FlowCmd.Result(
+        original = FlowCmd("noop"),
+        exitCode = exitCode,
+        output = output,
+        errors = errors,
+    )
+
+    @Test
+    fun `a refused uninstall throws with the shell output`() {
+        val host = createHost(
+            result(
+                exitCode = FlowProcess.ExitCode(1),
+                output = listOf("Failure [DELETE_FAILED_INTERNAL_ERROR]"),
+                errors = listOf("Exception occurred while executing"),
+            )
+        )
+
+        val thrown = shouldThrow<Exception> { host.uninstallPackage("com.example.app", 0) }
+
+        thrown.message!! shouldContain "Failure [DELETE_FAILED_INTERNAL_ERROR]"
+        thrown.message!! shouldContain "Exception occurred while executing"
+        executed.captured.instructions shouldBe listOf("pm uninstall --user 0 com.example.app")
+    }
+
+    @Test
+    fun `an accepted uninstall reports success`() {
+        val host = createHost(result(exitCode = FlowProcess.ExitCode.OK, output = listOf("Success")))
+
+        host.uninstallPackage("com.example.app", 0) shouldBe true
+    }
+
+    @Test
+    fun `a refused clear data throws with the shell output`() {
+        val host = createHost(
+            result(
+                exitCode = FlowProcess.ExitCode(255),
+                output = listOf("Failed"),
+                errors = listOf("Permission Denial"),
+            )
+        )
+
+        val thrown = shouldThrow<Exception> { host.clearData("com.example.app", 10) }
+
+        thrown.message!! shouldContain "Failed"
+        thrown.message!! shouldContain "Permission Denial"
+        executed.captured.instructions shouldBe listOf("pm clear --user 10 com.example.app")
+    }
+
+    @Test
+    fun `an accepted clear data reports success`() {
+        val host = createHost(result(exitCode = FlowProcess.ExitCode.OK, output = listOf("Success")))
+
+        host.clearData("com.example.app", 0) shouldBe true
+    }
+}

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/AppsWorkspace.kt
@@ -340,7 +340,12 @@ class AppsWorkspace @AssistedInject constructor(
                 }
             }
             if (failures.isNotEmpty()) {
-                throw PkgOpsException("Failed to uninstall ${failures.size}/${apps.size} apps", failures.first().second)
+                // The first failure's text is appended because only the top-level message is
+                // rendered - a bare summary would not say why anything failed.
+                throw PkgOpsException(
+                    "Failed to uninstall ${failures.size}/${apps.size} apps: ${failures.first().second.message}",
+                    failures.first().second,
+                )
             }
         } finally {
             appsEngine.refresh()
@@ -361,7 +366,10 @@ class AppsWorkspace @AssistedInject constructor(
                 }
             }
             if (failures.isNotEmpty()) {
-                throw PkgOpsException("Failed to clear data for ${failures.size}/${apps.size} apps", failures.first().second)
+                throw PkgOpsException(
+                    "Failed to clear data for ${failures.size}/${apps.size} apps: ${failures.first().second.message}",
+                    failures.first().second,
+                )
             }
         } finally {
             appSizeCache.invalidate(apps.map { it.pkg.installId })

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
+import java.util.concurrent.atomic.AtomicBoolean
 
 class AppDetailsWorkspace @AssistedInject constructor(
     @Assisted override val id: Workspace.Id,
@@ -300,6 +301,24 @@ class AppDetailsWorkspace @AssistedInject constructor(
         null
     }
 
+    /**
+     * Number of package operations (enable/disable/uninstall/clear/component toggle) currently
+     * running. Package operations don't go through OperationsManager, so this is the only signal
+     * that keeps a pause from releasing the workspace mid-operation.
+     *
+     * Declared before [state], which reads it: properties initialise in declaration order.
+     */
+    private val pkgOpsInFlight = MutableStateFlow(0)
+
+    private suspend fun <T> trackPkgOp(block: suspend () -> T): T {
+        pkgOpsInFlight.update { it + 1 }
+        try {
+            return block()
+        } finally {
+            pkgOpsInFlight.update { it - 1 }
+        }
+    }
+
     data class State(
         val appState: AppInfoState = AppInfoState.Loading,
         val selectedTab: DetailTab = DetailTab.OVERVIEW,
@@ -311,6 +330,7 @@ class AppDetailsWorkspace @AssistedInject constructor(
         val hasAdb: Boolean = false,
         val componentToggleState: ComponentToggleState = ComponentToggleState.UNSUPPORTED,
         val packageInfo: PackageInfoState = PackageInfoState.Loading,
+        val isPkgActionRunning: Boolean = false,
     ) {
         val app: AppInfo? get() = (appState as? AppInfoState.Ready)?.info
         val isLoading: Boolean get() = appState is AppInfoState.Loading
@@ -330,8 +350,9 @@ class AppDetailsWorkspace @AssistedInject constructor(
         _sizeLoading,
         packageInfoLoader.state,
         pathInsights,
+        pkgOpsInFlight,
     ) { appState, selectedTab, hasRoot, hasAdb, componentToggleState, sizeSnapshot, sizesAvailable, isLoadingSize,
-        packageInfo, insights ->
+        packageInfo, insights, opsInFlight ->
         val withSize = when (appState) {
             is AppInfoState.Ready -> when (val size = sizeSnapshot.sizes[appState.info.installId]) {
                 null -> appState
@@ -358,28 +379,13 @@ class AppDetailsWorkspace @AssistedInject constructor(
             hasAdb = hasAdb,
             componentToggleState = componentToggleState,
             packageInfo = packageInfo,
+            isPkgActionRunning = opsInFlight > 0,
         )
     }
 
     // Same derivation the factory hands the paused stand-in, so both name this tab identically.
     // The live tab enriches this to the app label once package data resolves.
     private val seedDisplay = deriveAppDetailsDisplay(args)
-
-    /**
-     * Number of package operations (enable/disable/uninstall/clear/component toggle) currently
-     * running. Package operations don't go through OperationsManager, so this is the only signal
-     * that keeps a pause from releasing the workspace mid-operation.
-     */
-    private val pkgOpsInFlight = MutableStateFlow(0)
-
-    private suspend fun <T> trackPkgOp(block: suspend () -> T): T {
-        pkgOpsInFlight.update { it + 1 }
-        try {
-            return block()
-        } finally {
-            pkgOpsInFlight.update { it - 1 }
-        }
-    }
 
     override val info: StateFlow<Workspace.Info> = combine(
         appInfoOrNull,
@@ -453,27 +459,60 @@ class AppDetailsWorkspace @AssistedInject constructor(
     // Package operations live here, not on the ViewModel, so pkgOpsInFlight actually covers them.
     // Exceptions propagate to the caller, which owns error surfacing and any fallback.
 
-    suspend fun uninstallApp(app: AppInfo): Boolean = trackPkgOp {
-        log(tag) { "uninstallApp(${app.packageName})" }
-        pkgOps.uninstall(app.installId).also { refreshAfterPkgOp() }
+    /**
+     * Rejects a second app-wide package action while one is running. The rows going disabled is
+     * feedback only - two taps can both be delivered before a recomposition, so this is what
+     * actually stops the second one.
+     *
+     * Component toggles stay out of it: they have their own selection and confirmation flow, and
+     * one lock across both would let a component toggle block an uninstall.
+     */
+    private val pkgActionRunning = AtomicBoolean(false)
+
+    private suspend fun singleFlightPkgOp(name: String, block: suspend () -> Unit) {
+        if (!pkgActionRunning.compareAndSet(false, true)) {
+            log(tag, WARN) { "$name rejected, another package action is still running" }
+            return
+        }
+        try {
+            block()
+        } finally {
+            pkgActionRunning.set(false)
+        }
+    }
+
+    suspend fun uninstallApp(app: AppInfo) = singleFlightPkgOp("uninstallApp(${app.packageName})") {
+        trackPkgOp {
+            log(tag) { "uninstallApp(${app.packageName})" }
+            pkgOps.uninstall(app.installId)
+            refreshAfterPkgOp()
+        }
     }
 
     // No refresh: a force-stop changes no package data, and every refresh re-gathers every source.
-    suspend fun forceStopApp(app: AppInfo): Boolean = trackPkgOp {
-        log(tag) { "forceStopApp(${app.packageName})" }
-        pkgOps.forceStop(app.id)
+    suspend fun forceStopApp(app: AppInfo) = singleFlightPkgOp("forceStopApp(${app.packageName})") {
+        trackPkgOp {
+            log(tag) { "forceStopApp(${app.packageName})" }
+            pkgOps.forceStop(app.id)
+        }
     }
 
-    suspend fun clearDataApp(app: AppInfo): Boolean = trackPkgOp {
-        log(tag) { "clearDataApp(${app.packageName})" }
-        pkgOps.clearData(app.installId).also { refreshAfterPkgOp() }
+    suspend fun clearDataApp(app: AppInfo) = singleFlightPkgOp("clearDataApp(${app.packageName})") {
+        trackPkgOp {
+            log(tag) { "clearDataApp(${app.packageName})" }
+            pkgOps.clearData(app.installId)
+            refreshAfterPkgOp()
+        }
     }
 
-    suspend fun setAppEnabled(app: AppInfo, enabled: Boolean) = trackPkgOp {
-        log(tag) { "setAppEnabled(${app.packageName}, enabled=$enabled)" }
-        pkgOps.changePackageState(app.id, enabled = enabled)
-        refreshAfterPkgOp()
-    }
+    suspend fun setAppEnabled(app: AppInfo, enabled: Boolean) =
+        singleFlightPkgOp("setAppEnabled(${app.packageName}, enabled=$enabled)") {
+            trackPkgOp {
+                log(tag) { "setAppEnabled(${app.packageName}, enabled=$enabled)" }
+                pkgOps.changePackageState(app.id, enabled = enabled)
+                refreshAfterPkgOp()
+            }
+        }
 
     /**
      * Deliberately not in a `finally`: [PkgRepo.refresh] rethrows a source error, which would then

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
@@ -34,7 +34,6 @@ import eu.darken.butler.common.pkgs.apk.ApkArchiveParser
 import eu.darken.butler.common.pkgs.features.SourceAvailable
 import eu.darken.butler.common.pkgs.pkgops.PkgOps
 import eu.darken.butler.common.pkgs.pkgops.PkgOpsException
-import eu.darken.butler.common.pkgs.pkgs
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.permissions.core.PathPermissionCheck
@@ -62,7 +61,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -126,25 +124,30 @@ class AppDetailsWorkspace @AssistedInject constructor(
     private val selectedTabFlow = MutableStateFlow(args.initialTab)
     private var wasAppSeen = false
 
-    // Fetch app info from package manager; shared so `state` and `info` collect pkgs() once.
-    // Plain stateIn (not shareLatest): null is a legitimate value meaning "package gone".
-    private val appInfoFlow: StateFlow<AppInfo?> = pkgRepo.pkgs().map { pkgs ->
-        val pkg = pkgs.firstOrNull { it.installId == args.installId } ?: return@map null
-
-        AppInfo(
-            install = pkg,
-        )
-    }
-        .catch { error ->
-            log(tag, ERROR) { "Failed to resolve app info: ${error.asLog()}" }
-            emit(null)
+    // Fetch app info from package manager; shared so `state` and `info` collect the repo once.
+    // Built from `data` rather than `pkgs()`: `catch` is terminal, so a source error would end the
+    // flow for good and leave the workspace stuck with no way to retry. Reading `error` first keeps
+    // `pkgs` - which throws while an error is set - out of reach until it cannot throw.
+    private val appInfoFlow: StateFlow<AppInfoState> = pkgRepo.data
+        .map { data ->
+            data.error?.let { error ->
+                log(tag, ERROR) { "Failed to resolve app info: ${error.asLog()}" }
+                return@map AppInfoState.SourceError(error)
+            }
+            val pkg = data.pkgs.firstOrNull { it.installId == args.installId }
+            if (pkg == null) AppInfoState.Gone else AppInfoState.Ready(AppInfo(install = pkg))
         }
+        .stateIn(scope, SharingStarted.Eagerly, AppInfoState.Loading)
+
+    /** For consumers that only ever cared about the app itself; anything else reads as null. */
+    private val appInfoOrNull: StateFlow<AppInfo?> = appInfoFlow
+        .map { (it as? AppInfoState.Ready)?.info }
         .stateIn(scope, SharingStarted.Eagerly, null)
 
     // Declared after appInfoFlow on purpose: it reads that flow, so it has to see the shared one.
     private val packageInfoLoader = PackageInfoLoader(
         scope = scope,
-        appInfo = appInfoFlow,
+        appInfo = appInfoOrNull,
         load = { app -> loadPackageInfo(app) },
     )
 
@@ -187,7 +190,7 @@ class AppDetailsWorkspace @AssistedInject constructor(
     // Declared after appInfoFlow on purpose: it probes that flow, so it has to see the shared one.
     private val componentToggleAvailability = ComponentToggleAvailability(
         scope = scope,
-        appInfo = appInfoFlow,
+        appInfo = appInfoOrNull,
         rootManager = rootManager,
         adbManager = adbManager,
         ownPackageName = context.packageName,
@@ -298,10 +301,9 @@ class AppDetailsWorkspace @AssistedInject constructor(
     }
 
     data class State(
-        val app: AppInfo? = null,
+        val appState: AppInfoState = AppInfoState.Loading,
         val selectedTab: DetailTab = DetailTab.OVERVIEW,
         val availablePaths: List<AppPath> = emptyList(),
-        val isLoading: Boolean = true,
         val isLoadingSize: Boolean = false,
         val sizesAvailable: Boolean = true,
         val callerWorkspaceId: Workspace.Id? = null,
@@ -310,6 +312,8 @@ class AppDetailsWorkspace @AssistedInject constructor(
         val componentToggleState: ComponentToggleState = ComponentToggleState.UNSUPPORTED,
         val packageInfo: PackageInfoState = PackageInfoState.Loading,
     ) {
+        val app: AppInfo? get() = (appState as? AppInfoState.Ready)?.info
+        val isLoading: Boolean get() = appState is AppInfoState.Loading
         val canEnableDisable: Boolean get() = hasRoot || hasAdb
         val canForceStop: Boolean get() = hasRoot || hasAdb
         val canClearData: Boolean get() = hasRoot || hasAdb
@@ -326,22 +330,27 @@ class AppDetailsWorkspace @AssistedInject constructor(
         _sizeLoading,
         packageInfoLoader.state,
         pathInsights,
-    ) { app, selectedTab, hasRoot, hasAdb, componentToggleState, sizeSnapshot, sizesAvailable, isLoadingSize,
+    ) { appState, selectedTab, hasRoot, hasAdb, componentToggleState, sizeSnapshot, sizesAvailable, isLoadingSize,
         packageInfo, insights ->
-        val withSize = app?.let { info ->
-            val size = sizeSnapshot.sizes[info.installId] ?: return@let info
-            info.copy(
-                appSize = size.appBytes,
-                dataSize = size.dataBytes,
-                cacheSize = size.cacheBytes,
-            )
+        val withSize = when (appState) {
+            is AppInfoState.Ready -> when (val size = sizeSnapshot.sizes[appState.info.installId]) {
+                null -> appState
+                else -> AppInfoState.Ready(
+                    appState.info.copy(
+                        appSize = size.appBytes,
+                        dataSize = size.dataBytes,
+                        cacheSize = size.cacheBytes,
+                    )
+                )
+            }
+
+            else -> appState
         }
-        val paths = if (withSize != null) buildAppPaths(insights) else emptyList()
+        val paths = if (withSize is AppInfoState.Ready) buildAppPaths(insights) else emptyList()
         State(
             selectedTab = selectedTab,
-            app = withSize,
+            appState = withSize,
             availablePaths = paths,
-            isLoading = withSize == null,
             isLoadingSize = isLoadingSize,
             sizesAvailable = sizesAvailable,
             callerWorkspaceId = args.callerWorkspaceId,
@@ -373,7 +382,7 @@ class AppDetailsWorkspace @AssistedInject constructor(
     }
 
     override val info: StateFlow<Workspace.Info> = combine(
-        appInfoFlow,
+        appInfoOrNull,
         selectedTabFlow,
         pkgOpsInFlight,
     ) { app, _, opsInFlight ->
@@ -433,6 +442,12 @@ class AppDetailsWorkspace @AssistedInject constructor(
         selectedTabFlow.value = tab
         // Every entry re-runs the load, which is also the retry after a transient Unavailable.
         if (tab == DetailTab.PACKAGE_INFO) packageInfoLoader.onRequested()
+    }
+
+    /** Retry after a [AppInfoState.SourceError]; the result arrives through [state]. */
+    suspend fun refreshPackageData() {
+        log(tag) { "refreshPackageData()" }
+        pkgRepo.refresh()
     }
 
     // Package operations live here, not on the ViewModel, so pkgOpsInFlight actually covers them.
@@ -495,16 +510,22 @@ class AppDetailsWorkspace @AssistedInject constructor(
         // Auto-close when the package is removed (e.g. after uninstall)
         // Only close after app was seen at least once (to avoid closing during initial load)
         appInfoFlow
-            .onEach { appInfo ->
+            .onEach { appState ->
                 // Only ever upgrades: a gone package must not erase the cached label.
-                normalizedAppLabel(appInfo?.label?.get(context), args.packageName)
+                normalizedAppLabel((appState as? AppInfoState.Ready)?.info?.label?.get(context), args.packageName)
                     ?.let { cachedAppLabel = it }
 
-                if (appInfo != null) {
-                    wasAppSeen = true
-                } else if (wasAppSeen) {
-                    log(tag, INFO) { "Package ${args.packageName} removed, auto-closing workspace" }
-                    workspaceRemote.execute(WorkspaceAction.Close(id))
+                when (appState) {
+                    is AppInfoState.Ready -> wasAppSeen = true
+
+                    AppInfoState.Gone -> if (wasAppSeen) {
+                        log(tag, INFO) { "Package ${args.packageName} removed, auto-closing workspace" }
+                        workspaceRemote.execute(WorkspaceAction.Close(id))
+                    }
+
+                    // Neither says the package is gone, and closing on a source error would take
+                    // the screen away from the user with nothing left to retry from.
+                    AppInfoState.Loading, is AppInfoState.SourceError -> Unit
                 }
             }
             .launchIn(scope)
@@ -514,7 +535,7 @@ class AppDetailsWorkspace @AssistedInject constructor(
         // stay empty forever after any invalidation.
         scope.launch {
             combine(
-                appInfoFlow,
+                appInfoOrNull,
                 appSizeCache.snapshot,
                 appSizeCache.isAvailable,
             ) { app, snapshot, isAvailable ->

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspace.kt
@@ -455,9 +455,10 @@ class AppDetailsWorkspace @AssistedInject constructor(
 
     suspend fun uninstallApp(app: AppInfo): Boolean = trackPkgOp {
         log(tag) { "uninstallApp(${app.packageName})" }
-        pkgOps.uninstall(app.installId)
+        pkgOps.uninstall(app.installId).also { refreshAfterPkgOp() }
     }
 
+    // No refresh: a force-stop changes no package data, and every refresh re-gathers every source.
     suspend fun forceStopApp(app: AppInfo): Boolean = trackPkgOp {
         log(tag) { "forceStopApp(${app.packageName})" }
         pkgOps.forceStop(app.id)
@@ -465,12 +466,28 @@ class AppDetailsWorkspace @AssistedInject constructor(
 
     suspend fun clearDataApp(app: AppInfo): Boolean = trackPkgOp {
         log(tag) { "clearDataApp(${app.packageName})" }
-        pkgOps.clearData(app.installId)
+        pkgOps.clearData(app.installId).also { refreshAfterPkgOp() }
     }
 
     suspend fun setAppEnabled(app: AppInfo, enabled: Boolean) = trackPkgOp {
         log(tag) { "setAppEnabled(${app.packageName}, enabled=$enabled)" }
         pkgOps.changePackageState(app.id, enabled = enabled)
+        refreshAfterPkgOp()
+    }
+
+    /**
+     * Deliberately not in a `finally`: [PkgRepo.refresh] rethrows a source error, which would then
+     * replace the operation's own failure. A failure here is swallowed because the operation itself
+     * succeeded, and the source error still reaches the screen through [state].
+     */
+    private suspend fun refreshAfterPkgOp() {
+        try {
+            pkgRepo.refresh()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(tag, WARN) { "Refresh after package operation failed: ${e.asLog()}" }
+        }
     }
 
     suspend fun setComponentsEnabled(entries: List<ComponentEntry>, enabled: Boolean) = trackPkgOp {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModel.kt
@@ -3,7 +3,6 @@ package eu.darken.butler.apps.core.details
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.provider.Settings
 import androidx.core.net.toUri
 import dagger.assisted.Assisted
@@ -17,6 +16,7 @@ import eu.darken.butler.apps.core.details.components.AppComponentsController
 import eu.darken.butler.apps.core.details.components.AppComponentsLoader
 import eu.darken.butler.apps.core.details.components.ComponentEntry
 import eu.darken.butler.apps.core.details.components.ComponentToggleState
+import eu.darken.butler.apps.ui.details.AppDetailsConfirmRequest
 import eu.darken.butler.apps.ui.details.components.ComponentsActionBarItem
 import eu.darken.butler.apps.ui.details.components.ComponentsConfirmRequest
 import eu.darken.butler.common.ElevatedAccessUnavailableException
@@ -118,6 +118,11 @@ class AppDetailsWorkspaceViewModel @AssistedInject constructor(
     // shadows the kotlinx one inside every subclass and returns a plain Flow.
     val componentConfirm: StateFlow<ComponentsConfirmRequest?> = componentConfirmFlow
 
+    private val appConfirmFlow = MutableStateFlow<AppDetailsConfirmRequest?>(null)
+
+    // Assigned for the same reason as componentConfirm above.
+    val appConfirm: StateFlow<AppDetailsConfirmRequest?> = appConfirmFlow
+
     init {
         // Driven from the nullable source, not from `state`: that one filters the absent workspace
         // away and would never emit, leaving the controller holding data, a live selection and a
@@ -127,6 +132,7 @@ class AppDetailsWorkspaceViewModel @AssistedInject constructor(
             .onEach { workspaceState ->
                 componentsController.onAppChanged(workspaceState?.app)
                 componentsController.onComponentsRouteActive(workspaceState?.selectedTab == DetailTab.COMPONENTS)
+                retireStaleAppConfirm(workspaceState)
             }
             .launchInViewModel()
 
@@ -269,20 +275,73 @@ class AppDetailsWorkspaceViewModel @AssistedInject constructor(
     }
 
     fun onUninstall(app: AppInfo) = launch {
+        val hasElevatedAccess = state.first().let { it.hasRoot || it.hasAdb }
+        if (!hasElevatedAccess) {
+            // Android's dialog IS the confirmation on this path, and it is launched directly rather
+            // than through the workspace: deciding on availability and then dispatching would
+            // re-read root/ADB a moment later, so a flip to available in between would run an
+            // elevated uninstall that nobody ever confirmed.
+            log(tag) { "onUninstall(${app.packageName}): no elevated access, using the system dialog" }
+            startSystemUninstall(app)
+            return@launch
+        }
+        log(tag) { "onUninstall(${app.packageName}): asking for confirmation" }
+        appConfirmFlow.value = AppDetailsConfirmRequest.Uninstall(app)
+    }
+
+    private fun startSystemUninstall(app: AppInfo) {
+        val intent = Intent(Intent.ACTION_DELETE).apply {
+            data = "package:${app.packageName}".toUri()
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+
+    /** A pending dialog must not outlive its target: the package can vanish or change under it. */
+    private fun retireStaleAppConfirm(workspaceState: AppDetailsWorkspace.State?) {
+        val pending = appConfirmFlow.value ?: return
+        val live = (workspaceState?.appState as? AppInfoState.Ready)?.info
+        if (live == null || live.installId != pending.app.installId) {
+            log(tag, WARN) { "Retiring pending confirmation, its target is gone" }
+            appConfirmFlow.value = null
+        }
+    }
+
+    fun onAppConfirm(request: AppDetailsConfirmRequest) = launch {
+        // Consumed atomically before dispatching, so a duplicated callback cannot act twice.
+        if (!appConfirmFlow.compareAndSet(request, null)) {
+            log(tag, WARN) { "onAppConfirm($request): request is no longer pending, ignoring" }
+            return@launch
+        }
+        log(tag) { "onAppConfirm($request)" }
+        when (request) {
+            is AppDetailsConfirmRequest.ClearData -> {
+                getWorkspace().clearDataApp(request.app)
+                appSizeCache.invalidate(listOf(request.app.installId))
+            }
+
+            is AppDetailsConfirmRequest.Uninstall -> performUninstall(request.app)
+        }
+    }
+
+    fun onAppConfirmDismiss() {
+        log(tag) { "onAppConfirmDismiss()" }
+        appConfirmFlow.value = null
+    }
+
+    private suspend fun performUninstall(app: AppInfo) {
         log(tag) { "Uninstalling app: ${app.packageName}" }
         try {
             getWorkspace().uninstallApp(app)
             // Don't close here — auto-close in AppDetailsWorkspace handles it reactively
         } catch (e: Exception) {
+            // The safety net for the opposite flip: elevated access lost between the confirmation
+            // and the dispatch, which leaves the user with Android's dialog after Butler's.
             val isElevatedUnavailable = generateSequence<Throwable>(e) { it.cause }
                 .any { it is ElevatedAccessUnavailableException }
             if (isElevatedUnavailable) {
                 log(tag) { "Elevated access unavailable, falling back to system uninstall intent" }
-                val intent = Intent(Intent.ACTION_DELETE).apply {
-                    data = Uri.parse("package:${app.packageName}")
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-                context.startActivity(intent)
+                startSystemUninstall(app)
             } else {
                 throw e
             }
@@ -363,10 +422,10 @@ class AppDetailsWorkspaceViewModel @AssistedInject constructor(
         getWorkspace().forceStopApp(app)
     }
 
-    fun onClearData(app: AppInfo) = launch {
-        log(tag) { "Clearing data: ${app.packageName}" }
-        getWorkspace().clearDataApp(app)
-        appSizeCache.invalidate(listOf(app.installId))
+    /** Always confirmed: there is no undo, and no system dialog stands between tap and wipe. */
+    fun onClearData(app: AppInfo) {
+        log(tag) { "onClearData(${app.packageName}): asking for confirmation" }
+        appConfirmFlow.value = AppDetailsConfirmRequest.ClearData(app)
     }
 
     fun onOpenSizePermissionSetup() = launch {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModel.kt
@@ -225,6 +225,19 @@ class AppDetailsWorkspaceViewModel @AssistedInject constructor(
         getWorkspace().updateSelectedTab(tab)
     }
 
+    fun onRetryAppInfo() = launch {
+        log(tag) { "onRetryAppInfo()" }
+        try {
+            getWorkspace().refreshPackageData()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Swallowed on purpose: a failed retry arrives on the screen through the state flow as
+            // the same error card, so raising a dialog on top of it would say it twice.
+            log(tag, WARN) { "onRetryAppInfo() failed: ${e.asLog()}" }
+        }
+    }
+
     fun onLaunchApp(app: AppInfo) = launch {
         log(tag) { "Launching app: ${app.packageName}" }
         val launchIntent = context.packageManager.getLaunchIntentForPackage(app.packageName)

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppInfo.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppInfo.kt
@@ -9,6 +9,7 @@ import eu.darken.butler.common.pkgs.features.Installed
 import eu.darken.butler.common.pkgs.features.InstallerInfo
 import eu.darken.butler.common.pkgs.isEnabled
 import eu.darken.butler.common.pkgs.isSystemApp
+import eu.darken.butler.common.pkgs.isUninstalled
 import kotlin.time.Instant
 
 data class AppInfo(
@@ -50,6 +51,10 @@ data class AppInfo(
 
     val isSystemApp: Boolean
         get() = install.isSystemApp
+
+    /** Uninstalled for this user while its files stay on the device, e.g. a system app. */
+    val isUninstalled: Boolean
+        get() = install.isUninstalled
 
     val targetSdk: Int?
         get() = install.applicationInfo?.targetSdkVersion

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppInfoState.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/details/AppInfoState.kt
@@ -1,0 +1,19 @@
+package eu.darken.butler.apps.core.details
+
+/**
+ * What the package repository can say about the app this workspace was opened for.
+ *
+ * "Uninstalled for this user" is not a state of its own: the package is still known and its
+ * metadata still valid, so it is [Ready] with [AppInfo.isUninstalled] set.
+ */
+sealed interface AppInfoState {
+
+    data object Loading : AppInfoState
+
+    data class Ready(val info: AppInfo) : AppInfoState
+
+    /** The package source itself failed. Says nothing about whether the app is still installed. */
+    data class SourceError(val error: Throwable) : AppInfoState
+
+    data object Gone : AppInfoState
+}

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/engine/AppItem.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/engine/AppItem.kt
@@ -11,6 +11,7 @@ import eu.darken.butler.common.pkgs.features.InstallDetails
 import eu.darken.butler.common.pkgs.features.Installed
 import eu.darken.butler.common.pkgs.features.InstallerInfo
 import eu.darken.butler.common.pkgs.features.SourceAvailable
+import eu.darken.butler.common.pkgs.isUninstalled
 import eu.darken.butler.common.user.UserProfile2
 import eu.darken.butler.workspace.contracts.apps.AppTag
 import eu.darken.butler.workspace.contracts.apps.SortSettings
@@ -39,6 +40,8 @@ data class AppItem(
 
     // Body properties, not constructor defaults: the generated copy() passes existing property
     // values instead of re-evaluating defaults, which would keep stale derived values around.
+    val isUninstalled: Boolean = pkg.isUninstalled
+
     val isSideloaded: Boolean = if (isSystemApp) {
         false
     } else {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceViewModel.kt
@@ -234,6 +234,9 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
 
     private fun buildSelectionActions(wsState: AppsWorkspace.State.Ready): List<AppsActionBarItem> {
         val selectedApps = wsState.selectedApps
+        // Package commands would target an install that is no longer there. Opening, selecting,
+        // exporting and sharing still make sense for those entries, so they keep the full selection.
+        val commandable = selectedApps.filter { !it.isUninstalled }
         return buildList {
             add(AppsActionBarItem.OpenInTab(selectedApps))
 
@@ -241,19 +244,19 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
                 add(AppsActionBarItem.SelectAll)
             }
 
-            if (wsState.canEnableDisable) {
-                val disableAction = AppsActionBarItem.Disable(selectedApps)
+            if (wsState.canEnableDisable && commandable.isNotEmpty()) {
+                val disableAction = AppsActionBarItem.Disable(commandable)
                 if (disableAction.isVisible) add(disableAction)
 
-                val enableAction = AppsActionBarItem.Enable(selectedApps)
+                val enableAction = AppsActionBarItem.Enable(commandable)
                 if (enableAction.isVisible) add(enableAction)
             }
 
-            if (wsState.canClearData) {
-                add(AppsActionBarItem.ClearData(selectedApps))
+            if (wsState.canClearData && commandable.isNotEmpty()) {
+                add(AppsActionBarItem.ClearData(commandable))
             }
 
-            add(AppsActionBarItem.Uninstall(selectedApps))
+            if (commandable.isNotEmpty()) add(AppsActionBarItem.Uninstall(commandable))
             add(AppsActionBarItem.ExportApk(selectedApps))
 
             val shareAction = AppsActionBarItem.Share(selectedApps)
@@ -532,6 +535,18 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
+    /**
+     * The barrier for package commands, placed at the dispatch point because the long-press dialog
+     * builds its own action items and never passes through [buildSelectionActions]. Null means
+     * nothing is left to act on.
+     */
+    private fun commandableOrNull(apps: List<AppItem>, what: String): List<AppItem>? {
+        val commandable = apps.filter { !it.isUninstalled }
+        if (commandable.isNotEmpty()) return commandable
+        log(tag, WARN) { "$what: every selected app is uninstalled, nothing to do" }
+        return null
+    }
+
     private fun onActionBarClick(action: AppsActionBarItem) {
         log(tag) { "onActionBarClick: ${action.javaClass.simpleName}" }
 
@@ -551,23 +566,27 @@ class AppsWorkspaceViewModel @AssistedInject constructor(
             }
 
             is AppsActionBarItem.Disable -> launch {
-                log(tag) { "Disable action for ${action.apps.size} apps" }
-                dialogStateFlow.value = AppsDialogState.ConfirmDisable(action.apps)
+                val apps = commandableOrNull(action.apps, "Disable") ?: return@launch
+                log(tag) { "Disable action for ${apps.size} apps" }
+                dialogStateFlow.value = AppsDialogState.ConfirmDisable(apps)
             }
 
             is AppsActionBarItem.Enable -> launch {
-                log(tag) { "Enable action for ${action.apps.size} apps" }
-                dialogStateFlow.value = AppsDialogState.ConfirmEnable(action.apps)
+                val apps = commandableOrNull(action.apps, "Enable") ?: return@launch
+                log(tag) { "Enable action for ${apps.size} apps" }
+                dialogStateFlow.value = AppsDialogState.ConfirmEnable(apps)
             }
 
             is AppsActionBarItem.Uninstall -> launch {
-                log(tag) { "Uninstall action for ${action.apps.size} apps" }
-                dialogStateFlow.value = AppsDialogState.ConfirmUninstall(action.apps)
+                val apps = commandableOrNull(action.apps, "Uninstall") ?: return@launch
+                log(tag) { "Uninstall action for ${apps.size} apps" }
+                dialogStateFlow.value = AppsDialogState.ConfirmUninstall(apps)
             }
 
             is AppsActionBarItem.ClearData -> launch {
-                log(tag) { "Clear data action for ${action.apps.size} apps" }
-                dialogStateFlow.value = AppsDialogState.ConfirmClearData(action.apps)
+                val apps = commandableOrNull(action.apps, "Clear data") ?: return@launch
+                log(tag) { "Clear data action for ${apps.size} apps" }
+                dialogStateFlow.value = AppsDialogState.ConfirmClearData(apps)
             }
 
             is AppsActionBarItem.ExportApk -> launch {

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/dialogs/AppDetailsDialog.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/apps/dialogs/AppDetailsDialog.kt
@@ -280,53 +280,54 @@ private fun AppDetailsContent(
                 Text(stringResource(R.string.apps_action_open_info))
             }
 
-            // Enable/Disable
-            if (app.isEnabled) {
-                FilledTonalButton(
-                    onClick = {
-                        onAction(AppsActionBarItem.Disable(listOf(app)))
-                        onDismiss()
+            // Enable/Disable and Uninstall need an install to act on.
+            if (!app.isUninstalled) {
+                if (app.isEnabled) {
+                    FilledTonalButton(
+                        onClick = {
+                            onAction(AppsActionBarItem.Disable(listOf(app)))
+                            onDismiss()
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Block,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text(stringResource(R.string.apps_action_disable))
                     }
-                ) {
-                    Icon(
-                        imageVector = Icons.TwoTone.Block,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.size(8.dp))
-                    Text(stringResource(R.string.apps_action_disable))
-                }
-            } else {
-                FilledTonalButton(
-                    onClick = {
-                        onAction(AppsActionBarItem.Enable(listOf(app)))
-                        onDismiss()
+                } else {
+                    FilledTonalButton(
+                        onClick = {
+                            onAction(AppsActionBarItem.Enable(listOf(app)))
+                            onDismiss()
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.TwoTone.CheckCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text(stringResource(R.string.apps_action_enable))
                     }
-                ) {
-                    Icon(
-                        imageVector = Icons.TwoTone.CheckCircle,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.size(8.dp))
-                    Text(stringResource(R.string.apps_action_enable))
                 }
-            }
 
-            // Uninstall
-            FilledTonalButton(
-                onClick = {
-                    onAction(AppsActionBarItem.Uninstall(listOf(app)))
-                    onDismiss()
+                FilledTonalButton(
+                    onClick = {
+                        onAction(AppsActionBarItem.Uninstall(listOf(app)))
+                        onDismiss()
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.TwoTone.Delete,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(stringResource(R.string.apps_action_uninstall))
                 }
-            ) {
-                Icon(
-                    imageVector = Icons.TwoTone.Delete,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.size(8.dp))
-                Text(stringResource(R.string.apps_action_uninstall))
             }
 
             // Export APK

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/ActionsSection.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/ActionsSection.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapp
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.apps.R
 import eu.darken.butler.apps.core.details.AppInfo
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -98,17 +99,13 @@ sealed class AppAction {
 sealed class ActionGroup {
     abstract val actions: List<AppAction>
 
-    data object Primary : ActionGroup() {
-        override val actions = listOf(AppAction.Launch, AppAction.OpenInfo)
-    }
+    data class Primary(override val actions: List<AppAction>) : ActionGroup()
 
     data class Management(
         override val actions: List<AppAction>,
     ) : ActionGroup()
 
-    data object Export : ActionGroup() {
-        override val actions = listOf(AppAction.ExportApk, AppAction.ShareApk)
-    }
+    data class Export(override val actions: List<AppAction>) : ActionGroup()
 
     data class Destructive(override val actions: List<AppAction>) : ActionGroup()
 }
@@ -128,24 +125,40 @@ fun ActionsSection(
     canEnableDisable: Boolean = true,
     canForceStop: Boolean = true,
     canClearData: Boolean = true,
+    isUninstalled: Boolean = false,
 ) {
     if (app == null) return
 
+    // Nothing that needs an installed package is offered: there is no launch intent, no APK to
+    // export, and every package command would target something that is no longer there. Sharing
+    // stays, it shares text about the app rather than the APK.
+    val primaryActions = buildList {
+        if (!isUninstalled) add(AppAction.Launch)
+        add(AppAction.OpenInfo)
+    }
+
     val managementActions = buildList {
+        if (isUninstalled) return@buildList
         if (canEnableDisable) add(AppAction.EnableDisable(app.isEnabled))
         if (canForceStop) add(AppAction.ForceStop)
     }
 
+    val exportActions = buildList {
+        if (!isUninstalled) add(AppAction.ExportApk)
+        add(AppAction.ShareApk)
+    }
+
     val destructiveActions = buildList {
+        if (isUninstalled) return@buildList
         if (canClearData) add(AppAction.ClearData)
         add(AppAction.Uninstall)
     }
 
     val actionGroups = buildList {
-        add(ActionGroup.Primary)
+        add(ActionGroup.Primary(primaryActions))
         if (managementActions.isNotEmpty()) add(ActionGroup.Management(managementActions))
-        add(ActionGroup.Export)
-        add(ActionGroup.Destructive(destructiveActions))
+        add(ActionGroup.Export(exportActions))
+        if (destructiveActions.isNotEmpty()) add(ActionGroup.Destructive(destructiveActions))
     }
 
     val actionHandlers = mapOf<AppAction, () -> Unit>(
@@ -259,5 +272,40 @@ private fun ActionsSectionPreview() {
         onShareApk = {},
         onForceStop = {},
         onClearData = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ActionsSectionInstalledPreview() {
+    ActionsSection(
+        app = AppsMockDataProvider.Presets.chrome,
+        onLaunchApp = {},
+        onShowAppInfo = {},
+        onEnableDisable = {},
+        onUninstall = {},
+        onExportApk = {},
+        onShareApk = {},
+        onForceStop = {},
+        onClearData = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ActionsSectionUninstalledPreview() {
+    ActionsSection(
+        app = AppsMockDataProvider.Presets.chrome,
+        onLaunchApp = {},
+        onShowAppInfo = {},
+        onEnableDisable = {},
+        onUninstall = {},
+        onExportApk = {},
+        onShareApk = {},
+        onForceStop = {},
+        onClearData = {},
+        isUninstalled = true,
     )
 }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/ActionsSection.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/ActionsSection.kt
@@ -126,6 +126,7 @@ fun ActionsSection(
     canForceStop: Boolean = true,
     canClearData: Boolean = true,
     isUninstalled: Boolean = false,
+    enabled: Boolean = true,
 ) {
     if (app == null) return
 
@@ -181,6 +182,7 @@ fun ActionsSection(
                 group = group,
                 actionHandlers = actionHandlers,
                 showDivider = index < actionGroups.size - 1,
+                enabled = enabled,
             )
         }
     }
@@ -191,6 +193,7 @@ private fun ActionGroupSection(
     group: ActionGroup,
     actionHandlers: Map<AppAction, () -> Unit>,
     showDivider: Boolean,
+    enabled: Boolean = true,
 ) {
     group.actions.forEach { action ->
         val isDestructive = group is ActionGroup.Destructive
@@ -199,6 +202,7 @@ private fun ActionGroupSection(
             title = stringResource(action.titleRes),
             description = stringResource(action.descriptionRes),
             onClick = actionHandlers[action] ?: {},
+            enabled = enabled,
             tintColor = if (isDestructive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
         )
     }
@@ -219,12 +223,13 @@ private fun ActionItem(
     description: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     tintColor: Color = MaterialTheme.colorScheme.primary,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -289,6 +294,24 @@ private fun ActionsSectionInstalledPreview() {
         onShareApk = {},
         onForceStop = {},
         onClearData = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ActionsSectionBusyPreview() {
+    ActionsSection(
+        app = AppsMockDataProvider.Presets.chrome,
+        onLaunchApp = {},
+        onShowAppInfo = {},
+        onEnableDisable = {},
+        onUninstall = {},
+        onExportApk = {},
+        onShareApk = {},
+        onForceStop = {},
+        onClearData = {},
+        enabled = false,
     )
 }
 

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsConfirmDialog.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsConfirmDialog.kt
@@ -1,0 +1,112 @@
+package eu.darken.butler.apps.ui.details
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.apps.R
+import eu.darken.butler.apps.core.details.AppInfo
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
+import eu.darken.butler.common.R as CommonR
+
+/** A destructive app-wide package action awaiting confirmation. */
+sealed interface AppDetailsConfirmRequest {
+    val app: AppInfo
+
+    data class ClearData(override val app: AppInfo) : AppDetailsConfirmRequest
+
+    /** Only raised on the elevated path; without it Android's own dialog does the asking. */
+    data class Uninstall(override val app: AppInfo) : AppDetailsConfirmRequest
+}
+
+/**
+ * Confirmation for clearing data or uninstalling.
+ *
+ * Pane-bound like every other dialog in this workspace, so it never covers a sibling pane.
+ */
+@Composable
+fun AppDetailsConfirmDialog(
+    modifier: Modifier = Modifier,
+    request: AppDetailsConfirmRequest,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val label = request.app.label.get(context)
+
+    PaneBoundAlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = {
+            Text(
+                text = when (request) {
+                    is AppDetailsConfirmRequest.ClearData ->
+                        stringResource(R.string.apps_details_confirm_clear_data_title)
+
+                    is AppDetailsConfirmRequest.Uninstall ->
+                        stringResource(R.string.apps_details_confirm_uninstall_title)
+                },
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+        text = {
+            Text(
+                text = when (request) {
+                    is AppDetailsConfirmRequest.ClearData ->
+                        stringResource(R.string.apps_details_confirm_clear_data_message, label)
+
+                    is AppDetailsConfirmRequest.Uninstall ->
+                        stringResource(R.string.apps_details_confirm_uninstall_message, label)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = when (request) {
+                        is AppDetailsConfirmRequest.ClearData -> stringResource(R.string.apps_action_clear_data)
+                        is AppDetailsConfirmRequest.Uninstall -> stringResource(R.string.apps_action_uninstall)
+                    },
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AppDetailsConfirmDialogClearDataPreview() {
+    AppDetailsConfirmDialog(
+        request = AppDetailsConfirmRequest.ClearData(AppsMockDataProvider.Presets.chrome),
+        onConfirm = {},
+        onDismiss = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AppDetailsConfirmDialogUninstallPreview() {
+    AppDetailsConfirmDialog(
+        request = AppDetailsConfirmRequest.Uninstall(AppsMockDataProvider.Presets.chrome),
+        onConfirm = {},
+        onDismiss = {},
+    )
+}

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspaceOverlays.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspaceOverlays.kt
@@ -10,6 +10,7 @@ import eu.darken.butler.apps.core.details.components.ComponentEnabledState
 import eu.darken.butler.apps.core.details.components.ComponentEntry
 import eu.darken.butler.apps.core.details.components.ComponentKind
 import eu.darken.butler.apps.core.details.components.ComponentToggleState
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
 import eu.darken.butler.apps.ui.details.components.ComponentDetailsSheet
 import eu.darken.butler.apps.ui.details.components.ComponentsConfirmDialog
 import eu.darken.butler.apps.ui.details.components.ComponentsConfirmRequest
@@ -45,12 +46,15 @@ fun AppDetailsWorkspaceOverlaysHost(
         selectedSource = vm.selectedComponent,
         toggleStateSource = vm.componentToggleState,
         confirmSource = vm.componentConfirm,
+        appConfirmSource = vm.appConfirm,
         onDismiss = vm::onComponentSheetDismissed,
         onLaunch = { vm.onLaunchComponent(packageName = it.packageName, className = it.className) },
         onSetEnabled = { entry, enabled -> vm.onSetComponentEnabled(entry, enabled) },
         onSetupRequested = vm::openElevatedAccessSetup,
         onConfirm = vm::onComponentConfirm,
         onConfirmDismiss = vm::onComponentConfirmDismiss,
+        onAppConfirm = vm::onAppConfirm,
+        onAppConfirmDismiss = vm::onAppConfirmDismiss,
     )
 
     // Last on purpose: layers stack in composition order, so an error raised while one of this
@@ -64,12 +68,15 @@ fun AppDetailsWorkspaceOverlays(
     selectedSource: Flow<ComponentEntry?>,
     toggleStateSource: Flow<ComponentToggleState> = flowOf(ComponentToggleState.UNSUPPORTED),
     confirmSource: Flow<ComponentsConfirmRequest?> = flowOf(null),
+    appConfirmSource: Flow<AppDetailsConfirmRequest?> = flowOf(null),
     onDismiss: () -> Unit = {},
     onLaunch: (ComponentEntry) -> Unit = {},
     onSetEnabled: (ComponentEntry, Boolean) -> Unit = { _, _ -> },
     onSetupRequested: () -> Unit = {},
     onConfirm: (ComponentsConfirmRequest) -> Unit = {},
     onConfirmDismiss: () -> Unit = {},
+    onAppConfirm: (AppDetailsConfirmRequest) -> Unit = {},
+    onAppConfirmDismiss: () -> Unit = {},
 ) {
     // The real sources are eagerly shared StateFlows, so a remount reads the current values with no
     // null first frame — which would briefly unmount the sheet's layer.
@@ -82,6 +89,9 @@ fun AppDetailsWorkspaceOverlays(
     )
     val confirmRequest by confirmSource.collectAsState(
         initial = (confirmSource as? StateFlow<ComponentsConfirmRequest?>)?.value
+    )
+    val appConfirmRequest by appConfirmSource.collectAsState(
+        initial = (appConfirmSource as? StateFlow<AppDetailsConfirmRequest?>)?.value
     )
 
     val paneInsets = design.paneInsets()
@@ -107,6 +117,14 @@ fun AppDetailsWorkspaceOverlays(
             request = request,
             onConfirm = { onConfirm(request) },
             onDismiss = onConfirmDismiss,
+        )
+    }
+
+    appConfirmRequest?.let { request ->
+        AppDetailsConfirmDialog(
+            request = request,
+            onConfirm = { onAppConfirm(request) },
+            onDismiss = onAppConfirmDismiss,
         )
     }
 }
@@ -153,6 +171,18 @@ private fun AppDetailsWorkspaceOverlaysProviderPreview() {
 @Composable
 private fun AppDetailsWorkspaceOverlaysNoSelectionPreview() {
     AppDetailsWorkspaceOverlays(selectedSource = flowOf(null))
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AppDetailsWorkspaceOverlaysAppConfirmPreview() {
+    AppDetailsWorkspaceOverlays(
+        selectedSource = flowOf(null),
+        appConfirmSource = flowOf(
+            AppDetailsConfirmRequest.ClearData(AppsMockDataProvider.Presets.chrome)
+        ),
+    )
 }
 
 @Preview2

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
@@ -36,6 +36,7 @@ import eu.darken.butler.apps.core.AppPath
 import eu.darken.butler.apps.core.details.AppDetailsWorkspace
 import eu.darken.butler.apps.core.details.AppDetailsWorkspaceViewModel
 import eu.darken.butler.apps.core.details.AppInfo
+import eu.darken.butler.apps.core.details.AppInfoState
 import eu.darken.butler.apps.core.details.PackageInfoState
 import eu.darken.butler.apps.core.details.components.ComponentEntry
 import eu.darken.butler.apps.core.details.components.ComponentsData
@@ -70,6 +71,7 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import eu.darken.butler.workspace.ui.scroll.rememberWorkspaceLazyListState
 import kotlinx.coroutines.flow.drop
+import java.io.IOException
 
 sealed interface AppDetailsPageAction {
     data object Close : AppDetailsPageAction
@@ -90,6 +92,7 @@ sealed interface AppDetailsPageAction {
     data class ForceStop(val app: AppInfo) : AppDetailsPageAction
     data class ClearData(val app: AppInfo) : AppDetailsPageAction
     data object OpenSizeSetup : AppDetailsPageAction
+    data object RetryAppInfo : AppDetailsPageAction
 }
 
 @Composable
@@ -138,6 +141,7 @@ fun AppDetailsWorkspacePageHost(
                     is AppDetailsPageAction.ForceStop -> vm.onForceStop(action.app)
                     is AppDetailsPageAction.ClearData -> vm.onClearData(action.app)
                     is AppDetailsPageAction.OpenSizeSetup -> vm.onOpenSizePermissionSetup()
+                    is AppDetailsPageAction.RetryAppInfo -> vm.onRetryAppInfo()
                 }
             },
         )
@@ -280,6 +284,17 @@ fun AppDetailsWorkspacePage(
             // Cards on the overview are spaced apart; the flat component list stays dense.
             verticalArrangement = Arrangement.spacedBy(if (showComponents) 0.dp else 8.dp),
         ) {
+            // Outside the tab guard below: a source error while the user is on Components or
+            // Package info would otherwise leave a blank page with no way back.
+            (state.appState as? AppInfoState.SourceError)?.let { sourceError ->
+                item {
+                    AppInfoErrorCard(
+                        error = sourceError.error,
+                        onRetry = { onPageAction(AppDetailsPageAction.RetryAppInfo) },
+                    )
+                }
+            }
+
             if (appInfo != null) {
                 when (state.selectedTab) {
                     DetailTab.COMPONENTS -> appComponentsItems(
@@ -521,7 +536,7 @@ private fun AppDetailsWorkspacePageComponentsPreview() {
     AppDetailsWorkspacePage(
         design = WorkspaceDesign(),
         state = AppDetailsWorkspace.State(
-            app = AppsMockDataProvider.Presets.chrome,
+            appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
             selectedTab = DetailTab.COMPONENTS,
         ),
         componentsState = ComponentsUiState.Ready(previewComponentsData),
@@ -538,7 +553,7 @@ private fun AppDetailsWorkspacePageComponentsSelectionPreview() {
     AppDetailsWorkspacePage(
         design = WorkspaceDesign(),
         state = AppDetailsWorkspace.State(
-            app = AppsMockDataProvider.Presets.chrome,
+            appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
             selectedTab = DetailTab.COMPONENTS,
         ),
         componentsState = ComponentsUiState.Ready(previewComponentsData),
@@ -559,7 +574,7 @@ private fun AppDetailsWorkspacePagePackageInfoPreview() {
     AppDetailsWorkspacePage(
         design = WorkspaceDesign(),
         state = AppDetailsWorkspace.State(
-            app = AppsMockDataProvider.Presets.chrome,
+            appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
             selectedTab = DetailTab.PACKAGE_INFO,
             packageInfo = PackageInfoState.Ready(previewPackageInfo),
         ),
@@ -575,7 +590,7 @@ private fun AppDetailsWorkspacePagePackageInfoUnavailablePreview() {
     AppDetailsWorkspacePage(
         design = WorkspaceDesign(),
         state = AppDetailsWorkspace.State(
-            app = AppsMockDataProvider.Presets.chrome,
+            appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
             selectedTab = DetailTab.PACKAGE_INFO,
             packageInfo = PackageInfoState.Unavailable,
         ),
@@ -591,7 +606,7 @@ private fun AppDetailsWorkspacePagePreview() {
     AppDetailsWorkspacePage(
         design = WorkspaceDesign(),
         state = AppDetailsWorkspace.State(
-            app = AppsMockDataProvider.Presets.chrome,
+            appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
             availablePaths = listOf(
                 AppPath(
                     label = "App Data".toCaString(),
@@ -607,6 +622,21 @@ private fun AppDetailsWorkspacePagePreview() {
                 ),
             ),
         ),
+        onPageAction = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AppDetailsWorkspacePageSourceErrorPreview() {
+    AppDetailsWorkspacePage(
+        design = WorkspaceDesign(),
+        state = AppDetailsWorkspace.State(
+            appState = AppInfoState.SourceError(IOException("Package manager query timed out")),
+            selectedTab = DetailTab.COMPONENTS,
+        ),
+        workspaceId = Workspace.Id(),
         onPageAction = {},
     )
 }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
@@ -436,6 +436,12 @@ private fun LazyListScope.overviewItems(
         }
     }
 
+    if (appInfo.isUninstalled) {
+        item {
+            UninstalledNotice()
+        }
+    }
+
     // Actions Section (full-width row highlight → no content horizontal padding)
     item {
         DetailSectionCard(
@@ -455,6 +461,7 @@ private fun LazyListScope.overviewItems(
                 canEnableDisable = state.canEnableDisable,
                 canForceStop = state.canForceStop,
                 canClearData = state.canClearData,
+                isUninstalled = appInfo.isUninstalled,
             )
         }
     }
@@ -499,6 +506,43 @@ private fun LazyListScope.overviewItems(
             )
         }
     }
+}
+
+/** The package is still listed and its metadata still valid, only the install is gone. */
+@Composable
+private fun UninstalledNotice(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.apps_details_uninstalled_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = stringResource(R.string.apps_details_uninstalled_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun UninstalledNoticePreview() {
+    UninstalledNotice()
 }
 
 @Composable

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePage.kt
@@ -462,6 +462,7 @@ private fun LazyListScope.overviewItems(
                 canForceStop = state.canForceStop,
                 canClearData = state.canClearData,
                 isUninstalled = appInfo.isUninstalled,
+                enabled = !state.isPkgActionRunning,
             )
         }
     }

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppInfoErrorCard.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/ui/details/AppInfoErrorCard.kt
@@ -1,0 +1,101 @@
+package eu.darken.butler.apps.ui.details
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Error
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.apps.R
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.error.localized
+import java.io.IOException
+import eu.darken.butler.common.R as CommonR
+
+/**
+ * Shown when the package source failed, which says nothing about the app still being installed —
+ * so the screen stays put and offers a retry instead of closing itself.
+ */
+@Composable
+fun AppInfoErrorCard(
+    modifier: Modifier = Modifier,
+    error: Throwable,
+    onRetry: () -> Unit,
+) {
+    val context = LocalContext.current
+    val description = remember(error) { error.localized(context).description.get(context) }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.Error,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(24.dp),
+                )
+                Text(
+                    text = stringResource(R.string.apps_details_pkgdata_error_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            TextButton(
+                modifier = Modifier.align(Alignment.End),
+                onClick = onRetry,
+            ) {
+                Text(text = stringResource(CommonR.string.general_retry_action))
+            }
+        }
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun AppInfoErrorCardPreview() {
+    AppInfoErrorCard(
+        error = IOException("Package manager query timed out"),
+        onRetry = {},
+    )
+}

--- a/app-workspace-apps/src/main/res/values/strings.xml
+++ b/app-workspace-apps/src/main/res/values/strings.xml
@@ -131,6 +131,9 @@
     <!-- App Details Action Bar -->
     <string name="apps_details_more_options">More options</string>
 
+    <!-- App Details package data -->
+    <string name="apps_details_pkgdata_error_title">Could not load app data</string>
+
     <!-- App Information -->
     <string name="apps_type_label">Type</string>
     <string name="apps_type_system">System app</string>

--- a/app-workspace-apps/src/main/res/values/strings.xml
+++ b/app-workspace-apps/src/main/res/values/strings.xml
@@ -136,6 +136,12 @@
     <string name="apps_details_uninstalled_title">Uninstalled for this user</string>
     <string name="apps_details_uninstalled_message">The app is no longer installed for this user, but its files are still on the device.</string>
 
+    <!-- App Details confirmations -->
+    <string name="apps_details_confirm_clear_data_title">Clear app data?</string>
+    <string name="apps_details_confirm_clear_data_message">All data and settings of %1$s will be deleted. This cannot be undone.</string>
+    <string name="apps_details_confirm_uninstall_title">Uninstall app?</string>
+    <string name="apps_details_confirm_uninstall_message">%1$s will be removed from this device.</string>
+
     <!-- App Information -->
     <string name="apps_type_label">Type</string>
     <string name="apps_type_system">System app</string>

--- a/app-workspace-apps/src/main/res/values/strings.xml
+++ b/app-workspace-apps/src/main/res/values/strings.xml
@@ -133,6 +133,8 @@
 
     <!-- App Details package data -->
     <string name="apps_details_pkgdata_error_title">Could not load app data</string>
+    <string name="apps_details_uninstalled_title">Uninstalled for this user</string>
+    <string name="apps_details_uninstalled_message">The app is no longer installed for this user, but its files are still on the device.</string>
 
     <!-- App Information -->
     <string name="apps_type_label">Type</string>

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceAppInfoStateTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceAppInfoStateTest.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.adb.AdbManager
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.Existence
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.PkgRepo
 import eu.darken.butler.common.pkgs.features.InstallId
 import eu.darken.butler.common.pkgs.features.Installed
+import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.common.user.UserHandle2
 import eu.darken.butler.permissions.core.PathRequirements
 import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
@@ -22,6 +24,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -47,7 +51,14 @@ class AppDetailsWorkspaceAppInfoStateTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val installId = InstallId(Pkg.Id(PKG), UserHandle2(0))
-    private val pkgData = MutableStateFlow(PkgRepo.PkgData())
+    // A shared flow with nothing emitted yet, because that is what PkgRepo.data is: a cache flow
+    // that stays silent until the package cache resolves. A StateFlow seeded with an empty PkgData
+    // would instead say "queried, found nothing", which is a different situation (Gone).
+    private val pkgData = MutableSharedFlow<PkgRepo.PkgData>(
+        replay = 1,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
     private val workspaceRemote = mockk<WorkspaceRemote>(relaxed = true)
 
     private val installed: Installed = AppsMockDataProvider.createMockInstalled(packageName = PKG, label = "Butler")
@@ -66,8 +77,10 @@ class AppDetailsWorkspaceAppInfoStateTest {
         },
         gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
         pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
-        rootManager = mockk(relaxed = true),
-        adbManager = mockk(relaxed = true),
+        // Real flows, not relaxed mocks: `state` combines both, and a relaxed flow never emits,
+        // so the combine would never produce a state to collect.
+        rootManager = mockk<RootManager> { every { useRoot } returns flowOf(false) },
+        adbManager = mockk<AdbManager> { every { useAdb } returns flowOf(false) },
         workspaceRemote = workspaceRemote,
     )
 
@@ -94,7 +107,7 @@ class AppDetailsWorkspaceAppInfoStateTest {
     @Test
     fun `a matching package is ready`() = runTest {
         val seen = statesOf(createWorkspace()) {
-            pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+            pkgData.tryEmit(PkgRepo.PkgData.from(listOf(installed)))
         }
 
         seen.last().appState.shouldBeInstanceOf<AppInfoState.Ready>().info.packageName shouldBe PKG
@@ -103,7 +116,7 @@ class AppDetailsWorkspaceAppInfoStateTest {
     @Test
     fun `a package that is not there is gone`() = runTest {
         val seen = statesOf(createWorkspace()) {
-            pkgData.value = PkgRepo.PkgData.from(emptyList())
+            pkgData.tryEmit(PkgRepo.PkgData.from(emptyList()))
         }
 
         seen.last().appState shouldBe AppInfoState.Gone
@@ -113,7 +126,7 @@ class AppDetailsWorkspaceAppInfoStateTest {
     fun `a failing source is not a missing package`() = runTest {
         val boom = IOException("Package source unavailable")
         val seen = statesOf(createWorkspace()) {
-            pkgData.value = PkgRepo.PkgData(error = boom)
+            pkgData.tryEmit(PkgRepo.PkgData(error = boom))
         }
 
         seen.last().appState.shouldBeInstanceOf<AppInfoState.SourceError>().error shouldBe boom
@@ -123,9 +136,9 @@ class AppDetailsWorkspaceAppInfoStateTest {
     fun `the workspace closes once the package is gone`() = runTest {
         val workspace = createWorkspace()
 
-        pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+        pkgData.tryEmit(PkgRepo.PkgData.from(listOf(installed)))
         advanceUntilIdle()
-        pkgData.value = PkgRepo.PkgData.from(emptyList())
+        pkgData.tryEmit(PkgRepo.PkgData.from(emptyList()))
         advanceUntilIdle()
 
         coVerify { workspaceRemote.execute(any<WorkspaceAction.Close>()) }
@@ -135,9 +148,9 @@ class AppDetailsWorkspaceAppInfoStateTest {
     fun `a source error does not close the workspace`() = runTest {
         val workspace = createWorkspace()
 
-        pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+        pkgData.tryEmit(PkgRepo.PkgData.from(listOf(installed)))
         advanceUntilIdle()
-        pkgData.value = PkgRepo.PkgData(error = IOException("Package source unavailable"))
+        pkgData.tryEmit(PkgRepo.PkgData(error = IOException("Package source unavailable")))
         advanceUntilIdle()
 
         coVerify(exactly = 0) { workspaceRemote.execute(any<WorkspaceAction.Close>()) }
@@ -147,9 +160,9 @@ class AppDetailsWorkspaceAppInfoStateTest {
     @Test
     fun `a recovered source is ready again`() = runTest {
         val seen = statesOf(createWorkspace()) {
-            pkgData.value = PkgRepo.PkgData(error = IOException("Package source unavailable"))
+            pkgData.tryEmit(PkgRepo.PkgData(error = IOException("Package source unavailable")))
             advanceUntilIdle()
-            pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+            pkgData.tryEmit(PkgRepo.PkgData.from(listOf(installed)))
         }
 
         seen.map { it.appState }.any { it is AppInfoState.SourceError } shouldBe true

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceAppInfoStateTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceAppInfoStateTest.kt
@@ -1,0 +1,162 @@
+package eu.darken.butler.apps.core.details
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.apps.core.AppSizeCache
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.PkgRepo
+import eu.darken.butler.common.pkgs.features.InstallId
+import eu.darken.butler.common.pkgs.features.Installed
+import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathRequirements
+import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * A failing package source is not the same situation as a removed package: it says nothing about
+ * the app, so the screen has to stay put and stay recoverable.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AppDetailsWorkspaceAppInfoStateTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val installId = InstallId(Pkg.Id(PKG), UserHandle2(0))
+    private val pkgData = MutableStateFlow(PkgRepo.PkgData())
+    private val workspaceRemote = mockk<WorkspaceRemote>(relaxed = true)
+
+    private val installed: Installed = AppsMockDataProvider.createMockInstalled(packageName = PKG, label = "Butler")
+
+    private fun TestScope.createWorkspace(): AppDetailsWorkspace = AppDetailsWorkspace(
+        id = Workspace.Id(),
+        creationArguments = AppDetailsArguments(installId = installId),
+        context = context,
+        dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+        pkgRepo = mockk<PkgRepo> { every { data } returns pkgData },
+        pkgOps = mockk(relaxed = true),
+        apkArchiveParser = mockk(relaxed = true),
+        appSizeCache = mockk(relaxed = true) {
+            every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
+            every { isAvailable } returns MutableStateFlow(false)
+        },
+        gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
+        pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
+        rootManager = mockk(relaxed = true),
+        adbManager = mockk(relaxed = true),
+        workspaceRemote = workspaceRemote,
+    )
+
+    private fun TestScope.statesOf(
+        workspace: AppDetailsWorkspace,
+        block: TestScope.() -> Unit = {},
+    ): List<AppDetailsWorkspace.State> {
+        val seen = mutableListOf<AppDetailsWorkspace.State>()
+        val job = launch { workspace.state.collect { seen += it } }
+        advanceUntilIdle()
+        block()
+        advanceUntilIdle()
+        job.cancel()
+        return seen
+    }
+
+    @Test
+    fun `nothing is known before the first emission`() = runTest {
+        val seen = statesOf(createWorkspace())
+
+        seen.first().appState shouldBe AppInfoState.Loading
+    }
+
+    @Test
+    fun `a matching package is ready`() = runTest {
+        val seen = statesOf(createWorkspace()) {
+            pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+        }
+
+        seen.last().appState.shouldBeInstanceOf<AppInfoState.Ready>().info.packageName shouldBe PKG
+    }
+
+    @Test
+    fun `a package that is not there is gone`() = runTest {
+        val seen = statesOf(createWorkspace()) {
+            pkgData.value = PkgRepo.PkgData.from(emptyList())
+        }
+
+        seen.last().appState shouldBe AppInfoState.Gone
+    }
+
+    @Test
+    fun `a failing source is not a missing package`() = runTest {
+        val boom = IOException("Package source unavailable")
+        val seen = statesOf(createWorkspace()) {
+            pkgData.value = PkgRepo.PkgData(error = boom)
+        }
+
+        seen.last().appState.shouldBeInstanceOf<AppInfoState.SourceError>().error shouldBe boom
+    }
+
+    @Test
+    fun `the workspace closes once the package is gone`() = runTest {
+        val workspace = createWorkspace()
+
+        pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+        advanceUntilIdle()
+        pkgData.value = PkgRepo.PkgData.from(emptyList())
+        advanceUntilIdle()
+
+        coVerify { workspaceRemote.execute(any<WorkspaceAction.Close>()) }
+    }
+
+    @Test
+    fun `a source error does not close the workspace`() = runTest {
+        val workspace = createWorkspace()
+
+        pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+        advanceUntilIdle()
+        pkgData.value = PkgRepo.PkgData(error = IOException("Package source unavailable"))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { workspaceRemote.execute(any<WorkspaceAction.Close>()) }
+    }
+
+    /** The whole point of not using a terminal `catch`: the same instance has to recover. */
+    @Test
+    fun `a recovered source is ready again`() = runTest {
+        val seen = statesOf(createWorkspace()) {
+            pkgData.value = PkgRepo.PkgData(error = IOException("Package source unavailable"))
+            advanceUntilIdle()
+            pkgData.value = PkgRepo.PkgData.from(listOf(installed))
+        }
+
+        seen.map { it.appState }.any { it is AppInfoState.SourceError } shouldBe true
+        seen.last().appState.shouldBeInstanceOf<AppInfoState.Ready>().info.packageName shouldBe PKG
+    }
+
+    companion object {
+        private const val PKG = "eu.darken.butler"
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceComponentConfirmTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceComponentConfirmTest.kt
@@ -61,7 +61,7 @@ class AppDetailsWorkspaceComponentConfirmTest : BaseTest() {
         workspace = mockk<AppDetailsWorkspace>(relaxed = true).apply {
             every { state } returns flowOf(
                 AppDetailsWorkspace.State(
-                    app = appInfo,
+                    appState = AppInfoState.Ready(appInfo),
                     selectedTab = DetailTab.COMPONENTS,
                     componentToggleState = ComponentToggleState.AVAILABLE,
                 )

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspacePkgActionGateTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspacePkgActionGateTest.kt
@@ -1,0 +1,140 @@
+package eu.darken.butler.apps.core.details
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.apps.core.AppSizeCache
+import eu.darken.butler.apps.core.details.components.ComponentEntry
+import eu.darken.butler.apps.core.details.components.ComponentKind
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.PkgRepo
+import eu.darken.butler.common.pkgs.features.InstallId
+import eu.darken.butler.common.pkgs.pkgops.PkgOps
+import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathRequirements
+import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
+import eu.darken.butler.workspace.core.Workspace
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Disabling the rows in Compose is feedback, not a barrier: two taps can both be delivered before
+ * a recomposition, and an uninstall dispatched twice is a second `pm uninstall` on a package the
+ * first one is still removing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AppDetailsWorkspacePkgActionGateTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val installId = InstallId(Pkg.Id(PKG), UserHandle2(0))
+    private val installed = AppsMockDataProvider.createMockInstalled(packageName = PKG, label = "Butler")
+    private val appInfo = AppInfo(install = installed)
+
+    private val pkgOps = mockk<PkgOps>(relaxed = true)
+
+    private fun TestScope.createWorkspace(): AppDetailsWorkspace = AppDetailsWorkspace(
+        id = Workspace.Id(),
+        creationArguments = AppDetailsArguments(installId = installId),
+        context = context,
+        dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+        pkgRepo = mockk<PkgRepo> {
+            every { data } returns MutableStateFlow(PkgRepo.PkgData.from(listOf(installed)))
+            coEvery { refresh() } returns listOf(installed)
+        },
+        pkgOps = pkgOps,
+        apkArchiveParser = mockk(relaxed = true),
+        appSizeCache = mockk(relaxed = true) {
+            every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
+            every { isAvailable } returns MutableStateFlow(false)
+        },
+        gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
+        pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
+        rootManager = mockk(relaxed = true),
+        adbManager = mockk(relaxed = true),
+        workspaceRemote = mockk(relaxed = true),
+    )
+
+    @Test
+    fun `a second uninstall while the first runs is rejected`() = runTest {
+        val release = Channel<Unit>(Channel.UNLIMITED)
+        coEvery { pkgOps.uninstall(any(), any()) } coAnswers {
+            release.receive()
+            true
+        }
+        val workspace = createWorkspace()
+
+        launch { workspace.uninstallApp(appInfo) }
+        advanceUntilIdle()
+        launch { workspace.uninstallApp(appInfo) }
+        advanceUntilIdle()
+
+        release.send(Unit)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { pkgOps.uninstall(any(), any()) }
+    }
+
+    @Test
+    fun `a later uninstall goes through once the first finished`() = runTest {
+        coEvery { pkgOps.uninstall(any(), any()) } returns true
+        val workspace = createWorkspace()
+
+        workspace.uninstallApp(appInfo)
+        workspace.uninstallApp(appInfo)
+
+        coVerify(exactly = 2) { pkgOps.uninstall(any(), any()) }
+    }
+
+    /** One lock across both would let a running app action block the component screen. */
+    @Test
+    fun `a component toggle is not blocked by a running app action`() = runTest {
+        val release = Channel<Unit>(Channel.UNLIMITED)
+        coEvery { pkgOps.uninstall(any(), any()) } coAnswers {
+            release.receive()
+            true
+        }
+        val workspace = createWorkspace()
+
+        launch { workspace.uninstallApp(appInfo) }
+        advanceUntilIdle()
+        workspace.setComponentsEnabled(
+            listOf(
+                ComponentEntry(
+                    kind = ComponentKind.ACTIVITY,
+                    packageName = PKG,
+                    className = "$PKG.MainActivity",
+                    isExported = true,
+                )
+            ),
+            enabled = false,
+        )
+
+        coVerify(exactly = 1) { pkgOps.changeComponentState(any(), any(), any(), any()) }
+
+        release.send(Unit)
+        advanceUntilIdle()
+    }
+
+    companion object {
+        private const val PKG = "eu.darken.butler"
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceRefreshTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceRefreshTest.kt
@@ -1,0 +1,107 @@
+package eu.darken.butler.apps.core.details
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.apps.core.AppSizeCache
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.files.Existence
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.PkgRepo
+import eu.darken.butler.common.pkgs.features.InstallId
+import eu.darken.butler.common.pkgs.pkgops.PkgOps
+import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.permissions.core.PathRequirements
+import eu.darken.butler.workspace.contracts.apps.AppDetailsArguments
+import eu.darken.butler.workspace.core.Workspace
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * Enabling or disabling an app leaves the cached package data stale, so the screen kept showing the
+ * old state until something else happened to refresh it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AppDetailsWorkspaceRefreshTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val installId = InstallId(Pkg.Id(PKG), UserHandle2(0))
+    private val installed = AppsMockDataProvider.createMockInstalled(packageName = PKG, label = "Butler")
+    private val appInfo = AppInfo(install = installed)
+
+    private val pkgRepo = mockk<PkgRepo>().also {
+        every { it.data } returns MutableStateFlow(PkgRepo.PkgData.from(listOf(installed)))
+        coEvery { it.refresh() } returns listOf(installed)
+    }
+    private val pkgOps = mockk<PkgOps>(relaxed = true)
+
+    private fun TestScope.createWorkspace(): AppDetailsWorkspace = AppDetailsWorkspace(
+        id = Workspace.Id(),
+        creationArguments = AppDetailsArguments(installId = installId),
+        context = context,
+        dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+        pkgRepo = pkgRepo,
+        pkgOps = pkgOps,
+        apkArchiveParser = mockk(relaxed = true),
+        appSizeCache = mockk(relaxed = true) {
+            every { snapshot } returns MutableStateFlow(AppSizeCache.Snapshot())
+            every { isAvailable } returns MutableStateFlow(false)
+        },
+        gatewaySwitch = mockk { coEvery { existsStrict(any()) } returns Existence.PRESENT },
+        pathPermissionCheck = mockk { every { monitor(any<APath<*>>()) } returns flowOf(PathRequirements()) },
+        rootManager = mockk(relaxed = true),
+        adbManager = mockk(relaxed = true),
+        workspaceRemote = mockk(relaxed = true),
+    )
+
+    @Test
+    fun `enabling an app refreshes the package data`() = runTest {
+        createWorkspace().setAppEnabled(appInfo, enabled = true)
+
+        coVerify(exactly = 1) { pkgRepo.refresh() }
+    }
+
+    @Test
+    fun `uninstalling refreshes the package data`() = runTest {
+        createWorkspace().uninstallApp(appInfo)
+
+        coVerify(exactly = 1) { pkgRepo.refresh() }
+    }
+
+    /** A force-stop changes no package data, and a refresh re-gathers every source. */
+    @Test
+    fun `force stopping does not refresh the package data`() = runTest {
+        createWorkspace().forceStopApp(appInfo)
+
+        coVerify(exactly = 0) { pkgRepo.refresh() }
+    }
+
+    /** The operation succeeded; the source error reaches the screen through the state flow. */
+    @Test
+    fun `a failing refresh does not fail the operation`() = runTest {
+        coEvery { pkgRepo.refresh() } throws IOException("Package source unavailable")
+
+        createWorkspace().setAppEnabled(appInfo, enabled = false)
+
+        coVerify(exactly = 1) { pkgRepo.refresh() }
+    }
+
+    companion object {
+        private const val PKG = "eu.darken.butler"
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModelConfirmTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceViewModelConfirmTest.kt
@@ -1,0 +1,148 @@
+package eu.darken.butler.apps.core.details
+
+import android.app.Application
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.apps.core.details.components.ComponentsData
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.apps.ui.details.AppDetailsConfirmRequest
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Clearing data has no undo and no system dialog in front of it, and an elevated uninstall skips
+ * Android's confirmation entirely — both need Butler's own.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AppDetailsWorkspaceViewModelConfirmTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private val appInfo = AppsMockDataProvider.Presets.chrome
+    private val workspaceState = MutableStateFlow(
+        AppDetailsWorkspace.State(appState = AppInfoState.Ready(appInfo)),
+    )
+
+    private lateinit var workspace: AppDetailsWorkspace
+
+    private fun createVM(hasRoot: Boolean = true, hasAdb: Boolean = false): AppDetailsWorkspaceViewModel {
+        workspaceState.value = AppDetailsWorkspace.State(
+            appState = AppInfoState.Ready(appInfo),
+            hasRoot = hasRoot,
+            hasAdb = hasAdb,
+        )
+        workspace = mockk<AppDetailsWorkspace>(relaxed = true).apply {
+            every { state } returns workspaceState
+        }
+        val id = Workspace.Id()
+        return AppDetailsWorkspaceViewModel(
+            id = id,
+            context = context,
+            dispatchers = TestDispatcherProvider(),
+            workspaceProvider = mockk<WorkspaceProvider> { every { retrieve(id) } returns flowOf(workspace) },
+            workspaceRemote = mockk<WorkspaceRemote>(relaxed = true),
+            appSizeCache = mockk(relaxed = true),
+            componentsLoader = mockk(relaxed = true) {
+                coEvery { load(any()) } returns ComponentsData()
+                coEvery { resolveEnabledStates(any()) } returns emptyMap()
+            },
+        )
+    }
+
+    private fun nextStartedActivity(): Intent? = shadowOf(context).nextStartedActivity
+
+    @Test
+    fun `clearing data asks first`() = runTest {
+        val vm = createVM()
+
+        vm.onClearData(appInfo)
+
+        vm.appConfirm.value.shouldBeInstanceOf<AppDetailsConfirmRequest.ClearData>()
+        coVerify(exactly = 0) { workspace.clearDataApp(any()) }
+    }
+
+    @Test
+    fun `a confirmed clear data is dispatched once`() = runTest {
+        val vm = createVM()
+        vm.onClearData(appInfo)
+        val request = vm.appConfirm.value!!
+
+        vm.onAppConfirm(request)
+        // The dialog's callback can be delivered twice before it leaves composition.
+        vm.onAppConfirm(request)
+
+        coVerify(exactly = 1) { workspace.clearDataApp(appInfo) }
+        vm.appConfirm.value shouldBe null
+    }
+
+    @Test
+    fun `an elevated uninstall asks first`() = runTest {
+        val vm = createVM(hasRoot = true)
+
+        vm.onUninstall(appInfo)
+
+        vm.appConfirm.value.shouldBeInstanceOf<AppDetailsConfirmRequest.Uninstall>()
+        coVerify(exactly = 0) { workspace.uninstallApp(any()) }
+    }
+
+    @Test
+    fun `a confirmed uninstall is dispatched`() = runTest {
+        val vm = createVM(hasRoot = true)
+        vm.onUninstall(appInfo)
+
+        vm.onAppConfirm(vm.appConfirm.value!!)
+
+        coVerify(exactly = 1) { workspace.uninstallApp(appInfo) }
+    }
+
+    /** Without elevated access Android's own dialog is the confirmation, so Butler must not add one. */
+    @Test
+    fun `without elevated access the system dialog does the asking`() = runTest {
+        val vm = createVM(hasRoot = false, hasAdb = false)
+
+        vm.onUninstall(appInfo)
+
+        vm.appConfirm.value shouldBe null
+        coVerify(exactly = 0) { workspace.uninstallApp(any()) }
+        nextStartedActivity()?.action shouldBe Intent.ACTION_DELETE
+    }
+
+    @Test
+    fun `a pending request is retired when its target goes away`() = runTest {
+        val vm = createVM()
+        vm.onClearData(appInfo)
+
+        workspaceState.value = AppDetailsWorkspace.State(appState = AppInfoState.Gone)
+
+        vm.appConfirm.value shouldBe null
+    }
+
+    @Test
+    fun `confirming a retired request dispatches nothing`() = runTest {
+        val vm = createVM()
+        vm.onClearData(appInfo)
+        val stale = vm.appConfirm.value!!
+
+        workspaceState.value = AppDetailsWorkspace.State(appState = AppInfoState.Gone)
+        vm.onAppConfirm(stale)
+
+        coVerify(exactly = 0) { workspace.clearDataApp(any()) }
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceUninstalledGateTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceUninstalledGateTest.kt
@@ -6,6 +6,7 @@ import eu.darken.butler.apps.core.engine.AppItem
 import eu.darken.butler.apps.ui.apps.dialogs.AppsDialogState
 import eu.darken.butler.apps.ui.apps.elements.AppsActionBarItem
 import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.pkgs.container.UninstalledPkg
 import eu.darken.butler.common.user.UserHandle2
 import eu.darken.butler.common.user.UserProfile2
@@ -33,11 +34,28 @@ class AppsWorkspaceUninstalledGateTest : BaseTest() {
         packageName = "com.example.installed",
         label = "Installed App",
     )
-    private val uninstalledApp = AppItem.from(
+    // Assembled by hand instead of via AppItem.from(): that reads PackageInfo.longVersionCode,
+    // which an unmocked android.jar stub refuses to answer in a plain unit test. What the gate
+    // reads is AppItem.isUninstalled, and that derives from the pkg being an UninstalledPkg.
+    private val uninstalledApp = AppItem(
         pkg = UninstalledPkg(
             packageInfo = PackageInfo().apply { packageName = "com.example.uninstalled" },
             userHandle = UserHandle2(0),
         ),
+        label = "Uninstalled App".toCaString(),
+        icon = null,
+        packageName = "com.example.uninstalled",
+        versionName = null,
+        versionCode = 0L,
+        appSize = null,
+        isSystemApp = false,
+        isEnabled = true,
+        isUpdatedSystemApp = false,
+        installedAt = null,
+        updatedAt = null,
+        installerInfo = null,
+        isSplitApk = false,
+        isDebuggable = false,
         userProfile = UserProfile2(handle = UserHandle2(0)),
     )
 

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceUninstalledGateTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/apps/AppsWorkspaceUninstalledGateTest.kt
@@ -1,0 +1,126 @@
+package eu.darken.butler.apps.ui.apps
+
+import android.content.pm.PackageInfo
+import eu.darken.butler.apps.core.AppsWorkspace
+import eu.darken.butler.apps.core.engine.AppItem
+import eu.darken.butler.apps.ui.apps.dialogs.AppsDialogState
+import eu.darken.butler.apps.ui.apps.elements.AppsActionBarItem
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.pkgs.container.UninstalledPkg
+import eu.darken.butler.common.user.UserHandle2
+import eu.darken.butler.common.user.UserProfile2
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.WorkspaceProvider
+import eu.darken.butler.workspace.core.WorkspaceRemote
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * A package command needs an install to act on. The long-press dialog builds its own action items,
+ * so filtering only in the action-bar builder would leave that path wide open.
+ */
+class AppsWorkspaceUninstalledGateTest : BaseTest() {
+
+    private val installedApp = AppsMockDataProvider.createMockAppItem(
+        packageName = "com.example.installed",
+        label = "Installed App",
+    )
+    private val uninstalledApp = AppItem.from(
+        pkg = UninstalledPkg(
+            packageInfo = PackageInfo().apply { packageName = "com.example.uninstalled" },
+            userHandle = UserHandle2(0),
+        ),
+        userProfile = UserProfile2(handle = UserHandle2(0)),
+    )
+
+    private lateinit var vm: AppsWorkspaceViewModel
+
+    private fun createVM(selected: List<AppItem> = emptyList()): AppsWorkspaceViewModel {
+        val apps = listOf(installedApp, uninstalledApp)
+        val workspace = mockk<AppsWorkspace>(relaxed = true)
+        every { workspace.state } returns flowOf(
+            AppsWorkspace.State.Ready(
+                apps = apps,
+                filteredApps = apps,
+                selectedAppIds = selected.map { it.pkg.installId }.toSet(),
+                hasRoot = true,
+            )
+        )
+        val id = Workspace.Id()
+        return AppsWorkspaceViewModel(
+            id = id,
+            context = mockk(relaxed = true),
+            dispatchers = TestDispatcherProvider(),
+            workspaceProvider = mockk<WorkspaceProvider> { every { retrieve(id) } returns flowOf(workspace) },
+            workspaceRemote = mockk<WorkspaceRemote>(relaxed = true),
+            appsSettings = mockk(relaxed = true),
+            appSizeCache = mockk(relaxed = true),
+        ).also { vm = it }
+    }
+
+    private suspend fun dialogState(): AppsDialogState =
+        vm.state.first().shouldBeInstanceOf<AppsWorkspaceViewModel.State.Ready>().dialogState
+
+    @Test
+    fun `an uninstalled entry raises no uninstall confirmation`() = runTest {
+        createVM()
+
+        vm.onPageAction(AppsPageAction.ActionBarClick(AppsActionBarItem.Uninstall(listOf(uninstalledApp))))
+
+        dialogState() shouldBe AppsDialogState.None
+    }
+
+    @Test
+    fun `an uninstalled entry raises no clear data confirmation`() = runTest {
+        createVM()
+
+        vm.onPageAction(AppsPageAction.ActionBarClick(AppsActionBarItem.ClearData(listOf(uninstalledApp))))
+
+        dialogState() shouldBe AppsDialogState.None
+    }
+
+    @Test
+    fun `an uninstalled entry raises no enable or disable confirmation`() = runTest {
+        createVM()
+
+        vm.onPageAction(AppsPageAction.ActionBarClick(AppsActionBarItem.Disable(listOf(uninstalledApp))))
+        dialogState() shouldBe AppsDialogState.None
+
+        vm.onPageAction(AppsPageAction.ActionBarClick(AppsActionBarItem.Enable(listOf(uninstalledApp))))
+        dialogState() shouldBe AppsDialogState.None
+    }
+
+    @Test
+    fun `a mixed selection acts on the installed entries only`() = runTest {
+        createVM()
+
+        vm.onPageAction(
+            AppsPageAction.ActionBarClick(AppsActionBarItem.Uninstall(listOf(installedApp, uninstalledApp)))
+        )
+
+        dialogState().shouldBeInstanceOf<AppsDialogState.ConfirmUninstall>().apps shouldBe listOf(installedApp)
+    }
+
+    @Test
+    fun `the action bar offers no package commands for an uninstalled selection`() = runTest {
+        createVM(selected = listOf(uninstalledApp))
+
+        val actions = vm.state.first()
+            .shouldBeInstanceOf<AppsWorkspaceViewModel.State.Ready>()
+            .availableActions
+
+        actions.filterIsInstance<AppsActionBarItem.Uninstall>() shouldBe emptyList()
+        actions.filterIsInstance<AppsActionBarItem.ClearData>() shouldBe emptyList()
+        actions.filterIsInstance<AppsActionBarItem.Disable>() shouldBe emptyList()
+        actions.filterIsInstance<AppsActionBarItem.Enable>() shouldBe emptyList()
+        actions.filterIsInstance<AppsActionBarItem.ExportApk>().size shouldBe 1
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/ActionsSectionTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/ActionsSectionTest.kt
@@ -1,0 +1,77 @@
+package eu.darken.butler.apps.ui.details
+
+import android.content.pm.PackageInfo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.butler.apps.core.details.AppInfo
+import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.pkgs.container.UninstalledPkg
+import eu.darken.butler.common.user.UserHandle2
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * An app uninstalled for this user has no install to command: no launch intent, no APK to export,
+ * and every package command would target something that is not there.
+ */
+class ActionsSectionTest : ComposeTest() {
+
+    private val uninstalled = AppInfo(
+        install = UninstalledPkg(
+            packageInfo = PackageInfo().apply { packageName = PKG },
+            userHandle = UserHandle2(0),
+        ),
+    )
+
+    private fun setContent(app: AppInfo) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                ActionsSection(
+                    app = app,
+                    onLaunchApp = {},
+                    onShowAppInfo = {},
+                    onEnableDisable = {},
+                    onUninstall = {},
+                    onExportApk = {},
+                    onShareApk = {},
+                    onForceStop = {},
+                    onClearData = {},
+                    isUninstalled = app.isUninstalled,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `an uninstalled package is recognized as one`() {
+        uninstalled.isUninstalled shouldBe true
+        AppsMockDataProvider.Presets.chrome.isUninstalled shouldBe false
+    }
+
+    @Test
+    fun `an uninstalled app offers app info and share only`() {
+        setContent(uninstalled)
+
+        composeTestRule.onNodeWithText("App info").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Share info").assertIsDisplayed()
+
+        listOf("Launch", "Disable", "Enable", "Force stop", "Clear data", "Uninstall", "Export APK").forEach {
+            composeTestRule.onNodeWithText(it).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `an installed app keeps every action`() {
+        setContent(AppsMockDataProvider.Presets.chrome)
+
+        listOf("Launch", "App info", "Force stop", "Clear data", "Uninstall", "Export APK", "Share info").forEach {
+            composeTestRule.onNodeWithText(it).assertExists()
+        }
+    }
+
+    companion object {
+        private const val PKG = "com.example.app"
+    }
+}

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsComponentsModalityTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsComponentsModalityTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import eu.darken.butler.apps.core.details.AppDetailsWorkspace
+import eu.darken.butler.apps.core.details.AppInfoState
 import eu.darken.butler.apps.core.details.components.ComponentEnabledState
 import eu.darken.butler.apps.core.details.components.ComponentEntry
 import eu.darken.butler.apps.core.details.components.ComponentKind
@@ -61,7 +62,7 @@ class AppDetailsComponentsModalityTest : ComposeTest() {
                         AppDetailsWorkspacePage(
                             design = WorkspaceDesign(),
                             state = AppDetailsWorkspace.State(
-                                app = AppsMockDataProvider.Presets.chrome,
+                                appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                                 selectedTab = DetailTab.COMPONENTS,
                                 // Stacked on its caller, as App Details is on a phone. Also keeps
                                 // the workspace button out, whose mascot never idles here.

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePageTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePageTest.kt
@@ -204,6 +204,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
             composeTestRule.waitForIdle()
 
             composeTestRule.onNodeWithText("Could not load app data").assertIsDisplayed()
+            composeTestRule.onNode(hasScrollToNodeAction()).performScrollToNode(hasText("Retry"))
             composeTestRule.onNodeWithText("Retry").performClick()
         }
 

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePageTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/AppDetailsWorkspacePageTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import eu.darken.butler.apps.core.details.AppDetailsWorkspace
+import eu.darken.butler.apps.core.details.AppInfoState
 import eu.darken.butler.apps.core.details.PackageInfoState
 import eu.darken.butler.apps.core.details.components.ComponentsUiState
 import eu.darken.butler.apps.ui.apps.preview.AppsMockDataProvider
@@ -29,6 +30,7 @@ import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
+import java.io.IOException
 
 class AppDetailsWorkspacePageTest : ComposeTest() {
 
@@ -51,7 +53,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                 AppDetailsWorkspacePage(
                     design = multiPane,
                     state = AppDetailsWorkspace.State(
-                        app = AppsMockDataProvider.Presets.chrome,
+                        appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                         selectedTab = DetailTab.COMPONENTS,
                         callerWorkspaceId = stackedOnCaller,
                     ),
@@ -76,7 +78,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                 AppDetailsWorkspacePage(
                     design = multiPane,
                     state = AppDetailsWorkspace.State(
-                        app = AppsMockDataProvider.Presets.chrome,
+                        appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                         selectedTab = DetailTab.PACKAGE_INFO,
                         packageInfo = packageInfo,
                         callerWorkspaceId = stackedOnCaller,
@@ -134,7 +136,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                 AppDetailsWorkspacePage(
                     design = multiPane,
                     state = AppDetailsWorkspace.State(
-                        app = AppsMockDataProvider.Presets.chrome,
+                        appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                         selectedTab = DetailTab.OVERVIEW,
                         callerWorkspaceId = stackedOnCaller,
                     ),
@@ -158,7 +160,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                 AppDetailsWorkspacePage(
                     design = multiPane,
                     state = AppDetailsWorkspace.State(
-                        app = AppsMockDataProvider.Presets.chrome,
+                        appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                         selectedTab = DetailTab.OVERVIEW,
                         // Modal so the toolbar renders a back button.
                         callerWorkspaceId = Workspace.Id(),
@@ -174,6 +176,40 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
         composeTestRule.onNodeWithText("com.android.chrome").assertIsDisplayed()
     }
 
+    /**
+     * The tab branches are all guarded on a resolved app, so an error rendered inside that guard
+     * would leave Components and Package info blank with no route back.
+     */
+    @Test
+    fun `a source error is offered on every tab`() {
+        val actions = mutableListOf<AppDetailsPageAction>()
+        var tab by mutableStateOf(DetailTab.OVERVIEW)
+        composeTestRule.setContent {
+            PreviewWrapper {
+                AppDetailsWorkspacePage(
+                    design = multiPane,
+                    state = AppDetailsWorkspace.State(
+                        appState = AppInfoState.SourceError(IOException("Package source unavailable")),
+                        selectedTab = tab,
+                        callerWorkspaceId = stackedOnCaller,
+                    ),
+                    workspaceId = Workspace.Id(),
+                    onPageAction = { actions += it },
+                )
+            }
+        }
+
+        DetailTab.entries.forEach { entry ->
+            composeTestRule.runOnIdle { tab = entry }
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithText("Could not load app data").assertIsDisplayed()
+            composeTestRule.onNodeWithText("Retry").performClick()
+        }
+
+        actions shouldBe DetailTab.entries.map { AppDetailsPageAction.RetryAppInfo }
+    }
+
     private fun setComponentsPage(
         selectedComponentKeys: Set<String>,
         componentActions: List<ComponentsActionBarItem>,
@@ -183,7 +219,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                 AppDetailsWorkspacePage(
                     design = multiPane,
                     state = AppDetailsWorkspace.State(
-                        app = AppsMockDataProvider.Presets.chrome,
+                        appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                         selectedTab = DetailTab.COMPONENTS,
                         callerWorkspaceId = stackedOnCaller,
                     ),
@@ -240,7 +276,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                     AppDetailsWorkspacePage(
                         design = multiPane,
                         state = AppDetailsWorkspace.State(
-                            app = AppsMockDataProvider.Presets.chrome,
+                            appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                             selectedTab = DetailTab.COMPONENTS,
                             callerWorkspaceId = stackedOnCaller,
                         ),
@@ -277,7 +313,7 @@ class AppDetailsWorkspacePageTest : ComposeTest() {
                 AppDetailsWorkspacePage(
                     design = multiPane,
                     state = AppDetailsWorkspace.State(
-                        app = AppsMockDataProvider.Presets.chrome,
+                        appState = AppInfoState.Ready(AppsMockDataProvider.Presets.chrome),
                         selectedTab = DetailTab.COMPONENTS,
                         callerWorkspaceId = stackedOnCaller,
                     ),


### PR DESCRIPTION
## What changed

App Details' package actions could fail without telling you anything. A failed uninstall or data wipe now shows an error explaining why it failed, instead of quietly doing nothing. The same fix applies to the Apps list's batch actions.

The screen also kept showing stale information after an action succeeded: disabling an app left the row still offering "Disable". App Details now reloads package data once an action completes.

When package data could not be loaded at all, App Details closed itself as though the app had been uninstalled. It now shows an error with a retry instead, on every tab rather than leaving a blank page.

Clearing an app's data now asks for confirmation first. Uninstalling asks too, but only where Butler carries out the uninstall itself — without root or Shizuku, Android's own dialog remains the only prompt, so there is no double prompt.

Tapping an action twice no longer sends the command twice.

An app that has been uninstalled for the current user, while its files stay on the device, is now shown as exactly that, with the actions that no longer apply removed. The Apps list stops offering package commands for those entries as well.

## Technical Context

- Root cause: `PkgOpsHost.uninstallPackage` and `clearData` returned `false` on a non-OK shell exit, and all four call sites discarded it. They now throw carrying the command, exit code and shell output, mirroring the shape `forceStop` already had. The AIDL, `PkgOpsClient` and `PkgOps` signatures are unchanged.
- Surfacing the reason needed a second step: the error dialog renders only the top-level `localizedMessage`, and its details button requires an `infoAction` the generic branch never sets. So `PkgOps` and `AppsWorkspace` append the cause text to their own messages — without that the shell's reason would stay in logcat and the user would see only `uninstall(…) failed`.
- The details screen's state is built from `PkgRepo.data`, reading `PkgData.error` *before* touching `pkgs`, which throws while an error is set. A `.catch` was deliberately avoided: `catch` terminates the flow and `stateIn` does not resubscribe, which would strand the screen in the error state with a retry that could never work.
- The post-action refresh is deliberately not in a `finally` — `PkgRepo.refresh()` rethrows a source error and would replace the operation's own failure. Force stop gets no refresh: it changes no package data, and every refresh is a full multi-source re-gather.
- Worth close review: the uninstall path chooses between Butler's confirmation and Android's dialog from `hasRoot || hasAdb`, then launches `ACTION_DELETE` directly on the non-elevated branch instead of re-entering `PkgOps.uninstall(AUTO)`. Going through `AUTO` would re-read root/ADB availability a moment later, and a flip to available in between would run an elevated uninstall that was never confirmed.
- Scope note: the uninstalled-for-this-user state is only reachable for packages declaring `android:hasFragileUserData`, because that is the flag `NotInstalledPkgsSource` keys its classification on for API 29+. For every other package a per-user uninstall drops it from the repository entirely and the existing auto-close is already the correct signal. The misleading predicate itself is untouched here — it is a shared lower layer, and changing it would alter what the Apps list shows app-wide.
- Routing these actions through `OperationsManager` was deliberately deferred to later work. Building operations on top of the silent-failure defect would have encoded false successes into the operations bar, notifications and durable history.
