### PR TITLE
Explorer: Fix a crash when a folder holds two files with the same name

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,13 +21,19 @@
     "deny": []
   },
   "enabledPlugins": {
-    "android-translation@claude-code-cafe": true,
-    "debugbadger@claude-code-cafe": true,
-    "jvm-tools@claude-code-cafe": true,
+    "android-translation@claude-code-cafe": false,
+    "debugbadger@claude-code-cafe": false,
+    "jvm-tools@claude-code-cafe": false,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "devtools@claude-code-cafe": true,
-    "google-play@claude-code-cafe": true,
-    "support@claude-code-cafe": true
+    "devtools@claude-code-cafe": false,
+    "google-play@claude-code-cafe": false,
+    "support@claude-code-cafe": false,
+    "android-translation@clanker-cafe": true,
+    "debugbadger@clanker-cafe": true,
+    "jvm-tools@clanker-cafe": true,
+    "devtools@clanker-cafe": true,
+    "google-play@clanker-cafe": true,
+    "support@clanker-cafe": true
   }
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFDocFile.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFDocFile.kt
@@ -177,7 +177,10 @@ data class SAFDocFile(
     /** [partial] = the provider flagged this listing as still loading or errored; entries may be missing. */
     data class ChildListing(
         val entries: List<ChildEntry>,
+        /** The provider flagged the listing as still loading; more entries are expected to arrive. */
         val partial: Boolean,
+        /** The provider's own message for a listing it could not load fully, or null. */
+        val error: String?,
     )
 
     fun getLookupData(): LookupData = resolver.query(
@@ -325,8 +328,8 @@ data class SAFDocFile(
             val extras = cursor.extras
             ChildListing(
                 entries = entries,
-                partial = extras.getBoolean(DocumentsContract.EXTRA_LOADING, false) ||
-                    extras.getString(DocumentsContract.EXTRA_ERROR) != null,
+                partial = extras.getBoolean(DocumentsContract.EXTRA_LOADING, false),
+                error = extras.getString(DocumentsContract.EXTRA_ERROR),
             )
         }
 

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/saf/SAFFileSystemOps.kt
@@ -118,8 +118,10 @@ class SAFFileSystemOps @Inject constructor(
         val resolved: Map<SAFPath, SAFDocFile>,
         /** Child paths the listing carried more than once. */
         val duplicated: Set<SAFPath>,
-        /** The provider flagged the listing as still loading or errored. */
+        /** The listing cannot prove a name absent: still loading, errored, or carrying unnamed rows. */
         val partial: Boolean,
+        /** The provider's own message for a listing it could not load fully, or null. */
+        val error: String?,
         val cachedAt: Instant,
     )
 
@@ -252,8 +254,9 @@ class SAFFileSystemOps @Inject constructor(
             resolved = resolved,
             duplicated = duplicated,
             // A row we could not name is indexed under a URI-derived fallback, so this listing
-            // cannot prove any name absent.
-            partial = listing.partial || listing.entries.any { it.name == null },
+            // cannot prove any name absent. Same for one the provider could not load fully.
+            partial = listing.partial || listing.error != null || listing.entries.any { it.name == null },
+            error = listing.error,
             cachedAt = now,
         )
         childrenCache[parentPath] = cacheEntry
@@ -440,7 +443,15 @@ class SAFFileSystemOps @Inject constructor(
         val docFile = path.resolveDocFile()
         log(TAG, VERBOSE) { "listFiles($path) -> $docFile" }
 
-        cacheChildren(path, docFile, Clock.System.now()).first
+        val (childPaths, entry) = cacheChildren(path, docFile, Clock.System.now())
+
+        // A listing the provider could not load fully must not be handed over as if it were the
+        // directory's contents: an empty one would read to the caller as an empty directory.
+        // EXTRA_LOADING is deliberately not treated this way — it is a normal transient state on
+        // remote providers, and what has arrived so far is real.
+        entry.error?.let { throw ReadException("Provider could not list $path: $it", path) }
+
+        childPaths
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFDocFileTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFDocFileTest.kt
@@ -145,7 +145,7 @@ class SAFDocFileTest : BaseTest() {
     }
 
     @Test
-    fun `listFilesWithLookupData reports a loading or errored cursor as partial`() {
+    fun `listFilesWithLookupData reports a loading cursor as partial`() {
         val row = arrayOf<Any?>("42", "text/plain", 0L, 0L, "a.txt")
 
         listChildren(childrenCursor(row)).partial shouldBe false
@@ -153,10 +153,29 @@ class SAFDocFileTest : BaseTest() {
         listChildren(
             childrenCursor(row).apply { extras = Bundle().apply { putBoolean(DocumentsContract.EXTRA_LOADING, true) } }
         ).partial shouldBe true
+    }
 
-        listChildren(
+    /**
+     * Kept apart from [partial]: a still-loading listing is a normal transient state whose entries
+     * are real, while an errored one is a listing the provider could not load fully. Only the second
+     * may not be handed to a caller as the directory's contents.
+     */
+    @Test
+    fun `listFilesWithLookupData carries the provider's error message separately from loading`() {
+        val row = arrayOf<Any?>("42", "text/plain", 0L, 0L, "a.txt")
+
+        listChildren(childrenCursor(row)).error shouldBe null
+
+        val loading = listChildren(
+            childrenCursor(row).apply { extras = Bundle().apply { putBoolean(DocumentsContract.EXTRA_LOADING, true) } }
+        )
+        loading.error shouldBe null
+
+        val errored = listChildren(
             childrenCursor(row).apply { extras = Bundle().apply { putString(DocumentsContract.EXTRA_ERROR, "boom") } }
-        ).partial shouldBe true
+        )
+        errored.error shouldBe "boom"
+        errored.partial shouldBe false
     }
 
     // Helper to create cursor with MIME type

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/saf/SAFFileSystemOpsTest.kt
@@ -22,6 +22,7 @@ import eu.darken.butler.common.files.saf.location.SAFLocation
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
 import eu.darken.butler.common.files.saf.location.SAFLocationMatch
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
@@ -535,6 +536,34 @@ class SAFFileSystemOpsTest : BaseTest() {
     @Test
     fun `a listing the provider flagged as errored is inconclusive, not absent`() = runTest {
         assertPartialListingIsInconclusive(Bundle().apply { putString(DocumentsContract.EXTRA_ERROR, "boom") })
+    }
+
+    /**
+     * An errored listing must not reach the caller as the directory's contents. An empty one is
+     * otherwise indistinguishable from an empty directory, which is what the Explorer then shows.
+     */
+    @Test
+    fun `listFiles refuses a listing the provider could not load fully`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        opaqueListingExtras[OPAQUE_ROOT_ID] = Bundle().apply {
+            putString(DocumentsContract.EXTRA_ERROR, "provider is unhappy")
+        }
+
+        val failure = shouldThrow<ReadException> { fileSystemOps.listFiles(opaqueRoot) }
+        failure.cause!!.message!! shouldContain "provider is unhappy"
+    }
+
+    /** A still-loading listing is a normal transient state, so what has arrived is handed over. */
+    @Test
+    fun `listFiles returns what a still-loading listing carries`() = runTest {
+        useOpaqueProvider()
+        addOpaqueChild(parentId = OPAQUE_ROOT_ID, id = "42", name = "a.txt")
+        opaqueListingExtras[OPAQUE_ROOT_ID] = Bundle().apply {
+            putBoolean(DocumentsContract.EXTRA_LOADING, true)
+        }
+
+        fileSystemOps.listFiles(opaqueRoot) shouldBe listOf(opaqueRoot.child("a.txt"))
     }
 
     @Test

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelect.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dragselect/ExplorerDragSelect.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.explorer.ui.explorer.dragselect
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.core.engine.needsSignIn
 import eu.darken.butler.explorer.ui.explorer.ExplorerWorkspaceViewModel
+import eu.darken.butler.explorer.ui.explorer.elements.unambiguousItemIds
 import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
 
 /**
@@ -12,13 +13,21 @@ import eu.darken.butler.workspace.contracts.dnd.WorkspaceDragPayload
  * A picker also skips network locations that need a sign-in: the tap and long-press routes send them
  * to the sign-in form instead of selecting them, and a drag must not be the one way to get an
  * unbrowsable location into the result.
+ *
+ * Rows whose id repeats are skipped too. A provider may serve two documents under one display name,
+ * and every id-keyed route here - resolving a key back to an item, membership, the claim test -
+ * would have to pick one of them arbitrarily. A press on such a row falls through to the ordinary
+ * long-press instead of being claimed by a gesture that cannot address it.
  */
 fun explorerDragSelectKeys(state: ExplorerWorkspaceViewModel.State): List<String> {
     val selectable = state.selectionState.selectableItems
     val isPicking = state.pickerConfig != null
-    return state.items.orEmpty()
+    val items = state.items.orEmpty()
+    val unambiguous = items.unambiguousItemIds()
+    return items
         .filter { it in selectable && it !in state.disabledItems }
         .filterNot { isPicking && it.needsSignIn() }
+        .filter { it.id in unambiguous }
         .map { it.id }
 }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
@@ -137,11 +138,12 @@ internal fun ExplorerGridContent(
                 }
             }
         } else {
-            items(
+            val itemKeys = state.items.uniqueItemKeys()
+            itemsIndexed(
                 items = state.items,
-                key = { it.id },
-                contentType = ExplorerItem::contentType,
-            ) { item ->
+                key = { index, _ -> itemKeys[index] },
+                contentType = { _, item -> item.contentType() },
+            ) { _, item ->
                 ExplorerItemRenderer(
                     item = item,
                     viewStyle = state.viewStyle,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeys.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeys.kt
@@ -1,0 +1,23 @@
+package eu.darken.butler.explorer.ui.explorer.elements
+
+import eu.darken.butler.explorer.core.engine.ExplorerItem
+
+/**
+ * List keys for [items], disambiguated only where they would collide.
+ *
+ * A file item's id is its path, and two documents in one directory can carry the same display name,
+ * which makes those paths equal. Compose rejects duplicate keys outright, so the second occurrence
+ * takes the whole listing down before it renders.
+ *
+ * Only repeats are suffixed, so an item whose id is unique keeps exactly the key it had, and with it
+ * its scroll position and item animations.
+ *
+ *     ["a.txt", "dup.txt", "dup.txt"] -> ["a.txt", "dup.txt", "dup.txt#2"]
+ */
+internal fun List<ExplorerItem>.uniqueItemKeys(): List<String> {
+    val seen = mutableMapOf<String, Int>()
+    return map { item ->
+        val occurrence = seen.merge(item.id, 1, Int::plus)!!
+        if (occurrence == 1) item.id else "${item.id}#$occurrence"
+    }
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeys.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeys.kt
@@ -3,7 +3,7 @@ package eu.darken.butler.explorer.ui.explorer.elements
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 
 /**
- * List keys for [items], disambiguated only where they would collide.
+ * List keys for [this], disambiguated only where they would collide.
  *
  * A file item's id is its path, and two documents in one directory can carry the same display name,
  * which makes those paths equal. Compose rejects duplicate keys outright, so the second occurrence
@@ -13,11 +13,33 @@ import eu.darken.butler.explorer.core.engine.ExplorerItem
  * its scroll position and item animations.
  *
  *     ["a.txt", "dup.txt", "dup.txt"] -> ["a.txt", "dup.txt", "dup.txt#2"]
+ *
+ * A suffix may not land on a name some other row already owns: a directory holding `dup.txt` twice
+ * *and* a literal `dup.txt#2` would otherwise collide all over again, which is the crash this exists
+ * to prevent. Every id in the list is reserved up front and suffixes skip anything taken.
  */
 internal fun List<ExplorerItem>.uniqueItemKeys(): List<String> {
-    val seen = mutableMapOf<String, Int>()
+    val taken = mapTo(mutableSetOf()) { it.id }
+    val seen = mutableSetOf<String>()
     return map { item ->
-        val occurrence = seen.merge(item.id, 1, Int::plus)!!
-        if (occurrence == 1) item.id else "${item.id}#$occurrence"
+        if (seen.add(item.id)) return@map item.id
+
+        var occurrence = 2
+        var candidate = "${item.id}#$occurrence"
+        while (!taken.add(candidate)) {
+            occurrence++
+            candidate = "${item.id}#$occurrence"
+        }
+        candidate
     }
 }
+
+/**
+ * The ids [this] carries exactly once.
+ *
+ * Anything repeated is genuinely ambiguous: the whole Explorer keys selection, drag payloads and
+ * highlighting on the item id, so a repeated id addresses no single item. Callers that need to map a
+ * key back to one item must leave those rows out rather than pick arbitrarily.
+ */
+internal fun List<ExplorerItem>.unambiguousItemIds(): Set<String> =
+    groupingBy { it.id }.eachCount().filterValues { it == 1 }.keys

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
@@ -108,11 +109,12 @@ internal fun ExplorerListContent(
                 }
             }
         } else {
-            items(
+            val itemKeys = state.items.uniqueItemKeys()
+            itemsIndexed(
                 items = state.items,
-                key = { it.id },
-                contentType = ExplorerItem::contentType,
-            ) { item ->
+                key = { index, _ -> itemKeys[index] },
+                contentType = { _, item -> item.contentType() },
+            ) { _, item ->
                 ExplorerItemRenderer(
                     item = item,
                     viewStyle = state.viewStyle,

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeysTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeysTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.butler.explorer.ui.explorer.elements
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.explorer.core.engine.ExplorerItem
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ExplorerItemKeysTest : BaseTest() {
+
+    private fun file(name: String) = ExplorerItem.RegularFile(
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath.build("/storage/emulated/0/$name"),
+            fileType = FileType.FILE,
+            size = null,
+            modifiedAt = null,
+        ),
+        mimeType = MimeInfo("text/plain"),
+    )
+
+    @Test
+    fun `unique ids are handed back untouched`() {
+        val items = listOf(file("a.txt"), file("b.txt"))
+
+        uniqueItemKeys(items) shouldBe items.map { it.id }
+    }
+
+    /**
+     * Two documents in one directory can carry the same display name, which makes their paths equal.
+     * Compose rejects duplicate keys outright, so before this the second one crashed the listing.
+     */
+    @Test
+    fun `a repeated id is suffixed by occurrence`() {
+        val items = listOf(file("dup.txt"), file("other.txt"), file("dup.txt"), file("dup.txt"))
+
+        val keys = uniqueItemKeys(items)
+
+        keys.toSet().size shouldBe keys.size
+        keys[0] shouldBe items[0].id
+        keys[1] shouldBe items[1].id
+        keys[2] shouldBe "${items[2].id}#2"
+        keys[3] shouldBe "${items[3].id}#3"
+    }
+
+    @Test
+    fun `an empty list has no keys`() {
+        uniqueItemKeys(emptyList()) shouldBe emptyList()
+    }
+
+    private fun uniqueItemKeys(items: List<ExplorerItem>) = items.uniqueItemKeys()
+}

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeysTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerItemKeysTest.kt
@@ -50,5 +50,43 @@ class ExplorerItemKeysTest : BaseTest() {
         uniqueItemKeys(emptyList()) shouldBe emptyList()
     }
 
+    /**
+     * The suffix must not land on a name another row already owns, or the crash simply moves: here
+     * the second `dup.txt` would take `dup.txt#2`, which the third row is literally called.
+     */
+    @Test
+    fun `a suffix never collides with a row that already owns that name`() {
+        val items = listOf(file("dup.txt"), file("dup.txt"), file("dup.txt#2"))
+
+        val keys = uniqueItemKeys(items)
+
+        keys.toSet().size shouldBe keys.size
+        keys[0] shouldBe items[0].id
+        keys[2] shouldBe items[2].id
+        keys[1] shouldBe "${items[0].id}#3"
+    }
+
+    @Test
+    fun `a suffix skips several taken names`() {
+        val items = listOf(
+            file("dup.txt"),
+            file("dup.txt#2"),
+            file("dup.txt#3"),
+            file("dup.txt"),
+        )
+
+        val keys = uniqueItemKeys(items)
+
+        keys.toSet().size shouldBe keys.size
+        keys[3] shouldBe "${items[0].id}#4"
+    }
+
+    @Test
+    fun `only ids carried exactly once count as unambiguous`() {
+        val items = listOf(file("a.txt"), file("dup.txt"), file("dup.txt"), file("b.txt"))
+
+        items.unambiguousItemIds() shouldBe setOf(items[0].id, items[3].id)
+    }
+
     private fun uniqueItemKeys(items: List<ExplorerItem>) = items.uniqueItemKeys()
 }


### PR DESCRIPTION
## What changed

Two fixes, both found by running Butler against the test provider from #170.

**Butler no longer crashes when a folder holds two files with the same name.** Opening such a folder killed the app to the home screen before a single row appeared. Local storage cannot produce this, so it only ever happened through storage added from another app, which is why it went unnoticed.

**A folder that failed to load no longer claims to be empty.** When a storage app reports that it could not list a folder, Butler showed the normal "this folder is empty" state. It now surfaces the failure, with the storage app's own message.

## Technical Context

- The crash: a file item's id is its path, and both the list and grid handed that id to Compose as the lazy-list key. Two documents in one directory can share a display name, making their paths equal, and Compose rejects duplicate keys outright. `uniqueItemKeys()` suffixes only the repeats, so an item whose id is already unique keeps its exact key, and with it its scroll position and item animations. Suffixes are allocated against every id in the list, because a directory holding `dup.txt` twice plus a literal `dup.txt#2` would otherwise collide again and simply move the crash.
- `ChildListing` conflated `EXTRA_LOADING` and `EXTRA_ERROR` into one `partial` flag. Resolution wants them together, since neither can prove a name absent, but `listFiles` needs them apart. They are separate fields now and `ChildrenEntry.partial` ORs them back together along with unnamed rows, so resolution behaviour is unchanged.
- `listFiles` throws on an errored listing rather than returning it. Handing one over means an errored *empty* listing is indistinguishable from an empty directory, which is precisely what the Explorer then draws. This routes into the loader's existing navigation-error path, so no new plumbing was needed. `EXTRA_LOADING` still returns what arrived: it is a normal transient state on remote providers and those entries are real.
- Drag-selection keys on the raw item id in four places, so a suffixed key could neither anchor nor end a selection. Those routes were already ambiguous for repeats (`associateBy` keeps one of two), so repeated rows are now excluded from the gesture and the press falls through to the ordinary long-press, which can address the row it landed on.
- **Known residual, deliberately not fixed here.** Selecting one of two same-named rows visibly checks both, while the count correctly reads "1 selected": selection membership is `Set<ExplorerItem>` and the two rows are equal. Same root cause as the crash, and fixing it properly means giving items an identity independent of their path, which is a larger change than stopping the crash. It fails safely in the meantime, because any operation on that selection resolves an ambiguous path and the SAF layer refuses it rather than acting on an arbitrary document.

Verified on an Android 16 emulator against the test provider: no crash on repeat listings, a clear error when tapping an ambiguous row, the unique sibling still opens, a failed listing shows a navigation error quoting the provider, and a genuinely empty folder still shows its empty state. The drag gesture itself could not be exercised, since the automation offers no press-hold-drag primitive; that path is covered by unit tests only.
