### PR TITLE
General: Fix the SAF test fixture's shell controls

### DIFF
--- a/saf-test-provider/README.md
+++ b/saf-test-provider/README.md
@@ -18,7 +18,7 @@ adb install -r saf-test-provider/build/outputs/apk/debug/saf-test-provider-debug
 ```
 
 The second command runs host-side Robolectric tests, without a device or emulator.
-The APK uses application ID `eu.darken.butler.saftestprovider` and authority
+The APK uses application ID `eu.darken.butler.saftestprovider` and documents authority
 `eu.darken.butler.saftestprovider.documents`. Its provider is exported, grants URI
 permissions, and requires `android.permission.MANAGE_DOCUMENTS` for both reading
 and writing. The system picker can grant Butler access to a tree normally.
@@ -57,39 +57,44 @@ Do not carry dynamic document handles across resets or process restarts.
 
 ## Controls
 
-Use the shell UID (normal `adb shell`, without `su`). Custom `call()` methods accept
-only shell UID 2000 or the provider's own UID. Unknown methods retain superclass
-dispatch, including Android's standard document operations. Controls are
-idempotent: repeating them leaves the requested tree/listing state unchanged;
+Use the shell UID (normal `adb shell`, without `su`). The exported control provider
+at `eu.darken.butler.saftestprovider.controls` has no manifest permission requirement
+and accepts only shell UID 2000 or the app's own UID, checked with
+`Binder.getCallingUid()`. It clears the calling identity after that check, acquires
+the existing documents provider in the same process, and calls its control method
+directly. The calling identity is restored and the provider client is closed even
+when a control fails. The control authority supports only the methods below; other
+methods and CRUD operations are rejected. Controls are idempotent: repeating them
+leaves the requested tree/listing state unchanged;
 `reset` starts a new journal session each time. `stats` does not record itself.
 
 These are the direct `content call` commands for every method:
 
 ```sh
 # Restore seeds and clear the journal.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method reset
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method reset
 
 # Return a partial loading listing, then publish its full contents.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method setLoading --arg loading
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method completeLoading --arg loading
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method setLoading --arg loading
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method completeLoading --arg loading
 
 # Set and clear an error string. --extra strings below avoid shell quoting issues.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method setError --arg errored/empty --extra message:s:Injected_empty_failure
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method setError --arg errored/partial --extra message:s:Injected_partial_failure
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method clearError --arg errored/empty
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method clearError --arg errored/partial
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method setError --arg errored/empty --extra message:s:Injected_empty_failure
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method setError --arg errored/partial --extra message:s:Injected_partial_failure
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method clearError --arg errored/empty
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method clearError --arg errored/partial
 
 # Turn the previously unique c directory below b into two c rows.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method makeDuplicate --arg deep/a/b --extra name:s:c
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method makeDuplicate --arg deep/a/b --extra name:s:c
 
 # Without name, duplicate the first named child; repeat calls do not add a third.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method makeDuplicate --arg plain
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method makeDuplicate --arg plain
 
 # Counters and the first journal page.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method stats
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method stats
 
 # Subsequent page: replace 200 with the previous response's nextAfter value.
-adb shell content call --uri content://eu.darken.butler.saftestprovider.documents --method stats --extra after:l:200 --extra limit:i:200
+adb shell content call --uri content://eu.darken.butler.saftestprovider.controls --method stats --extra after:l:200 --extra limit:i:200
 ```
 
 The folder may alternatively be supplied as `--extra folder:s:loading` instead of
@@ -98,13 +103,24 @@ folder. `makeDuplicate` requires an existing named child, creates a fresh ID wit
 the same name and MIME type, and does nothing if that name already has at least
 two rows. A duplicate file has distinct contents; a duplicate directory is empty.
 
-The implemented control route is `ContentProvider.call`. The UID checks and
-superclass dispatch are covered by host tests. No device tests were run, so
-`adb shell content call` acquisition through `MANAGE_DOCUMENTS` has **not been
-verified on a device**. No Activity fallback was added without evidence of a
-permission block. A device-side permission denial would require verifying that
-route and adding the minimal shell-accessible control Activity described in the
-build spec; host tests do not establish device permission behavior.
+The content CLI cannot reach the documents provider. Device testing on an
+Android 16 emulator verified both failures, before `ContentProvider.call` runs:
+
+- Shell UID 2000 holds `ACCESS_CONTENT_PROVIDERS_EXTERNALLY`, but acquisition is
+  blocked by `MANAGE_DOCUMENTS`. `ContentProviderHelper.checkAssociationAndPermissionLocked`,
+  reached through `ActivityManagerService.getContentProviderExternal`, throws
+  `SecurityException`: "requires that you obtain access using ACTION_OPEN_DOCUMENT
+  or related APIs". The fixture's own UID check is never reached.
+- Running the content CLI through `run-as eu.darken.butler.saftestprovider` uses
+  the provider's own UID and passes the documents-provider permission check, but
+  `getContentProviderExternal()` throws `SecurityException`: "Permission Denial:
+  Do not have permission in call getContentProviderExternal()" and "requires
+  android.permission.ACCESS_CONTENT_PROVIDERS_EXTERNALLY".
+
+The existing `call()` methods remain available to in-process and instrumentation
+callers, with their UID checks and superclass dispatch intact, including Android's
+standard document operations. The control authority is covered by host-side tests;
+on-device verification of the new route remains a separate QA step.
 
 ## Journal and negative assertions
 

--- a/saf-test-provider/src/main/AndroidManifest.xml
+++ b/saf-test-provider/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
         android:label="@string/saf_test_provider_name"
         android:supportsRtl="true">
         <provider
+            android:name=".TestControlsProvider"
+            android:authorities="eu.darken.butler.saftestprovider.controls"
+            android:exported="true" />
+        <provider
             android:name=".TestDocumentsProvider"
             android:authorities="eu.darken.butler.saftestprovider.documents"
             android:enabled="true"

--- a/saf-test-provider/src/main/java/eu/darken/butler/saftestprovider/TestControlsProvider.kt
+++ b/saf-test-provider/src/main/java/eu/darken/butler/saftestprovider/TestControlsProvider.kt
@@ -1,0 +1,60 @@
+package eu.darken.butler.saftestprovider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.Bundle
+import android.os.Process
+
+class TestControlsProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        val uid = Binder.getCallingUid()
+        if (uid != Process.myUid() && uid != SHELL_UID) {
+            throw SecurityException("Fixture controls require shell or self UID")
+        }
+        require(method in CONTROL_METHODS) { "Unknown fixture control: $method" }
+
+        // Acquire and call the local provider as self, after authenticating the external caller.
+        val identity = Binder.clearCallingIdentity()
+        try {
+            val resolver = requireNotNull(context).contentResolver
+            return checkNotNull(resolver.acquireContentProviderClient(TestDocumentsProvider.AUTHORITY)).use { client ->
+                val provider = checkNotNull(client.localContentProvider) { "Documents provider must be in-process" }
+                provider.call(method, arg, extras)
+            }
+        } finally {
+            Binder.restoreCallingIdentity(identity)
+        }
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor = throw UnsupportedOperationException("Use call() for fixture controls")
+
+    override fun getType(uri: Uri): String = throw UnsupportedOperationException("Use call() for fixture controls")
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri =
+        throw UnsupportedOperationException("Use call() for fixture controls")
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+        throw UnsupportedOperationException("Use call() for fixture controls")
+
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?): Int =
+        throw UnsupportedOperationException("Use call() for fixture controls")
+
+    companion object {
+        const val AUTHORITY = "eu.darken.butler.saftestprovider.controls"
+        private const val SHELL_UID = 2000
+        private val CONTROL_METHODS = setOf(
+            "reset", "setLoading", "completeLoading", "setError", "clearError", "makeDuplicate", "stats",
+        )
+    }
+}

--- a/saf-test-provider/src/test/java/eu/darken/butler/saftestprovider/TestControlsProviderTest.kt
+++ b/saf-test-provider/src/test/java/eu/darken/butler/saftestprovider/TestControlsProviderTest.kt
@@ -1,0 +1,169 @@
+package eu.darken.butler.saftestprovider
+
+import android.Manifest
+import android.net.Uri
+import android.os.Binder
+import android.os.Bundle
+import android.os.Process
+import android.provider.DocumentsContract
+import android.provider.DocumentsContract.Document
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowBinder
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class TestControlsProviderTest {
+    private lateinit var documents: TestDocumentsProvider
+    private lateinit var controls: TestControlsProvider
+    private val uri = Uri.parse("content://${TestControlsProvider.AUTHORITY}")
+
+    @Before
+    fun setup() {
+        documents = Robolectric.buildContentProvider(TestDocumentsProvider::class.java).create().get()
+        controls = Robolectric.buildContentProvider(TestControlsProvider::class.java).create().get()
+        control("reset")
+    }
+
+    @After
+    fun teardown() {
+        ShadowBinder.reset()
+    }
+
+    @Test
+    fun `manifest exports controls without a permission and keeps documents protected in the same process`() {
+        val pm = RuntimeEnvironment.getApplication().packageManager
+        val controlInfo = requireNotNull(pm.resolveContentProvider(TestControlsProvider.AUTHORITY, 0))
+        val documentInfo = requireNotNull(pm.resolveContentProvider(TestDocumentsProvider.AUTHORITY, 0))
+        assertTrue(controlInfo.exported)
+        assertNull(controlInfo.readPermission)
+        assertNull(controlInfo.writePermission)
+        assertFalse(controlInfo.grantUriPermissions)
+        assertEquals(documentInfo.processName, controlInfo.processName)
+        assertEquals(Manifest.permission.MANAGE_DOCUMENTS, documentInfo.readPermission)
+        assertEquals(Manifest.permission.MANAGE_DOCUMENTS, documentInfo.writePermission)
+        assertTrue(documentInfo.grantUriPermissions)
+    }
+
+    @Test
+    fun `shell and self reach the existing documents instance and reset its state`() {
+        val session = control("stats").getString("session")
+        documents.createDocument("70", "text/plain", "temporary.txt")
+        listOf(2000, Process.myUid()).forEach { uid ->
+            ShadowBinder.setCallingUid(uid)
+            val stats = control("stats")
+            assertEquals(session, stats.getString("session"))
+            assertEquals(1L, stats.getLong("createDocument"))
+            assertEquals(1L, stats.getBundle("counters")!!.getLong("createDocument"))
+            assertEquals(uid, Binder.getCallingUid())
+        }
+        ShadowBinder.setCallingUid(2000)
+        val reset = control("reset")
+        assertNotEquals(session, reset.getString("session"))
+        assertEquals(reset.getString("session"), documents.call("stats", null, null)!!.getString("session"))
+        assertEquals(0L, control("stats").getLong("totalEntries"))
+        documents.queryChildDocuments("70", null, sortOrder = null).use { assertEquals(0, it.count) }
+        assertEquals(2000, Binder.getCallingUid())
+    }
+
+    @Test
+    fun `shell forwards every folder control with arguments and extras`() {
+        ShadowBinder.setCallingUid(2000)
+        assertEquals("50", control("completeLoading", "loading").getString("documentId"))
+        documents.queryChildDocuments("50", null, sortOrder = null).use {
+            assertEquals(2, it.count)
+            assertFalse(it.extras.getBoolean(DocumentsContract.EXTRA_LOADING))
+        }
+        control("setLoading", extras = Bundle().apply { putString("folder", "loading") })
+        documents.queryChildDocuments("50", null, sortOrder = null).use {
+            assertEquals(1, it.count)
+            assertTrue(it.extras.getBoolean(DocumentsContract.EXTRA_LOADING))
+        }
+        control("setError", "empty", Bundle().apply { putString("message", "Injected failure") })
+        documents.queryChildDocuments("70", null, sortOrder = null).use {
+            assertEquals("Injected failure", it.extras.getString(DocumentsContract.EXTRA_ERROR))
+        }
+        control("clearError", "empty")
+        documents.queryChildDocuments("70", null, sortOrder = null).use {
+            assertFalse(it.extras.containsKey(DocumentsContract.EXTRA_ERROR))
+        }
+        repeat(2) {
+            control("makeDuplicate", "deep/a/b", Bundle().apply { putString("name", "c") })
+        }
+        documents.queryChildDocuments("82", null, sortOrder = null).use {
+            assertEquals(2, it.count)
+            while (it.moveToNext()) {
+                assertEquals("c", it.getString(it.getColumnIndexOrThrow(Document.COLUMN_DISPLAY_NAME)))
+            }
+        }
+    }
+
+    @Test
+    fun `stats preserves journal payload and typed pagination extras`() {
+        documents.queryDocument("42", null).close()
+        documents.queryDocument("43", null).close()
+        documents.queryDocument("85", null).close()
+        ShadowBinder.setCallingUid(2000)
+        val page = control("stats", extras = Bundle().apply {
+            putLong("after", 1L)
+            putInt("limit", 1)
+        })
+        assertEquals(3L, page.getLong("queryDocument"))
+        assertEquals(3L, page.getLong("totalEntries"))
+        assertEquals(2L, page.getLong("nextAfter"))
+        assertTrue(page.getBoolean("hasMore"))
+        val fields = page.getString("journal")!!.split('\t')
+        assertEquals(listOf("2", "queryDocument", "43"), fields.take(3))
+        assertEquals(5, fields.size)
+        assertEquals(3L, control("stats").getLong("totalEntries"))
+    }
+
+    @Test
+    fun `foreign app root and system UIDs cannot read stats or mutate the fixture`() {
+        val session = control("stats").getString("session")
+        listOf(12345, 0, 1000).forEach { uid ->
+            ShadowBinder.setCallingUid(uid)
+            listOf("stats", "reset", "unknown", "android:isChildDocument").forEach { method ->
+                assertThrows(SecurityException::class.java) { control(method) }
+                assertEquals(uid, Binder.getCallingUid())
+            }
+        }
+        ShadowBinder.reset()
+        assertEquals(session, control("stats").getString("session"))
+        assertEquals(0L, control("stats").getLong("totalEntries"))
+    }
+
+    @Test
+    fun `invalid controls propagate failures without changing caller identity or journal`() {
+        ShadowBinder.setCallingUid(2000)
+        listOf("unknown", "android:deleteDocument").forEach { method ->
+            assertThrows(IllegalArgumentException::class.java) { control(method) }
+        }
+        assertThrows(IllegalArgumentException::class.java) { control("setError", "empty") }
+        assertThrows(IllegalStateException::class.java) { control("setLoading", "missing") }
+        assertThrows(IllegalArgumentException::class.java) {
+            control("stats", extras = Bundle().apply { putLong("after", 1L) })
+        }
+        assertEquals(2000, Binder.getCallingUid())
+        assertEquals(0L, control("stats").getLong("totalEntries"))
+    }
+
+    @Test
+    fun `control authority exposes no CRUD operations`() {
+        assertThrows(UnsupportedOperationException::class.java) { controls.query(uri, null, null, null, null) }
+        assertThrows(UnsupportedOperationException::class.java) { controls.getType(uri) }
+        assertThrows(UnsupportedOperationException::class.java) { controls.insert(uri, null) }
+        assertThrows(UnsupportedOperationException::class.java) { controls.delete(uri, null, null) }
+        assertThrows(UnsupportedOperationException::class.java) { controls.update(uri, null, null, null) }
+    }
+
+    private fun control(method: String, arg: String? = null, extras: Bundle? = null): Bundle =
+        requireNotNull(RuntimeEnvironment.getApplication().contentResolver.call(uri, method, arg, extras))
+}


### PR DESCRIPTION
## What changed

No user-facing behavior change. The test fixture added in #170 documented an `adb shell content call` control interface that could not actually be reached. This replaces it with one that works, verified on a device.

## Technical Context

- The documented commands failed two different ways, both confirmed on an Android 16 emulator. As shell: `SecurityException: Permission Denial: opening provider ... (uid=2000) requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs`, thrown from `ActivityManagerService.getContentProviderExternal`. As the app's own uid via `run-as`: `Permission Denial: Do not have permission in call getContentProviderExternal() ... requires android.permission.ACCESS_CONTENT_PROVIDERS_EXTERNALLY`. Shell holds the external-provider permission but is blocked by `MANAGE_DOCUMENTS`; the app uid passes `MANAGE_DOCUMENTS` but lacks the external-provider permission. The failure happens in ActivityManager before `ContentProvider.call` runs, so the fixture's own caller check was never even reached.
- The fix is a second provider authority, `…saftestprovider.controls`, declared without `android:permission` so shell can open it, which forwards each control method in-process to the unchanged documents provider. Same-uid access needs no permission, so the forwarding is what gets past the wall.
- A broadcast receiver was considered and rejected. `am broadcast` does return `setResultData`, so the mechanism works, but Android 16 hides the sender uid from receivers and its authenticated-shell flag admits root as well, so a receiver cannot enforce the shell-or-self restriction the control surface needs. The separate authority keeps `Binder.getCallingUid()` meaningful, and keeps the command shape the README already documented.
- The documents provider keeps its own `call()` methods, so in-process and instrumentation callers are unaffected.
- The README's unverified caveat is replaced with the verified finding, including both permission errors, so the next reader does not retry the CLI against the documents authority and rediscover this.

Verified on device after the change: `stats` returns the operation journal, `makeDuplicate` mints a document, and `reset` restores the tree, all through plain `adb shell content call`. Unit tests cover the uid rejection path, including that a foreign app and system uids are refused.
