### PR TITLE
IO: Fix detection of ShizukuPlus forks

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapper.kt
@@ -35,29 +35,35 @@ class ShizukuWrapper @Inject constructor(
 ) {
 
     /**
-     * Package that declares the Shizuku permission, or null if no installed app declares it.
+     * Packages that declare a Shizuku manager permission, in [MANAGER_PERMISSIONS] order.
      *
-     * Detects Shizuku via its permission ([ShizukuProvider.PERMISSION]) instead of a fixed package
-     * name. The permission name is shared across Shizuku forks, so this keeps working when a fork
-     * hides its package from enumeration ("Hide Shizuku from other apps") or ships under a different
-     * package name. Permissions live in a global namespace, so the lookup isn't subject to the
-     * package-visibility filtering that hides the app itself.
+     * Detects Shizuku via its permissions instead of a fixed package name. The permission names are
+     * shared across Shizuku forks, so this keeps working when a fork hides its package from
+     * enumeration ("Hide Shizuku from other apps") or ships under a different package name.
+     * Permissions live in a global namespace, so the lookup isn't subject to the package-visibility
+     * filtering that hides the app itself. Every name is tried because Shizuku+'s Plus flavor
+     * declares only its own permission and just requests the stock one.
      */
-    suspend fun getManagerPackage(): String? = withContext(dispatcherProvider.IO) {
-        try {
-            context.packageManager
-                .getPermissionInfo(ShizukuProvider.PERMISSION, 0)
-                .packageName
-                ?.takeUnless { it.isBlank() }
-        } catch (e: PackageManager.NameNotFoundException) {
-            log(TAG) { "getManagerPackage(): Shizuku permission not declared by any app" }
-            null
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            log(TAG, WARN) { "getManagerPackage(): Lookup failed: ${e.asLog()}" }
-            null
-        }
+    suspend fun getManagerPackages(): List<String> = withContext(dispatcherProvider.IO) {
+        MANAGER_PERMISSIONS.mapNotNull { resolvePermissionOwner(it) }.distinct()
+    }
+
+    /** The manager package to treat as *the* Shizuku app, see [getManagerPackages]. */
+    suspend fun getManagerPackage(): String? = getManagerPackages().firstOrNull()
+
+    private fun resolvePermissionOwner(permission: String): String? = try {
+        context.packageManager
+            .getPermissionInfo(permission, 0)
+            .packageName
+            ?.takeUnless { it.isBlank() }
+    } catch (e: PackageManager.NameNotFoundException) {
+        log(TAG) { "resolvePermissionOwner($permission): not declared by any app" }
+        null
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "resolvePermissionOwner($permission): Lookup failed: ${e.asLog()}" }
+        null
     }
 
     private val handlerThread: HandlerThread by lazy {
@@ -189,6 +195,11 @@ class ShizukuWrapper @Inject constructor(
 
     companion object {
         private val TAG = logTag("ADB", "Shizuku", "Wrapper")
+
+        private const val SHIZUKU_PLUS_PERMISSION = "af.shizuku.plus.permission.API_V23"
+
+        // Prefer the stock permission owner when both permissions are declared.
+        private val MANAGER_PERMISSIONS = listOf(ShizukuProvider.PERMISSION, SHIZUKU_PLUS_PERMISSION)
 
         /**
          * Combined budget for the two binder round-trips behind [isGranted].

--- a/app-common-adb/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -28,6 +28,9 @@ class ShizukuWrapperTest {
     private val context = mockk<Context>()
     private val packageManager = mockk<PackageManager>()
 
+    private val stockPermission = "moe.shizuku.manager.permission.API_V23"
+    private val plusPermission = "af.shizuku.plus.permission.API_V23"
+
     private val dispatcherProvider = object : DispatcherProvider {
         override val IO: CoroutineDispatcher = Dispatchers.Unconfined
     }
@@ -43,6 +46,14 @@ class ShizukuWrapperTest {
     // mockk gives us a real (Objenesis-instantiated) PermissionInfo whose inherited public
     // packageName field we can set directly, without invoking the Android constructor.
     private fun permissionInfo(pkg: String?) = mockk<PermissionInfo>().apply { packageName = pkg }
+
+    private fun definePermission(name: String, owner: String?) {
+        every { packageManager.getPermissionInfo(name, any<Int>()) } returns permissionInfo(owner)
+    }
+
+    private fun undefinePermission(name: String) {
+        every { packageManager.getPermissionInfo(name, any<Int>()) } throws PackageManager.NameNotFoundException()
+    }
 
     @Test
     fun `resolves the declaring package when the Shizuku permission exists`() = runTest {
@@ -80,6 +91,50 @@ class ShizukuWrapperTest {
         every { packageManager.getPermissionInfo(any(), any<Int>()) } returns permissionInfo("")
 
         wrapper().getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `falls back to the Shizuku+ permission when the stock permission is undefined`() = runTest {
+        undefinePermission(stockPermission)
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        wrapper().getManagerPackage() shouldBe "af.shizuku.plus.api"
+    }
+
+    @Test
+    fun `prefers the stock permission owner when both are defined`() = runTest {
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+        val wrapper = wrapper()
+
+        wrapper.getManagerPackage() shouldBe "moe.shizuku.privileged.api"
+        wrapper.getManagerPackages() shouldBe listOf("moe.shizuku.privileged.api", "af.shizuku.plus.api")
+    }
+
+    @Test
+    fun `collapses one app defining both permissions to a single entry`() = runTest {
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "moe.shizuku.privileged.api")
+
+        wrapper().getManagerPackages() shouldBe listOf("moe.shizuku.privileged.api")
+    }
+
+    @Test
+    fun `getManagerPackages is empty when no permission is defined`() = runTest {
+        undefinePermission(stockPermission)
+        undefinePermission(plusPermission)
+        val wrapper = wrapper()
+
+        wrapper.getManagerPackages() shouldBe emptyList()
+        wrapper.getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `a failing lookup for one permission does not hide the other`() = runTest {
+        every { packageManager.getPermissionInfo(stockPermission, any<Int>()) } throws RuntimeException("OEM quirk")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        wrapper().getManagerPackage() shouldBe "af.shizuku.plus.api"
     }
 
     @Test

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
@@ -62,8 +62,8 @@ class ShizukuManager @Inject constructor(
         }
         .replayingShare(appScope)
 
-    // The reference package plus, if a fork under a different package name is installed, its package too.
-    suspend fun managerIds(): Set<Pkg.Id> = setOf(PKG_ID) + listOfNotNull(getManagerId())
+    // The reference package plus every installed app that declares a Shizuku manager permission.
+    suspend fun managerIds(): Set<Pkg.Id> = setOf(PKG_ID) + shizukuWrapper.getManagerPackages().map { it.toPkgId() }
 
     val permissionGrantEvents: Flow<ShizukuWrapper.ShizukuPermissionRequest> = shizukuWrapper.permissionGrantEvents
         .setupCommonEventHandlers(TAG) { "grantEvents" }

--- a/app-common-io/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuManagerTest.kt
@@ -70,6 +70,7 @@ class ShizukuManagerTest : BaseTest() {
     )
 
     private fun setShizukuPackage(pkg: String?) {
+        coEvery { shizukuWrapper.getManagerPackages() } returns listOfNotNull(pkg)
         coEvery { shizukuWrapper.getManagerPackage() } returns pkg
     }
 
@@ -216,5 +217,14 @@ class ShizukuManagerTest : BaseTest() {
         val forkPkg = "com.example.shizuku.fork"
         setShizukuPackage(forkPkg)
         runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, forkPkg.toPkgId())
+    }
+
+    @Test fun `managerIds includes every detected manager package`() {
+        coEvery { shizukuWrapper.getManagerPackages() } returns listOf(
+            "moe.shizuku.privileged.api",
+            "af.shizuku.plus.api",
+        )
+
+        runBlocking { manager().managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, "af.shizuku.plus.api".toPkgId())
     }
 }


### PR DESCRIPTION
## What changed

Butler now detects ShizukuPlus installations that declare their own API permission, allowing Shizuku access to be enabled for those forks.

## Technical Context

- Ports SD Maid SE commit `1e7a2fbb8`. Butler already resolved the stock permission owner; ShizukuPlus's Plus flavor declares `af.shizuku.plus.permission.API_V23` and only requests the stock permission.
- Looks up both permission owners, preserves stock priority, deduplicates packages, and isolates lookup failures. Manager tracking includes both Plus and its Compat Hub when installed together.
