### PR TITLE
Workspace: Let operations keep their tab open and describe their result shape

### DIFF
--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/DeveloperOperation.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/DeveloperOperation.kt
@@ -9,7 +9,7 @@ import kotlin.time.Instant
 
 abstract class DeveloperOperation : Operation {
 
-    interface Report : Operation.Report
+    interface Report : Operation.Report.Paths
 
     abstract override fun perform(operationContext: Operation.Context): Flow<State>
 

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/TestDataOperationReport.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/TestDataOperationReport.kt
@@ -6,7 +6,7 @@ import eu.darken.butler.common.ca.caString
 import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.developer.R
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class TestDataOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspaceViewModel.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/ui/DeveloperWorkspaceViewModel.kt
@@ -379,9 +379,9 @@ class DeveloperWorkspaceViewModel @AssistedInject constructor(
                 val pathEntities = storedPaths.mapIndexed { i, name ->
                     val fullPath = "${spec.pathRoot}/$name"
                     val change = when (spec.kind) {
-                        Operation.Metadata.Kind.DELETE -> Operation.Report.PathChange.Change.REMOVED
-                        Operation.Metadata.Kind.MOVE -> Operation.Report.PathChange.Change.MOVED
-                        else -> Operation.Report.PathChange.Change.ADDED
+                        Operation.Metadata.Kind.DELETE -> Operation.Report.Paths.PathChange.Change.REMOVED
+                        Operation.Metadata.Kind.MOVE -> Operation.Report.Paths.PathChange.Change.MOVED
+                        else -> Operation.Report.Paths.PathChange.Change.ADDED
                     }
                     OperationHistoryPathEntity(
                         operationHistoryId = rowId,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperationReport.kt
@@ -7,7 +7,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.explorer.R
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class CompressOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CopyOperationReport.kt
@@ -9,7 +9,7 @@ import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.explorer.R
-import eu.darken.butler.workspace.core.operations.Operation.Report.*
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class CopyOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CreateOperationReport.kt
@@ -7,7 +7,7 @@ import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.explorer.R
 import eu.darken.butler.workspace.core.filesystem.FileSystemEvent
-import eu.darken.butler.workspace.core.operations.Operation.Report.*
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class CreateOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DeleteOperationReport.kt
@@ -4,7 +4,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.core.operations.BaseDeleteOperationReport
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class DeleteOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExplorerOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExplorerOperation.kt
@@ -11,7 +11,7 @@ import kotlin.time.Instant
 
 abstract class ExplorerOperation : Operation {
 
-    interface Report : Operation.Report, Operation.HasPerformanceHistory {
+    interface Report : Operation.Report.Paths, Operation.HasPerformanceHistory {
         override val performanceHistory: PerformanceHistory? get() = null
     }
 

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperationReport.kt
@@ -7,7 +7,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.explorer.R
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class ExtractOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperationReport.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/MoveOperationReport.kt
@@ -9,7 +9,7 @@ import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.explorer.R
-import eu.darken.butler.workspace.core.operations.Operation.Report.*
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class MoveOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/RestoreOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/RestoreOperation.kt
@@ -72,8 +72,8 @@ class RestoreOperation @AssistedInject constructor(
                 restoredPaths.size,
             )
         }
-        override val affectedPaths: Collection<Operation.Report.PathChange> = restoredPaths.map {
-            Operation.Report.PathChange(path = it, change = Operation.Report.PathChange.Change.ADDED)
+        override val affectedPaths: Collection<Operation.Report.Paths.PathChange> = restoredPaths.map {
+            Operation.Report.Paths.PathChange(path = it, change = Operation.Report.Paths.PathChange.Change.ADDED)
         }
         override val partialErrorCount: Int = conflictCount + failedCount
     }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -1291,7 +1291,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 ExplorerCommand.Extract(archive = archive, destinationDir = destinationDir, entries = null)
             )
             if (completed.error == null) {
-                completed.report?.affectedPaths?.map { it.path }?.let { revealItems(it) }
+                (completed.report as? Operation.Report.Paths)?.affectedPaths?.map { it.path }?.let { revealItems(it) }
             }
         }
     }
@@ -1341,7 +1341,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 ExplorerCommand.DownloadLocalCopy(source = container, destinationDir = destinationDir),
             )
             if (completed.error == null) {
-                completed.report?.affectedPaths?.firstOrNull()?.path?.let { copied ->
+                (completed.report as? Operation.Report.Paths)?.affectedPaths?.firstOrNull()?.path?.let { copied ->
                     getWorkspace().navigate(
                         ExplorerNavigation.Target.Directory(ArchivePath(container = copied, segments = emptyList())),
                     )
@@ -1417,7 +1417,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
     private suspend fun executeCompress(command: ExplorerCommand.Compress) {
         val completed = getWorkspace().execute(command)
         if (completed.error == null) {
-            completed.report?.affectedPaths?.map { it.path }?.let { revealItems(it) }
+            (completed.report as? Operation.Report.Paths)?.affectedPaths?.map { it.path }?.let { revealItems(it) }
         }
     }
 
@@ -1512,8 +1512,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
             // Reveal the newly created item on success
             if (completed.error == null) {
-                val createdPath = completed.report?.affectedPaths
-                    ?.firstOrNull { it.change == Operation.Report.PathChange.Change.ADDED }
+                val createdPath = (completed.report as? Operation.Report.Paths)?.affectedPaths
+                    ?.firstOrNull { it.change == Operation.Report.Paths.PathChange.Change.ADDED }
                     ?.path
                 createdPath?.let { revealItems(listOf(it)) }
             }
@@ -1853,8 +1853,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
                     // Reveal all added items on success (scroll to first, highlight all)
                     if (completed.error == null) {
-                        val addedPaths = completed.report?.affectedPaths
-                            ?.filter { it.change == Operation.Report.PathChange.Change.ADDED || it.change == Operation.Report.PathChange.Change.MOVED }
+                        val addedPaths = (completed.report as? Operation.Report.Paths)?.affectedPaths
+                            ?.filter { it.change == Operation.Report.Paths.PathChange.Change.ADDED || it.change == Operation.Report.Paths.PathChange.Change.MOVED }
                             ?.map { it.path }
                             ?: emptyList()
                         revealItems(addedPaths)
@@ -1982,8 +1982,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
         val completed = getWorkspace().execute(command)
         if (completed.error == null) {
-            val addedPaths = completed.report?.affectedPaths
-                ?.filter { it.change == Operation.Report.PathChange.Change.ADDED || it.change == Operation.Report.PathChange.Change.MOVED }
+            val addedPaths = (completed.report as? Operation.Report.Paths)?.affectedPaths
+                ?.filter { it.change == Operation.Report.Paths.PathChange.Change.ADDED || it.change == Operation.Report.Paths.PathChange.Change.MOVED }
                 ?.map { it.path }
                 ?: emptyList()
             // Only the listing that shows the destination can reveal them; for a drop onto some
@@ -2014,8 +2014,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                 if (completed.error == null) {
                     log(tag, INFO) { "Created text file: $filename with ${clip.content.length} characters" }
                     // Resolving a name conflict by renaming lands the file somewhere other than filePath.
-                    val createdPath = completed.report?.affectedPaths
-                        ?.firstOrNull { it.change == Operation.Report.PathChange.Change.ADDED }
+                    val createdPath = (completed.report as? Operation.Report.Paths)?.affectedPaths
+                        ?.firstOrNull { it.change == Operation.Report.Paths.PathChange.Change.ADDED }
                         ?.path
                     revealItems(listOfNotNull(createdPath))
                     clipboardRepo.remove(clip.id)

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
@@ -371,9 +371,9 @@ object MockDataProvider {
             state = OperationDisplay.State.Completed(
                 summary = description.toCaString(),
                 completedAt = MockTimes.minutesAgo(minutesAgo),
-                report = object : Operation.Report {
+                report = object : Operation.Report.Paths {
                     override val summary = description.toCaString()
-                    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                     override val subjectPath = null
                 }
             ),

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/CreateTextFileOperationTest.kt
@@ -140,7 +140,7 @@ class CreateTextFileOperationTest : BaseTest() {
         // Reporting the requested path leaves the renamed file out of the listing until a refresh.
         completed.report.affectedPaths.single().let {
             it.path shouldBe renamedPath
-            it.change shouldBe Operation.Report.PathChange.Change.ADDED
+            it.change shouldBe Operation.Report.Paths.PathChange.Change.ADDED
         }
         completed.report.subjectPath shouldBe renamedPath
         events.single().shouldBeInstanceOf<FileSystemEvent.Added>().paths.single().lookedUp shouldBe renamedPath

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/RestoreOperationTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/operations/RestoreOperationTest.kt
@@ -91,7 +91,7 @@ class RestoreOperationTest : BaseTest() {
         completed.error shouldBe null
         val report = completed.report.shouldBeInstanceOf<RestoreOperation.Report>()
         report.restoredPaths shouldBe setOf(restoredPath)
-        report.affectedPaths.single().change shouldBe Operation.Report.PathChange.Change.ADDED
+        report.affectedPaths.single().change shouldBe Operation.Report.Paths.PathChange.Change.ADDED
         events.single().shouldBeInstanceOf<FileSystemEvent.Added>().paths.single().lookedUp shouldBe restoredPath
     }
 

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryLabels.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/core/HistoryLabels.kt
@@ -44,6 +44,7 @@ internal val HistoryEntry.OriginType.labelRes: Int
         HistoryEntry.OriginType.SAVER -> R.string.history_origin_saver
         HistoryEntry.OriginType.DEVELOPER -> R.string.history_origin_developer
         HistoryEntry.OriginType.VIEWER -> R.string.history_origin_viewer
+        HistoryEntry.OriginType.APPS -> R.string.history_origin_apps
     }
 
 /** Past tense, unlike [labelRes]: the row headline reads as what happened, not as a filter value. */

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryEntryRow.kt
@@ -267,7 +267,7 @@ private fun HistoryEntryRowPreview() {
                 HistoryEntry.PathChange(
                     path = "/storage/emulated/0/backup/photo1.jpg",
                     previousPath = null,
-                    change = Operation.Report.PathChange.Change.ADDED,
+                    change = Operation.Report.Paths.PathChange.Change.ADDED,
                 ),
             ),
         ),
@@ -303,7 +303,7 @@ private fun HistoryEntryRowFailedPreview() {
                 HistoryEntry.PathChange(
                     path = "/sdcard/protected/notes.txt",
                     previousPath = null,
-                    change = Operation.Report.PathChange.Change.REMOVED,
+                    change = Operation.Report.Paths.PathChange.Change.REMOVED,
                 ),
             ),
         ),
@@ -339,7 +339,7 @@ private fun HistoryEntryRowTruncatedPreview() {
                 HistoryEntry.PathChange(
                     path = "/sdcard/cache/file_$it.bin",
                     previousPath = null,
-                    change = Operation.Report.PathChange.Change.REMOVED,
+                    change = Operation.Report.Paths.PathChange.Change.REMOVED,
                 )
             },
         ),
@@ -406,7 +406,7 @@ private fun HistoryEntryRowSelectedPreview() {
                 HistoryEntry.PathChange(
                     path = "/storage/emulated/0/Documents/todo.txt",
                     previousPath = "/storage/emulated/0/Documents/notes.txt",
-                    change = Operation.Report.PathChange.Change.MOVED,
+                    change = Operation.Report.Paths.PathChange.Change.MOVED,
                 ),
             ),
         ),

--- a/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspacePage.kt
+++ b/app-workspace-history/src/main/java/eu/darken/butler/history/ui/HistoryWorkspacePage.kt
@@ -339,7 +339,7 @@ internal fun mockEntry(
             HistoryEntry.PathChange(
                 path = path,
                 previousPath = null,
-                change = Operation.Report.PathChange.Change.ADDED,
+                change = Operation.Report.Paths.PathChange.Change.ADDED,
             ),
         ),
     )

--- a/app-workspace-history/src/main/res/values/strings.xml
+++ b/app-workspace-history/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="history_origin_saver">Saver</string>
     <string name="history_origin_developer">Developer</string>
     <string name="history_origin_viewer">Viewer</string>
+    <string name="history_origin_apps">Apps</string>
 
     <!-- Duration formats -->
     <string name="history_duration_ms">%1$d ms</string>

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/core/HistoryShareTextTest.kt
@@ -43,7 +43,7 @@ class HistoryShareTextTest : BaseTest() {
             HistoryEntry.PathChange(
                 path = "/storage/emulated/0/DCIM/photo.jpg",
                 previousPath = null,
-                change = Operation.Report.PathChange.Change.ADDED,
+                change = Operation.Report.Paths.PathChange.Change.ADDED,
             ),
         ),
     ) = HistoryEntry(
@@ -101,7 +101,7 @@ class HistoryShareTextTest : BaseTest() {
                         HistoryEntry.PathChange(
                             path = "/sdcard/new.txt",
                             previousPath = "/sdcard/old.txt",
-                            change = Operation.Report.PathChange.Change.MOVED,
+                            change = Operation.Report.Paths.PathChange.Change.MOVED,
                         ),
                     ),
                 )
@@ -122,7 +122,7 @@ class HistoryShareTextTest : BaseTest() {
                         HistoryEntry.PathChange(
                             path = "/sdcard/file_$it.bin",
                             previousPath = null,
-                            change = Operation.Report.PathChange.Change.REMOVED,
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED,
                         )
                     },
                 )
@@ -194,7 +194,7 @@ class HistoryShareTextTest : BaseTest() {
                         HistoryEntry.PathChange(
                             path = "/sdcard/we`ird`.txt",
                             previousPath = null,
-                            change = Operation.Report.PathChange.Change.ADDED,
+                            change = Operation.Report.Paths.PathChange.Change.ADDED,
                         ),
                     ),
                 )
@@ -216,7 +216,7 @@ class HistoryShareTextTest : BaseTest() {
                     HistoryEntry.PathChange(
                         path = "/storage/emulated/0/DCIM/folder_$index/photo_$it.jpg",
                         previousPath = null,
-                        change = Operation.Report.PathChange.Change.ADDED,
+                        change = Operation.Report.Paths.PathChange.Change.ADDED,
                     )
                 },
             )
@@ -256,7 +256,7 @@ class HistoryShareTextTest : BaseTest() {
     private fun added(path: String) = HistoryEntry.PathChange(
         path = path,
         previousPath = null,
-        change = Operation.Report.PathChange.Change.ADDED,
+        change = Operation.Report.Paths.PathChange.Change.ADDED,
     )
 
     /**

--- a/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
+++ b/app-workspace-history/src/test/java/eu/darken/butler/history/ui/HistoryEntryRowLabelTest.kt
@@ -47,7 +47,7 @@ class HistoryEntryRowLabelTest : ComposeTest() {
             HistoryEntry.PathChange(
                 path = it,
                 previousPath = null,
-                change = Operation.Report.PathChange.Change.ADDED,
+                change = Operation.Report.Paths.PathChange.Change.ADDED,
             )
         },
         primaryPath = primaryPath,

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesReport.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesReport.kt
@@ -11,7 +11,7 @@ import eu.darken.butler.workspace.core.operations.Operation
 data class SaveFilesReport(
     val results: List<FileResult>,
     override val performanceHistory: PerformanceHistory? = null,
-) : Operation.Report, Operation.HasPerformanceHistory {
+) : Operation.Report.Paths, Operation.HasPerformanceHistory {
 
     sealed class FileResult {
         abstract val filename: String
@@ -72,9 +72,9 @@ data class SaveFilesReport(
         }
     }
 
-    override val affectedPaths: Collection<Operation.Report.PathChange>
+    override val affectedPaths: Collection<Operation.Report.Paths.PathChange>
         get() = successes.map {
-            Operation.Report.PathChange(it.savedPath, Operation.Report.PathChange.Change.ADDED)
+            Operation.Report.Paths.PathChange(it.savedPath, Operation.Report.Paths.PathChange.Change.ADDED)
         }
 
     /**

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperationReport.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/DeleteOperationReport.kt
@@ -4,7 +4,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.core.operations.BaseDeleteOperationReport
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class DeleteOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/SearcherOperation.kt
+++ b/app-workspace-searcher/src/main/java/eu/darken/butler/searcher/core/operations/SearcherOperation.kt
@@ -11,7 +11,7 @@ import kotlin.time.Instant
 
 abstract class SearcherOperation : Operation {
 
-    interface Report : Operation.Report, Operation.HasPerformanceHistory {
+    interface Report : Operation.Report.Paths, Operation.HasPerformanceHistory {
         override val performanceHistory: PerformanceHistory? get() = null
     }
 

--- a/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspaceViewModel.kt
+++ b/app-workspace-templates/src/main/java/eu/darken/butler/templates/ui/TemplatesWorkspaceViewModel.kt
@@ -94,6 +94,9 @@ class TemplatesWorkspaceViewModel @AssistedInject constructor(
             is WorkspaceAction.Create.Result.LimitReached -> {
                 log(tag, WARN) { "Workspace creation blocked - limit reached" }
             }
+            is WorkspaceAction.Create.Result.Refused -> {
+                log(tag, WARN) { "Workspace creation refused - the replaced tab is busy" }
+            }
         }
     }
 

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperationReport.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/DeleteOperationReport.kt
@@ -4,7 +4,7 @@ import eu.darken.butler.common.files.APath
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.workspace.core.operations.BaseDeleteOperationReport
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 data class DeleteOperationReport(
     override val affectedPaths: Collection<PathChange>,

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/ViewerOperation.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/core/operations/ViewerOperation.kt
@@ -11,7 +11,7 @@ import kotlin.time.Instant
 
 abstract class ViewerOperation : Operation {
 
-    interface Report : Operation.Report, Operation.HasPerformanceHistory {
+    interface Report : Operation.Report.Paths, Operation.HasPerformanceHistory {
         override val performanceHistory: PerformanceHistory? get() = null
     }
 

--- a/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
+++ b/app-workspace-viewer/src/main/java/eu/darken/butler/viewer/ui/viewer/ViewerWorkspaceViewModel.kt
@@ -917,7 +917,7 @@ class ViewerWorkspaceViewModel @AssistedInject constructor(
                 }
                 // A delete the user resolved by skipping succeeds without removing anything, and
                 // the file is still there to look at.
-                if (completed.report?.affectedPaths.isNullOrEmpty()) {
+                if ((completed.report as? Operation.Report.Paths)?.affectedPaths.isNullOrEmpty()) {
                     log(tag, INFO) { "Delete removed nothing, leaving the viewer open" }
                     return@launch
                 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceAction.kt
@@ -66,6 +66,14 @@ sealed interface WorkspaceAction {
              * the existing tab instead of creating a duplicate.
              */
             data class AlreadyOpen(val existingId: Workspace.Id) : Result
+
+            /**
+             * The [Create.replace] target runs an operation that must keep its workspace
+             * ([eu.darken.butler.workspace.core.operations.Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN]),
+             * so nothing was created and the old tab is untouched. A [WorkspaceEvent.CloseRefused]
+             * carries the notice, callers need no dialog of their own.
+             */
+            data object Refused : Result
         }
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceEvent.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceEvent.kt
@@ -56,6 +56,24 @@ sealed interface WorkspaceEvent {
     data object AllClosed : WorkspaceEvent
 
     /**
+     * A close was refused because a workspace in its subtree runs an operation with
+     * [eu.darken.butler.workspace.core.operations.Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN].
+     * Nothing was released.
+     *
+     * @param requestedId the close target; null for Close All and Close Selected, which name no
+     * single tab.
+     * @param hostId the workspace the request was invoked from, i.e. where feedback is actually
+     * visible: a stacked child covers its parent with an opaque layer, so a notice filed under the
+     * parent would be hidden behind it. Null when the request came from global chrome.
+     * @param busyWorkspaceIds the members that hold the operations, not the roots that were refused.
+     */
+    data class CloseRefused(
+        val requestedId: Workspace.Id?,
+        val hostId: Workspace.Id?,
+        val busyWorkspaceIds: Set<Workspace.Id>,
+    ) : WorkspaceEvent
+
+    /**
      * Emitted when batch workspace creation completes.
      * Used to trigger feedback banner targeted to the workspace that initiated the request.
      *

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceRemoteExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceRemoteExtensions.kt
@@ -142,6 +142,9 @@ suspend fun WorkspaceRemote.createAndFocus(
         }
 
         WorkspaceAction.Create.Result.LimitReached -> Unit
+
+        // The refusal notice travels as a CloseRefused event; focusing nothing is the whole handling.
+        WorkspaceAction.Create.Result.Refused -> Unit
     }
 
     return result

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/BaseDeleteOperationReport.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/BaseDeleteOperationReport.kt
@@ -9,7 +9,7 @@ import eu.darken.butler.common.files.extensions.isDirectory
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.getQuantityString2
 import eu.darken.butler.workspace.R
-import eu.darken.butler.workspace.core.operations.Operation.Report.PathChange
+import eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange
 
 abstract class BaseDeleteOperationReport(
     override val affectedPaths: Collection<PathChange>,
@@ -21,7 +21,7 @@ abstract class BaseDeleteOperationReport(
     open val bytesFreed: Long,
     override val performanceHistory: PerformanceHistory?,
     override val subjectPath: APath<*>?,
-) : Operation.Report, Operation.HasPerformanceHistory {
+) : Operation.Report.Paths, Operation.HasPerformanceHistory {
 
     override val summary: CaString = caString {
         buildString {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/ManagedOperation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/ManagedOperation.kt
@@ -55,12 +55,15 @@ class ManagedOperation(
     fun claimCompletionEmission(): Boolean = completionEmitted.compareAndSet(false, true)
 
     val canCancel: Boolean
-        get() = when (state.value) {
+        get() = metadata.isCancellable && when (state.value) {
             is Operation.State.Queued -> true  // Can cancel before it starts
             is Operation.State.Active -> scope.coroutineContext[Job]?.isActive == true  // Can cancel if running
             is Operation.State.Waiting -> scope.coroutineContext[Job]?.isActive == true  // Can cancel if waiting
             else -> false  // Cannot cancel completed/failed/cancelled
         }
+
+    /** Queued and Waiting count as unfinished: only a terminal state does not. */
+    val isUnfinished: Boolean get() = state.value !is Operation.State.Completed
 
     val canPause: Boolean get() = false
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
@@ -54,7 +54,7 @@ interface Operation {
          * What the operation set out to do, in paths: its targets, an optional destination, and the
          * per-consumer views ([OperationPathPlan.scopePaths], [OperationPathPlan.representativePath])
          * derived from them. Captured at submit time so failed/cancelled ops are still queryable by
-         * path scope, even when [Report.affectedPaths] is null/empty (because nothing was actually
+         * path scope, even when [Report.Paths.affectedPaths] is null/empty (because nothing was actually
          * completed). Persistence stores the union of planned + actually-affected paths.
          */
         val pathPlan: OperationPathPlan? get() = null
@@ -130,22 +130,15 @@ interface Operation {
         }
     }
 
-    interface Report {
+    /**
+     * What an operation has to say about itself once it finished.
+     *
+     * Sealed so consumers can switch exhaustively over the report SHAPES. [Paths] is the
+     * file-operation shape and is open, because every file operation refines it with its own
+     * counters. Further shapes are added beside it, in this file.
+     */
+    sealed interface Report {
         val summary: CaString
-        val affectedPaths: Collection<PathChange>
-
-        /**
-         * The path this operation was ABOUT, shown as its history row label.
-         *
-         * The conflict-resolved path of what the user selected, or - for operations that fan out -
-         * the container or archive the user acted on. Never a path whose name the user did not
-         * choose: an extraction's entries and a recursive delete's descendants are audit records,
-         * not subjects.
-         *
-         * Null when THIS REPORT cannot name one (nothing completed, or the operation is not
-         * history-eligible). The history then falls back to the path plan's representative path.
-         */
-        val subjectPath: APath<*>?
 
         /**
          * Number of sub-items that DIDN'T complete as intended even though the operation as a whole
@@ -156,18 +149,36 @@ interface Operation {
          */
         val partialErrorCount: Int get() = 0
 
-        data class PathChange(
-            val path: APath<*>,
-            val change: Change,
+        /** The shape of a report about paths: what changed on disk, and what it was about. */
+        interface Paths : Report {
+            val affectedPaths: Collection<PathChange>
+
             /**
-             * For [Change.MOVED]: the source path before the move (i.e., the rename source).
-             * History details show as `previousPath → path`. Null for non-move changes or when
-             * the source isn't tracked.
+             * The path this operation was ABOUT, shown as its history row label.
+             *
+             * The conflict-resolved path of what the user selected, or - for operations that fan out -
+             * the container or archive the user acted on. Never a path whose name the user did not
+             * choose: an extraction's entries and a recursive delete's descendants are audit records,
+             * not subjects.
+             *
+             * Null when THIS REPORT cannot name one (nothing completed, or the operation is not
+             * history-eligible). The history then falls back to the path plan's representative path.
              */
-            val previousPath: APath<*>? = null,
-        ) {
-            enum class Change {
-                ADDED, REMOVED, MODIFIED, TRASHED, MOVED,
+            val subjectPath: APath<*>?
+
+            data class PathChange(
+                val path: APath<*>,
+                val change: Change,
+                /**
+                 * For [Change.MOVED]: the source path before the move (i.e., the rename source).
+                 * History details show as `previousPath → path`. Null for non-move changes or when
+                 * the source isn't tracked.
+                 */
+                val previousPath: APath<*>? = null,
+            ) {
+                enum class Change {
+                    ADDED, REMOVED, MODIFIED, TRASHED, MOVED,
+                }
             }
         }
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
@@ -99,6 +99,7 @@ interface Operation {
             data class Saver(override val workspaceId: Workspace.Id) : Origin
             data class Developer(override val workspaceId: Workspace.Id) : Origin
             data class Viewer(override val workspaceId: Workspace.Id) : Origin
+            data class Apps(override val workspaceId: Workspace.Id) : Origin
         }
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/Operation.kt
@@ -59,6 +59,34 @@ interface Operation {
          */
         val pathPlan: OperationPathPlan? get() = null
 
+        /**
+         * Whether the USER may ask for this operation to stop: the operations bar/sheet cancel
+         * button, the notification's Cancel action, and [OperationsManager.cancel] itself.
+         * False for work that cannot be interrupted once dispatched, e.g. a blocking IPC call whose
+         * peer keeps going regardless.
+         *
+         * Independent of [closePolicy]: this is about the user asking, that one is about the owner
+         * workspace going away.
+         */
+        val isCancellable: Boolean get() = true
+
+        val closePolicy: ClosePolicy get() = ClosePolicy.CANCEL_WITH_ORIGIN
+
+        /** What closing the origin workspace does to an unfinished operation. */
+        enum class ClosePolicy {
+            /** Closing the origin workspace cancels the operation and drops its receipt. */
+            CANCEL_WITH_ORIGIN,
+
+            /**
+             * The origin workspace - and any tab whose close would take it down - cannot be closed
+             * while the operation is unfinished: the close is refused and the user is told.
+             *
+             * Never detaches. An operation always keeps the workspace that can show its progress and
+             * answer its [State.Waiting] state.
+             */
+            REQUIRE_ORIGIN,
+        }
+
         enum class Kind { COPY, MOVE, DELETE, RESTORE, CREATE_FOLDER, CREATE_FILE, SAVE, COMPRESS, EXTRACT, INSTALL }
 
         enum class Intent { RENAME, PASTE_COPY, PASTE_MOVE, DROP_COPY, DROP_MOVE }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsManager.kt
@@ -129,9 +129,39 @@ class OperationsManager @Inject constructor(
         val operation = _operations.value.find { it.id == id }
         if (operation == null) log(TAG, WARN) { "cancel(): Operation not found $id" }
         else log(TAG, VERBOSE) { "cancel(): Cancelling $operation" }
+        // The notification's Cancel action routes here, and a stale notification outlives the UI
+        // gate that hid the button, so the refusal has to live at the entry point too.
+        if (operation != null && !operation.metadata.isCancellable) {
+            log(TAG, WARN) { "cancel(): $id is not user-cancellable, ignoring" }
+            return@withLock
+        }
         // Don't synthesize here — observer stays alive and will emit the real Completed
         // when ManagedOperation.onCompletion fires after scope cancellation.
         operation?.cancel()
+    }
+
+    /**
+     * The subset of [workspaceIds] that currently hosts at least one unfinished operation with
+     * [Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN], i.e. the ones whose teardown a caller must
+     * refuse instead of performing.
+     *
+     * Non-suspending on purpose: [eu.darken.butler.workspace.core.WorkspaceRepo] asks this while
+     * holding its own lock, before it releases anything.
+     *
+     * Answers about the instant it is called. An operation submitted after the answer and before the
+     * teardown is cancelled by [removeWorkspace] like any other - that submit-vs-close race predates
+     * this and is not closed by it.
+     */
+    fun closeBlockers(workspaceIds: Collection<Workspace.Id>): Set<Workspace.Id> {
+        if (workspaceIds.isEmpty()) return emptySet()
+        val wanted = workspaceIds.toSet()
+        return _operations.value
+            .filter { op ->
+                op.metadata.closePolicy == Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN &&
+                    op.metadata.origin.workspaceId in wanted &&
+                    op.isUnfinished
+            }
+            .mapTo(mutableSetOf()) { it.metadata.origin.workspaceId }
     }
 
     suspend fun remove(id: Operation.Id) = mutex.withLock {
@@ -158,6 +188,13 @@ class OperationsManager @Inject constructor(
         completed.forEach { stateObservers.remove(it.id)?.cancel() }
     }
 
+    /**
+     * Cancels and drops everything that named [id] as its origin.
+     *
+     * Only reached for workspaces [closeBlockers] did not name, so a
+     * [Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN] operation that still arrives here - submitted
+     * inside the race that method documents - is cancelled like any other.
+     */
     suspend fun removeWorkspace(id: Workspace.Id) {
         // Build snapshots inside the lock (state-snapshot consistency), emit OUTSIDE (avoid blocking
         // ops-manager mutations on SharedFlow backpressure).

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/HistoryEntry.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/HistoryEntry.kt
@@ -40,7 +40,7 @@ data class HistoryEntry(
     data class PathChange(
         val path: String,
         val previousPath: String?,
-        val change: Operation.Report.PathChange.Change,
+        val change: Operation.Report.Paths.PathChange.Change,
     )
 
     companion object {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/HistoryEntry.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/HistoryEntry.kt
@@ -35,7 +35,7 @@ data class HistoryEntry(
      */
     val primaryPath: String? = null,
 ) {
-    enum class OriginType { EXPLORER, SEARCHER, SAVER, DEVELOPER, VIEWER }
+    enum class OriginType { EXPLORER, SEARCHER, SAVER, DEVELOPER, VIEWER, APPS }
 
     data class PathChange(
         val path: String,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -133,7 +133,7 @@ class OperationHistoryRepo @Inject constructor(
             affectedPathsCount = reportedChanges.size,
             partialErrorCount = state.report?.partialErrorCount ?: 0,
             pathsTruncated = reportedChanges.size > MAX_PATHS_PER_OP,
-            primaryPath = state.report?.subjectPath?.userReadablePath?.get(context)
+            primaryPath = (state.report as? Operation.Report.Paths)?.subjectPath?.userReadablePath?.get(context)
                 ?: metadata.pathPlan?.representativePath?.userReadablePath?.get(context),
         )
 
@@ -211,7 +211,7 @@ class OperationHistoryRepo @Inject constructor(
         val seen = mutableSetOf<String>()
         val out = mutableListOf<HistoryEntry.PathChange>()
 
-        state.report?.affectedPaths?.forEach { change ->
+        (state.report as? Operation.Report.Paths)?.affectedPaths?.forEach { change ->
             val pathStr = change.path.userReadablePath.get(context)
             if (seen.add(pathStr)) {
                 out += HistoryEntry.PathChange(
@@ -243,7 +243,7 @@ class OperationHistoryRepo @Inject constructor(
     ): List<String> {
         val candidates = buildList<APath<*>> {
             metadata.pathPlan?.let { addAll(it.allPaths) }
-            state.report?.affectedPaths?.forEach { change ->
+            (state.report as? Operation.Report.Paths)?.affectedPaths?.forEach { change ->
                 add(change.path)
                 change.previousPath?.let { add(it) }
             }
@@ -389,7 +389,7 @@ class OperationHistoryRepo @Inject constructor(
             HistoryEntry.PathChange(
                 path = p.path,
                 previousPath = p.previousPath,
-                change = Operation.Report.PathChange.Change.valueOf(p.change),
+                change = Operation.Report.Paths.PathChange.Change.valueOf(p.change),
             )
         },
     )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryRepo.kt
@@ -89,6 +89,7 @@ class OperationHistoryRepo @Inject constructor(
             is Operation.Metadata.Origin.Saver -> HistoryEntry.OriginType.SAVER
             is Operation.Metadata.Origin.Developer -> HistoryEntry.OriginType.DEVELOPER
             is Operation.Metadata.Origin.Viewer -> HistoryEntry.OriginType.VIEWER
+            is Operation.Metadata.Origin.Apps -> HistoryEntry.OriginType.APPS
         }
 
         val reportedChanges = collectReportedChanges(state)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryEntity.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryEntity.kt
@@ -20,7 +20,7 @@ data class OperationHistoryEntity(
     val kind: String,
     /** Operation.Metadata.Intent name, null when no intent override */
     val intent: String?,
-    /** Origin discriminator: EXPLORER | SEARCHER | SAVER | DEVELOPER */
+    /** Origin discriminator: EXPLORER | SEARCHER | SAVER | DEVELOPER | VIEWER | APPS */
     val originType: String,
     /** Workspace ID at submit time. Forensic — workspace may no longer exist. */
     val originWorkspaceId: String,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryPathEntity.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/history/db/OperationHistoryPathEntity.kt
@@ -27,7 +27,7 @@ data class OperationHistoryPathEntity(
     val path: String,
     /** For MOVED entries (rename source). Null for non-move changes or untracked. */
     val previousPath: String?,
-    /** [eu.darken.butler.workspace.core.operations.Operation.Report.PathChange.Change] name. */
+    /** [eu.darken.butler.workspace.core.operations.Operation.Report.Paths.PathChange.Change] name. */
     val change: String,
     val sortIndex: Int,
 )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/WorkspacePageManager.kt
@@ -130,6 +130,11 @@ class WorkspacePageManager @Inject constructor(
                         // Handled by WorkspacesViewModel for banner feedback
                     }
 
+                    is WorkspaceEvent.CloseRefused -> {
+                        // Nothing was closed, so there is no placement to update; the notice is
+                        // handled by WorkspacesViewModel
+                    }
+
                     is WorkspaceEvent.SelectionRequested -> {
                         log(TAG) { "Selection requested for workspace: ${event.workspaceId}" }
                         handleWorkspaceSelection(event.workspaceId, event.sourceWorkspaceId)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/feedback/BannerState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/feedback/BannerState.kt
@@ -34,6 +34,13 @@ sealed interface BannerState {
         val failed: Int,
         val skipped: Int,
     ) : BannerState
+
+    /**
+     * A close was refused because operations that must keep their workspace are still running.
+     *
+     * @param busyCount Number of workspaces holding such an operation
+     */
+    data class CloseBlocked(val busyCount: Int) : BannerState
 }
 
 /**
@@ -43,6 +50,7 @@ val BannerState.successCount: Int
     get() = when (this) {
         is BannerState.Success -> count
         is BannerState.Partial -> success
+        is BannerState.CloseBlocked -> 0
     }
 
 /**
@@ -52,6 +60,7 @@ val BannerState.icon: ImageVector
     get() = when (this) {
         is BannerState.Success -> Icons.TwoTone.CheckCircle
         is BannerState.Partial -> Icons.TwoTone.Warning
+        is BannerState.CloseBlocked -> Icons.TwoTone.Warning
     }
 
 /**
@@ -61,6 +70,7 @@ val BannerState.containerColor: Color
     @Composable get() = when (this) {
         is BannerState.Success -> MaterialTheme.colorScheme.primaryContainer
         is BannerState.Partial -> MaterialTheme.colorScheme.tertiaryContainer
+        is BannerState.CloseBlocked -> MaterialTheme.colorScheme.errorContainer
     }
 
 /**
@@ -70,4 +80,5 @@ val BannerState.contentColor: Color
     @Composable get() = when (this) {
         is BannerState.Success -> MaterialTheme.colorScheme.onPrimaryContainer
         is BannerState.Partial -> MaterialTheme.colorScheme.onTertiaryContainer
+        is BannerState.CloseBlocked -> MaterialTheme.colorScheme.onErrorContainer
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/feedback/WorkspaceBanner.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/feedback/WorkspaceBanner.kt
@@ -75,11 +75,19 @@ fun WorkspaceBanner(
                     )
 
                     Text(
-                        text = pluralStringResource(
-                            R.plurals.workspace_banner_opened_tabs,
-                            bannerState.successCount,
-                            bannerState.successCount
-                        ),
+                        text = when (bannerState) {
+                            is BannerState.CloseBlocked -> pluralStringResource(
+                                R.plurals.workspace_banner_close_blocked_busy,
+                                bannerState.busyCount,
+                                bannerState.busyCount
+                            )
+
+                            else -> pluralStringResource(
+                                R.plurals.workspace_banner_opened_tabs,
+                                bannerState.successCount,
+                                bannerState.successCount
+                            )
+                        },
                         style = MaterialTheme.typography.bodyMedium,
                         color = bannerState.contentColor,
                         modifier = Modifier.weight(1f)
@@ -118,6 +126,16 @@ private fun WorkspaceBannerSuccessPreview() {
 private fun WorkspaceBannerPartialPreview() {
     WorkspaceBanner(
         state = BannerState.Partial(success = 3, failed = 1, skipped = 2),
+        onDismiss = {}
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceBannerCloseBlockedPreview() {
+    WorkspaceBanner(
+        state = BannerState.CloseBlocked(busyCount = 2),
         onDismiss = {}
     )
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
@@ -126,9 +126,9 @@ private fun OperationActionIndicatorPreview() {
             state = OperationDisplay.State.Completed(
                 summary = "Done".toCaString(),
                 completedAt = Clock.System.now(),
-                report = object : Operation.Report {
+                report = object : Operation.Report.Paths {
                     override val summary = "Done".toCaString()
-                    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                     override val subjectPath = null
                 }
             ),
@@ -138,9 +138,9 @@ private fun OperationActionIndicatorPreview() {
             state = OperationDisplay.State.Failed(
                 summary = "Error".toCaString(),
                 completedAt = Clock.System.now(),
-                report = object : Operation.Report {
+                report = object : Operation.Report.Paths {
                     override val summary = "Error".toCaString()
-                    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                     override val subjectPath = null
                 }
             ),
@@ -149,9 +149,9 @@ private fun OperationActionIndicatorPreview() {
         OperationActionIndicator(
             state = OperationDisplay.State.Cancelled(
                 completedAt = Clock.System.now(),
-                report = object : Operation.Report {
+                report = object : Operation.Report.Paths {
                     override val summary = "Cancelled".toCaString()
-                    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                     override val subjectPath = null
                 }
             ),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
@@ -475,9 +475,9 @@ private fun OperationEntryRowCompletedPreview() {
                 state = OperationDisplay.State.Completed(
                     summary = "Deleted 5 items".toCaString(),
                     completedAt = Clock.System.now() + 2.5.seconds,
-                    report = object : Operation.Report {
+                    report = object : Operation.Report.Paths {
                         override val summary = "Deleted 5 items".toCaString()
-                        override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                        override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                         override val subjectPath = null
                     }
                 ),
@@ -497,9 +497,9 @@ private fun OperationEntryRowCompletedPreview() {
                 state = OperationDisplay.State.Completed(
                     summary = "Deleted 5 items".toCaString(),
                     completedAt = Clock.System.now() + 2.5.seconds,
-                    report = object : Operation.Report {
+                    report = object : Operation.Report.Paths {
                         override val summary = "Deleted 5 items".toCaString()
-                        override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                        override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                         override val subjectPath = null
                     }
                 ),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBar.kt
@@ -269,9 +269,9 @@ private fun OperationsBarPreview() {
             state = OperationDisplay.State.Completed(
                 summary = "Success".toCaString(),
                 completedAt = Clock.System.now(),
-                report = object : Operation.Report {
+                report = object : Operation.Report.Paths {
                     override val summary = "Success".toCaString()
-                    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                     override val subjectPath = null
                 }
             ),
@@ -354,9 +354,9 @@ private fun OperationsBarExpandedPreview() {
             state = OperationDisplay.State.Completed(
                 summary = "Success".toCaString(),
                 completedAt = Clock.System.now(),
-                report = object : Operation.Report {
+                report = object : Operation.Report.Paths {
                     override val summary = "Success".toCaString()
-                    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                     override val subjectPath = null
                 }
             ),

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationAffectedFilesSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationAffectedFilesSection.kt
@@ -22,7 +22,7 @@ import eu.darken.butler.workspace.core.operations.Operation
 
 @Composable
 internal fun OperationAffectedFilesSection(
-    affectedPaths: Collection<Operation.Report.PathChange>,
+    affectedPaths: Collection<Operation.Report.Paths.PathChange>,
 ) {
     val affectedPathList = remember(affectedPaths) { affectedPaths.toList() }
 
@@ -48,20 +48,20 @@ internal fun OperationAffectedFilesSection(
                 ) {
                     Text(
                         text = when (pathChange.change) {
-                            Operation.Report.PathChange.Change.ADDED -> "+"
-                            Operation.Report.PathChange.Change.REMOVED -> "\u2212"
-                            Operation.Report.PathChange.Change.MODIFIED -> "~"
-                            Operation.Report.PathChange.Change.TRASHED -> "\u267B"
-                            Operation.Report.PathChange.Change.MOVED -> "\u2192"
+                            Operation.Report.Paths.PathChange.Change.ADDED -> "+"
+                            Operation.Report.Paths.PathChange.Change.REMOVED -> "\u2212"
+                            Operation.Report.Paths.PathChange.Change.MODIFIED -> "~"
+                            Operation.Report.Paths.PathChange.Change.TRASHED -> "\u267B"
+                            Operation.Report.Paths.PathChange.Change.MOVED -> "\u2192"
                         },
                         style = MaterialTheme.typography.labelSmall,
                         fontFamily = FontFamily.Monospace,
                         color = when (pathChange.change) {
-                            Operation.Report.PathChange.Change.ADDED -> MaterialTheme.colorScheme.primary
-                            Operation.Report.PathChange.Change.REMOVED -> MaterialTheme.colorScheme.error
-                            Operation.Report.PathChange.Change.MODIFIED -> MaterialTheme.colorScheme.secondary
-                            Operation.Report.PathChange.Change.TRASHED -> MaterialTheme.colorScheme.tertiary
-                            Operation.Report.PathChange.Change.MOVED -> MaterialTheme.colorScheme.primary
+                            Operation.Report.Paths.PathChange.Change.ADDED -> MaterialTheme.colorScheme.primary
+                            Operation.Report.Paths.PathChange.Change.REMOVED -> MaterialTheme.colorScheme.error
+                            Operation.Report.Paths.PathChange.Change.MODIFIED -> MaterialTheme.colorScheme.secondary
+                            Operation.Report.Paths.PathChange.Change.TRASHED -> MaterialTheme.colorScheme.tertiary
+                            Operation.Report.Paths.PathChange.Change.MOVED -> MaterialTheme.colorScheme.primary
                         },
                         modifier = Modifier.width(16.dp)
                     )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationDetailsSheet.kt
@@ -113,9 +113,9 @@ private fun OperationDetailsContent(
 
         // Affected Files Section (for completed operations with affected paths)
         val affectedPaths = when (operation.state) {
-            is OperationDisplay.State.Completed -> operation.state.report?.affectedPaths ?: emptyList()
-            is OperationDisplay.State.Failed -> operation.state.report?.affectedPaths ?: emptyList()
-            is OperationDisplay.State.Cancelled -> operation.state.report?.affectedPaths ?: emptyList()
+            is OperationDisplay.State.Completed -> operation.state.report.pathChanges()
+            is OperationDisplay.State.Failed -> operation.state.report.pathChanges()
+            is OperationDisplay.State.Cancelled -> operation.state.report.pathChanges()
             else -> emptyList()
         }
 
@@ -190,10 +190,14 @@ private fun OperationDetailsHeader(
 }
 
 
+/** Empty for a report shape that is not about paths, which this section has nothing to show for. */
+private fun Operation.Report?.pathChanges(): Collection<Operation.Report.Paths.PathChange> =
+    (this as? Operation.Report.Paths)?.affectedPaths ?: emptyList()
+
 // Helper functions
 private fun createMockReport(
-    affectedPaths: List<Operation.Report.PathChange> = emptyList()
-): Operation.Report = object : Operation.Report {
+    affectedPaths: List<Operation.Report.Paths.PathChange> = emptyList()
+): Operation.Report.Paths = object : Operation.Report.Paths {
     override val summary = "Completed successfully".toCaString()
     override val affectedPaths = affectedPaths
     override val subjectPath = null
@@ -285,31 +289,31 @@ private fun OperationDetailsSheetCompletedWithFilesPreview() {
                 completedAt = Clock.System.now(),
                 report = createMockReport(
                     affectedPaths = listOf(
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/home", "user", "documents", "file1.txt"),
-                            change = Operation.Report.PathChange.Change.REMOVED
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/home", "user", "documents", "file2.pdf"),
-                            change = Operation.Report.PathChange.Change.REMOVED
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/home", "user", "downloads", "temp"),
-                            change = Operation.Report.PathChange.Change.REMOVED
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/home", "user", "backup", "copy1.txt"),
-                            change = Operation.Report.PathChange.Change.ADDED
+                            change = Operation.Report.Paths.PathChange.Change.ADDED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/home", "user", "config.xml"),
-                            change = Operation.Report.PathChange.Change.MODIFIED
+                            change = Operation.Report.Paths.PathChange.Change.MODIFIED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/home", "user", "old", "archive.zip"),
-                            change = Operation.Report.PathChange.Change.REMOVED
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build(
                                 "/storage",
                                 "emulated",
@@ -320,11 +324,11 @@ private fun OperationDetailsSheetCompletedWithFilesPreview() {
                                 "cache",
                                 "temp.log"
                             ),
-                            change = Operation.Report.PathChange.Change.REMOVED
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED
                         ),
-                        Operation.Report.PathChange(
+                        Operation.Report.Paths.PathChange(
                             path = LocalPath.build("/sdcard", "Pictures", "Screenshots", "screenshot_1.png"),
-                            change = Operation.Report.PathChange.Change.REMOVED
+                            change = Operation.Report.Paths.PathChange.Change.REMOVED
                         ),
                     )
                 )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -197,9 +197,9 @@ private fun OperationOverviewGrid(
     }
 }
 
-private fun previewReport(text: String) = object : Operation.Report {
+private fun previewReport(text: String) = object : Operation.Report.Paths {
     override val summary = text.toCaString()
-    override val affectedPaths = emptyList<Operation.Report.PathChange>()
+    override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
     override val subjectPath = null
 }
 

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -334,7 +334,7 @@
         <item quantity="other">Opened %1$d tabs</item>
     </plurals>
     <plurals name="workspace_banner_close_blocked_busy">
-        <item quantity="one">Can\'t close: an operation is still running in this tab</item>
+        <item quantity="one">Can\'t close: an operation is still running in %1$d tab</item>
         <item quantity="other">Can\'t close: operations are still running in %1$d tabs</item>
     </plurals>
 

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -333,6 +333,10 @@
         <item quantity="one">Opened %1$d tab</item>
         <item quantity="other">Opened %1$d tabs</item>
     </plurals>
+    <plurals name="workspace_banner_close_blocked_busy">
+        <item quantity="one">Can\'t close: an operation is still running in this tab</item>
+        <item quantity="other">Can\'t close: operations are still running in %1$d tabs</item>
+    </plurals>
 
     <!-- Workspace > Settings-->
     <string name="workspace_settings_title">Tabs</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationsManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationsManagerTest.kt
@@ -35,13 +35,19 @@ class OperationsManagerTest : BaseTest() {
     private fun create() = OperationsManager(TestDispatcherProvider())
 
     /** Emits nothing until told to, so an operation stays unfinished for as long as a test needs. */
-    private class FakeOperation(workspaceId: Workspace.Id) : Operation {
+    private class FakeOperation(
+        workspaceId: Workspace.Id,
+        cancellable: Boolean = true,
+        policy: Operation.Metadata.ClosePolicy = Operation.Metadata.ClosePolicy.CANCEL_WITH_ORIGIN,
+    ) : Operation {
         // replay = 1: the collector subscribes when the manager starts the operation, a test finishes
         // it afterwards, and nothing should hinge on which of the two the dispatcher runs first.
         private val states = MutableSharedFlow<Operation.State>(replay = 1)
 
         override val metadata: Operation.Metadata = mockk<Operation.Metadata>().apply {
             every { origin } returns Operation.Metadata.Origin.Explorer(workspaceId)
+            every { isCancellable } returns cancellable
+            every { closePolicy } returns policy
         }
 
         override fun perform(operationContext: Operation.Context): Flow<Operation.State> = states
@@ -158,6 +164,63 @@ class OperationsManagerTest : BaseTest() {
         seen.single().state.error.shouldBeInstanceOf<CancellationException>()
         // The synthesis took the operation's one claim, which is what suppresses the real Completed
         // if it still reaches an observer that has not finished cancelling yet.
+        managed.claimCompletionEmission() shouldBe false
+    }
+
+    @Test
+    fun `a non-cancellable operation ignores a cancel request`() = runTest {
+        val manager = create()
+        val operation = FakeOperation(workspaceId, cancellable = false)
+
+        val managed = manager.submitManaged(operation)
+        manager.cancel(managed.id)
+        runCurrent()
+
+        managed.isUnfinished shouldBe true
+        managed.canCancel shouldBe false
+    }
+
+    @Test
+    fun `closeBlockers names the workspace of an unfinished REQUIRE_ORIGIN operation`() = runTest {
+        val manager = create()
+        val operation = FakeOperation(workspaceId, policy = Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN)
+        manager.submitManaged(operation)
+        runCurrent()
+
+        manager.closeBlockers(listOf(workspaceId)) shouldBe setOf(workspaceId)
+        // An unrelated workspace is never named, even while the blocker is live
+        manager.closeBlockers(listOf(Workspace.Id())).shouldBeEmpty()
+
+        operation.finish(epoch)
+        runCurrent()
+
+        manager.closeBlockers(listOf(workspaceId)).shouldBeEmpty()
+    }
+
+    @Test
+    fun `closeBlockers ignores an operation that closes with its origin`() = runTest {
+        val manager = create()
+        manager.submitManaged(FakeOperation(workspaceId))
+        runCurrent()
+
+        manager.closeBlockers(listOf(workspaceId)).shouldBeEmpty()
+    }
+
+    @Test
+    fun `a workspace removal still cancels a REQUIRE_ORIGIN operation`() = runTest {
+        val manager = create()
+        val seen = recordCompletions(manager)
+        val managed = manager.submitManaged(
+            FakeOperation(workspaceId, policy = Operation.Metadata.ClosePolicy.REQUIRE_ORIGIN)
+        )
+
+        // The policy is enforced by whoever asks closeBlockers first; arriving here means the
+        // submit-vs-close race happened, and then the operation goes down like any other.
+        manager.removeWorkspace(workspaceId)
+        runCurrent()
+
+        seen.single().state.error.shouldBeInstanceOf<CancellationException>()
+        manager.operations.first().map { it.id }.shouldBeEmpty()
         managed.claimCompletionEmission() shouldBe false
     }
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryBulkDeleteTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryBulkDeleteTest.kt
@@ -97,7 +97,7 @@ class OperationHistoryBulkDeleteTest : BaseTest() {
                     operationHistoryId = id,
                     path = "/sdcard/$id.txt",
                     previousPath = null,
-                    change = Operation.Report.PathChange.Change.ADDED.name,
+                    change = Operation.Report.Paths.PathChange.Change.ADDED.name,
                     sortIndex = 0,
                 )
             )

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
@@ -155,7 +155,7 @@ class OperationHistoryPersistTest : BaseTest() {
                 state = TestCompletedState(
                     report = TestReport(
                         affectedPaths = listOf(
-                            changeOf(created, Operation.Report.PathChange.Change.ADDED),
+                            changeOf(created, Operation.Report.Paths.PathChange.Change.ADDED),
                         ),
                     ),
                 ),
@@ -165,7 +165,7 @@ class OperationHistoryPersistTest : BaseTest() {
         val stored = database.operationHistoryDao().getById(id)!!
         stored.paths.size shouldBe 1
         stored.paths.single().path shouldBe created.path
-        stored.paths.single().change shouldBe Operation.Report.PathChange.Change.ADDED.name
+        stored.paths.single().change shouldBe Operation.Report.Paths.PathChange.Change.ADDED.name
 
         // The source was only read and the destination folder only gained a child - neither is a change.
         stored.paths.map { it.path } shouldNotContain source.path
@@ -204,7 +204,7 @@ class OperationHistoryPersistTest : BaseTest() {
                 state = TestCompletedState(
                     report = TestReport(
                         affectedPaths = listOf(
-                            changeOf(created, Operation.Report.PathChange.Change.ADDED),
+                            changeOf(created, Operation.Report.Paths.PathChange.Change.ADDED),
                         ),
                     ),
                 ),
@@ -280,7 +280,7 @@ class OperationHistoryPersistTest : BaseTest() {
                 state = TestCompletedState(
                     report = TestReport(
                         affectedPaths = reported.map {
-                            changeOf(it, Operation.Report.PathChange.Change.ADDED)
+                            changeOf(it, Operation.Report.Paths.PathChange.Change.ADDED)
                         },
                         subjectPath = reported.first(),
                     ),
@@ -311,7 +311,7 @@ class OperationHistoryPersistTest : BaseTest() {
                 state = TestCompletedState(
                     report = TestReport(
                         affectedPaths = directories.map {
-                            changeOf(it, Operation.Report.PathChange.Change.REMOVED)
+                            changeOf(it, Operation.Report.Paths.PathChange.Change.REMOVED)
                         },
                     ),
                 ),
@@ -364,8 +364,8 @@ class OperationHistoryPersistTest : BaseTest() {
                 state = TestCompletedState(
                     report = TestReport(
                         affectedPaths = listOf(
-                            changeOf(savedA, Operation.Report.PathChange.Change.ADDED),
-                            changeOf(savedB, Operation.Report.PathChange.Change.ADDED),
+                            changeOf(savedA, Operation.Report.Paths.PathChange.Change.ADDED),
+                            changeOf(savedB, Operation.Report.Paths.PathChange.Change.ADDED),
                         ),
                     ),
                 ),
@@ -413,7 +413,7 @@ class OperationHistoryPersistTest : BaseTest() {
                 state = TestCompletedState(
                     report = TestReport(
                         affectedPaths = listOf(
-                            changeOf(archived, Operation.Report.PathChange.Change.ADDED),
+                            changeOf(archived, Operation.Report.Paths.PathChange.Change.ADDED),
                         ),
                     ),
                 ),
@@ -483,7 +483,7 @@ class OperationHistoryPersistTest : BaseTest() {
         primaryPathOf(
             labelSnapshot(
                 TestReport(
-                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.PathChange.Change.ADDED)),
+                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.Paths.PathChange.Change.ADDED)),
                     subjectPath = subject,
                 ),
             )
@@ -495,7 +495,7 @@ class OperationHistoryPersistTest : BaseTest() {
         primaryPathOf(
             labelSnapshot(
                 TestReport(
-                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.PathChange.Change.ADDED)),
+                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.Paths.PathChange.Change.ADDED)),
                     subjectPath = null,
                 ),
             )
@@ -512,7 +512,7 @@ class OperationHistoryPersistTest : BaseTest() {
         primaryPathOf(
             labelSnapshot(
                 report = TestReport(
-                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.PathChange.Change.ADDED)),
+                    affectedPaths = listOf(changeOf(firstReported, Operation.Report.Paths.PathChange.Change.ADDED)),
                     subjectPath = subject,
                     partialErrorCount = 1,
                 ),
@@ -535,8 +535,8 @@ class OperationHistoryPersistTest : BaseTest() {
                     report = TestReport(
                         // Post-order removal: the folder is the last change, not the first.
                         affectedPaths = listOf(
-                            changeOf(descendant, Operation.Report.PathChange.Change.REMOVED),
-                            changeOf(folder, Operation.Report.PathChange.Change.REMOVED),
+                            changeOf(descendant, Operation.Report.Paths.PathChange.Change.REMOVED),
+                            changeOf(folder, Operation.Report.Paths.PathChange.Change.REMOVED),
                         ),
                         subjectPath = folder,
                     ),

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryPersistTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.operations.CompletedOperationSnapshot
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.core.operations.OperationPathPlan
@@ -191,6 +192,25 @@ class OperationHistoryPersistTest : BaseTest() {
         // An install writes no file of its own, so the container is all there is to name the row by.
         stored.paths.shouldBeEmpty()
         stored.entry.primaryPath shouldBe container.path
+    }
+
+    @Test
+    fun `an Apps origin is stored as APPS`() = runTest {
+        val workspaceId = Workspace.Id()
+        val id = persist(
+            testSnapshot(
+                metadata = testMetadata(
+                    operationKind = Operation.Metadata.Kind.INSTALL,
+                    plan = planOver(source),
+                    operationOrigin = Operation.Metadata.Origin.Apps(workspaceId),
+                ),
+                state = TestCompletedState(report = null),
+            )
+        )
+
+        val stored = database.operationHistoryDao().getById(id)!!
+        stored.entry.originType shouldBe HistoryEntry.OriginType.APPS.name
+        stored.entry.originWorkspaceId shouldBe workspaceId.longTag
     }
 
     @Test

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryScopeQueryTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryScopeQueryTest.kt
@@ -184,7 +184,7 @@ class OperationHistoryScopeQueryTest : BaseTest() {
                         affectedPaths = listOf(
                             changeOf(
                                 LocalPath.build("/sdcard/New/file.txt"),
-                                Operation.Report.PathChange.Change.ADDED,
+                                Operation.Report.Paths.PathChange.Change.ADDED,
                             ),
                         ),
                     ),
@@ -213,7 +213,7 @@ class OperationHistoryScopeQueryTest : BaseTest() {
                         affectedPaths = listOf(
                             changeOf(
                                 path = LocalPath.build("/sdcard/New/renamed.txt"),
-                                change = Operation.Report.PathChange.Change.MOVED,
+                                change = Operation.Report.Paths.PathChange.Change.MOVED,
                                 previousPath = LocalPath.build("/sdcard/Legacy/original.txt"),
                             ),
                         ),

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
@@ -30,11 +30,11 @@ import kotlin.time.Instant
  */
 
 internal class TestReport(
-    override val affectedPaths: Collection<Operation.Report.PathChange>,
+    override val affectedPaths: Collection<Operation.Report.Paths.PathChange>,
     override val subjectPath: APath<*>? = null,
     override val partialErrorCount: Int = 0,
     override val summary: CaString = "report".toCaString(),
-) : Operation.Report
+) : Operation.Report.Paths
 
 internal class TestCompletedState(
     override val report: Operation.Report?,
@@ -81,9 +81,9 @@ internal fun testSnapshot(
 
 internal fun changeOf(
     path: APath<*>,
-    change: Operation.Report.PathChange.Change,
+    change: Operation.Report.Paths.PathChange.Change,
     previousPath: APath<*>? = null,
-) = Operation.Report.PathChange(
+) = Operation.Report.Paths.PathChange(
     path = path,
     change = change,
     previousPath = previousPath,

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/history/OperationHistoryTestFixtures.kt
@@ -48,8 +48,9 @@ internal fun testMetadata(
     operationKind: Operation.Metadata.Kind,
     plan: OperationPathPlan? = null,
     operationIntent: Operation.Metadata.Intent? = null,
+    operationOrigin: Operation.Metadata.Origin = Operation.Metadata.Origin.Explorer(Workspace.Id()),
 ): Operation.Metadata = mockk<Operation.Metadata>().apply {
-    every { origin } returns Operation.Metadata.Origin.Explorer(Workspace.Id())
+    every { origin } returns operationOrigin
     every { icon } returns mockk()
     every { title } returns "title".toCaString()
     every { description } returns "description".toCaString()

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayStateTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayStateTest.kt
@@ -32,9 +32,9 @@ class OperationsDisplayStateTest : BaseTest() {
     )
 
     private val now = Clock.System.now()
-    private val dummyReport = object : Operation.Report {
+    private val dummyReport = object : Operation.Report.Paths {
         override val summary = "done".toCaString()
-        override val affectedPaths = emptyList<Operation.Report.PathChange>()
+        override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
         override val subjectPath = null
     }
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRowTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRowTest.kt
@@ -96,9 +96,9 @@ class OperationEntryRowTest : ComposeTest() {
                         state = OperationDisplay.State.Completed(
                             summary = "Deleted 5 items successfully".toCaString(),
                             completedAt = Clock.System.now(),
-                            report = object : Operation.Report {
+                            report = object : Operation.Report.Paths {
                                 override val summary = "Deleted 5 items".toCaString()
-                                override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                                override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                                 override val subjectPath = null
                             },
                         )

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSectionTest.kt
@@ -44,9 +44,9 @@ class OperationOverviewSectionTest : ComposeTest() {
         state = OperationDisplay.State.Completed(
             summary = "Moved 12 files".toCaString(),
             completedAt = Clock.System.now(),
-            report = object : Operation.Report {
+            report = object : Operation.Report.Paths {
                 override val summary = "Moved 12 files".toCaString()
-                override val affectedPaths = emptyList<Operation.Report.PathChange>()
+                override val affectedPaths = emptyList<Operation.Report.Paths.PathChange>()
                 override val subjectPath = null
             },
         ),

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -1667,6 +1667,7 @@ class WorkspaceRepo @Inject constructor(
         sourceWorkspaceId: Workspace.Id?,
     ): WorkspaceAction.CreateBatch.Result.Success {
         val results = mutableMapOf<WorkspaceAction.Create, WorkspaceAction.CreateBatch.CreationResult>()
+        val refusals = mutableListOf<WorkspaceEvent.CloseRefused>()
 
         // Seed results with pre-resolved entries (instances that existed before this batch ran)
         preResolved.forEach { (req, existingId) ->
@@ -1693,12 +1694,10 @@ class WorkspaceRepo @Inject constructor(
                 val blockers = closeBlockedBy(listOf(replaceId))
                 if (blockers.isNotEmpty()) {
                     log(TAG, INFO) { "Batch replace of $replaceId refused, busy members: $blockers" }
-                    _events.emit(
-                        WorkspaceEvent.CloseRefused(
-                            requestedId = replaceId,
-                            hostId = anchorId ?: replaceId,
-                            busyWorkspaceIds = blockers,
-                        )
+                    refusals += WorkspaceEvent.CloseRefused(
+                        requestedId = replaceId,
+                        hostId = sourceWorkspaceId ?: replaceId,
+                        busyWorkspaceIds = blockers,
                     )
                     results[createRequest] = WorkspaceAction.CreateBatch.CreationResult.Failure(
                         IllegalStateException("Replacement refused: workspace $replaceId is busy")
@@ -1783,6 +1782,9 @@ class WorkspaceRepo @Inject constructor(
                 sourceWorkspaceId = sourceWorkspaceId,
             )
         )
+
+        // Emitted after the completion event so its banner is the one left standing
+        refusals.forEach { _events.emit(it) }
 
         return WorkspaceAction.CreateBatch.Result.Success(
             results = results,

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -1687,6 +1687,26 @@ class WorkspaceRepo @Inject constructor(
                 return@forEach
             }
 
+            // A replace tears the old instance down, so it is a close in everything but name.
+            val replaceId = createRequest.replace
+            if (replaceId != null) {
+                val blockers = closeBlockedBy(listOf(replaceId))
+                if (blockers.isNotEmpty()) {
+                    log(TAG, INFO) { "Batch replace of $replaceId refused, busy members: $blockers" }
+                    _events.emit(
+                        WorkspaceEvent.CloseRefused(
+                            requestedId = replaceId,
+                            hostId = anchorId ?: replaceId,
+                            busyWorkspaceIds = blockers,
+                        )
+                    )
+                    results[createRequest] = WorkspaceAction.CreateBatch.CreationResult.Failure(
+                        IllegalStateException("Replacement refused: workspace $replaceId is busy")
+                    )
+                    return@forEach
+                }
+            }
+
             try {
                 log(TAG) { "Creating workspace: ${createRequest.type}" }
                 val replacedAnchor = createRequest.replace != null && createRequest.replace == anchorId

--- a/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/core/WorkspaceRepo.kt
@@ -576,6 +576,25 @@ class WorkspaceRepo @Inject constructor(
                     return@withLock WorkspaceAction.Create.Result.LimitReached
                 }
 
+                // A replace tears the old instance down, so it is a close in everything but name.
+                // Checked here rather than in commitWorkspace, which runs after the replacement is
+                // already built and would have to unwind it.
+                val replaceId = action.replace
+                if (replaceId != null) {
+                    val blockers = closeBlockedBy(listOf(replaceId))
+                    if (blockers.isNotEmpty()) {
+                        log(TAG, INFO) { "Replace of $replaceId refused, busy members: $blockers" }
+                        _events.emit(
+                            WorkspaceEvent.CloseRefused(
+                                requestedId = replaceId,
+                                hostId = action.sourceWorkspaceId ?: replaceId,
+                                busyWorkspaceIds = blockers,
+                            )
+                        )
+                        return@withLock WorkspaceAction.Create.Result.Refused
+                    }
+                }
+
                 val newId = create(
                     type = action.type,
                     arguments = action.arguments,
@@ -783,10 +802,18 @@ class WorkspaceRepo @Inject constructor(
             }
             is WorkspaceAction.CloseSelected -> {
                 log(TAG, INFO) { "Closing ${action.ownerIds.size} selected workspace(s)" }
+                // Decided per root, before the first release: a busy member is usually a stacked
+                // child, so what has to be skipped is the owner it hangs under, not the member id.
+                val busyMembers = closeBlockedBy(action.ownerIds)
+                val refused = blockedRoots(action.ownerIds)
                 // executeClose is the post-confirmation path, so an unsaved member goes down with
                 // the rest instead of parking another dialog the caller already asked about.
                 var closed = 0
                 action.ownerIds.forEach { id ->
+                    if (id in refused) {
+                        log(TAG, INFO) { "Selected workspace $id is busy, skipping it" }
+                        return@forEach
+                    }
                     if (_workspaces.value.none { it.id == id }) {
                         log(TAG) { "Selected workspace $id already gone, skipping" }
                         return@forEach
@@ -794,11 +821,34 @@ class WorkspaceRepo @Inject constructor(
                     executeClose(id)
                     closed++
                 }
+                if (refused.isNotEmpty()) {
+                    _events.emit(
+                        WorkspaceEvent.CloseRefused(
+                            requestedId = null,
+                            hostId = null,
+                            busyWorkspaceIds = busyMembers,
+                        )
+                    )
+                }
                 WorkspaceAction.CloseSelected.Result(closed)
             }
 
             WorkspaceAction.CloseAll -> {
                 log(TAG, INFO) { "Closing all workspaces" }
+                // All or nothing: a partial Close All that leaves one tab behind is harder to make
+                // sense of than a refusal that names the tab standing in the way.
+                val busyMembers = closeBlockedBy(_workspaces.value.map { it.id })
+                if (busyMembers.isNotEmpty()) {
+                    log(TAG, INFO) { "Close all refused, busy members: $busyMembers" }
+                    _events.emit(
+                        WorkspaceEvent.CloseRefused(
+                            requestedId = null,
+                            hostId = null,
+                            busyWorkspaceIds = busyMembers,
+                        )
+                    )
+                    return@withLock WorkspaceAction.CloseAll.Result
+                }
                 _workspaces.value.forEach {
                     it.release()
                     operationsManager.removeWorkspace(it.id)
@@ -1045,6 +1095,10 @@ class WorkspaceRepo @Inject constructor(
             // on that path, so the claim is never cleared - the pause waits instead.
             contentClaims.values.any { it == workspace.id } -> WorkspaceAction.Pause.Reason.CLAIM_HELD
             info.operationCount > 0 || info.attentionCount > 0 -> WorkspaceAction.Pause.Reason.BUSY
+            // Pausing releases the instance, and with it the operation's progress surface and the
+            // resolver for its Waiting state. Asked of the manager because the counter above is
+            // projected asynchronously and can still read zero.
+            closeBlockedBy(listOf(workspace.id)).isNotEmpty() -> WorkspaceAction.Pause.Reason.BUSY
             info.hasUnsavedChanges -> WorkspaceAction.Pause.Reason.UNSAVED_CHANGES
             !info.isPausable -> WorkspaceAction.Pause.Reason.NOT_PAUSABLE
             info.lifecycleState !is Workspace.LifecycleState.Ready -> WorkspaceAction.Pause.Reason.NOT_READY
@@ -1286,6 +1340,9 @@ class WorkspaceRepo @Inject constructor(
         if (info.hasUnsavedChanges) return WorkspaceLimitCandidate.Blocker.UNSAVED_CHANGES
         if (info.attentionCount > 0) return WorkspaceLimitCandidate.Blocker.NEEDS_ATTENTION
         if (info.operationCount > 0) return WorkspaceLimitCandidate.Blocker.BUSY
+        // The counters above are projected by the workspace asynchronously, so an operation the
+        // manager already holds can coexist with operationCount == 0. Asked directly for that reason.
+        if (closeBlockedBy(listOf(info.id)).isNotEmpty()) return WorkspaceLimitCandidate.Blocker.BUSY
         // Zero counters while setup is still running says nothing about what would be lost
         if (info.lifecycleState is Workspace.LifecycleState.Initializing) {
             return WorkspaceLimitCandidate.Blocker.LOADING
@@ -1729,6 +1786,30 @@ class WorkspaceRepo @Inject constructor(
     }
 
     /**
+     * The members inside the closing subtrees of [rootIds] that run an operation whose close policy
+     * is REQUIRE_ORIGIN - i.e. the ones a close must refuse rather than take down. Empty means the
+     * close may proceed.
+     *
+     * Must be called while holding [lock] and before any `release()`: teardown is what this exists
+     * to prevent, so an answer obtained afterwards is worthless.
+     */
+    private fun closeBlockedBy(rootIds: Collection<Workspace.Id>): Set<Workspace.Id> =
+        operationsManager.closeBlockers(rootIds.flatMap { closingSubtreeOf(it) }.map { it.id })
+
+    /**
+     * The subset of [rootIds] whose own closing subtree holds one of [closeBlockedBy]'s members.
+     *
+     * Multi-root call sites decide per root with this. A busy member is usually a stacked child, so
+     * its id is not a root id, and comparing the two sets directly would close a root whose child
+     * must stay.
+     */
+    private fun blockedRoots(rootIds: Collection<Workspace.Id>): Set<Workspace.Id> {
+        val blocked = closeBlockedBy(rootIds)
+        if (blocked.isEmpty()) return emptySet()
+        return rootIds.filterTo(mutableSetOf()) { root -> closingSubtreeOf(root).any { it.id in blocked } }
+    }
+
+    /**
      * [closingSubtreeOf] as bare ids, always including [workspaceId] itself even when nothing holds
      * it. Two closes overlap exactly when either one's id set contains the other's target, which is
      * what tells a confirmation that a second one would decide the same workspaces over again.
@@ -1788,6 +1869,14 @@ class WorkspaceRepo @Inject constructor(
         val plan = lock.withLock {
             log(TAG, INFO) { "Closing workspace with id ${action.id}" }
 
+            // Before anything is parked, stashed or released: a refused close changes nothing.
+            val blockers = closeBlockedBy(listOf(action.id))
+            if (blockers.isNotEmpty()) {
+                log(TAG, INFO) { "Close of ${action.id} refused, busy members: $blockers" }
+                _events.emit(closeRefusalFor(action, blockers))
+                return WorkspaceAction.Close.Result
+            }
+
             // Closing a tab takes its whole modal stack down with it, so the guard has to
             // cover everything executeClose would destroy, not just the id the close names: a
             // clean tab can own a dirty child (a Saver still holding shared content), and that
@@ -1832,6 +1921,16 @@ class WorkspaceRepo @Inject constructor(
 
             // Phase 3
             lock.withLock {
+                // Ahead of the verdict, because the PLAIN branch never calls revalidateUndoCapture:
+                // an operation submitted while the capture suspended must not be taken down by a
+                // close that started out clean, whether or not that capture succeeded.
+                val blockers = closeBlockedBy(listOf(action.id))
+                if (blockers.isNotEmpty()) {
+                    log(TAG, INFO) { "Close of ${action.id} refused after capture, busy members: $blockers" }
+                    closedStash.abortClose(plan.closeToken)
+                    _events.emit(closeRefusalFor(action, blockers))
+                    return@withLock
+                }
                 val verdict = if (captured == null) CloseVerdict.PLAIN else revalidateUndoCapture(plan, captured)
                 when (verdict) {
                     CloseVerdict.UNDOABLE -> {
@@ -1858,6 +1957,19 @@ class WorkspaceRepo @Inject constructor(
 
         return WorkspaceAction.Close.Result
     }
+
+    /**
+     * The refusal notice for a close of a single tab. Anchored on the workspace the close was
+     * invoked from, the same overlay the close confirmation uses.
+     */
+    private fun closeRefusalFor(
+        action: WorkspaceAction.Close,
+        blockers: Set<Workspace.Id>,
+    ) = WorkspaceEvent.CloseRefused(
+        requestedId = action.id,
+        hostId = action.sourceWorkspaceId ?: action.id,
+        busyWorkspaceIds = blockers,
+    )
 
     /**
      * Installs the close confirmation for [action] WITHOUT acquiring [lock] - the caller already
@@ -1914,7 +2026,15 @@ class WorkspaceRepo @Inject constructor(
         log(TAG, INFO) { "Requesting confirmation to close workspace: ${action.id}, naming ${workspaceInfo.displayTitle}" }
 
         pendingActions[confirmationId] = {
-            executeClose(action.id)
+            // Re-asked here rather than only at parking time: this runs under a later acquisition of
+            // [lock], long after the user was asked, and an operation can have arrived meanwhile.
+            val blockers = closeBlockedBy(listOf(action.id))
+            if (blockers.isNotEmpty()) {
+                log(TAG, INFO) { "Confirmed close of ${action.id} refused, busy members: $blockers" }
+                _events.emit(closeRefusalFor(action, blockers))
+            } else {
+                executeClose(action.id)
+            }
             null
         }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerScreen.kt
@@ -48,6 +48,8 @@ import eu.darken.butler.workspace.ui.actions.WorkspaceActionBar
 import eu.darken.butler.workspace.ui.dialogs.ManagerDialog
 import eu.darken.butler.workspace.ui.dialogs.WorkspaceCloseConfirmationDialog
 import eu.darken.butler.workspace.ui.dialogs.WorkspaceRenameDialog
+import eu.darken.butler.workspace.ui.feedback.BannerState
+import eu.darken.butler.workspace.ui.feedback.WorkspaceBanner
 import eu.darken.butler.workspace.ui.floatingbar.BarPosition
 import eu.darken.butler.workspace.ui.floatingbar.BarScrollBehavior
 import eu.darken.butler.workspace.ui.floatingbar.FloatingBarStack
@@ -62,6 +64,9 @@ fun WorkspaceManagerScreen(
     closeConfirmation: ManagerDialog.WorkspaceTargeted.CloseConfirmation? = null,
     onCloseConfirmationResolve: (Boolean) -> Unit = {},
     onCloseConfirmationGoTo: () -> Unit = {},
+    /** A close this overlay refused, or null. Every pane is inactive while it is up. */
+    closeNotice: BannerState.CloseBlocked? = null,
+    onDismissCloseNotice: () -> Unit = {},
     onCloseWorkspace: (Workspace.Id) -> Unit,
     onReorderWorkspaces: (List<Workspace.Id>) -> Unit,
     onSelectWorkspace: (Workspace.Id) -> Unit,
@@ -175,6 +180,16 @@ fun WorkspaceManagerScreen(
                 onClearSelection = onClearSelection,
                 onFilterClick = onFilterClick,
                 lazyGridState = lazyGridState,
+            )
+
+            // Over the grid, not in the bar stack below: the FAB and the selection bar live there.
+            WorkspaceBanner(
+                state = closeNotice,
+                onDismiss = onDismissCloseNotice,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = paddingValues.calculateTopPadding())
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
             )
 
             FloatingBarStack(
@@ -463,6 +478,43 @@ private fun WorkspaceManagerScreenCloseConfirmationPreview() {
             workspaceTitle = "notes.txt".toCaString(),
             hasUnsavedChanges = true,
         ),
+        onCloseWorkspace = {},
+        onReorderWorkspaces = {},
+        onSelectWorkspace = {},
+        onPauseWorkspace = {},
+        onResumeWorkspace = {},
+        onCreateWorkspace = {},
+        onQuickCreate = {},
+        onNavigateBack = {},
+        onDismissBadgeExplanation = {},
+        onCloseAllWorkspaces = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceManagerScreenCloseNoticePreview() {
+    val explorerId = Workspace.Id()
+    WorkspaceManagerScreen(
+        state = WorkspaceManagerViewModel.State(
+            workspaces = listOf(
+                WorkspaceManagerViewModel.WorkspaceItem(
+                    id = explorerId,
+                    topId = explorerId,
+                    type = Workspace.Type.EXPLORER,
+                    title = "/storage/emulated/0/Download".toCaString(),
+                    autoTitle = "/storage/emulated/0/Download".toCaString(),
+                    subtitle = null,
+                    isFocused = true,
+                    isVisibleInPane = true,
+                    paneNumber = 0,
+                    operationCount = 1,
+                ),
+            ),
+            operationsCount = 1,
+        ),
+        closeNotice = BannerState.CloseBlocked(busyCount = 1),
         onCloseWorkspace = {},
         onReorderWorkspaces = {},
         onSelectWorkspace = {},

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -26,6 +26,7 @@ import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
 import eu.darken.butler.workspace.ui.template.availableTemplates
 import eu.darken.butler.workspace.ui.template.toQuickCreateItem
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -57,6 +58,7 @@ class WorkspaceManagerViewModel @Inject constructor(
     /**
      * The manager's own copy of a close refusal. While the overlay is up every pane is inactive, so
      * the pane banner the refusal also files neither shows nor counts down until the manager closes.
+     * A refusal is only kept while the manager is showing and is dropped again when it closes.
      */
     private val closeNoticeFlow = MutableStateFlow<BannerState.CloseBlocked?>(null)
 
@@ -66,7 +68,17 @@ class WorkspaceManagerViewModel @Inject constructor(
     init {
         workspaceRepo.events
             .filterIsInstance<WorkspaceEvent.CloseRefused>()
-            .onEach { closeNoticeFlow.value = BannerState.CloseBlocked(it.busyWorkspaceIds.size) }
+            .onEach {
+                if (workspacePageManager.state.value.isManagerOverlayVisible) {
+                    closeNoticeFlow.value = BannerState.CloseBlocked(it.busyWorkspaceIds.size)
+                }
+            }
+            .launchInViewModel()
+
+        workspacePageManager.state
+            .map { it.isManagerOverlayVisible }
+            .distinctUntilChanged()
+            .onEach { visible -> if (!visible) closeNoticeFlow.value = null }
             .launchInViewModel()
     }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -12,20 +12,24 @@ import eu.darken.butler.common.flow.combine
 import eu.darken.butler.common.ui.ViewModel4
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.core.WorkspaceEvent
 import eu.darken.butler.workspace.core.WorkspacePauseGate
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.WorkspaceStacks
 import eu.darken.butler.workspace.core.defaultArguments
 import eu.darken.butler.workspace.ui.WorkspacePageManager
+import eu.darken.butler.workspace.ui.feedback.BannerState
 import eu.darken.butler.workspace.ui.manager.preview.WorkspacePreviewManager
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
 import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
 import eu.darken.butler.workspace.ui.template.availableTemplates
 import eu.darken.butler.workspace.ui.template.toQuickCreateItem
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -50,8 +54,21 @@ class WorkspaceManagerViewModel @Inject constructor(
      */
     private val selectionFlow = MutableStateFlow<Set<Workspace.Id>?>(null)
 
+    /**
+     * The manager's own copy of a close refusal. While the overlay is up every pane is inactive, so
+     * the pane banner the refusal also files neither shows nor counts down until the manager closes.
+     */
+    private val closeNoticeFlow = MutableStateFlow<BannerState.CloseBlocked?>(null)
+
     private val quickCreateItems = workspaceTemplates.availableTemplates()
         .map { templates -> templates.filter { it.isQuickCreate }.map { it.toQuickCreateItem() } }
+
+    init {
+        workspaceRepo.events
+            .filterIsInstance<WorkspaceEvent.CloseRefused>()
+            .onEach { closeNoticeFlow.value = BannerState.CloseBlocked(it.busyWorkspaceIds.size) }
+            .launchInViewModel()
+    }
 
     val state = combine(
         workspaceRepo.state,
@@ -61,7 +78,8 @@ class WorkspaceManagerViewModel @Inject constructor(
         filterFlow,
         quickCreateItems,
         selectionFlow,
-    ) { repoState, showBadge, livePreview, pageManagerState, filter, quickCreate, selection ->
+        closeNoticeFlow,
+    ) { repoState, showBadge, livePreview, pageManagerState, filter, quickCreate, selection, closeNotice ->
         val stacks = WorkspaceStacks(repoState.infos)
         val focusedId = pageManagerState.focusedWorkspaceId
         val topChains = stacks.topChainByRoot(focusedId)
@@ -118,6 +136,7 @@ class WorkspaceManagerViewModel @Inject constructor(
                 // closed from elsewhere, so the mode is over. Left as an empty set the bar would sit
                 // at "0 selected" with no way back except Cancel.
                 ?.ifEmpty { null },
+            closeNotice = closeNotice,
         )
     }.asStateFlow()
 
@@ -279,6 +298,11 @@ class WorkspaceManagerViewModel @Inject constructor(
         workspaceSettings.showTipBadgeExplanation.value(false)
     }
 
+    fun dismissCloseNotice() {
+        log(tag) { "dismissCloseNotice()" }
+        closeNoticeFlow.value = null
+    }
+
     fun closeAllWorkspaces() = launch {
         log(tag) { "closeAllWorkspaces()" }
         workspaceRepo.execute(WorkspaceAction.CloseAll)
@@ -417,6 +441,8 @@ class WorkspaceManagerViewModel @Inject constructor(
         val hasUnsavedChanges: Boolean = false,
         /** Null when selection mode is off. Pruned to tabs that are still open. */
         val selectedIds: Set<Workspace.Id>? = null,
+        /** A close refused while the manager was open, shown as a banner over the grid. */
+        val closeNotice: BannerState.CloseBlocked? = null,
     ) {
         val workspaceCount: Int = workspaces.size
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModel.kt
@@ -264,6 +264,9 @@ class WorkspaceManagerViewModel @Inject constructor(
             is WorkspaceAction.Create.Result.LimitReached -> {
                 log(tag, WARN) { "Workspace creation blocked - limit reached" }
             }
+            is WorkspaceAction.Create.Result.Refused -> {
+                log(tag, WARN) { "Workspace creation refused - the replaced tab is busy" }
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -533,6 +533,8 @@ fun WorkspacesScreenHost(
                             )
                         }
                     },
+                    closeNotice = currentManagerState.closeNotice,
+                    onDismissCloseNotice = managerVm::dismissCloseNotice,
                     onCloseWorkspace = managerVm::closeWorkspace,
                     onReorderWorkspaces = managerVm::reorderWorkspaces,
                     onSelectWorkspace = managerVm::selectWorkspace,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -282,6 +282,20 @@ class WorkspacesViewModel @Inject constructor(
                             }
                         }
                     }
+                    is WorkspaceEvent.CloseRefused -> {
+                        log(tag, INFO) { "CloseRefused: $event" }
+
+                        // The host is where the request came from, which for a close invoked in a
+                        // stacked child is that child - the parent's banner would be behind it.
+                        val targetWorkspaceId = event.hostId
+                            ?: workspacePageManager.state.value.focusedWorkspaceId
+
+                        if (targetWorkspaceId != null) {
+                            _bannerStates.update { states ->
+                                states + (targetWorkspaceId to BannerState.CloseBlocked(event.busyWorkspaceIds.size))
+                            }
+                        }
+                    }
                     else -> {} // Ignore other events
                 }
             }
@@ -453,6 +467,9 @@ class WorkspacesViewModel @Inject constructor(
                     is WorkspaceAction.Create.Result.LimitReached -> {
                         log(tag, WARN) { "On-demand workspace creation blocked - limit reached" }
                     }
+                    is WorkspaceAction.Create.Result.Refused -> {
+                        log(tag, WARN) { "On-demand workspace creation refused - the replaced tab is busy" }
+                    }
                 }
             }
             is WorkspaceScreenAction.CreateForPane -> {
@@ -472,6 +489,9 @@ class WorkspacesViewModel @Inject constructor(
                     }
                     is WorkspaceAction.Create.Result.LimitReached -> {
                         log(tag, WARN) { "Workspace creation blocked - limit reached" }
+                    }
+                    is WorkspaceAction.Create.Result.Refused -> {
+                        log(tag, WARN) { "Workspace creation refused - the replaced tab is busy" }
                     }
                 }
             }
@@ -534,6 +554,9 @@ class WorkspacesViewModel @Inject constructor(
                     }
                     is WorkspaceAction.Create.Result.LimitReached -> {
                         log(tag, WARN) { "Workspace creation blocked - limit reached" }
+                    }
+                    is WorkspaceAction.Create.Result.Refused -> {
+                        log(tag, WARN) { "Workspace creation refused - the replaced tab is busy" }
                     }
                 }
             }

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceAutoPauseManagerTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceAutoPauseManagerTest.kt
@@ -4,6 +4,7 @@ import android.os.Parcel
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import eu.darken.butler.workspace.ui.WorkspacePageManager
 import eu.darken.butler.workspace.ui.WorkspaceVisibilityTracker
@@ -160,7 +161,10 @@ class WorkspaceAutoPauseManagerTest : BaseTest() {
             appScope = scope,
             factoryMap = Workspace.Type.entries.associateWith { FakeFactory() },
             workspaceSettings = workspaceSettings,
-            operationsManager = mockk(relaxed = true),
+            // A relaxed answer for a Set return type is not guaranteed to be empty
+            operationsManager = mockk<OperationsManager>(relaxed = true).apply {
+                every { closeBlockers(any()) } returns emptySet()
+            },
             upgradeRepo = upgradeRepo,
             usageRepo = mockk(relaxed = true),
             closedStash = closedStash,

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspacePauseGateTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspacePauseGateTest.kt
@@ -4,6 +4,7 @@ import android.os.Parcel
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -86,7 +87,10 @@ class WorkspacePauseGateTest : BaseTest() {
             appScope = backgroundScope,
             factoryMap = Workspace.Type.entries.associateWith { FakeFactory() },
             workspaceSettings = workspaceSettings,
-            operationsManager = mockk(relaxed = true),
+            // A relaxed answer for a Set return type is not guaranteed to be empty
+            operationsManager = mockk<OperationsManager>(relaxed = true).apply {
+                every { closeBlockers(any()) } returns emptySet()
+            },
             upgradeRepo = upgradeRepo,
             usageRepo = mockk(relaxed = true),
             closedStash = ClosedWorkspaceStash(backgroundScope),

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -15,6 +15,7 @@ import eu.darken.butler.workspace.core.usage.WorkspaceUsageRepo
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -3996,6 +3997,50 @@ class WorkspaceRepoTest : BaseTest() {
             fake(childId).released shouldBe false
             coVerify(exactly = 0) { operationsManager.removeWorkspace(originalId) }
             events.closeRefusals().single().requestedId shouldBe originalId
+        }
+
+    @Test
+    fun `a batch refusal is announced after the batch completion`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo()
+        val events = mutableListOf<WorkspaceEvent>()
+        repo.events.onEach { events += it }.launchIn(backgroundScope)
+        val originalId = repo.createTab(type = Workspace.Type.EXPLORER)
+        markOperationBlocked(originalId)
+        val request = WorkspaceAction.Create(
+            type = Workspace.Type.SEARCHER,
+            arguments = FakeArguments(Workspace.Type.SEARCHER),
+            replace = originalId,
+        )
+
+        repo.createBatch(request)
+
+        // Both events end up as a banner filed under a workspace id, and the later one wins
+        val refusalIndex = events.indexOfFirst { it is WorkspaceEvent.CloseRefused }
+        val completionIndex = events.indexOfFirst { it is WorkspaceEvent.BatchCreationCompleted }
+        completionIndex shouldBeGreaterThan -1
+        refusalIndex shouldBeGreaterThan completionIndex
+    }
+
+    @Test
+    fun `a batch refusal invoked from a stacked child is filed under that child`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val tabId = repo.createTab(type = Workspace.Type.EXPLORER)
+            val childId = repo.createSubWorkspace(caller = tabId)
+            markOperationBlocked(tabId)
+            val request = WorkspaceAction.Create(
+                type = Workspace.Type.SEARCHER,
+                arguments = FakeArguments(Workspace.Type.SEARCHER),
+                replace = tabId,
+            )
+
+            repo.createBatchFrom(childId, request)
+
+            val refused = events.closeRefusals().single()
+            refused.hostId shouldBe childId
+            refused.requestedId shouldBe tabId
         }
 
     @Test

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -181,7 +181,11 @@ class WorkspaceRepoTest : BaseTest() {
             FakeArguments(Workspace.Type.EXPLORER)
     }
 
-    private val operationsManager: OperationsManager = mockk(relaxed = true)
+    // A relaxed answer for a Set return type is not guaranteed to be empty, and the repo reads
+    // this on every close, pause and limit admission.
+    private val operationsManager: OperationsManager = mockk<OperationsManager>(relaxed = true).apply {
+        every { closeBlockers(any()) } returns emptySet()
+    }
 
     private val usageRepo: WorkspaceUsageRepo = mockk(relaxed = true)
 
@@ -212,6 +216,7 @@ class WorkspaceRepoTest : BaseTest() {
         val workspaceSettings = mockk<WorkspaceSettings>(relaxed = true).apply {
             every { layoutModePortrait.flow } returns flowOf(WorkspacePanelMode.AUTO)
             every { layoutModeLandscape.flow } returns flowOf(WorkspacePanelMode.AUTO)
+            every { undoCloseEnabled.flow } returns flowOf(true)
         }
         return WorkspaceRepo(
             appScope = backgroundScope,
@@ -3763,4 +3768,214 @@ class WorkspaceRepoTest : BaseTest() {
 
         coVerify(exactly = 1) { usageRepo.track(Workspace.Type.SEARCHER, any()) }
     }
+
+    // ─── REQUIRE_ORIGIN close refusal ─────────────────────────────────────────────
+
+    /**
+     * Mirrors [OperationsManager.closeBlockers]: the intersection of what is asked about with what
+     * is busy, so a query about an unrelated workspace is answered honestly.
+     */
+    private fun markOperationBlocked(vararg ids: Workspace.Id) {
+        val busy = ids.toSet()
+        every { operationsManager.closeBlockers(any()) } answers {
+            firstArg<Collection<Workspace.Id>>().toSet() intersect busy
+        }
+    }
+
+    private fun List<WorkspaceEvent>.closeRefusals(): List<WorkspaceEvent.CloseRefused> =
+        filterIsInstance<WorkspaceEvent.CloseRefused>()
+
+    @Test
+    fun `a close is refused while a member runs a REQUIRE_ORIGIN operation`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val tabId = repo.createTab()
+            val childId = repo.createReadyChild(caller = tabId)
+            markOperationBlocked(childId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+
+            repo.workspaceIds() shouldBe listOf(tabId, childId)
+            fake(tabId).released shouldBe false
+            fake(childId).released shouldBe false
+            coVerify(exactly = 0) { operationsManager.removeWorkspace(any()) }
+            val refused = events.closeRefusals().single()
+            refused.requestedId shouldBe tabId
+            refused.busyWorkspaceIds shouldBe setOf(childId)
+        }
+
+    @Test
+    fun `a close invoked from a stacked child files the refusal under that child`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val tabId = repo.createTab()
+            val childId = repo.createReadyChild(caller = tabId)
+            markOperationBlocked(tabId)
+
+            repo.execute(WorkspaceAction.Close(tabId, sourceWorkspaceId = childId))
+
+            // The child covers its parent with an opaque layer, so a notice filed under the parent
+            // would never be seen
+            events.closeRefusals().single().hostId shouldBe childId
+        }
+
+    @Test
+    fun `a confirmed close re-checks the blocker before closing`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val tabId = repo.createTab()
+            markDirty(tabId)
+
+            repo.execute(WorkspaceAction.Close(tabId))
+            val confirmation = repo.pendingConfirmations.first().values.single {
+                it.data is PendingWorkspaceConfirmation.ConfirmationData.WorkspaceCloseConfirmation
+            }
+            // Arrives while the user is looking at the dialog
+            markOperationBlocked(tabId)
+            repo.resolveConfirmation(confirmation.id, confirmed = true)
+
+            repo.workspaceIds() shouldBe listOf(tabId)
+            fake(tabId).released shouldBe false
+            events.closeRefusals().single().requestedId shouldBe tabId
+        }
+
+    @Test
+    fun `an undoable close re-checks the blocker after capture`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val tabId = repo.createReadyTab()
+            // Phase 1 sees nothing; the operation is submitted while createArguments suspends
+            fake(tabId).whileCapturingArguments = { markOperationBlocked(tabId) }
+
+            repo.execute(WorkspaceAction.Close(tabId, undoable = true))
+
+            repo.workspaceIds() shouldBe listOf(tabId)
+            fake(tabId).released shouldBe false
+            closedStash.peekEntry() shouldBe null
+            closedStash.closeTokenFor(tabId) shouldBe null
+            events.closeRefusals().single().requestedId shouldBe tabId
+        }
+
+    @Test
+    fun `an undoable close whose capture failed still re-checks the blocker`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val tabId = repo.createReadyTab()
+            // A failed capture degrades to a PLAIN close, which never revalidates - the refusal has
+            // to sit ahead of that branch or this tab goes down
+            fake(tabId).whileCapturingArguments = { markOperationBlocked(tabId) }
+            fake(tabId).argumentsError = IllegalStateException("Cannot serialize state")
+
+            repo.execute(WorkspaceAction.Close(tabId, undoable = true))
+
+            repo.workspaceIds() shouldBe listOf(tabId)
+            fake(tabId).released shouldBe false
+            closedStash.peekEntry() shouldBe null
+            events.closeRefusals().single().requestedId shouldBe tabId
+        }
+
+    @Test
+    fun `Close All is refused atomically while any tab is busy`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo()
+        val events = mutableListOf<WorkspaceEvent>()
+        repo.events.onEach { events += it }.launchIn(backgroundScope)
+        val first = repo.createTab()
+        val busy = repo.createTab()
+        val last = repo.createTab()
+        markOperationBlocked(busy)
+
+        repo.execute(WorkspaceAction.CloseAll)
+
+        repo.workspaceIds() shouldBe listOf(first, busy, last)
+        createdWorkspaces.count { it.released } shouldBe 0
+        val refused = events.closeRefusals().single()
+        refused.requestedId shouldBe null
+        refused.hostId shouldBe null
+        refused.busyWorkspaceIds shouldBe setOf(busy)
+    }
+
+    @Test
+    fun `Close Selected skips an owner whose child is busy and closes the rest`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val ownerA = repo.createTab()
+            val childB = repo.createReadyChild(caller = ownerA)
+            val unrelatedC = repo.createTab()
+            markOperationBlocked(childB)
+
+            val result = repo.execute(WorkspaceAction.CloseSelected(setOf(ownerA, unrelatedC)))
+
+            result shouldBe WorkspaceAction.CloseSelected.Result(closed = 1)
+            repo.workspaceIds() shouldBe listOf(ownerA, childB)
+            fake(ownerA).released shouldBe false
+            fake(childB).released shouldBe false
+            fake(unrelatedC).released shouldBe true
+            events.closeRefusals().single().busyWorkspaceIds shouldBe setOf(childB)
+        }
+
+    @Test
+    fun `a replace is refused while the replaced tab is busy`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo()
+        val events = mutableListOf<WorkspaceEvent>()
+        repo.events.onEach { events += it }.launchIn(backgroundScope)
+        val originalId = repo.createTab(type = Workspace.Type.EXPLORER)
+        markOperationBlocked(originalId)
+
+        val result = repo.execute(
+            WorkspaceAction.Create(
+                type = Workspace.Type.SEARCHER,
+                arguments = FakeArguments(Workspace.Type.SEARCHER),
+                replace = originalId,
+            )
+        )
+
+        result shouldBe WorkspaceAction.Create.Result.Refused
+        repo.workspaceIds() shouldBe listOf(originalId)
+        repo.infoFor(originalId).type shouldBe Workspace.Type.EXPLORER
+        fake(originalId).released shouldBe false
+        events.closeRefusals().single().requestedId shouldBe originalId
+    }
+
+    @Test
+    fun `tab-limit recovery treats a manager-known blocker as busy with zero counters`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo(isPro = false)
+            val ids = repo.fillWithReadyTabs()
+            markOperationBlocked(ids[0])
+
+            repo.createRecoverable()
+
+            // The projected counters say idle; only the manager knows about the operation
+            repo.infoFor(ids[0]).operationCount shouldBe 0
+            repo.blockerFor(ids[0]) shouldBe WorkspaceLimitCandidate.Blocker.BUSY
+            repo.closableIds() shouldBe ids.drop(1)
+        }
+
+    @Test
+    fun `pause is refused for a manager-known blocker with zero counters`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val id = repo.createReadyTab()
+            repo.infoFor(id).operationCount shouldBe 0
+            markOperationBlocked(id)
+
+            val result = repo.pause(id)
+
+            result.shouldBeInstanceOf<WorkspaceAction.Pause.Result.Refused>()
+            result.reason shouldBe WorkspaceAction.Pause.Reason.BUSY
+            fake(id).released shouldBe false
+            repo.infoFor(id).isPaused shouldBe false
+        }
 }

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceRepoTest.kt
@@ -3949,6 +3949,56 @@ class WorkspaceRepoTest : BaseTest() {
     }
 
     @Test
+    fun `a batch replace is refused while the replaced tab is busy`() = runTest(UnconfinedTestDispatcher()) {
+        val repo = createRepo()
+        val events = mutableListOf<WorkspaceEvent>()
+        repo.events.onEach { events += it }.launchIn(backgroundScope)
+        val originalId = repo.createTab(type = Workspace.Type.EXPLORER)
+        markOperationBlocked(originalId)
+        val request = WorkspaceAction.Create(
+            type = Workspace.Type.SEARCHER,
+            arguments = FakeArguments(Workspace.Type.SEARCHER),
+            replace = originalId,
+        )
+
+        val result = repo.createBatch(request)
+
+        result.results.getValue(request)
+            .shouldBeInstanceOf<WorkspaceAction.CreateBatch.CreationResult.Failure>()
+        repo.workspaceIds() shouldBe listOf(originalId)
+        repo.infoFor(originalId).type shouldBe Workspace.Type.EXPLORER
+        fake(originalId).released shouldBe false
+        coVerify(exactly = 0) { operationsManager.removeWorkspace(originalId) }
+        events.closeRefusals().single().requestedId shouldBe originalId
+    }
+
+    @Test
+    fun `a batch replace is refused while a child of the replaced tab is busy`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val repo = createRepo()
+            val events = mutableListOf<WorkspaceEvent>()
+            repo.events.onEach { events += it }.launchIn(backgroundScope)
+            val originalId = repo.createTab(type = Workspace.Type.EXPLORER)
+            val childId = repo.createSubWorkspace(caller = originalId)
+            markOperationBlocked(childId)
+            val request = WorkspaceAction.Create(
+                type = Workspace.Type.SEARCHER,
+                arguments = FakeArguments(Workspace.Type.SEARCHER),
+                replace = originalId,
+            )
+
+            val result = repo.createBatch(request)
+
+            result.results.getValue(request)
+                .shouldBeInstanceOf<WorkspaceAction.CreateBatch.CreationResult.Failure>()
+            repo.workspaceIds() shouldBe listOf(originalId, childId)
+            fake(originalId).released shouldBe false
+            fake(childId).released shouldBe false
+            coVerify(exactly = 0) { operationsManager.removeWorkspace(originalId) }
+            events.closeRefusals().single().requestedId shouldBe originalId
+        }
+
+    @Test
     fun `tab-limit recovery treats a manager-known blocker as busy with zero counters`() =
         runTest(UnconfinedTestDispatcher()) {
             val repo = createRepo(isPro = false)

--- a/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceUndoCloseTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/core/WorkspaceUndoCloseTest.kt
@@ -144,7 +144,10 @@ class WorkspaceUndoCloseTest : BaseTest() {
         scope = TestScope(UnconfinedTestDispatcher())
         stash = ClosedWorkspaceStash(scope)
         scrollPositions = WorkspaceScrollPositions()
-        operationsManager = mockk(relaxed = true)
+        // A relaxed answer for a Set return type is not guaranteed to be empty
+        operationsManager = mockk<OperationsManager>(relaxed = true).apply {
+            every { closeBlockers(any()) } returns emptySet()
+        }
 
         val upgradeInfo = mockk<UpgradeRepo.Info>().apply {
             every { isPro } returns false

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
@@ -771,6 +771,7 @@ class WorkspaceManagerViewModelTest : BaseTest() {
             val eventsFlow = MutableSharedFlow<WorkspaceEvent>()
             every { workspaceRepo.events } returns eventsFlow
             repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA)))
+            pageState.value = WorkspacePageManager.State(isManagerOverlayVisible = true)
             val vm = createViewModel()
 
             vm.currentState().closeNotice shouldBe null
@@ -789,4 +790,47 @@ class WorkspaceManagerViewModelTest : BaseTest() {
 
             vm.currentState().closeNotice shouldBe null
         }
+
+    @Test
+    fun `a refusal while the manager is closed leaves no notice`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val eventsFlow = MutableSharedFlow<WorkspaceEvent>()
+            every { workspaceRepo.events } returns eventsFlow
+            repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA)))
+            pageState.value = WorkspacePageManager.State(isManagerOverlayVisible = false)
+            val vm = createViewModel()
+
+            eventsFlow.emit(
+                WorkspaceEvent.CloseRefused(
+                    requestedId = null,
+                    hostId = null,
+                    busyWorkspaceIds = setOf(Workspace.Id()),
+                )
+            )
+
+            vm.currentState().closeNotice shouldBe null
+        }
+
+    @Test
+    fun `closing the manager clears its notice`() = runTest(UnconfinedTestDispatcher()) {
+        val eventsFlow = MutableSharedFlow<WorkspaceEvent>()
+        every { workspaceRepo.events } returns eventsFlow
+        repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA)))
+        pageState.value = WorkspacePageManager.State(isManagerOverlayVisible = true)
+        val vm = createViewModel()
+
+        eventsFlow.emit(
+            WorkspaceEvent.CloseRefused(
+                requestedId = null,
+                hostId = null,
+                busyWorkspaceIds = setOf(Workspace.Id()),
+            )
+        )
+
+        vm.currentState().closeNotice shouldBe BannerState.CloseBlocked(1)
+
+        pageState.value = WorkspacePageManager.State(isManagerOverlayVisible = false)
+
+        vm.currentState().closeNotice shouldBe null
+    }
 }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceManagerViewModelTest.kt
@@ -3,18 +3,21 @@ package eu.darken.butler.workspace.ui.manager
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.core.WorkspaceEvent
 import eu.darken.butler.workspace.core.WorkspacePauseGate
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.WorkspaceStacks
 import eu.darken.butler.workspace.ui.WorkspacePageManager
+import eu.darken.butler.workspace.ui.feedback.BannerState
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -761,4 +764,29 @@ class WorkspaceManagerViewModelTest : BaseTest() {
 
         vm.currentState().isSelectionActive shouldBe false
     }
+
+    @Test
+    fun `a refused close raises a notice in the manager until dismissed`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val eventsFlow = MutableSharedFlow<WorkspaceEvent>()
+            every { workspaceRepo.events } returns eventsFlow
+            repoState.value = WorkspaceRemote.State(infos = listOf(readyInfo(idA)))
+            val vm = createViewModel()
+
+            vm.currentState().closeNotice shouldBe null
+
+            eventsFlow.emit(
+                WorkspaceEvent.CloseRefused(
+                    requestedId = null,
+                    hostId = null,
+                    busyWorkspaceIds = setOf(Workspace.Id()),
+                )
+            )
+
+            vm.currentState().closeNotice shouldBe BannerState.CloseBlocked(1)
+
+            vm.dismissCloseNotice()
+
+            vm.currentState().closeNotice shouldBe null
+        }
 }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/session/WorkspaceSessionManagerTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/session/WorkspaceSessionManagerTest.kt
@@ -17,6 +17,7 @@ import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.core.operations.OperationsManager
 import eu.darken.butler.workspace.core.session.WorkspaceSessionStorage
 import eu.darken.butler.workspace.core.session.WorkspaceSessionStorage.Companion.DEFAULT_SESSION_ID
 import eu.darken.butler.workspace.core.session.db.WorkspaceInstanceEntity
@@ -769,7 +770,10 @@ class WorkspaceSessionManagerTest : BaseTest() {
                 appScope = restoreScope,
                 factoryMap = factoryMap,
                 workspaceSettings = workspaceSettings,
-                operationsManager = mockk(relaxed = true),
+                // A relaxed answer for a Set return type is not guaranteed to be empty
+                operationsManager = mockk<OperationsManager>(relaxed = true).apply {
+                    every { closeBlockers(any()) } returns emptySet()
+                },
                 upgradeRepo = upgradeRepo,
                 usageRepo = mockk(relaxed = true),
                 closedStash = closedStash,


### PR DESCRIPTION
## What changed

No user-facing behavior change: nothing sets the new flags yet. This is the second piece of the App Details package-actions work (after #172), laying the framework contracts the package operations will use.

- An operation can now declare that the user must not be able to cancel it, and that its tab has to stay open while it runs. Every way of closing a tab (close, confirmed close, undoable close, Close Selected, Close All, replacing the tab, the tab-limit auto-close, pausing) refuses to take such a tab down and says so: a banner on the tab the close came from, or inside the tab manager when the close was requested there.
- Operation reports are now a family of shapes. The file-path shape (affected paths, subject path) is the open one every existing operation uses; a per-package shape can be added beside it later.
- The operation history can label operations started from the Apps workspace.

## Technical Context

- The close policy is "refuse", not "detach": operations bars and `Waiting` resolvers are bound to the origin tab and no global operations surface exists, so an operation that outlived its tab would be invisible and unanswerable. A protected operation therefore keeps its tab (`ClosePolicy.REQUIRE_ORIGIN`), and `isCancellable` is enforced at `OperationsManager.cancel()` as well as in the UI so a stale notification intent cannot bypass the hidden button.
- The guard lives in `WorkspaceRepo`, under its lock and before any `release()`, on all eight teardown paths (single close before and after the undo capture, the parked confirmation, Close Selected per root, Close All atomically, single and batch replace, tab-limit recovery, pause). The manager is asked directly (`OperationsManager.closeBlockers`) rather than trusting `Workspace.Info.operationCount`, which workspaces project asynchronously and the Apps workspaces hard-code to 0.
- `Operation.Report` is sealed with `summary` and `partialErrorCount` on the root; `affectedPaths`, `subjectPath` and `PathChange` moved into the open nested `Report.Paths`, which every descendant and preview now implements. Consumers narrow with `as? Report.Paths`; behaviour is unchanged because every existing report is a path report.
- The refusal notice is filed under the workspace the close was invoked from (a stacked child covers its parent), and additionally inside the tab manager while it is open, since pane banners are inactive under the overlay. The manager's copy is only recorded while the overlay is showing and is dropped when it closes.
- Worth a close look: the guard placements in `WorkspaceRepo.executeCloseAction` (Phase 1 and post-capture) and the parked confirmation lambda, `executeBatchCreation`'s refusal ordering relative to `BatchCreationCompleted`, and `WorkspaceManagerViewModel`'s notice lifetime.
