### PR TITLE
Workspace: Switch the pane layout from the tab rail's Butler menu

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/layout/WorkspacePanelMode.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/layout/WorkspacePanelMode.kt
@@ -8,6 +8,9 @@ enum class WorkspacePanelMode {
     @SerialName("AUTO")
     AUTO,
 
+    @SerialName("ADAPTIVE")
+    ADAPTIVE,
+
     @SerialName("SINGLE")
     SINGLE,
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/LayoutPickerDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/LayoutPickerDialog.kt
@@ -1,0 +1,116 @@
+package eu.darken.butler.workspace.ui.layout
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+
+data class LayoutPickerOption(
+    val icon: ImageVector,
+    val label: String,
+    val description: String,
+    val selected: Boolean,
+    val onSelect: () -> Unit,
+)
+
+@Composable
+fun LayoutPickerDialog(
+    modifier: Modifier = Modifier,
+    title: String,
+    options: List<LayoutPickerOption>,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                options.forEach { option ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = option.selected,
+                                onClick = option.onSelect,
+                            )
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = option.icon,
+                            contentDescription = null,
+                            tint = if (option.selected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                            },
+                            modifier = Modifier.size(32.dp),
+                        )
+                        Column(modifier = Modifier.padding(start = 16.dp)) {
+                            Text(
+                                text = option.label,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Text(
+                                text = option.description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun LayoutPickerDialogPreview() {
+    LayoutPickerDialog(
+        title = "Layout",
+        options = listOf(
+            LayoutPickerOption(
+                icon = WorkspacePanelIcons.Auto,
+                label = "Automatic",
+                description = "Classic on small screens, tab rail with panes on large ones.",
+                selected = true,
+                onSelect = {},
+            ),
+            LayoutPickerOption(
+                icon = WorkspacePanelIcons.Single,
+                label = "Classic",
+                description = "One pane at a time, without the tab rail.",
+                selected = false,
+                onSelect = {},
+            ),
+            LayoutPickerOption(
+                icon = WorkspacePanelIcons.Adaptive,
+                label = "Adaptive",
+                description = "Tab rail plus as many panes as the screen fits.",
+                selected = false,
+                onSelect = {},
+            ),
+        ),
+        onDismiss = {},
+    )
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurface.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurface.kt
@@ -1,0 +1,67 @@
+package eu.darken.butler.workspace.ui.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+
+/** What Settings offers: which surface, not which geometry. */
+enum class WorkspaceLayoutSurface {
+    AUTOMATIC,
+    CLASSIC,
+    ADAPTIVE,
+}
+
+val WorkspacePanelMode.surface: WorkspaceLayoutSurface
+    get() = when (this) {
+        WorkspacePanelMode.AUTO -> WorkspaceLayoutSurface.AUTOMATIC
+        WorkspacePanelMode.SINGLE -> WorkspaceLayoutSurface.CLASSIC
+        else -> WorkspaceLayoutSurface.ADAPTIVE
+    }
+
+fun WorkspaceLayoutSurface.toPanelMode(): WorkspacePanelMode = when (this) {
+    WorkspaceLayoutSurface.AUTOMATIC -> WorkspacePanelMode.AUTO
+    WorkspaceLayoutSurface.CLASSIC -> WorkspacePanelMode.SINGLE
+    WorkspaceLayoutSurface.ADAPTIVE -> WorkspacePanelMode.ADAPTIVE
+}
+
+@Composable
+fun WorkspaceLayoutSurface.label(): String = when (this) {
+    WorkspaceLayoutSurface.AUTOMATIC -> stringResource(R.string.workspace_settings_layout_mode_auto)
+    WorkspaceLayoutSurface.CLASSIC -> stringResource(R.string.workspace_settings_layout_mode_classic)
+    WorkspaceLayoutSurface.ADAPTIVE -> stringResource(R.string.workspace_settings_layout_mode_adaptive)
+}
+
+@Composable
+fun WorkspaceLayoutSurface.description(): String = when (this) {
+    WorkspaceLayoutSurface.AUTOMATIC -> stringResource(R.string.workspace_settings_layout_mode_auto_desc)
+    WorkspaceLayoutSurface.CLASSIC -> stringResource(R.string.workspace_settings_layout_mode_classic_desc)
+    WorkspaceLayoutSurface.ADAPTIVE -> stringResource(R.string.workspace_settings_layout_mode_adaptive_desc)
+}
+
+fun WorkspaceLayoutSurface.icon(): ImageVector = when (this) {
+    WorkspaceLayoutSurface.AUTOMATIC -> WorkspacePanelIcons.Auto
+    WorkspaceLayoutSurface.CLASSIC -> WorkspacePanelIcons.Single
+    WorkspaceLayoutSurface.ADAPTIVE -> WorkspacePanelIcons.Adaptive
+}
+
+/** The geometries a rail user can pin; every one of them composes the rail. */
+val ADAPTIVE_GEOMETRIES: List<WorkspacePanelMode> = listOf(
+    WorkspacePanelMode.SINGLE_RAIL,
+    WorkspacePanelMode.DUAL_VERTICAL,
+    WorkspacePanelMode.DUAL_HORIZONTAL,
+    WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT,
+    WorkspacePanelMode.TRIPLE_SIDEBAR_RIGHT,
+    WorkspacePanelMode.QUAD_GRID,
+)
+
+val WorkspacePanelMode.isPinnedGeometry: Boolean get() = this in ADAPTIVE_GEOMETRIES
+
+/** The Settings item's value: the surface, with the pinned geometry named where there is one. */
+@Composable
+fun WorkspacePanelMode.surfaceValueLabel(): String = if (isPinnedGeometry) {
+    stringResource(R.string.workspace_settings_layout_mode_adaptive_pinned_format, label())
+} else {
+    surface.label()
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurface.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurface.kt
@@ -3,6 +3,8 @@ package eu.darken.butler.workspace.ui.layout
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 
@@ -57,6 +59,32 @@ val ADAPTIVE_GEOMETRIES: List<WorkspacePanelMode> = listOf(
 )
 
 val WorkspacePanelMode.isPinnedGeometry: Boolean get() = this in ADAPTIVE_GEOMETRIES
+
+/**
+ * The geometries a window can host, from its long and short side so that rotating never changes
+ * the set; only which dual splits the long side depends on orientation. The stored geometry is
+ * always listed so the marked row stays visible after a window shrinks.
+ */
+fun offeredGeometries(width: Dp, height: Dp, stored: WorkspacePanelMode): List<WorkspacePanelMode> {
+    val long = maxOf(width, height)
+    val short = minOf(width, height)
+    val budget: List<WorkspacePanelMode> = when {
+        long < 840.dp -> listOf(WorkspacePanelMode.SINGLE_RAIL)
+        short < 480.dp -> listOf(
+            WorkspacePanelMode.SINGLE_RAIL,
+            if (width > height) WorkspacePanelMode.DUAL_VERTICAL else WorkspacePanelMode.DUAL_HORIZONTAL,
+        )
+        short < 840.dp -> listOf(
+            WorkspacePanelMode.SINGLE_RAIL,
+            WorkspacePanelMode.DUAL_VERTICAL,
+            WorkspacePanelMode.DUAL_HORIZONTAL,
+            WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT,
+            WorkspacePanelMode.TRIPLE_SIDEBAR_RIGHT,
+        )
+        else -> ADAPTIVE_GEOMETRIES
+    }
+    return ADAPTIVE_GEOMETRIES.filter { it in budget || it == stored }
+}
 
 /** The Settings item's value: the surface, with the pinned geometry named where there is one. */
 @Composable

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.workspace.ui.layout
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AutoAwesome
+import androidx.compose.material.icons.twotone.AutoAwesomeMosaic
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -12,6 +13,9 @@ import androidx.compose.ui.unit.dp
 object WorkspacePanelIcons {
     val Auto: ImageVector
         get() = Icons.TwoTone.AutoAwesome
+
+    val Adaptive: ImageVector
+        get() = Icons.TwoTone.AutoAwesomeMosaic
 
     val Single: ImageVector
         get() = ImageVector.Builder(

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
@@ -58,6 +58,31 @@ object WorkspacePanelIcons {
             }
         }.build()
 
+    val SingleRailStart: ImageVector
+        get() = ImageVector.Builder(
+            name = "LayoutSingleRailStart",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            autoMirror = true
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 4f)
+                lineTo(7f, 4f)
+                lineTo(7f, 20f)
+                lineTo(4f, 20f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(9f, 4f)
+                lineTo(20f, 4f)
+                lineTo(20f, 20f)
+                lineTo(9f, 20f)
+                close()
+            }
+        }.build()
+
     val DualVertical: ImageVector
         get() = ImageVector.Builder(
             name = "LayoutDualVertical",

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelModeExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelModeExtensions.kt
@@ -11,7 +11,8 @@ import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 fun WorkspacePanelMode.label(): String {
     return when (this) {
         WorkspacePanelMode.AUTO -> stringResource(R.string.workspace_settings_layout_mode_auto)
-        WorkspacePanelMode.SINGLE -> stringResource(R.string.workspace_settings_layout_mode_single)
+        WorkspacePanelMode.ADAPTIVE -> stringResource(R.string.workspace_settings_layout_mode_adaptive)
+        WorkspacePanelMode.SINGLE -> stringResource(R.string.workspace_settings_layout_mode_classic)
         WorkspacePanelMode.SINGLE_RAIL -> stringResource(R.string.workspace_settings_layout_mode_single_rail)
         WorkspacePanelMode.DUAL_VERTICAL -> stringResource(R.string.workspace_settings_layout_mode_dual_vertical)
         WorkspacePanelMode.DUAL_HORIZONTAL -> stringResource(R.string.workspace_settings_layout_mode_dual_horizontal)
@@ -25,7 +26,8 @@ fun WorkspacePanelMode.label(): String {
 fun WorkspacePanelMode.description(): String {
     return when (this) {
         WorkspacePanelMode.AUTO -> stringResource(R.string.workspace_settings_layout_mode_auto_desc)
-        WorkspacePanelMode.SINGLE -> stringResource(R.string.workspace_settings_layout_mode_single_desc)
+        WorkspacePanelMode.ADAPTIVE -> stringResource(R.string.workspace_settings_layout_mode_adaptive_desc)
+        WorkspacePanelMode.SINGLE -> stringResource(R.string.workspace_settings_layout_mode_classic_desc)
         WorkspacePanelMode.SINGLE_RAIL -> stringResource(R.string.workspace_settings_layout_mode_single_rail_desc)
         WorkspacePanelMode.DUAL_VERTICAL -> stringResource(R.string.workspace_settings_layout_mode_dual_vertical_desc)
         WorkspacePanelMode.DUAL_HORIZONTAL -> stringResource(R.string.workspace_settings_layout_mode_dual_horizontal_desc)
@@ -37,6 +39,7 @@ fun WorkspacePanelMode.description(): String {
 
 fun WorkspacePanelMode.icon(): ImageVector = when (this) {
     WorkspacePanelMode.AUTO -> WorkspacePanelIcons.Auto
+    WorkspacePanelMode.ADAPTIVE -> WorkspacePanelIcons.Adaptive
     WorkspacePanelMode.SINGLE -> WorkspacePanelIcons.Single
     WorkspacePanelMode.SINGLE_RAIL -> WorkspacePanelIcons.SingleRail
     WorkspacePanelMode.DUAL_VERTICAL -> WorkspacePanelIcons.DualVertical

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelModeExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelModeExtensions.kt
@@ -37,11 +37,12 @@ fun WorkspacePanelMode.description(): String {
     }
 }
 
-fun WorkspacePanelMode.icon(): ImageVector = when (this) {
+/** [landscape] picks the rail edge for the single-with-rail icon: bottom in portrait, start in landscape. */
+fun WorkspacePanelMode.icon(landscape: Boolean = false): ImageVector = when (this) {
     WorkspacePanelMode.AUTO -> WorkspacePanelIcons.Auto
     WorkspacePanelMode.ADAPTIVE -> WorkspacePanelIcons.Adaptive
     WorkspacePanelMode.SINGLE -> WorkspacePanelIcons.Single
-    WorkspacePanelMode.SINGLE_RAIL -> WorkspacePanelIcons.SingleRail
+    WorkspacePanelMode.SINGLE_RAIL -> if (landscape) WorkspacePanelIcons.SingleRailStart else WorkspacePanelIcons.SingleRail
     WorkspacePanelMode.DUAL_VERTICAL -> WorkspacePanelIcons.DualVertical
     WorkspacePanelMode.DUAL_HORIZONTAL -> WorkspacePanelIcons.DualHorizontal
     WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT -> WorkspacePanelIcons.TripleSidebarLeft

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/FakeWorkspaceButtonProvider.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/FakeWorkspaceButtonProvider.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.workspace.ui.manager
 
 import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -15,4 +16,5 @@ class FakeWorkspaceButtonProvider(
     override fun navToUpgradeButler() {}
     override fun createWorkspace(item: QuickCreateItem) {}
     override fun createTemplatesWorkspace() {}
+    override fun setPanelMode(landscape: Boolean, mode: WorkspacePanelMode) {}
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.workspace.ui.manager
 
 import android.annotation.SuppressLint
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -31,6 +32,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -48,6 +50,7 @@ import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults.sizeCompact
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults.sizeDefault
 
@@ -59,14 +62,19 @@ fun WorkspaceButton(
     containerColor: Color? = null,
     buttonSize: Dp = sizeDefault,
     currentWorkspaceId: Workspace.Id? = null,
+    showLayoutEntry: Boolean = false,
     mascotVariant: ButlerMascotMode = ButlerMascotMode.Animated.RandomCycling(),
 ) {
     val provider = LocalWorkspaceButtonProvider.current
     val revealOrigin = LocalWorkspaceRevealOrigin.current
     val state = provider?.state?.collectAsState(initial = null)?.value
 
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val currentPanelMode = if (isLandscape) state?.landscapePanelMode else state?.portraitPanelMode
+
     var expanded by remember { mutableStateOf(false) }
     var showCloseAllDialog by remember { mutableStateOf(false) }
+    var showLayoutDialog by remember { mutableStateOf(false) }
     // The button, not the surrounding box: the badges overflow that box, so its centre is offset
     // from the mascot the manager should appear to grow out of.
     var buttonBounds by remember { mutableStateOf(Rect.Zero) }
@@ -110,8 +118,10 @@ fun WorkspaceButton(
             state = state,
             currentWorkspaceId = currentWorkspaceId,
             provider = provider,
+            layoutEntryMode = if (showLayoutEntry) currentPanelMode ?: WorkspacePanelMode.AUTO else null,
             onCloseAllRequested = { showCloseAllDialog = true },
             onOpenManager = openManager,
+            onLayoutRequested = { showLayoutDialog = true },
         )
 
         // Close all confirmation dialog
@@ -123,6 +133,16 @@ fun WorkspaceButton(
             onConfirm = {
                 showCloseAllDialog = false
                 provider?.executeWorkspaceAction(WorkspaceAction.CloseAll)
+            }
+        )
+
+        WorkspaceLayoutDialog(
+            visible = showLayoutDialog,
+            currentMode = currentPanelMode ?: WorkspacePanelMode.AUTO,
+            onDismiss = { showLayoutDialog = false },
+            onSelect = { mode ->
+                showLayoutDialog = false
+                provider?.setPanelMode(isLandscape, mode)
             }
         )
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
@@ -51,6 +51,7 @@ import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.layout.offeredGeometries
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults.sizeCompact
 import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults.sizeDefault
 
@@ -71,6 +72,7 @@ fun WorkspaceButton(
 
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     val currentPanelMode = if (isLandscape) state?.landscapePanelMode else state?.portraitPanelMode
+    val windowSizeInfo = rememberWindowSizeInfo()
 
     var expanded by remember { mutableStateOf(false) }
     var showCloseAllDialog by remember { mutableStateOf(false) }
@@ -140,6 +142,11 @@ fun WorkspaceButton(
         WorkspaceLayoutDialog(
             visible = showLayoutDialog,
             currentMode = currentPanelMode ?: WorkspacePanelMode.AUTO,
+            geometries = offeredGeometries(
+                width = windowSizeInfo.widthDp,
+                height = windowSizeInfo.heightDp,
+                stored = currentPanelMode ?: WorkspacePanelMode.AUTO,
+            ),
             isLandscape = isLandscape,
             onDismiss = { showLayoutDialog = false },
             onSelect = { mode ->

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButton.kt
@@ -119,6 +119,7 @@ fun WorkspaceButton(
             currentWorkspaceId = currentWorkspaceId,
             provider = provider,
             layoutEntryMode = if (showLayoutEntry) currentPanelMode ?: WorkspacePanelMode.AUTO else null,
+            isLandscape = isLandscape,
             onCloseAllRequested = { showCloseAllDialog = true },
             onOpenManager = openManager,
             onLayoutRequested = { showLayoutDialog = true },
@@ -139,6 +140,7 @@ fun WorkspaceButton(
         WorkspaceLayoutDialog(
             visible = showLayoutDialog,
             currentMode = currentPanelMode ?: WorkspacePanelMode.AUTO,
+            isLandscape = isLandscape,
             onDismiss = { showLayoutDialog = false },
             onSelect = { mode ->
                 showLayoutDialog = false

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.ui.manager
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Add
@@ -33,6 +34,7 @@ import eu.darken.butler.workspace.core.defaultArguments
 import eu.darken.butler.workspace.core.icon
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.layout.icon
+import eu.darken.butler.workspace.ui.layout.label
 import eu.darken.butler.workspace.ui.modal.DismissWhenPaneUnfocused
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
 
@@ -117,7 +119,12 @@ fun WorkspaceButtonMenu(
         )
         if (layoutEntryMode != null) {
             DropdownMenuItem(
-                text = { Text(stringResource(R.string.workspace_button_menu_layout_action)) },
+                text = {
+                    MenuItemText(
+                        title = stringResource(R.string.workspace_button_menu_layout_action),
+                        subtitle = layoutEntryMode.label(),
+                    )
+                },
                 onClick = {
                     onDismissRequest()
                     onLayoutRequested()
@@ -203,6 +210,22 @@ fun MenuCategoryHeader(
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.primary,
     )
+}
+
+@Composable
+private fun MenuItemText(
+    modifier: Modifier = Modifier,
+    title: String,
+    subtitle: String,
+) {
+    Column(modifier = modifier) {
+        Text(text = title)
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 @Preview2

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
@@ -45,6 +45,7 @@ fun WorkspaceButtonMenu(
     currentWorkspaceId: Workspace.Id? = null,
     provider: WorkspaceButtonProvider?,
     layoutEntryMode: WorkspacePanelMode? = null,
+    isLandscape: Boolean = false,
     onCloseAllRequested: () -> Unit,
     onOpenManager: () -> Unit,
     onLayoutRequested: () -> Unit = {},
@@ -123,7 +124,7 @@ fun WorkspaceButtonMenu(
                 },
                 leadingIcon = {
                     Icon(
-                        imageVector = layoutEntryMode.icon(),
+                        imageVector = layoutEntryMode.icon(landscape = isLandscape),
                         contentDescription = null,
                     )
                 },

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonMenu.kt
@@ -31,6 +31,8 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.defaultArguments
 import eu.darken.butler.workspace.core.icon
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.layout.icon
 import eu.darken.butler.workspace.ui.modal.DismissWhenPaneUnfocused
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
 
@@ -42,8 +44,10 @@ fun WorkspaceButtonMenu(
     state: WorkspaceButtonViewModel.State?,
     currentWorkspaceId: Workspace.Id? = null,
     provider: WorkspaceButtonProvider?,
+    layoutEntryMode: WorkspacePanelMode? = null,
     onCloseAllRequested: () -> Unit,
     onOpenManager: () -> Unit,
+    onLayoutRequested: () -> Unit = {},
 ) {
     DismissWhenPaneUnfocused(expanded = expanded, onDismiss = onDismissRequest)
     DropdownMenu(
@@ -110,6 +114,21 @@ fun WorkspaceButtonMenu(
                 )
             },
         )
+        if (layoutEntryMode != null) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.workspace_button_menu_layout_action)) },
+                onClick = {
+                    onDismissRequest()
+                    onLayoutRequested()
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = layoutEntryMode.icon(),
+                        contentDescription = null,
+                    )
+                },
+            )
+        }
         DropdownMenuItem(
             text = { Text(stringResource(R.string.workspace_button_menu_settings_action)) },
             onClick = {
@@ -254,5 +273,22 @@ private fun WorkspaceButtonMenuNoRecentsPreview() {
         provider = FakeWorkspaceButtonProvider(),
         onCloseAllRequested = {},
         onOpenManager = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceButtonMenuWithLayoutPreview() {
+    WorkspaceButtonMenu(
+        expanded = true,
+        onDismissRequest = {},
+        state = WorkspaceButtonViewModel.State(workspaceCount = 2),
+        currentWorkspaceId = Workspace.Id(),
+        provider = FakeWorkspaceButtonProvider(),
+        layoutEntryMode = WorkspacePanelMode.DUAL_VERTICAL,
+        onCloseAllRequested = {},
+        onOpenManager = {},
+        onLayoutRequested = {},
     )
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonProvider.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonProvider.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.workspace.ui.manager
 
 import androidx.compose.runtime.staticCompositionLocalOf
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
 import kotlinx.coroutines.flow.Flow
 
@@ -12,6 +13,9 @@ interface WorkspaceButtonProvider : WorkspaceActionHandler {
 
     /** Opens the Templates picker as a new workspace and switches to it. */
     fun createTemplatesWorkspace()
+
+    /** Persists [mode] as the layout for the given orientation; a fake or absent provider no-ops. */
+    fun setPanelMode(landscape: Boolean, mode: WorkspacePanelMode)
 }
 
 val LocalWorkspaceButtonProvider = staticCompositionLocalOf<WorkspaceButtonProvider?> { null }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModel.kt
@@ -2,6 +2,7 @@ package eu.darken.butler.workspace.ui.manager
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.navigation.Nav
@@ -11,9 +12,11 @@ import eu.darken.butler.common.ui.ViewModel4
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.WorkspaceStacks
 import eu.darken.butler.workspace.contracts.templates.TemplatesArguments
 import eu.darken.butler.workspace.core.createAndFocus
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.core.usage.WorkspaceUsageRepo
 import eu.darken.butler.workspace.ui.WorkspacePageManager
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
@@ -30,6 +33,7 @@ class WorkspaceButtonViewModel @Inject constructor(
     dispatchers: DispatcherProvider,
     private val workspaceRemote: WorkspaceRemote,
     private val workspacePageManager: WorkspacePageManager,
+    private val workspaceSettings: WorkspaceSettings,
     workspaceTemplates: Set<@JvmSuppressWildcards WorkspaceTemplate>,
     usageRepo: WorkspaceUsageRepo,
 ) : ViewModel4(dispatchers, logTag("Workspace", "Button", "VM")), WorkspaceButtonProvider {
@@ -65,6 +69,8 @@ class WorkspaceButtonViewModel @Inject constructor(
             attentionCount = remoteState.attentionCount,
             hasUnsavedChanges = remoteState.infos.any { info -> info.hasUnsavedChanges },
             recentItems = recent,
+            portraitPanelMode = remoteState.portraitPanelMode,
+            landscapePanelMode = remoteState.landscapePanelMode,
             unitsByMember = remoteState.infos.associate { info ->
                 // Only resolvable units get unit semantics. A recovery unit is keyed on its first
                 // member in list order, which is not necessarily one the others hang off, so
@@ -113,6 +119,15 @@ class WorkspaceButtonViewModel @Inject constructor(
         }
     }
 
+    override fun setPanelMode(landscape: Boolean, mode: WorkspacePanelMode) = launch {
+        log(tag) { "setPanelMode(landscape=$landscape, $mode)" }
+        if (landscape) {
+            workspaceSettings.layoutModeLandscape.value(mode)
+        } else {
+            workspaceSettings.layoutModePortrait.value(mode)
+        }
+    }
+
     override fun navToWorkspaceManager() {
         log(tag) { "showWorkspaceManager()" }
         workspacePageManager.showManagerOverlay()
@@ -134,6 +149,8 @@ class WorkspaceButtonViewModel @Inject constructor(
         val attentionCount: Int = 0,
         val hasUnsavedChanges: Boolean = false,
         val recentItems: List<QuickCreateItem> = emptyList(),
+        val portraitPanelMode: WorkspacePanelMode = WorkspacePanelMode.AUTO,
+        val landscapePanelMode: WorkspacePanelMode = WorkspacePanelMode.AUTO,
         /**
          * The ownership unit each open workspace belongs to, keyed by member. The menu's close acts
          * on whole units: a tab and the overlays stacked on it are one thing to the user, so it has

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceLayoutDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceLayoutDialog.kt
@@ -1,0 +1,53 @@
+package eu.darken.butler.workspace.ui.manager
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import eu.darken.butler.common.compose.ButlerPreviewWrapper
+import eu.darken.butler.common.compose.Preview2
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.layout.ADAPTIVE_GEOMETRIES
+import eu.darken.butler.workspace.ui.layout.LayoutPickerDialog
+import eu.darken.butler.workspace.ui.layout.LayoutPickerOption
+import eu.darken.butler.workspace.ui.layout.description
+import eu.darken.butler.workspace.ui.layout.icon
+import eu.darken.butler.workspace.ui.layout.label
+
+@Composable
+fun WorkspaceLayoutDialog(
+    modifier: Modifier = Modifier,
+    visible: Boolean,
+    currentMode: WorkspacePanelMode,
+    onDismiss: () -> Unit,
+    onSelect: (WorkspacePanelMode) -> Unit,
+) {
+    if (!visible) return
+    LayoutPickerDialog(
+        modifier = modifier,
+        title = stringResource(R.string.workspace_settings_layout_title),
+        options = (listOf(WorkspacePanelMode.AUTO) + ADAPTIVE_GEOMETRIES).map { mode ->
+            LayoutPickerOption(
+                icon = mode.icon(),
+                label = mode.label(),
+                description = mode.description(),
+                selected = mode == currentMode,
+                onSelect = { onSelect(mode) },
+            )
+        },
+        onDismiss = onDismiss,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceLayoutDialogPreview() {
+    WorkspaceLayoutDialog(
+        visible = true,
+        currentMode = WorkspacePanelMode.DUAL_HORIZONTAL,
+        onDismiss = {},
+        onSelect = {},
+    )
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceLayoutDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceLayoutDialog.kt
@@ -20,6 +20,7 @@ fun WorkspaceLayoutDialog(
     modifier: Modifier = Modifier,
     visible: Boolean,
     currentMode: WorkspacePanelMode,
+    isLandscape: Boolean = false,
     onDismiss: () -> Unit,
     onSelect: (WorkspacePanelMode) -> Unit,
 ) {
@@ -29,7 +30,7 @@ fun WorkspaceLayoutDialog(
         title = stringResource(R.string.workspace_settings_layout_title),
         options = (listOf(WorkspacePanelMode.AUTO) + ADAPTIVE_GEOMETRIES).map { mode ->
             LayoutPickerOption(
-                icon = mode.icon(),
+                icon = mode.icon(landscape = isLandscape),
                 label = mode.label(),
                 description = mode.description(),
                 selected = mode == currentMode,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceLayoutDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceLayoutDialog.kt
@@ -20,6 +20,7 @@ fun WorkspaceLayoutDialog(
     modifier: Modifier = Modifier,
     visible: Boolean,
     currentMode: WorkspacePanelMode,
+    geometries: List<WorkspacePanelMode>,
     isLandscape: Boolean = false,
     onDismiss: () -> Unit,
     onSelect: (WorkspacePanelMode) -> Unit,
@@ -28,7 +29,7 @@ fun WorkspaceLayoutDialog(
     LayoutPickerDialog(
         modifier = modifier,
         title = stringResource(R.string.workspace_settings_layout_title),
-        options = (listOf(WorkspacePanelMode.AUTO) + ADAPTIVE_GEOMETRIES).map { mode ->
+        options = (listOf(WorkspacePanelMode.AUTO) + geometries).map { mode ->
             LayoutPickerOption(
                 icon = mode.icon(landscape = isLandscape),
                 label = mode.label(),
@@ -48,6 +49,7 @@ private fun WorkspaceLayoutDialogPreview() {
     WorkspaceLayoutDialog(
         visible = true,
         currentMode = WorkspacePanelMode.DUAL_HORIZONTAL,
+        geometries = ADAPTIVE_GEOMETRIES,
         onDismiss = {},
         onSelect = {},
     )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -1,14 +1,9 @@
 package eu.darken.butler.workspace.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.twotone.AdsClick
@@ -22,10 +17,8 @@ import androidx.compose.material.icons.twotone.SwipeLeft
 import androidx.compose.material.icons.twotone.SettingsBackupRestore
 import androidx.compose.material.icons.twotone.Timer
 import androidx.compose.material.icons.twotone.Visibility
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -34,12 +27,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -54,9 +45,15 @@ import eu.darken.butler.common.ui.MinutesDurationInputDialog
 import androidx.compose.runtime.collectAsState
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import eu.darken.butler.workspace.ui.layout.LayoutPickerDialog
+import eu.darken.butler.workspace.ui.layout.LayoutPickerOption
+import eu.darken.butler.workspace.ui.layout.WorkspaceLayoutSurface
 import eu.darken.butler.workspace.ui.layout.description
 import eu.darken.butler.workspace.ui.layout.icon
 import eu.darken.butler.workspace.ui.layout.label
+import eu.darken.butler.workspace.ui.layout.surface
+import eu.darken.butler.workspace.ui.layout.surfaceValueLabel
+import eu.darken.butler.workspace.ui.layout.toPanelMode
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import kotlin.time.Duration
 import eu.darken.butler.common.R as CommonR
@@ -136,7 +133,7 @@ fun WorkspaceSettingsScreen(
                     icon = Icons.TwoTone.StayPrimaryPortrait,
                     title = stringResource(R.string.workspace_settings_layout_mode_portrait_title),
                     subtitle = stringResource(R.string.workspace_settings_layout_mode_portrait_desc),
-                    value = state.layoutModePortrait.label(),
+                    value = state.layoutModePortrait.surfaceValueLabel(),
                     onClick = { showPortraitDialog = true }
                 )
             }
@@ -146,7 +143,7 @@ fun WorkspaceSettingsScreen(
                     icon = Icons.TwoTone.StayPrimaryLandscape,
                     title = stringResource(R.string.workspace_settings_layout_mode_landscape_title),
                     subtitle = stringResource(R.string.workspace_settings_layout_mode_landscape_desc),
-                    value = state.layoutModeLandscape.label(),
+                    value = state.layoutModeLandscape.surfaceValueLabel(),
                     onClick = { showLandscapeDialog = true }
                 )
             }
@@ -240,43 +237,40 @@ fun WorkspaceSettingsScreen(
     }
 
     if (showPortraitDialog) {
-        LayoutModeDialog(
+        LayoutPickerDialog(
             title = stringResource(R.string.workspace_settings_layout_mode_portrait_title),
-            currentMode = state.layoutModePortrait,
-            availableModes = listOf(
-                WorkspacePanelMode.AUTO,
-                WorkspacePanelMode.SINGLE,
-                WorkspacePanelMode.SINGLE_RAIL,
-                WorkspacePanelMode.DUAL_VERTICAL,
-                WorkspacePanelMode.DUAL_HORIZONTAL,
-            ),
+            options = WorkspaceLayoutSurface.entries.map { surface ->
+                LayoutPickerOption(
+                    icon = surface.icon(),
+                    label = surface.label(),
+                    description = surface.description(),
+                    selected = state.layoutModePortrait.surface == surface,
+                    onSelect = {
+                        onSetLayoutModePortrait(surface.toPanelMode())
+                        showPortraitDialog = false
+                    },
+                )
+            },
             onDismiss = { showPortraitDialog = false },
-            onConfirm = { mode ->
-                onSetLayoutModePortrait(mode)
-                showPortraitDialog = false
-            }
         )
     }
 
     if (showLandscapeDialog) {
-        LayoutModeDialog(
+        LayoutPickerDialog(
             title = stringResource(R.string.workspace_settings_layout_mode_landscape_title),
-            currentMode = state.layoutModeLandscape,
-            availableModes = listOf(
-                WorkspacePanelMode.AUTO,
-                WorkspacePanelMode.SINGLE,
-                WorkspacePanelMode.SINGLE_RAIL,
-                WorkspacePanelMode.DUAL_VERTICAL,
-                WorkspacePanelMode.DUAL_HORIZONTAL,
-                WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT,
-                WorkspacePanelMode.TRIPLE_SIDEBAR_RIGHT,
-                WorkspacePanelMode.QUAD_GRID,
-            ),
+            options = WorkspaceLayoutSurface.entries.map { surface ->
+                LayoutPickerOption(
+                    icon = surface.icon(),
+                    label = surface.label(),
+                    description = surface.description(),
+                    selected = state.layoutModeLandscape.surface == surface,
+                    onSelect = {
+                        onSetLayoutModeLandscape(surface.toPanelMode())
+                        showLandscapeDialog = false
+                    },
+                )
+            },
             onDismiss = { showLandscapeDialog = false },
-            onConfirm = { mode ->
-                onSetLayoutModeLandscape(mode)
-                showLandscapeDialog = false
-            }
         )
     }
 
@@ -310,60 +304,6 @@ private fun Duration.formatCoarse(): String {
     }
 }
 
-@Composable
-private fun LayoutModeDialog(
-    title: String,
-    currentMode: WorkspacePanelMode,
-    availableModes: List<WorkspacePanelMode>,
-    onDismiss: () -> Unit,
-    onConfirm: (WorkspacePanelMode) -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(title) },
-        text = {
-            Column {
-                availableModes.forEach { mode ->
-                    val isSelected = mode == currentMode
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = isSelected,
-                                onClick = { onConfirm(mode) }
-                            )
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = mode.icon(),
-                            contentDescription = null,
-                            tint = if (isSelected) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                            },
-                            modifier = Modifier.size(32.dp),
-                        )
-                        Column(modifier = Modifier.padding(start = 16.dp)) {
-                            Text(
-                                text = mode.label(),
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Text(
-                                text = mode.description(),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {}
-    )
-}
-
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
@@ -375,6 +315,37 @@ private fun WorkspaceSettingsScreenPreview() {
             livePreview = true,
             layoutModePortrait = WorkspacePanelMode.AUTO,
             layoutModeLandscape = WorkspacePanelMode.AUTO,
+            paneClickToFocus = true,
+            sessionRestoreEnabled = true,
+            undoCloseEnabled = true,
+            sessionWorkspaceCount = 3,
+            sessionDatabaseSizeBytes = 131072,
+        ),
+        onNavigateUp = {},
+        onToggleSwipeGestures = {},
+        onToggleOnDemandWorkspaceCreation = {},
+        onToggleLivePreview = {},
+        onSetLayoutModePortrait = {},
+        onSetLayoutModeLandscape = {},
+        onTogglePaneClickToFocus = {},
+        onToggleSessionRestore = {},
+        onToggleAutoPause = {},
+        onSetAutoPauseIdleTimeout = {},
+        onToggleUndoClose = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceSettingsScreenPinnedLayoutPreview() {
+    WorkspaceSettingsScreen(
+        state = WorkspaceSettingsViewModel.State(
+            swipeGesturesEnabled = true,
+            onDemandWorkspaceCreation = true,
+            livePreview = true,
+            layoutModePortrait = WorkspacePanelMode.DUAL_VERTICAL,
+            layoutModeLandscape = WorkspacePanelMode.ADAPTIVE,
             paneClickToFocus = true,
             sessionRestoreEnabled = true,
             undoCloseEnabled = true,

--- a/app-workspace/src/main/res/values-de/strings.xml
+++ b/app-workspace/src/main/res/values-de/strings.xml
@@ -350,8 +350,6 @@
     <string name="workspace_settings_layout_mode_landscape_desc">Wähle die Tab-Anordnung im Querformat.</string>
     <string name="workspace_settings_layout_mode_auto">Automatisch</string>
     <string name="workspace_settings_layout_mode_auto_desc">Anordnung automatisch an die Bildschirmgröße anpassen.</string>
-    <string name="workspace_settings_layout_mode_single">Ein Bereich</string>
-    <string name="workspace_settings_layout_mode_single_desc">Ein Tab-Bereich füllt den gesamten Bildschirm.</string>
     <string name="workspace_settings_layout_mode_dual_vertical">Zwei nebeneinander</string>
     <string name="workspace_settings_layout_mode_dual_vertical_desc">Zwei Bereiche nebeneinander (links/rechts).</string>
     <string name="workspace_settings_layout_mode_dual_horizontal">Zwei übereinander</string>

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="workspace_button_menu_category_other">Other</string>
     <string name="workspace_button_menu_category_current_tab">This tab</string>
     <string name="workspace_button_menu_manager_action">Tab manager</string>
+    <string name="workspace_button_menu_layout_action">Layout</string>
     <string name="workspace_button_menu_close_current_action">Close current tab</string>
     <plurals name="workspace_button_menu_close_current_stack_action">
         <item quantity="one">Close current tab (%d workspace)</item>

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -349,10 +349,13 @@
     <string name="workspace_settings_layout_mode_portrait_desc">Choose tab layout in portrait orientation.</string>
     <string name="workspace_settings_layout_mode_landscape_title">Landscape layout mode</string>
     <string name="workspace_settings_layout_mode_landscape_desc">Choose tab layout in landscape orientation.</string>
-    <string name="workspace_settings_layout_mode_auto">Auto</string>
-    <string name="workspace_settings_layout_mode_auto_desc">Automatically adapt layout based on screen size.</string>
-    <string name="workspace_settings_layout_mode_single">Single</string>
-    <string name="workspace_settings_layout_mode_single_desc">One tab pane takes the full screen.</string>
+    <string name="workspace_settings_layout_mode_auto">Automatic</string>
+    <string name="workspace_settings_layout_mode_auto_desc">Classic on small screens, tab rail with panes on large ones.</string>
+    <string name="workspace_settings_layout_mode_classic">Classic</string>
+    <string name="workspace_settings_layout_mode_classic_desc">One pane at a time, without the tab rail.</string>
+    <string name="workspace_settings_layout_mode_adaptive">Adaptive</string>
+    <string name="workspace_settings_layout_mode_adaptive_desc">Tab rail plus as many panes as the screen fits. Pin a layout from the Butler menu in the rail.</string>
+    <string name="workspace_settings_layout_mode_adaptive_pinned_format">Adaptive (%1$s)</string>
     <string name="workspace_settings_layout_mode_single_rail">Single with tab rail</string>
     <string name="workspace_settings_layout_mode_single_rail_desc">One tab pane plus the tab rail of the multi-pane layouts. Switch tabs from the rail instead of by swiping; the rail takes a strip of the screen.</string>
     <string name="workspace_settings_layout_mode_dual_vertical">Dual vertical</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurfaceTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurfaceTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.butler.workspace.ui.layout
+
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import testhelpers.BaseTest
+
+/**
+ * The three surfaces Settings offers, mapped onto the stored panel mode. Everything that is not
+ * AUTO or SINGLE is an adaptive surface, so a geometry pinned from the rail still reads as Adaptive.
+ */
+class WorkspaceLayoutSurfaceTest : BaseTest() {
+
+    @Test
+    fun `every panel mode maps to a surface`() {
+        WorkspacePanelMode.AUTO.surface shouldBe WorkspaceLayoutSurface.AUTOMATIC
+        WorkspacePanelMode.SINGLE.surface shouldBe WorkspaceLayoutSurface.CLASSIC
+        WorkspacePanelMode.entries
+            .filter { it != WorkspacePanelMode.AUTO && it != WorkspacePanelMode.SINGLE }
+            .forEach { it.surface shouldBe WorkspaceLayoutSurface.ADAPTIVE }
+    }
+
+    @Test
+    fun `each surface round-trips through its panel mode`() {
+        WorkspaceLayoutSurface.entries.forEach { surface ->
+            surface.toPanelMode().surface shouldBe surface
+        }
+    }
+
+    @Test
+    fun `the pinnable geometries are every mode but the three surfaces`() {
+        ADAPTIVE_GEOMETRIES shouldBe WorkspacePanelMode.entries.filter {
+            it != WorkspacePanelMode.AUTO &&
+                it != WorkspacePanelMode.SINGLE &&
+                it != WorkspacePanelMode.ADAPTIVE
+        }
+        WorkspacePanelMode.ADAPTIVE.isPinnedGeometry shouldBe false
+        WorkspacePanelMode.DUAL_VERTICAL.isPinnedGeometry shouldBe true
+    }
+
+    /** The setting is stored as JSON, so the added value needs a stable serial name. */
+    @Test
+    fun `the adaptive mode survives serialization`() {
+        val encoded = Json.encodeToString(WorkspacePanelMode.serializer(), WorkspacePanelMode.ADAPTIVE)
+        encoded shouldBe "\"ADAPTIVE\""
+        Json.decodeFromString(WorkspacePanelMode.serializer(), encoded) shouldBe WorkspacePanelMode.ADAPTIVE
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurfaceTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurfaceTest.kt
@@ -46,4 +46,13 @@ class WorkspaceLayoutSurfaceTest : BaseTest() {
         encoded shouldBe "\"ADAPTIVE\""
         Json.decodeFromString(WorkspacePanelMode.serializer(), encoded) shouldBe WorkspacePanelMode.ADAPTIVE
     }
+
+    /** The icon getters build a fresh instance per call, so compare by name. */
+    @Test
+    fun `the rail icon follows the orientation`() {
+        WorkspacePanelMode.SINGLE_RAIL.icon(landscape = false).name shouldBe "LayoutSingleRail"
+        WorkspacePanelMode.SINGLE_RAIL.icon(landscape = true).name shouldBe "LayoutSingleRailStart"
+        WorkspacePanelMode.DUAL_VERTICAL.icon(landscape = true).name shouldBe
+            WorkspacePanelMode.DUAL_VERTICAL.icon().name
+    }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurfaceTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/layout/WorkspaceLayoutSurfaceTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.ui.layout
 
+import androidx.compose.ui.unit.dp
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
@@ -45,6 +46,44 @@ class WorkspaceLayoutSurfaceTest : BaseTest() {
         val encoded = Json.encodeToString(WorkspacePanelMode.serializer(), WorkspacePanelMode.ADAPTIVE)
         encoded shouldBe "\"ADAPTIVE\""
         Json.decodeFromString(WorkspacePanelMode.serializer(), encoded) shouldBe WorkspacePanelMode.ADAPTIVE
+    }
+
+    @Test
+    fun `a small window offers only the single rail geometry`() {
+        offeredGeometries(360.dp, 780.dp, WorkspacePanelMode.AUTO) shouldBe listOf(WorkspacePanelMode.SINGLE_RAIL)
+    }
+
+    @Test
+    fun `a phone offers the dual that splits its long side`() {
+        offeredGeometries(915.dp, 412.dp, WorkspacePanelMode.AUTO) shouldBe listOf(
+            WorkspacePanelMode.SINGLE_RAIL,
+            WorkspacePanelMode.DUAL_VERTICAL,
+        )
+        offeredGeometries(412.dp, 915.dp, WorkspacePanelMode.AUTO) shouldBe listOf(
+            WorkspacePanelMode.SINGLE_RAIL,
+            WorkspacePanelMode.DUAL_HORIZONTAL,
+        )
+    }
+
+    @Test
+    fun `a tablet offers both duals and the triples`() {
+        offeredGeometries(1280.dp, 800.dp, WorkspacePanelMode.AUTO) shouldBe listOf(
+            WorkspacePanelMode.SINGLE_RAIL,
+            WorkspacePanelMode.DUAL_VERTICAL,
+            WorkspacePanelMode.DUAL_HORIZONTAL,
+            WorkspacePanelMode.TRIPLE_SIDEBAR_LEFT,
+            WorkspacePanelMode.TRIPLE_SIDEBAR_RIGHT,
+        )
+        offeredGeometries(1200.dp, 900.dp, WorkspacePanelMode.AUTO) shouldBe ADAPTIVE_GEOMETRIES
+    }
+
+    @Test
+    fun `the stored geometry is always offered`() {
+        offeredGeometries(412.dp, 915.dp, WorkspacePanelMode.QUAD_GRID) shouldBe listOf(
+            WorkspacePanelMode.SINGLE_RAIL,
+            WorkspacePanelMode.DUAL_HORIZONTAL,
+            WorkspacePanelMode.QUAD_GRID,
+        )
     }
 
     /** The icon getters build a fresh instance per call, so compare by name. */

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.ButlerMascotMode
@@ -477,13 +478,13 @@ class WorkspaceButtonTest : ComposeTest() {
     fun `the layout entry opens a dialog listing Automatic and the six geometries`() {
         openLayoutDialog(RecordingButtonProvider(WorkspaceButtonViewModel.State()))
 
-        composeTestRule.onNodeWithText("Automatic").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Single with tab rail").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Dual vertical").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Dual horizontal").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Triple sidebar left").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Triple sidebar right").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Quad grid").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Automatic").assertExists()
+        composeTestRule.onNodeWithText("Single with tab rail").assertExists()
+        composeTestRule.onNodeWithText("Dual vertical").assertExists()
+        composeTestRule.onNodeWithText("Dual horizontal").assertExists()
+        composeTestRule.onNodeWithText("Triple sidebar left").assertExists()
+        composeTestRule.onNodeWithText("Triple sidebar right").assertExists()
+        composeTestRule.onNodeWithText("Quad grid").assertExists()
 
         // The surfaces Settings offers are not geometries, so they have no row here
         composeTestRule.onNodeWithText("Classic").assertDoesNotExist()
@@ -507,7 +508,7 @@ class WorkspaceButtonTest : ComposeTest() {
         val provider = RecordingButtonProvider(WorkspaceButtonViewModel.State())
         openLayoutDialog(provider)
 
-        composeTestRule.onNodeWithText("Dual horizontal").performClick()
+        composeTestRule.onNodeWithText("Dual horizontal").performScrollTo().performClick()
 
         provider.panelModes shouldBe listOf(true to WorkspacePanelMode.DUAL_HORIZONTAL)
     }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
@@ -475,6 +475,7 @@ class WorkspaceButtonTest : ComposeTest() {
     }
 
     @Test
+    @Config(qualifiers = "w1200dp-h900dp")
     fun `the layout entry opens a dialog listing Automatic and the six geometries`() {
         openLayoutDialog(RecordingButtonProvider(WorkspaceButtonViewModel.State()))
 
@@ -492,6 +493,7 @@ class WorkspaceButtonTest : ComposeTest() {
     }
 
     @Test
+    @Config(qualifiers = "w412dp-h915dp-port")
     fun `picking a geometry writes the portrait setting in portrait`() {
         val provider = RecordingButtonProvider(WorkspaceButtonViewModel.State())
         openLayoutDialog(provider)
@@ -503,14 +505,14 @@ class WorkspaceButtonTest : ComposeTest() {
     }
 
     @Test
-    @Config(qualifiers = "land")
+    @Config(qualifiers = "w915dp-h412dp-land")
     fun `picking a geometry writes the landscape setting in landscape`() {
         val provider = RecordingButtonProvider(WorkspaceButtonViewModel.State())
         openLayoutDialog(provider)
 
-        composeTestRule.onNodeWithText("Dual horizontal").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Dual vertical").performScrollTo().performClick()
 
-        provider.panelModes shouldBe listOf(true to WorkspacePanelMode.DUAL_HORIZONTAL)
+        provider.panelModes shouldBe listOf(true to WorkspacePanelMode.DUAL_VERTICAL)
     }
 
     /** The selectable row merges its descendants, so the label resolves to the row itself. */
@@ -524,5 +526,32 @@ class WorkspaceButtonTest : ComposeTest() {
 
         composeTestRule.onNodeWithText("Dual vertical").assertIsSelected()
         composeTestRule.onNodeWithText("Automatic").assertIsNotSelected()
+    }
+
+    @Test
+    @Config(qualifiers = "w412dp-h915dp-port")
+    fun `a phone in portrait is offered only the geometries it fits`() {
+        openLayoutDialog(RecordingButtonProvider(WorkspaceButtonViewModel.State()))
+
+        composeTestRule.onNodeWithText("Automatic").assertExists()
+        composeTestRule.onNodeWithText("Single with tab rail").assertExists()
+        composeTestRule.onNodeWithText("Dual horizontal").assertExists()
+
+        composeTestRule.onNodeWithText("Dual vertical").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Triple sidebar left").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Triple sidebar right").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Quad grid").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a stored geometry outside the window budget is still listed and marked`() {
+        openLayoutDialog(
+            RecordingButtonProvider(
+                WorkspaceButtonViewModel.State(portraitPanelMode = WorkspacePanelMode.QUAD_GRID)
+            )
+        )
+
+        composeTestRule.onNodeWithText("Quad grid").assertIsSelected()
+        composeTestRule.onNodeWithText("Triple sidebar left").assertDoesNotExist()
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -22,11 +24,13 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.defaultArguments
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.ComposeTest
 
 class WorkspaceButtonTest : ComposeTest() {
@@ -46,6 +50,7 @@ class WorkspaceButtonTest : ComposeTest() {
     ) : WorkspaceButtonProvider {
         val created = mutableListOf<QuickCreateItem>()
         val actions = mutableListOf<WorkspaceAction>()
+        val panelModes = mutableListOf<Pair<Boolean, WorkspacePanelMode>>()
         var templatesCreated = 0
         var managerNavigations = 0
         var settingsNavigations = 0
@@ -56,6 +61,9 @@ class WorkspaceButtonTest : ComposeTest() {
         override fun navToUpgradeButler() {}
         override fun createWorkspace(item: QuickCreateItem) { created += item }
         override fun createTemplatesWorkspace() { templatesCreated++ }
+        override fun setPanelMode(landscape: Boolean, mode: WorkspacePanelMode) {
+            panelModes += landscape to mode
+        }
     }
 
     private fun openMenu() =
@@ -235,6 +243,7 @@ class WorkspaceButtonTest : ComposeTest() {
     private fun setContent(
         provider: RecordingButtonProvider,
         currentWorkspaceId: Workspace.Id? = null,
+        showLayoutEntry: Boolean = false,
     ) {
         composeTestRule.setContent {
             PreviewWrapper {
@@ -242,6 +251,7 @@ class WorkspaceButtonTest : ComposeTest() {
                     WorkspaceButton(
                         mascotVariant = testMascotVariant,
                         currentWorkspaceId = currentWorkspaceId,
+                        showLayoutEntry = showLayoutEntry,
                     )
                 }
             }
@@ -445,5 +455,73 @@ class WorkspaceButtonTest : ComposeTest() {
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
 
         composeTestRule.onNodeWithContentDescription("Butler mascot").assertDoesNotExist()
+    }
+
+    private fun openLayoutDialog(provider: RecordingButtonProvider) {
+        setContent(provider, showLayoutEntry = true)
+        openMenu()
+        composeTestRule.onNodeWithText("Layout").performClick()
+    }
+
+    @Test
+    fun `the layout entry is absent unless the button sits in the rail`() {
+        val provider = RecordingButtonProvider(WorkspaceButtonViewModel.State())
+        setContent(provider)
+
+        openMenu()
+
+        composeTestRule.onNodeWithText("Layout").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the layout entry opens a dialog listing Automatic and the six geometries`() {
+        openLayoutDialog(RecordingButtonProvider(WorkspaceButtonViewModel.State()))
+
+        composeTestRule.onNodeWithText("Automatic").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Single with tab rail").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Dual vertical").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Dual horizontal").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Triple sidebar left").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Triple sidebar right").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Quad grid").assertIsDisplayed()
+
+        // The surfaces Settings offers are not geometries, so they have no row here
+        composeTestRule.onNodeWithText("Classic").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Adaptive").assertDoesNotExist()
+    }
+
+    @Test
+    fun `picking a geometry writes the portrait setting in portrait`() {
+        val provider = RecordingButtonProvider(WorkspaceButtonViewModel.State())
+        openLayoutDialog(provider)
+
+        composeTestRule.onNodeWithText("Dual horizontal").performClick()
+
+        provider.panelModes shouldBe listOf(false to WorkspacePanelMode.DUAL_HORIZONTAL)
+        composeTestRule.onNodeWithText("Dual horizontal").assertDoesNotExist()
+    }
+
+    @Test
+    @Config(qualifiers = "land")
+    fun `picking a geometry writes the landscape setting in landscape`() {
+        val provider = RecordingButtonProvider(WorkspaceButtonViewModel.State())
+        openLayoutDialog(provider)
+
+        composeTestRule.onNodeWithText("Dual horizontal").performClick()
+
+        provider.panelModes shouldBe listOf(true to WorkspacePanelMode.DUAL_HORIZONTAL)
+    }
+
+    /** The selectable row merges its descendants, so the label resolves to the row itself. */
+    @Test
+    fun `the stored geometry is marked`() {
+        openLayoutDialog(
+            RecordingButtonProvider(
+                WorkspaceButtonViewModel.State(portraitPanelMode = WorkspacePanelMode.DUAL_VERTICAL)
+            )
+        )
+
+        composeTestRule.onNodeWithText("Dual vertical").assertIsSelected()
+        composeTestRule.onNodeWithText("Automatic").assertIsNotSelected()
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonTest.kt
@@ -475,6 +475,21 @@ class WorkspaceButtonTest : ComposeTest() {
     }
 
     @Test
+    fun `the layout entry shows the stored mode as its subtitle`() {
+        setContent(
+            RecordingButtonProvider(
+                WorkspaceButtonViewModel.State(portraitPanelMode = WorkspacePanelMode.DUAL_HORIZONTAL)
+            ),
+            showLayoutEntry = true,
+        )
+
+        openMenu()
+
+        composeTestRule.onNodeWithText("Layout").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Dual horizontal").assertIsDisplayed()
+    }
+
+    @Test
     @Config(qualifiers = "w1200dp-h900dp")
     fun `the layout entry opens a dialog listing Automatic and the six geometries`() {
         openLayoutDialog(RecordingButtonProvider(WorkspaceButtonViewModel.State()))

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModelTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/manager/WorkspaceButtonViewModelTest.kt
@@ -5,11 +5,14 @@ import androidx.compose.material.icons.twotone.Add
 import androidx.compose.ui.graphics.vector.ImageVector
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.datastore.DataStoreValue
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceEvent
 import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.defaultArguments
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.core.usage.WorkspaceUsageRepo
 import eu.darken.butler.workspace.ui.WorkspacePageManager
 import eu.darken.butler.workspace.ui.template.QuickCreateItem
@@ -66,10 +69,12 @@ class WorkspaceButtonViewModelTest : BaseTest() {
         templates: Set<WorkspaceTemplate> = emptySet(),
         ranked: Flow<List<Workspace.Type>> = flowOf(emptyList()),
         dispatcher: CoroutineDispatcher? = null,
+        workspaceSettings: WorkspaceSettings = mockk(relaxed = true),
     ) = WorkspaceButtonViewModel(
         dispatchers = TestDispatcherProvider(dispatcher),
         workspaceRemote = workspaceRemote,
         workspacePageManager = pageManager,
+        workspaceSettings = workspaceSettings,
         workspaceTemplates = templates,
         usageRepo = mockk<WorkspaceUsageRepo>().apply {
             every { rankedTypes } returns ranked
@@ -304,5 +309,64 @@ class WorkspaceButtonViewModelTest : BaseTest() {
         ranked.emit(listOf(Workspace.Type.EXPLORER))
 
         states.filterNotNull().last().recentItems.map { it.type } shouldBe listOf(Workspace.Type.EXPLORER)
+    }
+
+    private class PanelModeSettings {
+        val portrait = mockk<DataStoreValue<WorkspacePanelMode>>(relaxed = true)
+        val landscape = mockk<DataStoreValue<WorkspacePanelMode>>(relaxed = true)
+        val settings = mockk<WorkspaceSettings>(relaxed = true).apply {
+            every { layoutModePortrait } returns portrait
+            every { layoutModeLandscape } returns landscape
+        }
+    }
+
+    @Test
+    fun `setPanelMode writes only the portrait preference in portrait`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val settings = PanelModeSettings()
+            val vm = createVM(
+                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                workspaceSettings = settings.settings,
+            )
+
+            vm.setPanelMode(landscape = false, mode = WorkspacePanelMode.DUAL_VERTICAL)
+
+            val fn = slot<(WorkspacePanelMode) -> WorkspacePanelMode?>()
+            coVerify { settings.portrait.update(capture(fn)) }
+            fn.captured(WorkspacePanelMode.AUTO) shouldBe WorkspacePanelMode.DUAL_VERTICAL
+            coVerify(exactly = 0) { settings.landscape.update(any()) }
+        }
+
+    @Test
+    fun `setPanelMode writes only the landscape preference in landscape`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val settings = PanelModeSettings()
+            val vm = createVM(
+                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                workspaceSettings = settings.settings,
+            )
+
+            vm.setPanelMode(landscape = true, mode = WorkspacePanelMode.DUAL_VERTICAL)
+
+            val fn = slot<(WorkspacePanelMode) -> WorkspacePanelMode?>()
+            coVerify { settings.landscape.update(capture(fn)) }
+            fn.captured(WorkspacePanelMode.AUTO) shouldBe WorkspacePanelMode.DUAL_VERTICAL
+            coVerify(exactly = 0) { settings.portrait.update(any()) }
+        }
+
+    @Test
+    fun `state carries both stored panel modes`() = runTest(UnconfinedTestDispatcher()) {
+        every { workspaceRemote.state } returns flowOf(
+            WorkspaceRemote.State(
+                portraitPanelMode = WorkspacePanelMode.DUAL_VERTICAL,
+                landscapePanelMode = WorkspacePanelMode.QUAD_GRID,
+            )
+        )
+        val states = mutableListOf<WorkspaceButtonViewModel.State?>()
+        createVM().state.onEach { states += it }.launchIn(backgroundScope)
+
+        val state = states.filterNotNull().last()
+        state.portraitPanelMode shouldBe WorkspacePanelMode.DUAL_VERTICAL
+        state.landscapePanelMode shouldBe WorkspacePanelMode.QUAD_GRID
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelectable
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import eu.darken.butler.common.compose.PreviewWrapper

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
@@ -1,0 +1,114 @@
+package eu.darken.butler.workspace.ui.settings
+
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onAllNodes
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+
+/**
+ * Settings offers three surfaces, not the eight stored modes: a geometry pinned from the rail shows
+ * up as the Adaptive row, with the geometry named in the item's value.
+ *
+ * The landscape item is parked on SINGLE throughout, so the only labels colliding between the two
+ * preference items and the dialog rows are ones no assertion resolves by text alone.
+ */
+@Config(qualifiers = "w400dp-h800dp")
+class WorkspaceSettingsLayoutTest : ComposeTest() {
+
+    private val portraitModes = mutableListOf<WorkspacePanelMode>()
+
+    private fun setScreen(portraitMode: WorkspacePanelMode) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                WorkspaceSettingsScreen(
+                    state = WorkspaceSettingsViewModel.State(
+                        swipeGesturesEnabled = true,
+                        onDemandWorkspaceCreation = true,
+                        livePreview = true,
+                        layoutModePortrait = portraitMode,
+                        layoutModeLandscape = WorkspacePanelMode.SINGLE,
+                        paneClickToFocus = true,
+                        sessionRestoreEnabled = true,
+                    ),
+                    onNavigateUp = {},
+                    onToggleSwipeGestures = {},
+                    onToggleOnDemandWorkspaceCreation = {},
+                    onToggleLivePreview = {},
+                    onSetLayoutModePortrait = { portraitModes += it },
+                    onSetLayoutModeLandscape = {},
+                    onTogglePaneClickToFocus = {},
+                    onToggleSessionRestore = {},
+                    onToggleAutoPause = {},
+                    onSetAutoPauseIdleTimeout = {},
+                    onToggleUndoClose = {},
+                )
+            }
+        }
+    }
+
+    private fun openPortraitDialog(portraitMode: WorkspacePanelMode = WorkspacePanelMode.AUTO) {
+        setScreen(portraitMode)
+        composeTestRule.onNodeWithText("Portrait layout mode").performClick()
+    }
+
+    @Test
+    fun `the portrait dialog offers the three surfaces and no geometry`() {
+        openPortraitDialog()
+
+        val rows = composeTestRule.onAllNodes(isSelectable())
+        rows.assertCountEquals(3)
+        rows.assertAny(hasText("Automatic"))
+        rows.assertAny(hasText("Classic"))
+        rows.assertAny(hasText("Adaptive"))
+
+        composeTestRule.onNodeWithText("Dual vertical").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Single with tab rail").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Quad grid").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping adaptive stores the unpinned adaptive mode`() {
+        openPortraitDialog()
+
+        composeTestRule.onNode(isSelectable() and hasText("Adaptive")).performClick()
+
+        portraitModes shouldBe listOf(WorkspacePanelMode.ADAPTIVE)
+    }
+
+    @Test
+    fun `tapping classic stores the single mode`() {
+        openPortraitDialog()
+
+        composeTestRule.onNode(isSelectable() and hasText("Classic")).performClick()
+
+        portraitModes shouldBe listOf(WorkspacePanelMode.SINGLE)
+    }
+
+    @Test
+    fun `a pinned geometry reads as adaptive with the geometry named`() {
+        setScreen(WorkspacePanelMode.DUAL_VERTICAL)
+
+        composeTestRule.onNodeWithText("Adaptive (Dual vertical)").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Portrait layout mode").performClick()
+        composeTestRule.onNode(isSelectable() and hasText("Adaptive")).assertIsSelected()
+    }
+
+    @Test
+    fun `the single-with-rail geometry also reads as adaptive`() {
+        setScreen(WorkspacePanelMode.SINGLE_RAIL)
+
+        composeTestRule.onNodeWithText("Adaptive (Single with tab rail)").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -302,6 +302,7 @@ fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
 
     val effectivePaneLayout = when (effectivePanelMode) {
         WorkspacePanelMode.AUTO -> windowSizeInfo.recommendedLayout
+        WorkspacePanelMode.ADAPTIVE -> windowSizeInfo.recommendedLayout
         WorkspacePanelMode.SINGLE -> WorkspaceDesign.Layout.SINGLE
         WorkspacePanelMode.SINGLE_RAIL -> WorkspaceDesign.Layout.SINGLE
         WorkspacePanelMode.DUAL_VERTICAL -> WorkspaceDesign.Layout.DUAL_VERTICAL
@@ -319,7 +320,8 @@ fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
             WorkspaceDesign.RailPlacement.BOTTOM
         },
         hasNavigationRail = effectivePaneLayout != WorkspaceDesign.Layout.SINGLE ||
-            effectivePanelMode == WorkspacePanelMode.SINGLE_RAIL,
+            effectivePanelMode == WorkspacePanelMode.SINGLE_RAIL ||
+            effectivePanelMode == WorkspacePanelMode.ADAPTIVE,
     )
 }
 

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -341,6 +341,7 @@ fun WorkspaceNavigationRail(
                 RailPlacement.BOTTOM -> Modifier.padding(horizontal = RailSectionPadding)
             }.guidedTourTarget(WorkspaceTourTargets.BUTLER_BUTTON),
             currentWorkspaceId = focusedId,
+            showLayoutEntry = true,
         )
 
         RailSectionDivider(placement = placement)

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailSinglePaneTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailSinglePaneTest.kt
@@ -165,6 +165,26 @@ class WorkspaceRailSinglePaneTest : ComposeTest() {
             .assertDoesNotExist()
     }
 
+    @Test
+    @Config(qualifiers = "w360dp-h640dp-port")
+    fun `adaptive composes the rail on a compact window`() {
+        setScreen(mode = WorkspacePanelMode.ADAPTIVE)
+
+        composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .assertExists()
+
+        assertTheSolePaneHasHeight()
+    }
+
+    @Test
+    @Config(qualifiers = "w360dp-h640dp-port")
+    fun `automatic still composes no rail on a compact window`() {
+        setScreen(mode = WorkspacePanelMode.AUTO)
+
+        composeTestRule.onNodeWithTag(WorkspaceNavigationRailDefaults.SURFACE_TEST_TAG)
+            .assertDoesNotExist()
+    }
+
     /**
      * With one pane there is nothing to swap the entry against, so the menu's single assign item
      * selects the tab into the pane instead of rearranging assignments around it.

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspacePagerTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspacePagerTest.kt
@@ -27,6 +27,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceRemote
+import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.LocalWorkspacePageHosts
 import eu.darken.butler.workspace.ui.LocalWorkspacePagerVisibility
@@ -136,6 +137,7 @@ class ClassicWorkspacePagerTest : ComposeTest() {
         override fun navToUpgradeButler() = Unit
         override fun createWorkspace(item: QuickCreateItem) = Unit
         override fun createTemplatesWorkspace() = Unit
+        override fun setPanelMode(landscape: Boolean, mode: WorkspacePanelMode) = Unit
     }
 
     @Composable


### PR DESCRIPTION
## What changed

The tab layout settings under Settings → Tabs now offer three choices per orientation instead of eight: Automatic (unchanged), Classic (one pane, swipe between tabs, no tab rail) and Adaptive (tab rail always shown, pane count follows the screen size). Existing settings keep working: a previously chosen geometry such as "Dual vertical" shows up as "Adaptive (Dual vertical)".

While the tab rail is on screen, the Butler mascot menu has a new "Layout" entry. It opens a dialog listing Automatic plus the pane geometries the screen can hold, with the current choice marked, so a layout can be pinned for the current orientation without a trip to Settings. The offered set depends on the screen's size, not its orientation: a phone gets "Single with tab rail" plus the two-pane split along its long side (side by side in landscape, stacked in portrait), tablets add the other split and the triple layouts, and only screens that are large both ways get the 2×2 grid. A geometry already pinned stays listed. Picks are saved per orientation, like before. Picking Automatic on a phone in portrait returns to the classic layout and the rail disappears. The "Single with tab rail" icon now draws the rail on the edge it actually occupies: bottom in portrait, start edge in landscape. The Layout entry itself shows the currently stored mode as its subtitle.

Refs #83

## Technical Context

- "Adaptive with no pinned geometry" is a new ninth `WorkspacePanelMode` value; it resolves like Automatic but always composes the rail. No migration: the existing serialized values are untouched.
- The settings dialog and the new rail dialog share one extracted picker composable so the two lists cannot drift again.
- The offered geometries come from a pure function of the window's long and short side in dp (840dp and 480dp thresholds, the same numbers the resolver's size classes use), so rotating never changes the set; only which two-pane split is offered follows the orientation.
- The Layout entry is gated by a flag only the rail's button call site sets; every other mascot placement (toolbars, state pages, saver header, demo card, modal) keeps the default and never shows it. Writes go through the button provider, so the modal's nulled provider and the demo card's fake provider no-op.
- The two removed strings were pruned from `values-de` as well; the new strings and the reworded Automatic description have no translations yet.
