### PR TITLE
Explorer: Move refresh and folder favoriting into the action bar menu

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -800,6 +800,9 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
     fun onFavoriteFeedbackAction() = favoritesController.onFeedbackAction()
 
+    /** Breadcrumb-menu favorite toggle. Reaches any ancestor crumb, not just the listed folder. */
+    fun toggleFavorite(path: APath<*>) = favoritesController.toggleCurrent(path)
+
     fun clearSelection() = selection.clear()
 
     fun selectAll() = selection.selectAll()

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/actions/ExplorerActionBarItem.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/actions/ExplorerActionBarItem.kt
@@ -46,12 +46,14 @@ sealed interface ExplorerActionBarItem : WorkspaceActionBarItem {
 
     // Common actions shared across contexts
     sealed interface Common : ExplorerActionBarItem {
+        /** Menu-only: the pull gesture is the everyday route, this is the accessible one. */
         data class Refresh(
             override val isEnabled: Boolean = true,
             override val group: WorkspaceActionBarItem.Group = WorkspaceActionBarItem.Group.SECONDARY,
         ) : Common {
             override val icon = Icons.TwoTone.Refresh
             override val label = R.string.explorer_action_refresh.toCaString()
+            override val forceOverflow = true
         }
 
         data class Sort(
@@ -203,7 +205,7 @@ sealed interface ExplorerActionBarItem : WorkspaceActionBarItem {
         }
 
         /**
-         * Action-bar toggle for the currently-viewed folder, shown when no selection is active.
+         * Menu-only entry for the currently-viewed folder, shown when no selection is active.
          * `isFavorite` is for icon/label display only — execution must be atomic via repo.toggle().
          */
         data class ToggleFavoriteCurrent(
@@ -212,6 +214,7 @@ sealed interface ExplorerActionBarItem : WorkspaceActionBarItem {
             override val isEnabled: Boolean = true,
             override val group: WorkspaceActionBarItem.Group = WorkspaceActionBarItem.Group.PRIMARY,
         ) : Directory {
+            override val forceOverflow = true
             override val icon = if (isFavorite) Icons.TwoTone.Bookmark else Icons.TwoTone.BookmarkBorder
             override val label = (
                 if (isFavorite) R.string.explorer_action_remove_from_favorites

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/BreadcrumbBar.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/BreadcrumbBar.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Bookmark
+import androidx.compose.material.icons.twotone.BookmarkBorder
 import androidx.compose.material.icons.twotone.ChevronRight
 import androidx.compose.material.icons.twotone.ContentCopy
 import androidx.compose.material.icons.twotone.FolderZip
@@ -66,6 +68,7 @@ import eu.darken.butler.common.files.ArchivePath
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.SAFPath
 import eu.darken.butler.common.files.SmbPath
+import eu.darken.butler.common.files.extensions.matches
 import eu.darken.butler.common.files.saf.location.SAFLocationManager
 import eu.darken.butler.common.ui.pagerFriendlyHorizontalScroll
 import eu.darken.butler.explorer.R
@@ -90,6 +93,8 @@ fun BreadcrumbBar(
     onCommitEditedPath: ((APath<*>, String) -> Unit)? = null,
     onSetAsHome: ((ExplorerNavigation.Target) -> Unit)? = null,
     onCopyPath: ((String) -> Unit)? = null,
+    onToggleFavorite: ((APath<*>) -> Unit)? = null,
+    favoritePaths: List<APath<*>> = emptyList(),
     safLocationManager: SAFLocationManager? = null,
     showBackground: Boolean = true,
     cutoutWidth: Dp = 0.dp,
@@ -249,6 +254,8 @@ fun BreadcrumbBar(
                     }
                 },
                 onCopyPath = onCopyPath,
+                onToggleFavorite = onToggleFavorite,
+                favoritePaths = favoritePaths,
             )
         }
     }
@@ -520,6 +527,8 @@ private fun BreadcrumbDisplayRow(
     onChipClick: (Int, ExplorerBreadcrumb) -> Unit,
     onSetAsHome: ((Int, ExplorerNavigation.Target) -> Unit)?,
     onCopyPath: ((String) -> Unit)?,
+    onToggleFavorite: ((APath<*>) -> Unit)?,
+    favoritePaths: List<APath<*>>,
 ) {
     Row(
         modifier = modifier
@@ -532,6 +541,7 @@ private fun BreadcrumbDisplayRow(
         breadcrumbs.forEachIndexed { index, breadcrumb ->
             val isLast = index == breadcrumbs.lastIndex
             val isDirectory = breadcrumb.target is ExplorerNavigation.Target.Directory
+            val crumbPath = (breadcrumb.target as? ExplorerNavigation.Target.Directory)?.path
             val supportsContextMenu = when (breadcrumb.target) {
                 is ExplorerNavigation.Target.Home,
                 is ExplorerNavigation.Target.Device,
@@ -566,6 +576,13 @@ private fun BreadcrumbDisplayRow(
                             onCopyPath(breadcrumb.target.path.path)
                         }
                     } else null,
+                    onToggleFavorite = if (crumbPath != null && onToggleFavorite != null) {
+                        {
+                            onShowContextMenu(null)
+                            onToggleFavorite(crumbPath)
+                        }
+                    } else null,
+                    isFavorite = crumbPath != null && favoritePaths.any { it.matches(crumbPath) },
                 )
 
                 if (!isLast) {
@@ -596,6 +613,8 @@ private fun BreadcrumbChip(
     onDismissContextMenu: () -> Unit,
     onSetAsHome: (() -> Unit)?,
     onCopyPath: (() -> Unit)?,
+    onToggleFavorite: (() -> Unit)?,
+    isFavorite: Boolean,
 ) {
     val context = LocalContext.current
     Box(
@@ -653,6 +672,8 @@ private fun BreadcrumbChip(
                 onDismiss = onDismissContextMenu,
                 onSetAsHome = onSetAsHome,
                 onCopyPath = onCopyPath,
+                onToggleFavorite = onToggleFavorite,
+                isFavorite = isFavorite,
             )
         }
     }
@@ -673,6 +694,8 @@ private fun BreadcrumbChipPreview() {
             onDismissContextMenu = {},
             onSetAsHome = null,
             onCopyPath = null,
+            onToggleFavorite = null,
+            isFavorite = false,
         )
         BreadcrumbChip(
             breadcrumb = MockDataProvider.createHomeBreadcrumb(),
@@ -684,6 +707,8 @@ private fun BreadcrumbChipPreview() {
             onDismissContextMenu = {},
             onSetAsHome = null,
             onCopyPath = null,
+            onToggleFavorite = null,
+            isFavorite = false,
         )
     }
 }
@@ -697,6 +722,8 @@ private fun BreadcrumbContextMenu(
     onDismiss: () -> Unit,
     onSetAsHome: (() -> Unit)?,
     onCopyPath: (() -> Unit)?,
+    onToggleFavorite: (() -> Unit)?,
+    isFavorite: Boolean,
 ) {
     DismissWhenPaneUnfocused(expanded = true, onDismiss = onDismiss)
     DropdownMenu(
@@ -724,6 +751,26 @@ private fun BreadcrumbContextMenu(
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.TwoTone.ContentCopy,
+                        contentDescription = null,
+                    )
+                },
+            )
+        }
+        // Offered on every Directory crumb, so an ancestor can be favorited without navigating to it
+        if (onToggleFavorite != null) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        stringResource(
+                            if (isFavorite) R.string.explorer_action_remove_from_favorites
+                            else R.string.explorer_action_add_to_favorites
+                        )
+                    )
+                },
+                onClick = onToggleFavorite,
+                leadingIcon = {
+                    Icon(
+                        imageVector = if (isFavorite) Icons.TwoTone.Bookmark else Icons.TwoTone.BookmarkBorder,
                         contentDescription = null,
                     )
                 },

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
@@ -71,6 +71,8 @@ internal fun FloatingBarScope.ExplorerTopBars(
             onCommitEditedPath = { current, edited -> vm?.navigateToEditedPath(current, edited) },
             onSetAsHome = { target -> vm?.setAsDefaultStartLocation(target) },
             onCopyPath = { path -> vm?.copyPathToSystemClipboard(path) },
+            onToggleFavorite = { path -> vm?.toggleFavorite(path) },
+            favoritePaths = state.favoritePaths,
             safLocationManager = vm?.safLocationManager,
             pickerSelection = state.pickerConfig?.selection,
             selectionCount = state.selectionState.selectedItems.size,

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerToolbarCard.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerToolbarCard.kt
@@ -72,6 +72,8 @@ fun ExplorerToolbarCard(
     onCommitEditedPath: ((APath<*>, String) -> Unit)? = null,
     onSetAsHome: ((ExplorerNavigation.Target) -> Unit)? = null,
     onCopyPath: ((String) -> Unit)? = null,
+    onToggleFavorite: ((APath<*>) -> Unit)? = null,
+    favoritePaths: List<APath<*>> = emptyList(),
     safLocationManager: SAFLocationManager? = null,
     // Picker mode parameters (all null/default for normal mode)
     pickerSelection: PickerConfig.Selection? = null,
@@ -130,6 +132,8 @@ fun ExplorerToolbarCard(
                 onCommitEditedPath = onCommitEditedPath,
                 onSetAsHome = onSetAsHome,
                 onCopyPath = onCopyPath,
+                onToggleFavorite = onToggleFavorite,
+                favoritePaths = favoritePaths,
                 safLocationManager = safLocationManager,
             )
         }
@@ -146,6 +150,8 @@ private fun NormalToolbarContent(
     onCommitEditedPath: ((APath<*>, String) -> Unit)?,
     onSetAsHome: ((ExplorerNavigation.Target) -> Unit)?,
     onCopyPath: ((String) -> Unit)?,
+    onToggleFavorite: ((APath<*>) -> Unit)?,
+    favoritePaths: List<APath<*>>,
     safLocationManager: SAFLocationManager?,
 ) {
     if (isCollapsed) {
@@ -188,6 +194,8 @@ private fun NormalToolbarContent(
             onCommitEditedPath = onCommitEditedPath,
             onSetAsHome = onSetAsHome,
             onCopyPath = onCopyPath,
+            onToggleFavorite = onToggleFavorite,
+            favoritePaths = favoritePaths,
             safLocationManager = safLocationManager,
             showBackground = false,
             cutoutWidth = cutoutWidth,

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/BreadcrumbBarTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/BreadcrumbBarTest.kt
@@ -296,6 +296,101 @@ class BreadcrumbBarTest : ComposeTest() {
     }
 
     @Test
+    fun `long press on directory breadcrumb offers favoriting, labelled by current state`() {
+        var toggled: APath<*>? = null
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                BreadcrumbBar(
+                    breadcrumbs = listOf(
+                        homeBreadcrumb,
+                        directoryBreadcrumb("storage", "/storage"),
+                    ),
+                    onBreadcrumbClick = {},
+                    onToggleFavorite = { toggled = it },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("storage").performTouchInput { longClick() }
+        composeTestRule.onNodeWithText("Add to favorites").performClick()
+
+        toggled?.path shouldBe "/storage"
+        composeTestRule.onNodeWithText("Add to favorites").assertDoesNotExist()
+    }
+
+    @Test
+    fun `an already-favorited crumb offers removal instead`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                BreadcrumbBar(
+                    breadcrumbs = listOf(
+                        homeBreadcrumb,
+                        directoryBreadcrumb("storage", "/storage"),
+                    ),
+                    onBreadcrumbClick = {},
+                    onToggleFavorite = {},
+                    favoritePaths = listOf(LocalPath.build("/storage")),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("storage").performTouchInput { longClick() }
+
+        composeTestRule.onNodeWithText("Remove from favorites").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add to favorites").assertDoesNotExist()
+    }
+
+    @Test
+    fun `an ancestor crumb can be favorited without navigating to it`() {
+        var toggled: APath<*>? = null
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                BreadcrumbBar(
+                    breadcrumbs = listOf(
+                        homeBreadcrumb,
+                        directoryBreadcrumb("storage", "/storage"),
+                        directoryBreadcrumb("Documents", "/storage/Documents"),
+                    ),
+                    onBreadcrumbClick = {},
+                    onToggleFavorite = { toggled = it },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("storage").performTouchInput { longClick() }
+        composeTestRule.onNodeWithText("Add to favorites").performClick()
+
+        toggled?.path shouldBe "/storage"
+    }
+
+    @Test
+    fun `a non-directory crumb opens its menu but offers no favoriting`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                BreadcrumbBar(
+                    breadcrumbs = listOf(
+                        homeBreadcrumb,
+                        directoryBreadcrumb("storage", "/storage"),
+                    ),
+                    onBreadcrumbClick = {},
+                    // Provided so the menu demonstrably opens - otherwise an absent favorite entry
+                    // would also be satisfied by no menu at all
+                    onSetAsHome = {},
+                    onToggleFavorite = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Home").performTouchInput { longClick() }
+
+        composeTestRule.onNodeWithText("Set as home").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add to favorites").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Remove from favorites").assertDoesNotExist()
+    }
+
+    @Test
     fun `set as home from context menu fires callback and closes menu`() {
         var homeTarget: ExplorerNavigation.Target? = null
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/WorkspaceActionBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/actions/WorkspaceActionBar.kt
@@ -88,11 +88,11 @@ fun <T : WorkspaceActionBarItem> WorkspaceActionBar(
         val forcedActions = visibleActions.filter { it.forceOverflow }
         val budgetedActions = visibleActions.filter { !it.forceOverflow }
 
-        // Calculate space budget:
-        // - Horizontal padding: 16dp (8dp * 2)
-        // - Each action button: 48dp
-        // - Overflow button (if needed): 48dp
-        val horizontalPadding = 16.dp
+        // Calculate space budget. Must match what the Row below actually spends:
+        // - Horizontal padding: 8dp (4dp * 2)
+        // - Each action slot: 48dp, matching the hit region Compose gives its 40dp circle
+        // - Overflow button (if needed): 48dp, the Material IconButton default
+        val horizontalPadding = 8.dp
         val actionButtonWidth = 48.dp
         val overflowButtonWidth = 48.dp
 

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/actions/WorkspaceActionBarTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/actions/WorkspaceActionBarTest.kt
@@ -145,6 +145,26 @@ class WorkspaceActionBarTest : ComposeTest() {
     }
 
     @Test
+    fun `the width budget matches what the bar actually lays out`() {
+        // Five 48dp slots plus the 48dp overflow button and 8dp of Row padding need 296dp;
+        // a sixth slot would need 344dp, so 320dp must show exactly five
+        val actions = (1..8).map { SampleAction(Icons.TwoTone.Star, "Action $it") }
+        setBar(actions, width = 320)
+
+        val visible = actions.count {
+            composeTestRule.onAllNodesWithContentDescription(it.name).fetchSemanticsNodes().isNotEmpty()
+        }
+        visible shouldBe 5
+
+        composeTestRule.onNodeWithContentDescription(overflowLabel).performClick()
+        composeTestRule.waitForIdle()
+
+        actions.drop(5).forEach {
+            composeTestRule.onNodeWithText(it.name).assertIsDisplayed()
+        }
+    }
+
+    @Test
     fun `forced and naturally overflowing actions each appear exactly once`() {
         val actions = listOf(
             share,


### PR DESCRIPTION
## What changed

While browsing a folder, the Explorer's action bar now shows four buttons instead of six. Refresh and "add this folder to favorites" moved into the bar's overflow menu, because neither is needed often and both were competing for room with the actions that are.

Favoriting a folder also became available from the breadcrumb. Long-pressing any segment of the path now offers adding or removing it from favorites, next to "Set as home" and "Copy path". That works for parent folders too, so a folder further up the path can be favorited without navigating to it first.

## Technical Context

- Refresh is kept in the menu rather than deleted. `WorkspacePullToRefreshBox` attaches no semantics action to the pull gesture, so dropping the button would leave accessibility services with no way to refresh at all.
- `ToggleFavoriteCurrent` acts on the folder being listed, while every other bar action acts on that listing's contents or on the selection. That asymmetry is the reason it moved, not a space measurement.
- The shared bar's width budget reserved 16dp of horizontal padding while the Row it describes spends 4dp per side, so it under-counted its own usable width by 8dp. Now corrected. At the pane widths Butler renders at the correction does not cross a 48dp slot boundary, so no bar changes what it displays; the new test pins capacity to the layout constants so budget and layout cannot drift apart again.
- The breadcrumb entry routes through `ExplorerFavoritesController.toggleCurrent` rather than touching the repo directly, which is what keeps the undo and reveal feedback firing and picker suppression applying. The picker and save-as toolbar layout passes no callback, so pickers offer no favoriting.
- Worth a close look: two states now render a bar holding only the overflow button, an empty nested trash folder and empty root trash inside a file picker (where picker filtering strips the empty-bin action). Also note the breadcrumb menu is covered by unit tests but was not exercised on hardware: adb-injected long-presses do not reach the `combinedClickable` detector, and the pre-existing "Set as home" and "Copy path" entries are equally unreachable that way.
