### PR TITLE
General: Confirm rename dialogs with the enter key

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/RenameDialog.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/RenameDialog.kt
@@ -2,6 +2,8 @@ package eu.darken.butler.explorer.ui.explorer.dialogs
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -17,6 +19,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
@@ -63,6 +66,11 @@ fun RenameDialog(
 
     val validation = remember(textFieldValue.text) { onValidate(textFieldValue.text) }
     val isError = validation is FilenameValidator.ValidationResult.Invalid
+    val trimmedName = remember(textFieldValue.text) { textFieldValue.text.trim() }
+    val canConfirm = trimmedName.isNotBlank() && trimmedName != currentName && !isError
+    val handleConfirm = {
+        if (canConfirm) onConfirm(RenameResult(item, trimmedName))
+    }
 
     // Only pull focus (and with it the keyboard) while this dialog is the layer the user is
     // actually talking to — otherwise it steals input from whatever is on top of it.
@@ -99,20 +107,15 @@ fun RenameDialog(
                             Text(stringResource(CommonR.string.general_filename_validation_error, chars))
                         }
                     } else null,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { handleConfirm() }),
                 )
             }
         },
         confirmButton = {
             TextButton(
-                onClick = {
-                    val newName = textFieldValue.text.trim()
-                    if (newName.isNotBlank() && newName != currentName && !isError) {
-                        onConfirm(RenameResult(item, newName))
-                    }
-                },
-                enabled = textFieldValue.text.trim().isNotBlank() &&
-                    textFieldValue.text.trim() != currentName &&
-                    !isError
+                onClick = handleConfirm,
+                enabled = canConfirm
             ) {
                 Text(stringResource(CommonR.string.general_rename_action))
             }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/RenameDialogTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/RenameDialogTest.kt
@@ -8,8 +8,10 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.workspace.ui.modal.PaneLayer
@@ -50,6 +52,54 @@ class RenameDialogTest : ComposeTest() {
             result?.newName shouldBe "renamed.txt"
             result?.item shouldBe item
         }
+    }
+
+    @Test
+    fun `confirms a new name from the keyboard action`() {
+        var result: RenameResult? = null
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    RenameDialog(
+                        item = item,
+                        currentName = "file.txt",
+                        onDismiss = {},
+                        onConfirm = { result = it },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNode(hasSetTextAction()).performTextReplacement("renamed.txt")
+        composeTestRule.onNode(hasSetTextAction()).performImeAction()
+
+        composeTestRule.runOnIdle {
+            result?.newName shouldBe "renamed.txt"
+            result?.item shouldBe item
+        }
+    }
+
+    @Test
+    fun `the keyboard action does nothing while the name is unchanged`() {
+        var result: RenameResult? = null
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    RenameDialog(
+                        item = item,
+                        currentName = "file.txt",
+                        onDismiss = {},
+                        onConfirm = { result = it },
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNode(hasSetTextAction()).performImeAction()
+
+        composeTestRule.runOnIdle { result shouldBe null }
     }
 
     @Test

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/issues/PathIssueRenameDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/issues/PathIssueRenameDialog.kt
@@ -1,5 +1,7 @@
 package eu.darken.butler.workspace.ui.issues
 
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -13,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
@@ -35,6 +38,10 @@ fun PathIssueRenameDialog(
     val validation = remember(newName) { onValidate(newName) }
     val isError = validation is FilenameValidator.ValidationResult.Invalid
     val trimmedName = remember(newName) { newName.trim() }
+    val canConfirm = trimmedName.isNotBlank() && trimmedName != currentName && !isError
+    val handleConfirm = {
+        if (canConfirm) onConfirm(trimmedName)
+    }
 
     val focusRequester = remember { FocusRequester() }
 
@@ -63,16 +70,14 @@ fun PathIssueRenameDialog(
                         Text(stringResource(eu.darken.butler.common.R.string.general_filename_validation_error, chars))
                     }
                 } else null,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { handleConfirm() }),
             )
         },
         confirmButton = {
             TextButton(
-                onClick = {
-                    if (trimmedName.isNotBlank() && !isError) {
-                        onConfirm(trimmedName)
-                    }
-                },
-                enabled = trimmedName.isNotBlank() && trimmedName != currentName && !isError,
+                onClick = handleConfirm,
+                enabled = canConfirm,
             ) {
                 Text(stringResource(eu.darken.butler.common.R.string.general_rename_action))
             }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/issues/PathIssueRenameDialogTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/issues/PathIssueRenameDialogTest.kt
@@ -1,0 +1,50 @@
+package eu.darken.butler.workspace.ui.issues
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextReplacement
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+
+class PathIssueRenameDialogTest : ComposeTest() {
+
+    private fun setDialog(onConfirm: (String) -> Unit) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
+                    PathIssueRenameDialog(
+                        currentName = "file.txt",
+                        onConfirm = onConfirm,
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `confirms a new name from the keyboard action`() {
+        var result: String? = null
+        setDialog { result = it }
+
+        composeTestRule.onNode(hasSetTextAction()).performTextReplacement("  renamed.txt  ")
+        composeTestRule.onNode(hasSetTextAction()).performImeAction()
+
+        composeTestRule.runOnIdle { result shouldBe "renamed.txt" }
+    }
+
+    @Test
+    fun `the keyboard action does nothing while the name is unchanged`() {
+        var result: String? = null
+        setDialog { result = it }
+
+        composeTestRule.onNode(hasSetTextAction()).performImeAction()
+
+        composeTestRule.runOnIdle { result shouldBe null }
+    }
+}


### PR DESCRIPTION
## What changed

The rename dialog could only be submitted by tapping its Rename button. Pressing enter did nothing, even though the create file/folder dialog right next to it submits that way. Both rename dialogs now accept enter: renaming a file or folder in the Explorer, and renaming when a path problem is reported.

## Technical Context

- Root cause: the create-item dialog declares an IME action on its name field and routes it into its confirm action. The two rename dialogs declared neither, so the soft keyboard offered no confirm key and hardware enter was ignored.
- The button and the keyboard now share one guarded confirm lambda instead of each carrying its own copy of the "is this name acceptable" predicate, so the two entry points cannot disagree about what submits.
- `PathIssueRenameDialog`'s confirm-button `onClick` had been guarding on a weaker condition than its own `enabled` state (it omitted the "name actually changed" check). That was inert while the button was the only caller; collapsing both onto the shared predicate closes it now that enter reaches the same code path. Worth a look if you disagree that tightening it is the right direction.
