### PR TITLE
Explorer: Fix revealing saved SMB passwords in the edit dialog

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerDialogController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerDialogController.kt
@@ -30,6 +30,11 @@ class ExplorerDialogController(
         dialogStateFlow.value = dialog
     }
 
+    /** Updates only this exact dialog instance, including when an async result arrives after reopening. */
+    fun showIfCurrent(expected: ExplorerDialogState, replacement: ExplorerDialogState) {
+        dialogStateFlow.update { current -> if (current === expected) replacement else current }
+    }
+
     fun dismiss() {
         dialogStateFlow.value = ExplorerDialogState.None
     }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSmbLocationController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerSmbLocationController.kt
@@ -4,11 +4,13 @@ import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.butler.common.debug.logging.Logging.Priority.INFO
+import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.error.localized
 import eu.darken.butler.common.files.smb.SmbConnectionTester
 import eu.darken.butler.common.files.smb.credentials.SmbCredentialStore
+import eu.darken.butler.common.files.smb.credentials.SmbCredentialUnavailableException
 import eu.darken.butler.common.files.smb.SmbLocationInput
 import eu.darken.butler.common.files.smb.location.SmbLocation
 import eu.darken.butler.common.files.smb.location.SmbLocationManager
@@ -18,7 +20,9 @@ import eu.darken.butler.explorer.core.ExplorerWorkspace
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.core.engine.ExplorerLocation
 import eu.darken.butler.explorer.ui.explorer.dialogs.ExplorerDialogState
+import eu.darken.butler.explorer.ui.explorer.dialogs.RevealedPassword
 import eu.darken.butler.explorer.ui.explorer.dialogs.SmbLocationFormInput
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlin.uuid.Uuid
 
@@ -58,6 +62,28 @@ class ExplorerSmbLocationController(
             return@doLaunch
         }
         dialogs.show(ExplorerDialogState.SmbLocationForm(existing = location))
+    }
+
+    suspend fun revealPassword(form: ExplorerDialogState.SmbLocationForm): RevealedPassword? {
+        log(tag) { "revealPassword(${form.existing?.id})" }
+        if (dialogs.current() !== form) return null
+        val location = form.existing ?: return null
+        if (location.authType != SmbLocation.AuthType.PASSWORD) return null
+        return try {
+            val credential = credentialStore.resolve(location)
+            try {
+                RevealedPassword(String(credential.password))
+            } finally {
+                credential.wipe()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val priority = if (e is SmbCredentialUnavailableException) WARN else ERROR
+            log(tag, priority) { "revealPassword(): Stored credential unusable: ${e.asLog()}" }
+            dialogs.showIfCurrent(form, form.copy(error = e.localizedDescription()))
+            null
+        }
     }
 
     fun showRemoveConfirmation(items: List<ExplorerItem.Storage.Network>) {

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -1658,6 +1658,11 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
     fun onSmbLocationFormSubmit(input: SmbLocationFormInput) = smbLocations.onFormSubmit(input)
 
+    suspend fun onRevealSmbFormPassword(form: ExplorerDialogState.SmbLocationForm): RevealedPassword? =
+        withContext(dispatchers.IO) {
+            smbLocations.revealPassword(form)
+        }
+
     /**
      * Puts the stored password of an open network info sheet on screen.
      *

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogHost.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ExplorerDialogHost.kt
@@ -60,6 +60,7 @@ fun ExplorerDialogHost(
                 state = dialogState,
                 onDismiss = { vm?.dismissDialog() },
                 onSubmit = { input -> vm?.onSmbLocationFormSubmit(input) },
+                onRevealPassword = { vm?.onRevealSmbFormPassword(dialogState) },
                 topInset = topInset,
                 bottomInset = bottomInset,
             )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/SmbLocationFormSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/SmbLocationFormSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,6 +44,7 @@ import eu.darken.butler.common.files.smb.SmbLocationInput
 import eu.darken.butler.common.files.smb.location.SmbLocation
 import eu.darken.butler.explorer.R
 import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
+import kotlinx.coroutines.launch
 import eu.darken.butler.common.R as CommonR
 
 /** Raw field contents, validated by [SmbLocationInput] before anything is stored. */
@@ -64,6 +66,7 @@ fun SmbLocationFormSheet(
     state: ExplorerDialogState.SmbLocationForm,
     onDismiss: () -> Unit,
     onSubmit: (SmbLocationFormInput) -> Unit,
+    onRevealPassword: suspend () -> RevealedPassword? = { null },
     topInset: Dp = 0.dp,
     bottomInset: Dp = 0.dp,
 ) {
@@ -79,7 +82,9 @@ fun SmbLocationFormSheet(
     var username by remember { mutableStateOf(existing?.username.orEmpty()) }
     var domain by remember { mutableStateOf(existing?.domain.orEmpty()) }
     var password by remember { mutableStateOf("") }
-    var passwordVisible by remember { mutableStateOf(false) }
+    var passwordEdited by remember { mutableStateOf(false) }
+    var isRevealing by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
     var rememberCredential by remember { mutableStateOf(existing?.rememberCredential ?: true) }
 
     val usesPassword = authType == SmbLocation.AuthType.PASSWORD
@@ -89,7 +94,11 @@ fun SmbLocationFormSheet(
         username == existing.username.orEmpty() &&
         SmbLocationInput.normalizeDomain(domain) == SmbLocationInput.normalizeDomain(existing.domain) &&
         rememberCredential == existing.rememberCredential
-    val canSubmit = !state.isTesting &&
+    var passwordVisible by remember(usesPassword, keepsStoredCredential) { mutableStateOf(false) }
+    var revealedPassword by remember(usesPassword, keepsStoredCredential) {
+        mutableStateOf<RevealedPassword?>(null)
+    }
+    val canSubmit = !state.isTesting && !isRevealing &&
         host.isNotBlank() &&
         share.isNotBlank() &&
         (!usesPassword || password.isNotEmpty() || keepsStoredCredential)
@@ -191,8 +200,15 @@ fun SmbLocationFormSheet(
                 )
 
                 OutlinedTextField(
-                    value = password,
-                    onValueChange = { password = it },
+                    value = if (passwordVisible && !passwordEdited && keepsStoredCredential) {
+                        revealedPassword?.value ?: password
+                    } else password,
+                    onValueChange = {
+                        password = it
+                        passwordEdited = it.isNotEmpty()
+                        if (it.isEmpty()) passwordVisible = false
+                        revealedPassword = null
+                    },
                     label = { Text(stringResource(R.string.explorer_network_form_password_label)) },
                     supportingText = if (existing != null) {
                         { Text(stringResource(R.string.explorer_network_form_password_kept_hint)) }
@@ -205,14 +221,42 @@ fun SmbLocationFormSheet(
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                     trailingIcon = {
-                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        IconButton(
+                            enabled = !isRevealing && !state.isTesting,
+                            onClick = {
+                                if (passwordVisible) {
+                                    passwordVisible = false
+                                    revealedPassword = null
+                                } else if (!passwordEdited && keepsStoredCredential &&
+                                    existing.authType == SmbLocation.AuthType.PASSWORD
+                                ) {
+                                    isRevealing = true
+                                    scope.launch {
+                                        try {
+                                            val revealed = onRevealPassword()
+                                            if (!passwordEdited) {
+                                                revealedPassword = revealed
+                                                passwordVisible = revealed != null
+                                            }
+                                        } finally {
+                                            isRevealing = false
+                                        }
+                                    }
+                                } else {
+                                    passwordVisible = true
+                                }
+                            },
+                        ) {
                             Icon(
                                 imageVector = if (passwordVisible) {
                                     Icons.TwoTone.VisibilityOff
                                 } else {
                                     Icons.TwoTone.Visibility
                                 },
-                                contentDescription = null,
+                                contentDescription = stringResource(
+                                    if (passwordVisible) R.string.explorer_info_network_password_hide_action
+                                    else R.string.explorer_info_network_password_show_action
+                                ),
                             )
                         }
                     },
@@ -315,6 +359,7 @@ private fun SmbLocationFormSheetEditPreview() {
         state = ExplorerDialogState.SmbLocationForm(existing = previewLocation()),
         onDismiss = {},
         onSubmit = {},
+        onRevealPassword = { RevealedPassword("hunter2") },
     )
 }
 

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerDialogControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerDialogControllerTest.kt
@@ -45,6 +45,44 @@ class ExplorerDialogControllerTest : BaseTest() {
     }
 
     @Test
+    fun `an async replacement updates the exact open dialog`() {
+        val controller = controller()
+        val form = ExplorerDialogState.SmbLocationForm()
+        controller.show(form)
+        val replacement = form.copy(isTesting = true)
+
+        controller.showIfCurrent(form, replacement)
+
+        controller.current() shouldBe replacement
+    }
+
+    @Test
+    fun `an async replacement cannot reopen a dismissed dialog`() {
+        val controller = controller()
+        val form = ExplorerDialogState.SmbLocationForm()
+        controller.show(form)
+        controller.dismiss()
+
+        controller.showIfCurrent(form, form.copy(isTesting = true))
+
+        controller.current() shouldBe ExplorerDialogState.None
+    }
+
+    @Test
+    fun `an async replacement cannot update an equal but reopened dialog`() {
+        val controller = controller()
+        val form = ExplorerDialogState.SmbLocationForm()
+        controller.show(form)
+        controller.dismiss()
+        val reopened = form.copy()
+        controller.show(reopened)
+
+        controller.showIfCurrent(form, form.copy(isTesting = true))
+
+        (controller.current() === reopened) shouldBe true
+    }
+
+    @Test
     fun `rename event shows dialog and clears selection`() {
         var selectionCleared = false
         val controller = controller(clearSelection = { selectionCleared = true })

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSmbLocationControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerSmbLocationControllerTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.butler.explorer.ui.explorer
 
 import eu.darken.butler.common.files.smb.SmbConnectionTester
+import eu.darken.butler.common.files.smb.credentials.SmbCredential
+import eu.darken.butler.common.files.smb.credentials.SmbCredentialUnavailableException
 import eu.darken.butler.common.files.smb.credentials.SmbCredentialStore
 import eu.darken.butler.common.files.smb.location.SmbLocation
 import eu.darken.butler.common.files.smb.location.SmbLocationManager
@@ -10,8 +12,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -47,9 +51,10 @@ class ExplorerSmbLocationControllerTest : BaseTest() {
     private fun CoroutineScope.controller(
         locationManager: SmbLocationManager,
         dialogs: ExplorerDialogController,
+        credentialStore: SmbCredentialStore = mockk(relaxed = true),
     ) = ExplorerSmbLocationController(
         locationManager = locationManager,
-        credentialStore = mockk<SmbCredentialStore>(relaxed = true),
+        credentialStore = credentialStore,
         connectionTester = mockk<SmbConnectionTester>(relaxed = true),
         dialogs = dialogs,
         workspace = { mockk<ExplorerWorkspace>().apply { coEvery { navigate(any()) } just Runs } },
@@ -85,5 +90,81 @@ class ExplorerSmbLocationControllerTest : BaseTest() {
         advanceUntilIdle()
 
         dialogs.current() shouldBe ExplorerDialogState.None
+    }
+
+    @Test
+    fun `revealing resolves the saved credential and wipes its copy`() = runTest {
+        val form = ExplorerDialogState.SmbLocationForm(existing = location("NAS"))
+        val dialogs = dialogs().apply { show(form) }
+        val credential = SmbCredential("darken", null, "saved-password".toCharArray())
+        val store = mockk<SmbCredentialStore>().apply {
+            coEvery { resolve(form.existing!!) } returns credential
+        }
+
+        val revealed = controller(mockk(), dialogs, store).revealPassword(form)
+
+        revealed?.value shouldBe "saved-password"
+        revealed.toString().contains("saved-password") shouldBe false
+        credential.password.all { it == Char(0) } shouldBe true
+    }
+
+    @Test
+    fun `unavailable credentials show an error and keep the form editable`() = runTest {
+        val form = ExplorerDialogState.SmbLocationForm(existing = location("NAS"))
+        val dialogs = dialogs().apply { show(form) }
+        val store = mockk<SmbCredentialStore>().apply {
+            coEvery { resolve(any()) } throws SmbCredentialUnavailableException(locationId, "Missing")
+        }
+
+        controller(mockk(), dialogs, store).revealPassword(form) shouldBe null
+
+        val current = dialogs.current().shouldBeInstanceOf<ExplorerDialogState.SmbLocationForm>()
+        current.existing shouldBe form.existing
+        (current.error != null) shouldBe true
+        current.isTesting shouldBe false
+    }
+
+    @Test
+    fun `an equal but different form instance cannot resolve credentials`() = runTest {
+        val form = ExplorerDialogState.SmbLocationForm(existing = location("NAS"))
+        val dialogs = dialogs().apply { show(form.copy()) }
+        val store = mockk<SmbCredentialStore>()
+
+        controller(mockk(), dialogs, store).revealPassword(form) shouldBe null
+
+        coVerify(exactly = 0) { store.resolve(any()) }
+    }
+
+    @Test
+    fun `a dismissed form cannot resolve credentials`() = runTest {
+        val form = ExplorerDialogState.SmbLocationForm(existing = location("NAS"))
+        val dialogs = dialogs().apply {
+            show(form)
+            dismiss()
+        }
+        val store = mockk<SmbCredentialStore>()
+
+        controller(mockk(), dialogs, store).revealPassword(form) shouldBe null
+
+        coVerify(exactly = 0) { store.resolve(any()) }
+    }
+
+    @Test
+    fun `cancelling a reveal propagates without showing an error`() = runTest {
+        val form = ExplorerDialogState.SmbLocationForm(existing = location("NAS"))
+        val dialogs = dialogs().apply { show(form) }
+        val store = mockk<SmbCredentialStore>().apply {
+            coEvery { resolve(any()) } throws CancellationException("Dismissed")
+        }
+
+        var cancelled = false
+        try {
+            controller(mockk(), dialogs, store).revealPassword(form)
+        } catch (_: CancellationException) {
+            cancelled = true
+        }
+
+        cancelled shouldBe true
+        dialogs.current() shouldBe form
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/SmbLocationFormSheetTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/dialogs/SmbLocationFormSheetTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -15,6 +16,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.smb.location.SmbLocation
 import eu.darken.butler.workspace.ui.modal.PaneLayerHost
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.Test
 import org.robolectric.annotation.Config
 import testhelpers.ComposeTest
@@ -40,7 +42,10 @@ class SmbLocationFormSheetTest : ComposeTest() {
         updatedAt = Instant.fromEpochMilliseconds(0),
     )
 
-    private fun setSheetContent(state: ExplorerDialogState.SmbLocationForm) {
+    private fun setSheetContent(
+        state: ExplorerDialogState.SmbLocationForm,
+        onRevealPassword: suspend () -> RevealedPassword? = { null },
+    ) {
         composeTestRule.setContent {
             PreviewWrapper {
                 PaneLayerHost(modifier = Modifier.fillMaxSize(), paneFocused = true) {
@@ -48,6 +53,7 @@ class SmbLocationFormSheetTest : ComposeTest() {
                         state = state,
                         onDismiss = {},
                         onSubmit = { submitted = it },
+                        onRevealPassword = onRevealPassword,
                     )
                 }
             }
@@ -135,6 +141,7 @@ class SmbLocationFormSheetTest : ComposeTest() {
 
         composeTestRule.onNodeWithText("Connecting…").performScrollTo().assertIsDisplayed()
         composeTestRule.onNodeWithText("Test & save").performScrollTo().assertIsNotEnabled()
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().assertIsNotEnabled()
     }
 
     @Test
@@ -151,6 +158,127 @@ class SmbLocationFormSheetTest : ComposeTest() {
         submitted!!.password shouldBe "hunter2"
         submitted!!.rememberCredential shouldBe true
     }
+
+    @Test
+    fun `show password reveals the saved password without replacing it on save`() {
+        var reveals = 0
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) {
+            reveals++
+            RevealedPassword("saved-password")
+        }
+        reveals shouldBe 0
+
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("saved-password").assertIsDisplayed()
+        reveals shouldBe 1
+        composeTestRule.onNodeWithText("Test & save").performScrollTo().performClick()
+        submitted!!.password shouldBe ""
+
+        composeTestRule.onNodeWithContentDescription("Hide password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("saved-password").assertDoesNotExist()
+    }
+
+    @Test
+    fun `editing the revealed password submits its replacement`() {
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) {
+            RevealedPassword("saved-password")
+        }
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("saved-password").performTextReplacement("replacement")
+        composeTestRule.onNodeWithText("Test & save").performScrollTo().performClick()
+
+        submitted!!.password shouldBe "replacement"
+    }
+
+    @Test
+    fun `show password reveals newly typed text without reading the vault`() {
+        var reveals = 0
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) {
+            reveals++
+            RevealedPassword("saved-password")
+        }
+        composeTestRule.onNodeWithText("Password").performScrollTo().performTextInput("new-password")
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+
+        composeTestRule.onNodeWithText("new-password").assertIsDisplayed()
+        reveals shouldBe 0
+    }
+
+    @Test
+    fun `a delayed reveal does not overwrite a password typed while loading`() {
+        val pending = CompletableDeferred<RevealedPassword?>()
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) { pending.await() }
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Password").performScrollTo().performTextInput("replacement")
+        composeTestRule.runOnIdle { pending.complete(RevealedPassword("saved-password")) }
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+
+        composeTestRule.onNodeWithText("replacement").assertIsDisplayed()
+        composeTestRule.onNodeWithText("saved-password").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a failed reveal leaves the controls usable and the password hidden`() {
+        val pending = CompletableDeferred<RevealedPassword?>()
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) { pending.await() }
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithContentDescription("Show password").assertIsNotEnabled()
+        composeTestRule.onNodeWithText("Test & save").performScrollTo().assertIsNotEnabled()
+
+        composeTestRule.runOnIdle { pending.complete(null) }
+
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().assertIsEnabled()
+        composeTestRule.onNodeWithContentDescription("Hide password").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Test & save").performScrollTo().assertIsEnabled()
+    }
+
+    @Test
+    fun `changing the account drops the revealed password until explicitly revealed again`() {
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) {
+            RevealedPassword("saved-password")
+        }
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("saved-password").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("darken").performScrollTo().performTextReplacement("someone-else")
+        composeTestRule.onNodeWithText("saved-password").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().assertIsEnabled()
+        composeTestRule.onNodeWithText("someone-else").performScrollTo().performTextReplacement("darken")
+        composeTestRule.onNodeWithText("saved-password").assertDoesNotExist()
+
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("saved-password").assertIsDisplayed()
+    }
+
+    @Test
+    fun `switching to guest while loading discards the pending reveal`() {
+        val pending = CompletableDeferred<RevealedPassword?>()
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) { pending.await() }
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Guest").performScrollTo().performClick()
+        composeTestRule.runOnIdle { pending.complete(RevealedPassword("saved-password")) }
+        composeTestRule.onNodeWithText("Username and password").performScrollTo().performClick()
+
+        composeTestRule.onNodeWithText("saved-password").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().assertIsEnabled()
+    }
+
+    @Test
+    fun `clearing a replacement lets show password reveal the saved credential again`() {
+        setSheetContent(ExplorerDialogState.SmbLocationForm(existing = stored)) {
+            RevealedPassword("saved-password")
+        }
+        composeTestRule.onNodeWithText("Password").performScrollTo().performTextInput("replacement")
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("replacement").performTextReplacement("")
+
+        composeTestRule.onNodeWithContentDescription("Show password").performScrollTo().performClick()
+
+        composeTestRule.onNodeWithText("saved-password").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Test & save").performScrollTo().performClick()
+        submitted!!.password shouldBe ""
+    }
+
 }
 
 private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.onAllNodesWithTextCount(text: String): Int =


### PR DESCRIPTION
## What changed

Fix the SMB edit dialog's Show password button so it reveals the saved password, including after restarting the app or device. Newly entered passwords remain revealable and editable.

## Technical Context

- The edit field starts empty to preserve the saved credential. Revealing now reads the credential store on demand without treating the revealed value as a replacement password.
- Reuse the existing redacted password wrapper, wipe the resolved credential copy, and cancel loading with the sheet. Atomic error updates cannot reopen a dismissed dialog.
