### PR TITLE
Workspace: Fix dialogs shrinking for a keyboard in another pane

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/bottomsheet/PaneScopedBottomSheet.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/bottomsheet/PaneScopedBottomSheet.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -68,6 +67,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.workspace.ui.LocalWorkspaceFocused
 import eu.darken.butler.workspace.ui.insets.LocalPaneEdges
 import eu.darken.butler.workspace.ui.insets.paneHorizontalInsetPadding
+import eu.darken.butler.workspace.ui.insets.paneImePadding
 import eu.darken.butler.workspace.ui.modal.PaneLayer
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
 import eu.darken.butler.workspace.ui.modal.requestPaneFocusOnPress
@@ -334,8 +334,15 @@ private fun SheetCard(
     ) {
         Column(
             modifier = Modifier
-                .then(if (includeImePadding) Modifier.imePadding() else Modifier)
-                .padding(bottom = bottomInset),
+                .then(
+                    // The keyboard's inset already spans the region [bottomInset] covers, so the
+                    // two are unioned instead of stacked.
+                    if (includeImePadding) {
+                        Modifier.paneImePadding(extraBottom = bottomInset)
+                    } else {
+                        Modifier.padding(bottom = bottomInset)
+                    },
+                ),
         ) {
             // Outside the scrolling region below, so it stays put and stays grabbable
             dragHandle?.let {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/PaneBoundAlertDialog.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/dialogs/PaneBoundAlertDialog.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +43,7 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.ui.dialogs.ButlerAlertDialogContent
 import eu.darken.butler.workspace.ui.insets.LocalPaneEdges
 import eu.darken.butler.workspace.ui.insets.paneHorizontalInsetPadding
+import eu.darken.butler.workspace.ui.insets.paneImePadding
 import eu.darken.butler.workspace.ui.modal.LocalLayerActive
 import eu.darken.butler.workspace.ui.modal.PaneLayer
 import eu.darken.butler.workspace.ui.modal.WorkspaceBackHandler
@@ -163,7 +163,7 @@ fun PaneBoundAlertDialog(
             modifier = Modifier
                 .fillMaxSize()
                 .paneHorizontalInsetPadding(LocalPaneEdges.current)
-                .then(if (includeImePadding) Modifier.imePadding() else Modifier)
+                .then(if (includeImePadding) Modifier.paneImePadding() else Modifier)
                 .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/insets/WorkspacePaneInsets.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/insets/WorkspacePaneInsets.kt
@@ -1,14 +1,23 @@
 package eu.darken.butler.workspace.ui.insets
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.findRootCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
@@ -25,6 +34,7 @@ import eu.darken.butler.workspace.ui.floatingbar.PersistBarCollapse
 import eu.darken.butler.workspace.ui.floatingbar.rememberFloatingBarStackState
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
 import eu.darken.butler.workspace.ui.manager.WorkspaceDesign.PaneEdges
+import kotlin.math.roundToInt
 
 /**
  * Unmasked system bar insets of the window, in physical (left/right) orientation.
@@ -72,6 +82,13 @@ fun PaneEdges.includesSystemBarInset(position: BarPosition): Boolean = when (pos
     BarPosition.TOP -> touchesTop
     BarPosition.BOTTOM -> touchesBottom
 }
+
+/**
+ * Distance from a node's bottom edge to the bottom of the window, which is how much of the soft
+ * keyboard's inset never reaches that node.
+ */
+internal fun paneBottomGapPx(rootHeightPx: Int, nodeBottomInRootPx: Float): Int =
+    (rootHeightPx - nodeBottomInRootPx).roundToInt().coerceAtLeast(0)
 
 /**
  * The window's system bar insets, unmasked.
@@ -147,6 +164,38 @@ fun Modifier.paneHorizontalInsetPadding(edges: PaneEdges): Modifier {
         horizontalWindowInsets(insets, density)
     }
     return windowInsetsPadding(horizontalInsets)
+}
+
+/**
+ * Reserves the part of the soft keyboard that actually overlaps this node, unioned with
+ * [extraBottom] so chrome the caller already reserves is never stacked on top of the keyboard.
+ *
+ * [androidx.compose.foundation.layout.imePadding] would reserve the window's whole keyboard inset,
+ * which is wrong for any node that has window left below it - another pane, the bottom navigation
+ * rail, or both.
+ */
+@Composable
+fun Modifier.paneImePadding(extraBottom: Dp = 0.dp): Modifier {
+    val density = LocalDensity.current
+    // Measured, not derived from the pane edge model: a pane can clear the bottom window edge and
+    // still sit within keyboard reach, e.g. the lower pane of a dual-horizontal split.
+    var gapPx by remember { mutableIntStateOf(0) }
+    val imeInsets = WindowInsets.ime
+    val extraBottomPx = with(density) { extraBottom.roundToPx() }
+    val insets = remember(imeInsets, gapPx, extraBottomPx) {
+        imeInsets
+            .exclude(WindowInsets(bottom = gapPx))
+            .union(WindowInsets(bottom = extraBottomPx))
+    }
+    return this
+        // Before the padding, so what the padding does cannot move the node it measures.
+        .onGloballyPositioned { coords ->
+            gapPx = paneBottomGapPx(
+                rootHeightPx = coords.findRootCoordinates().size.height,
+                nodeBottomInRootPx = coords.positionInRoot().y + coords.size.height,
+            )
+        }
+        .windowInsetsPadding(insets)
 }
 
 private fun horizontalWindowInsets(insets: WorkspacePaneInsets, density: Density): WindowInsets = with(density) {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/insets/PaneImeInsetTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/insets/PaneImeInsetTest.kt
@@ -1,0 +1,260 @@
+package eu.darken.butler.workspace.ui.insets
+
+import android.view.View
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheet
+import eu.darken.butler.workspace.ui.bottomsheet.PaneScopedBottomSheetDefaults
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialog
+import eu.darken.butler.workspace.ui.dialogs.PaneBoundAlertDialogDefaults
+import eu.darken.butler.workspace.ui.modal.PaneLayerHost
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import testhelpers.TestApplication
+
+/**
+ * The keyboard's inset is a window value, but a pane only meets as much of it as reaches past the
+ * pane's own bottom edge. Every case here drives that distance by hosting the component a known
+ * distance above the root bottom, which is what the mask measures - not the pane edge model, which
+ * says nothing about how far above the window bottom a pane sits.
+ *
+ * The environment supplies no window insets of its own, so a keyboard is dispatched to the compose
+ * view; without it there is nothing to mask.
+ */
+@Config(application = TestApplication::class, sdk = [34], qualifiers = "w400dp-h800dp")
+class PaneImeInsetTest : ComposeTest() {
+
+    private lateinit var view: View
+    private lateinit var density: Density
+
+    @Test
+    fun `a dialog out of the keyboard's reach reserves nothing`() {
+        setDialog(gap = FAR_GAP)
+
+        dispatchIme(IME_INSET)
+
+        dialogImePadding() shouldBe 0.dp
+    }
+
+    @Test
+    fun `a dialog on the window bottom reserves the whole keyboard`() {
+        setDialog(gap = 0.dp)
+
+        dispatchIme(IME_INSET)
+
+        dialogImePadding() shouldBe IME_INSET
+    }
+
+    @Test
+    fun `a dialog with chrome below it reserves the keyboard less that chrome`() {
+        setDialog(gap = NEAR_GAP)
+
+        dispatchIme(IME_INSET)
+
+        dialogImePadding() shouldBe IME_INSET - NEAR_GAP
+    }
+
+    @Test
+    fun `the reservation follows the keyboard up and back down`() {
+        setDialog(gap = NEAR_GAP)
+
+        listOf(
+            0.dp to 0.dp,
+            NEAR_GAP / 2 to 0.dp,
+            IME_INSET to IME_INSET - NEAR_GAP,
+            0.dp to 0.dp,
+        ).forEach { (imeInset, expected) ->
+            dispatchIme(imeInset)
+            withClue("ime=$imeInset") { dialogImePadding() shouldBe expected }
+        }
+    }
+
+    @Test
+    fun `a sheet out of the keyboard's reach does not grow`() {
+        setSheet(gap = FAR_GAP)
+        val baseline = cardHeight()
+
+        dispatchIme(IME_INSET)
+
+        cardHeight() shouldBe baseline
+    }
+
+    @Test
+    fun `a sheet on the window bottom grows by the whole keyboard`() {
+        setSheet(gap = 0.dp)
+        val baseline = cardHeight()
+
+        dispatchIme(IME_INSET)
+
+        cardHeight() shouldBe baseline + IME_INSET
+    }
+
+    @Test
+    fun `a sheet with chrome below it grows by the keyboard less that chrome`() {
+        setSheet(gap = NEAR_GAP)
+        val baseline = cardHeight()
+
+        dispatchIme(IME_INSET)
+
+        cardHeight() shouldBe baseline + (IME_INSET - NEAR_GAP)
+    }
+
+    /**
+     * A host-supplied bottom inset covers window space the keyboard's inset already spans, so the
+     * two union instead of stacking - the sheet grows only by what the keyboard adds on top of it.
+     */
+    @Test
+    fun `a sheet unions its bottom inset with the keyboard`() {
+        setSheet(gap = 0.dp, bottomInset = BOTTOM_INSET)
+        val baseline = cardHeight()
+
+        dispatchIme(IME_INSET)
+
+        cardHeight() shouldBe baseline + (IME_INSET - BOTTOM_INSET)
+    }
+
+    private fun setDialog(gap: Dp) {
+        composeTestRule.setContent {
+            view = LocalView.current
+            density = LocalDensity.current
+            Pane(gap = gap) {
+                PaneBoundAlertDialog(
+                    onDismissRequest = {},
+                    includeImePadding = true,
+                    text = { TallContent() },
+                    confirmButton = { TextButton(onClick = {}) { Text("OK") } },
+                )
+            }
+        }
+    }
+
+    private fun setSheet(gap: Dp, bottomInset: Dp = 0.dp) {
+        composeTestRule.setContent {
+            view = LocalView.current
+            density = LocalDensity.current
+            Pane(gap = gap) {
+                PaneScopedBottomSheet(
+                    visible = true,
+                    onDismiss = {},
+                    bottomInset = bottomInset,
+                    includeImePadding = true,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(ITEM_HEIGHT),
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * A pane whose bottom edge sits [gap] above the bottom of the root, standing in for another pane
+     * or a bottom navigation rail below it.
+     */
+    @Composable
+    private fun Pane(gap: Dp, content: @Composable () -> Unit) {
+        PreviewWrapper {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = gap),
+            ) {
+                PaneLayerHost(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(PANE_TAG),
+                    paneFocused = true,
+                ) {
+                    content()
+                }
+            }
+        }
+    }
+
+    /** Taller than the pane, so the surface is clamped and its bottom tracks the reservation. */
+    @Composable
+    private fun TallContent() {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            repeat(ITEM_COUNT) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(ITEM_HEIGHT),
+                )
+            }
+        }
+    }
+
+    private fun dispatchIme(imeInset: Dp) {
+        val imeInsetPx = with(density) { imeInset.roundToPx() }
+        composeTestRule.runOnUiThread {
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeInsetPx))
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(view, insets)
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    /**
+     * The centering container shrinks by the reservation, so the clamped surface ends that much
+     * higher, plus the container's own padding.
+     */
+    private fun dialogImePadding(): Dp {
+        val pane = composeTestRule.onNodeWithTag(PANE_TAG).getUnclippedBoundsInRoot()
+        val surface = composeTestRule.onNodeWithTag(PaneBoundAlertDialogDefaults.SURFACE_TEST_TAG)
+            .getUnclippedBoundsInRoot()
+        return pane.bottom - CONTAINER_PADDING - surface.bottom
+    }
+
+    private fun cardHeight(): Dp = composeTestRule
+        .onNodeWithTag(PaneScopedBottomSheetDefaults.CARD_TEST_TAG)
+        .getUnclippedBoundsInRoot()
+        .height
+
+    companion object {
+        private val IME_INSET = 200.dp
+
+        /** Keyboard reaches past this pane's bottom edge, but not by its full height */
+        private val NEAR_GAP = 48.dp
+
+        /** Deeper than the keyboard is tall, so none of it reaches the pane */
+        private val FAR_GAP = 240.dp
+
+        private val BOTTOM_INSET = 32.dp
+
+        /** [PaneBoundAlertDialog]'s own padding around the surface */
+        private val CONTAINER_PADDING = 24.dp
+
+        private val ITEM_HEIGHT = 40.dp
+        private const val ITEM_COUNT = 30
+
+        private const val PANE_TAG = "workspace.insets.pane"
+    }
+}

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/insets/PaneInsetsResolverTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/insets/PaneInsetsResolverTest.kt
@@ -78,6 +78,21 @@ class PaneInsetsResolverTest : BaseTest() {
     }
 
     @Test
+    fun `a node flush with the window bottom has no keyboard gap`() {
+        paneBottomGapPx(rootHeightPx = 2400, nodeBottomInRootPx = 2400f) shouldBe 0
+    }
+
+    @Test
+    fun `a node above the window bottom gaps by that distance`() {
+        paneBottomGapPx(rootHeightPx = 2400, nodeBottomInRootPx = 2200f) shouldBe 200
+    }
+
+    @Test
+    fun `a node overhanging the window bottom is floored at zero`() {
+        paneBottomGapPx(rootHeightPx = 2400, nodeBottomInRootPx = 2600f) shouldBe 0
+    }
+
+    @Test
     fun `floating bar stacks follow the matching vertical edge`() {
         val topOnly = PaneEdges(touchesTop = true, touchesBottom = false, touchesStart = true, touchesEnd = true)
 


### PR DESCRIPTION
## What changed

In a split layout, opening a dialog or bottom sheet that contains a text field made it reserve room
for the whole soft keyboard, even in a pane the keyboard barely touches or cannot reach at all. In
dual-pane portrait this made a dialog in the top pane shrink and slide upward the moment a text field
was focused, with the keyboard nowhere near it. Reported by a beta tester on a Pixel 8 Pro in
dual-pane portrait, opening Explorer's Filter dialog in the top pane.

A dialog or sheet now reserves only the part of the keyboard that actually overlaps it. A pane the
keyboard cannot reach reserves nothing and its dialog stays exactly where it is; a pane the keyboard
partly covers reserves only the overlapping part; a full-height pane behaves as before.

The same change fixes a second, smaller problem: a bottom sheet in a pane along the bottom edge
reserved the keyboard height *and* the navigation bar height, so its content floated a navigation
bar above the keyboard instead of sitting on it. Those two are now combined rather than added up.

Only the stacked (dual horizontal) case changes. In the side-by-side landscape layout both panes run
the full height of the window, so nothing there behaves differently.

## Technical Context

- Root cause: `Modifier.imePadding()` resolves to the *window's* IME inset, and nothing in the tree
  consumes window insets, so every pane saw the full keyboard height regardless of where it sat.
- The mask is computed from **measured geometry**, not from the `PaneEdges` model. An earlier draft
  keyed on `touchesBottom`; that is unsound because the resizing divider allows a 0.2/0.8 split, so
  the "top" pane can sit well within keyboard reach while `touchesBottom` is false — and
  `TRIPLE_MAIN_LEFT`/`QUAD_GRID` have the same shape. Keying on the edge model would have removed
  padding from panes the keyboard does reach, hiding the focused field. `paneImePadding()` instead
  measures the node's own distance to the window bottom and reserves `max(ime - gap, 0)`.
- Consequence worth knowing: the bottom navigation rail needs no special case. It is laid out below
  the pane, so its thickness is already inside the measured gap — `LocalPaneBottomChrome` is not read
  here and is left alone for the floating-bar stack.
- Deliberately *not* copying `FloatingBarStackState`'s navigation-bar subtraction. That stack reserves
  the navigation bar itself and subtracts it to avoid double counting; these surfaces reserve no
  vertical system-bar inset, so subtracting it would under-pad by the navigation bar's height.
- Worth a close read: the `onGloballyPositioned` placement in `paneImePadding` sits *before* the
  padding in the modifier chain, so the padding it applies cannot move the node it measures. Both
  call sites have their outer bounds fixed by an ancestor (the dialog by `fillMaxSize()`, the sheet's
  column by the bottom-anchored card), which is what keeps the measurement from oscillating.
