### PR TITLE
General: Fix the sponsor button going dead after a system dialog

### DIFF
--- a/app/src/foss/java/eu/darken/butler/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/butler/upgrade/ui/UpgradeViewModel.kt
@@ -95,16 +95,26 @@ class UpgradeViewModel @AssistedInject constructor(
     // The pitch sponsor action: arms the 5s "visited the sponsor page" honor check.
     fun openSponsor() {
         log(tag) { "openSponsor()" }
-        // Single-flight: a second tap while a launch is still awaiting its return would restamp
-        // the timer and reset the window the return check evaluates.
-        if (hasPendingSponsorLaunch()) {
-            log(tag) { "A sponsor launch is already awaiting its return" }
-            return
+        // Single-flight, but bounded. A tap can only arrive while this screen holds focus, and a
+        // launch that reaches a browser takes focus away within milliseconds — so the only interval
+        // that needs guarding is the handoff right after startActivity, where a second tap of the same
+        // gesture would restamp the timer the return check evaluates. A tap that lands later, with the
+        // marker still present, means nothing ever took the foreground and no return check ever ran;
+        // blocking on that marker is what kills the button for the life of the ViewModel.
+        val pressedAt = savedStateHandle.get<Long>(KEY_SPONSOR_PRESSED_AT)
+        if (pressedAt != null) {
+            val age = SystemClock.elapsedRealtime() - pressedAt
+            if (age in 0 until SPONSOR_SINGLE_FLIGHT_MS) {
+                log(tag) { "A sponsor launch is already awaiting its return" }
+                return
+            }
+            log(tag, WARN) { "Sponsor launch armed ${age}ms ago was never resolved; relaunching" }
         }
         // Only arm the heuristic if the page actually opened; otherwise an unrelated later
         // background/foreground round-trip would grant supporter status with no page ever shown.
         if (!upgradeRepo.openGithubSponsorsPage()) {
-            log(tag) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            log(tag, WARN) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            snackbarEvent.tryEmit(R.string.upgrade_screen_sponsor_open_failed)
             return
         }
         savedStateHandle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
@@ -181,5 +191,8 @@ class UpgradeViewModel @AssistedInject constructor(
         private const val KEY_SPONSOR_PRESSED_AT = "sponsor_pressed_at"
         private const val KEY_SHOW_OPTIONS = "show_upgrade_options"
         private const val SPONSOR_DELAY_MS = 5_000L
+        // Covers the focus handoff right after startActivity, nothing longer: a wider window would
+        // swallow a genuine retry tap after e.g. an app chooser was dismissed.
+        private const val SPONSOR_SINGLE_FLIGHT_MS = 1_000L
     }
 }

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁.</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Back already? Your support keeps Butler alive — please take a moment to check out the sponsors page.</string>
+    <string name="upgrade_screen_sponsor_open_failed">Couldn\'t open the sponsors page. Try opening it in a browser instead.</string>
 
     <string name="upgrade_screen_status_free_title">You\'re on the free version</string>
     <string name="upgrade_screen_status_free_body">Butler FOSS is fully open source. Unlock the extra features by supporting development.</string>

--- a/app/src/testFoss/java/eu/darken/butler/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/butler/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
@@ -79,6 +80,38 @@ class FossUpgradeScreenHostTest : BaseTest() {
 
         composeRule.waitUntil { persisted == 1 }
         vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a pause without a stop leaves the sponsor button working`() {
+        // The reported journey: a dialog-themed activity (a system permission prompt) in the same
+        // task pauses the screen without stopping it, so the tracker never arms and no return check
+        // ever runs. The marker stays behind and must not brick the button.
+        val repo = mockRepo()
+        val vm = buildVm(repo)
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(manage = false, vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.openSponsor()
+        // Advanced before the transition: a return check, had one run, would have taken the persist
+        // branch rather than the too-fast one, so persisted == 0 below can only mean nothing ran.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        // STARTED, not CREATED: going down only this far emits ON_PAUSE without an ON_STOP.
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        persisted shouldBe 0
+
+        vm.openSponsor()
+        verify(exactly = 2) { repo.openGithubSponsorsPage() }
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/butler/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/butler/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -230,6 +230,133 @@ class FossUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `an unresolved sponsor launch no longer blocks the button`() = runTest2(context = testDispatcher) {
+        // A pause without a stop (a system dialog over the screen) leaves the marker armed with no
+        // return check ever running. Nothing else clears it, so an unbounded guard would make every
+        // later tap a silent no-op for the life of the ViewModel.
+        val repo = mockRepo()
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle, manage = false)
+
+        vm.openSponsor()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        val relaunchedAt = SystemClock.elapsedRealtime()
+        vm.openSponsor()
+        advanceUntilIdle()
+
+        verify(exactly = 2) { repo.openGithubSponsorsPage() }
+        // Mirrors the ViewModel's private KEY_SPONSOR_PRESSED_AT: the relaunch restamps, so the honor
+        // delay is measured from the visit the user is actually on.
+        handle.get<Long>("sponsor_pressed_at") shouldBe relaunchedAt
+    }
+
+    @Test
+    fun `relaunching an unresolved sponsor launch does not grant the upgrade`() = runTest2(context = testDispatcher) {
+        // A relaunch is not a return: only checkSponsorReturn evaluates a visit, so reopening the page
+        // must not hand out supporter status or any feedback of its own.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo, manage = false)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvent.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvent.collect { thanks.add(it) } }
+
+        vm.openSponsor()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.openSponsor()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        nudges.shouldBeEmpty()
+        thanks.shouldBeEmpty()
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a failed relaunch keeps the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The marker is never removed on its own, only overwritten by a successful launch: a marker
+        // restored by a failed unlock write is by construction older than the window, and dropping it
+        // here would destroy a qualified visit whenever the relaunch then fails too.
+        val repo = mockRepo()
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle, manage = false)
+
+        vm.openSponsor()
+        val armedAt = handle.get<Long>("sponsor_pressed_at")
+        advanceUntilIdle()
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        every { repo.openGithubSponsorsPage() } returns false
+        vm.openSponsor()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        handle.get<Long>("sponsor_pressed_at") shouldBe armedAt
+    }
+
+    @Test
+    fun `a sponsor launch stamped in the future does not block the button`() = runTest2(context = testDispatcher) {
+        // A stamp the clock has not reached yet (a clock source that moved backwards) is not a launch
+        // in flight. Treating a negative age as one would reinstate the permanent latch the bounded
+        // guard exists to remove.
+        val repo = mockRepo()
+        val handle = SavedStateHandle(mapOf("sponsor_pressed_at" to SystemClock.elapsedRealtime() + 60_000L))
+        val vm = buildVm(repo = repo, handle = handle, manage = false)
+
+        val pressedAt = SystemClock.elapsedRealtime()
+        vm.openSponsor()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+        handle.get<Long>("sponsor_pressed_at") shouldBe pressedAt
+    }
+
+    @Test
+    fun `the single-flight window ends exactly at its boundary`() = runTest2(context = testDispatcher) {
+        // The window covers the focus handoff right after startActivity and nothing longer — a tap
+        // that lands after it is a user retrying a launch that never took the foreground.
+        val blockedRepo = mockRepo()
+        val blockedVm = buildVm(repo = blockedRepo, manage = false)
+
+        blockedVm.openSponsor()
+        ShadowSystemClock.advanceBy(Duration.ofMillis(999))
+        blockedVm.openSponsor()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { blockedRepo.openGithubSponsorsPage() }
+
+        val relaunchRepo = mockRepo()
+        val relaunchVm = buildVm(repo = relaunchRepo, manage = false)
+
+        relaunchVm.openSponsor()
+        ShadowSystemClock.advanceBy(Duration.ofMillis(1000))
+        relaunchVm.openSponsor()
+        advanceUntilIdle()
+
+        verify(exactly = 2) { relaunchRepo.openGithubSponsorsPage() }
+    }
+
+    @Test
+    fun `a sponsor page that never opened tells the user`() = runTest2(context = testDispatcher) {
+        // The launch boolean carries no cause, so a silent return leaves a button that is
+        // indistinguishable from a dead one.
+        val repo = mockRepo()
+        every { repo.openGithubSponsorsPage() } returns false
+        val vm = buildVm(repo = repo, manage = false)
+
+        val nudge = async { vm.snackbarEvent.first() }
+        vm.openSponsor()
+        advanceUntilIdle()
+
+        nudge.await() shouldBe R.string.upgrade_screen_sponsor_open_failed
+    }
+
+    @Test
     fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
         context = testDispatcher,
     ) {


### PR DESCRIPTION
## What changed

Tapping "Sponsor development" on the upgrade screen could stop doing anything at all. No browser, no error message, nothing. Once it happened the button stayed dead for as long as that screen lived, so repeated taps had no effect either.

It was triggered by a system dialog appearing over the sponsoring screen (the notification-permission prompt, or an "open with" chooser). Dismissing the dialog left the screen looking normal while the button had already been disabled behind the scenes. The button now recovers on the very next tap in that situation.

Separately: when nothing on the device is able to open the sponsors link, the button used to fail silently, which looked exactly like the bug above. It now says the page could not be opened.

## Technical Context

- Root cause: `openSponsor()` returned early whenever the handle-backed `KEY_SPONSOR_PRESSED_AT` marker was set, and that marker has exactly one consumer, `checkSponsorReturn()`, reached from an `ON_RESUME` effect and only when `SponsorReturnTracker` was armed by an `ON_STOP`. A dialog-themed activity in the app's own task pauses the screen without stopping it, so no `ON_STOP` fires, nothing clears the marker, and every later tap is a silent no-op for the life of the ViewModel.
- The guard is now bounded by the age of the stored `elapsedRealtime` stamp. `SPONSOR_SINGLE_FLIGHT_MS` is 1s and deliberately a separate constant from the 5s `SPONSOR_DELAY_MS`, because the two answer different questions: the window only has to cover the focus handoff after `startActivity`. A wider window reproduces the reported dead-button symptom for its own duration whenever a chooser or dialog shows up instead of a browser and the user re-taps. The `age in 0 until …` form (rather than `age <`) is what makes a stamp from the future, i.e. a clock that moved backwards, relaunch instead of blocking.
- The marker is never removed on the stale path, only overwritten by a successful launch. `checkSponsorReturn()`'s catch block restores the original stamp after a failed unlock write so a later resume can retry, and removing it here would destroy that qualified visit whenever the relaunch also failed. Accepted residual: a successful relaunch does restamp it, costing the user one extra visit before the write is retried. `hasPendingSponsorLaunch()` is deliberately left unbounded, since it seeds `SponsorReturnTracker` after process recreation, where an arbitrarily old marker is the legitimate case.
- Worth a close read: `FossUpgradeScreenHostTest."a pause without a stop leaves the sponsor button working"`. Its step order is load-bearing. The clock advances before the lifecycle transition so that `persisted == 0` proves no return check ran; a version that merely counted two launches would pass whether or not the marker survived.
- Out of scope on purpose: a stale marker plus an Activity recreation still grants supporter status once past the honor delay. That behaviour is unchanged here and is not the reported symptom.
