### PR TITLE
Workspace: Fix the performance graph jumping while an operation runs

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -165,31 +166,34 @@ fun OperationPerformanceGraph(
                 null
             }
 
-            CartesianChartHost(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(180.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(backgroundColor),
-                chart = rememberCartesianChart(
-                    // Layer order matches the series order in the transaction above
-                    *listOfNotNull(bytesLayer, itemsLayer).toTypedArray(),
-                    startAxis = startAxis,
-                    endAxis = endAxis,
-                    bottomAxis = HorizontalAxis.rememberBottom(
-                        label = null,  // Hide X-axis labels like Windows Explorer
-                        guideline = null,  // Hide grid lines
-                        tick = null,  // Hide tick marks
+            // Keyed like the producer above so a mode flip pairs a fresh host with the fresh producer
+            key(byteSpeeds != null) {
+                CartesianChartHost(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(180.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(backgroundColor),
+                    chart = rememberCartesianChart(
+                        // Layer order matches the series order in the transaction above
+                        *listOfNotNull(bytesLayer, itemsLayer).toTypedArray(),
+                        startAxis = startAxis,
+                        endAxis = endAxis,
+                        bottomAxis = HorizontalAxis.rememberBottom(
+                            label = null,  // Hide X-axis labels like Windows Explorer
+                            guideline = null,  // Hide grid lines
+                            tick = null,  // Hide tick marks
+                        ),
                     ),
-                ),
-                modelProducer = modelProducer,
-                zoomState = rememberVicoZoomState(
-                    zoomEnabled = false,
-                    // Use content to fit all data without specifying exact range
-                    initialZoom = remember { Zoom.Content },
-                ),
-                animationSpec = null,  // Updates outpace the tween, it would never finish
-            )
+                    modelProducer = modelProducer,
+                    zoomState = rememberVicoZoomState(
+                        zoomEnabled = false,
+                        // Use content to fit all data without specifying exact range
+                        initialZoom = remember { Zoom.Content },
+                    ),
+                    animationSpec = null,  // Updates outpace the tween, it would never finish
+                )
+            }
 
             // Recent average byte speed label (top-left, matches left Y-axis)
             if (byteSpeeds != null) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -188,6 +188,7 @@ fun OperationPerformanceGraph(
                     // Use content to fit all data without specifying exact range
                     initialZoom = remember { Zoom.Content },
                 ),
+                animationSpec = null,  // Updates outpace the tween, it would never finish
             )
 
             // Recent average byte speed label (top-left, matches left Y-axis)

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.operations.core.PerformanceSample
+import eu.darken.butler.common.formatByteSpeed
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.ComposeTest
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+
+class OperationPerformanceGraphTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val graphTag = "test-performance-graph"
+
+    private val startTime = Instant.fromEpochMilliseconds(1000)
+
+    private val bytesPerSecond = 50_000_000L
+
+    private fun history(withBytes: Boolean) = PerformanceHistory(
+        samples = (0 until 20).map { i ->
+            PerformanceSample(
+                timestamp = startTime + 250.milliseconds * i,
+                bytesPerSecond = if (withBytes) bytesPerSecond else 0L,
+                itemsPerSecond = 5f,
+                totalBytesProcessed = if (withBytes) i * bytesPerSecond else 0L,
+                totalItemsProcessed = i,
+            )
+        },
+        startTime = startTime,
+        totalBytes = if (withBytes) 1_000_000_000L else 0L,
+        totalItems = 20,
+    )
+
+    private fun graphData(withBytes: Boolean) = PerformanceGraphData.from(history(withBytes))!!
+
+    @Test
+    fun `byte data appearing mid operation keeps the graph composed`() {
+        val itemsOnly = graphData(withBytes = false)
+        itemsOnly.byteSpeeds shouldBe null
+        val withBytes = graphData(withBytes = true)
+        withBytes.byteSpeeds.shouldNotBeNull()
+
+        val graphData = mutableStateOf(itemsOnly)
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraph(
+                    modifier = Modifier.testTag(graphTag),
+                    graphData = graphData.value,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+
+        graphData.value = withBytes
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+        composeTestRule.onNodeWithText(formatByteSpeed(context, bytesPerSecond)).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## What changed

While an operation is running, the performance graph no longer jerks downward and springs back. Previously the line was redrawn from the bottom of the chart on every progress update, so the graph looked like it was repeatedly collapsing to zero, and it only settled into the right shape once the operation had finished. It now updates smoothly as new speed samples arrive.

The same screen also had a crash. Opening the details of an operation whose byte throughput only starts partway through, so the graph begins with just an items axis and gains a second one later, could bring down the operation details sheet.

## Technical Context

- Root cause of the jumping: Vico's `CartesianChartHost` defaults to a 500 ms tween for difference animations. Progress samples arrive every 250 ms and each one starts a new model transaction, which cancels the running tween and restarts it from fraction 0. The animation therefore never finished and the line was permanently drawn mid-tween. A point whose x key changed since the previous model interpolates from a height fraction of zero, which is what produced the collapse to the baseline. Passing `animationSpec = null` applies each new model at once.
- Accepted side effect: Vico gates `animateIn` behind the same non-null check, so the chart's first-appearance animation goes away together with the difference animation. The API offers no way to keep one without the other, and for a live-updating graph appearing already drawn is the better behaviour.
- Root cause of the crash: the chart's model producer is keyed on whether the history carries a byte series. When byte data first appears while the graph is already composed, that key flips and builds a second producer while the host stays in the same composition slot. Vico's `collectAsState` pins the first producer's identity hash in an unkeyed `remember` and asserts it on every composition, so the new instance threw `IllegalStateException`. Keying the host on the same condition discards its composition group along with the producer.
- Worth a close look: the producer deliberately keeps its own key instead of becoming unkeyed. A single producer surviving the flip would briefly hand a one-series model to a chart that already carries two layers, trading one defect for another.
- Checked on-device in a way CI cannot show: the graph fix was verified by an A/B on one emulator with identical data, where the defect reproduced on the base build (6 of 8 rapid frames showed the line collapsed to the baseline) and was absent on the fixed build (0 of 8). That covers the animation change only, since a folder-size scan never gains a byte series; the crash fix is covered by the new regression test, which was confirmed to fail without it.
