### PR TITLE
Workspace: Show that an operation is canceling until it stops

### DIFF
--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/SaverWorkspace.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/SaverWorkspace.kt
@@ -124,7 +124,7 @@ class SaverWorkspace @AssistedInject constructor(
             if (managedOp == null) {
                 flowOf(null)
             } else {
-                managedOp.state.map { managedOp }
+                combine(managedOp.state, managedOp.cancelRequested) { _, _ -> managedOp }
             }
         }
 

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspacePage.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspacePage.kt
@@ -169,7 +169,10 @@ internal fun SaverWorkspacePage(
             dialogState = operationDialogState,
             operations = listOfNotNull(state.operationDisplay),
             onDismissDialog = { operationDialogState = OperationDialogState.None },
-            onCancelOperation = { operationDialogState = OperationDialogState.None },
+            onCancelOperation = { operationId ->
+                vm?.cancelOperation(operationId)
+                operationDialogState = OperationDialogState.None
+            },
             onShareError = { vm?.shareError(it) },
             onHandleIssue = { operationId ->
                 vm?.showConflictSheet(operationId)

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspaceViewModel.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/ui/saver/SaverWorkspaceViewModel.kt
@@ -406,6 +406,8 @@ class SaverWorkspaceViewModel @AssistedInject constructor(
         conflictUiStateFlow.update { it.copy(visible = false) }
     }
 
+    fun cancelOperation(operationId: Operation.Id) = chrome.cancelOperation(operationId)
+
     fun shareError(operationId: Operation.Id) = chrome.shareOperationError(operationId)
 
     fun showOperationInHistory(operationId: Operation.Id) = chrome.showOperationInHistory(operationId)

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/ManagedOperation.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/ManagedOperation.kt
@@ -43,6 +43,13 @@ class ManagedOperation(
     )
     val state: StateFlow<Operation.State> = _state
 
+    /**
+     * Set by [cancel] and never by [Operation.perform], so no state the operation emits can flip it
+     * back and make a cancelled operation read as running again.
+     */
+    private val _cancelRequested = MutableStateFlow(false)
+    val cancelRequested: StateFlow<Boolean> = _cancelRequested
+
     val metadata: Operation.Metadata = operation.metadata
 
     private val completionEmitted = AtomicBoolean(false)
@@ -55,7 +62,7 @@ class ManagedOperation(
     fun claimCompletionEmission(): Boolean = completionEmitted.compareAndSet(false, true)
 
     val canCancel: Boolean
-        get() = metadata.isCancellable && when (state.value) {
+        get() = metadata.isCancellable && !_cancelRequested.value && when (state.value) {
             is Operation.State.Queued -> true  // Can cancel before it starts
             is Operation.State.Active -> scope.coroutineContext[Job]?.isActive == true  // Can cancel if running
             is Operation.State.Waiting -> scope.coroutineContext[Job]?.isActive == true  // Can cancel if waiting
@@ -124,11 +131,26 @@ class ManagedOperation(
         // Fires exactly once when the job terminates for any reason — normal completion, error, or
         // cancellation, INCLUDING cancellation before perform() ever dispatched — and only after the
         // flow's own finalizers have run, so it never wipes state mid-operation.
-        job.invokeOnCompletion { runCatching { operation.onDiscarded() } }
+        job.invokeOnCompletion { cause ->
+            // A cancellation that lands before the collector body runs leaves the flow's own
+            // onCompletion unreachable, so nothing would ever publish a terminal state.
+            if (cause is CancellationException && _state.value !is Operation.State.Completed) {
+                log(tag, INFO) { "Operation $id was cancelled before it started collecting" }
+                _state.value = object : Operation.State.Completed {
+                    override val startedAt: Instant = startTime
+                    override val completedAt: Instant = Clock.System.now()
+                    override val summary: CaString = R.string.general_result_user_cancel_msg.toCaString()
+                    override val report: Operation.Report? = null
+                    override val error: Throwable = cause
+                }
+            }
+            runCatching { operation.onDiscarded() }
+        }
     }
 
     fun cancel() {
         log(tag) { "cancel()" }
+        _cancelRequested.value = true
         scope.cancel()
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsManagerExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/OperationsManagerExtensions.kt
@@ -21,7 +21,9 @@ fun Flow<List<ManagedOperation>>.withStateUpdates(): Flow<List<ManagedOperation>
     flatMapLatest { operations ->
         when {
             operations.isEmpty() -> flowOf(operations)
-            else -> kotlinCombine(operations.map { it.state }) { _ -> operations }
+            else -> kotlinCombine(
+                operations.flatMap { listOf<Flow<Any>>(it.state, it.cancelRequested) }
+            ) { _ -> operations }
         }
     }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationDisplay.kt
@@ -32,6 +32,9 @@ data class OperationDisplay(
         ) : State
 
         data class Waiting(val reason: CaString) : State
+
+        /** Cancel was requested, the work is still unwinding. */
+        data object Cancelling : State
         data class Completed(
             val summary: CaString,
             val completedAt: Instant,
@@ -63,20 +66,10 @@ fun ManagedOperation.toDisplayModel(): OperationDisplay {
         canCancel = canCancel,
         pathPlan = metadata.pathPlan,
         kind = metadata.kind,
-        state = when (state) {
-            is Operation.State.Queued -> OperationDisplay.State.Queued
-            is Operation.State.Active -> {
-                // Extract performanceHistory from primaryProgress.extra where it's stored
-                val performanceHistory = (state as? Operation.HasPerformanceHistory)?.performanceHistory
-                OperationDisplay.State.Running(
-                    primaryProgress = state.primaryProgress,
-                    secondaryProgress = state.secondaryProgress,
-                    canPause = canPause,
-                    performanceHistory = performanceHistory,
-                )
-            }
-            is Operation.State.Waiting -> OperationDisplay.State.Waiting(reason = state.reason)
-            is Operation.State.Completed -> {
+        // A terminal state is checked before the cancel request so an operation that has finished
+        // unwinding can never be described as still cancelling.
+        state = when {
+            state is Operation.State.Completed -> {
                 val errorValue = state.error
                 // Extract performanceHistory from report if available
                 val performanceHistory = (state as? Operation.HasPerformanceHistory)?.performanceHistory
@@ -106,6 +99,19 @@ fun ManagedOperation.toDisplayModel(): OperationDisplay {
                     }
                 }
             }
+            cancelRequested.value -> OperationDisplay.State.Cancelling
+            state is Operation.State.Queued -> OperationDisplay.State.Queued
+            state is Operation.State.Active -> {
+                // Extract performanceHistory from primaryProgress.extra where it's stored
+                val performanceHistory = (state as? Operation.HasPerformanceHistory)?.performanceHistory
+                OperationDisplay.State.Running(
+                    primaryProgress = state.primaryProgress,
+                    secondaryProgress = state.secondaryProgress,
+                    canPause = canPause,
+                    performanceHistory = performanceHistory,
+                )
+            }
+            state is Operation.State.Waiting -> OperationDisplay.State.Waiting(reason = state.reason)
             else -> throw IllegalStateException("Unknown state: $state")
         },
     )

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayState.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/OperationsDisplayState.kt
@@ -21,11 +21,12 @@ internal val operationDisplayComparator: Comparator<OperationDisplay> =
     compareBy<OperationDisplay> { op ->
         when (op.state) {
             is OperationDisplay.State.Running -> 0
-            is OperationDisplay.State.Waiting -> 1
-            is OperationDisplay.State.Queued -> 2
-            is OperationDisplay.State.Failed -> 3
-            is OperationDisplay.State.Cancelled -> 4
-            is OperationDisplay.State.Completed -> 5
+            is OperationDisplay.State.Cancelling -> 1
+            is OperationDisplay.State.Waiting -> 2
+            is OperationDisplay.State.Queued -> 3
+            is OperationDisplay.State.Failed -> 4
+            is OperationDisplay.State.Cancelled -> 5
+            is OperationDisplay.State.Completed -> 6
         }
     }.thenByDescending { it.startedAt }
 

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationActionIndicator.kt
@@ -51,6 +51,11 @@ internal fun operationStateVisuals(state: OperationDisplay.State): OperationStat
         contentDescription = stringResource(R.string.operations_state_waiting),
         tint = MaterialTheme.colorScheme.tertiary,
     )
+    is OperationDisplay.State.Cancelling -> OperationStateVisuals(
+        imageVector = Icons.TwoTone.Cancel,
+        contentDescription = stringResource(R.string.operations_state_cancelling),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
     is OperationDisplay.State.Completed -> OperationStateVisuals(
         imageVector = Icons.TwoTone.CheckCircle,
         contentDescription = stringResource(R.string.operations_state_successful),
@@ -121,6 +126,10 @@ private fun OperationActionIndicatorPreview() {
             state = OperationDisplay.State.Running(),
             modifier = Modifier.size(24.dp),
             onAction = {} // Shows cancel button
+        )
+        OperationActionIndicator(
+            state = OperationDisplay.State.Cancelling,
+            modifier = Modifier.size(24.dp)
         )
         OperationActionIndicator(
             state = OperationDisplay.State.Completed(

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
@@ -57,6 +57,7 @@ fun OperationEntryRow(
         is OperationDisplay.State.Completed,
         is OperationDisplay.State.Failed,
         is OperationDisplay.State.Cancelled,
+        is OperationDisplay.State.Cancelling,
         is OperationDisplay.State.Waiting -> true
         else -> false
     }
@@ -115,6 +116,7 @@ fun OperationEntryRow(
                             )
                             is OperationDisplay.State.Running -> Icons.TwoTone.Info to MaterialTheme.colorScheme.onSecondaryContainer
                             is OperationDisplay.State.Waiting -> Icons.TwoTone.Handyman to MaterialTheme.colorScheme.tertiary
+                            is OperationDisplay.State.Cancelling -> Icons.TwoTone.Cancel to MaterialTheme.colorScheme.onSurfaceVariant
                             else -> Icons.TwoTone.Info to MaterialTheme.colorScheme.onSecondaryContainer
                         }
 
@@ -131,6 +133,7 @@ fun OperationEntryRow(
                             is OperationDisplay.State.Completed -> operation.state.summary.asComposable()
                             is OperationDisplay.State.Failed -> operation.state.summary.asComposable()
                             is OperationDisplay.State.Waiting -> operation.state.reason.asComposable()
+                            is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
                             else -> operation.description.asComposable()
                         }
 
@@ -244,7 +247,9 @@ fun OperationEntryRow(
                             }
                         }
                     }
-                    is OperationDisplay.State.Waiting -> {
+                    // Work is still happening, it just has no measurable progress any more.
+                    is OperationDisplay.State.Waiting,
+                    is OperationDisplay.State.Cancelling -> {
                         // Indeterminate progress bar for waiting operations
                         Spacer(modifier = Modifier.height(2.dp))
 
@@ -298,6 +303,7 @@ fun OperationEntryRow(
                         is OperationDisplay.State.Running -> operation.state.primaryProgress.secondary.asComposable()
                         is OperationDisplay.State.Completed -> operation.state.summary.asComposable()
                         is OperationDisplay.State.Waiting -> operation.state.reason.asComposable()
+                        is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
                         else -> operation.description.asComposable()
                     }
                     Text(
@@ -312,6 +318,11 @@ fun OperationEntryRow(
                 // Progress bar for running operations
                 val progressData = (operation.state as? OperationDisplay.State.Running)?.primaryProgress
 
+                if (operation.state is OperationDisplay.State.Cancelling) {
+                    LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
 
                 progressData?.let { progressData ->
                     when (val count = progressData.count) {
@@ -602,4 +613,39 @@ private fun OperationEntryRowWaitingPreview() {
         onActionClick = {},
         isBarExpanded = false,
     )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationEntryRowCancellingPreview() {
+    Column {
+        OperationEntryRow(
+            operation = OperationDisplay(
+                id = Operation.Id(),
+                title = "Copy operation".toCaString(),
+                description = "Copying to backup folder".toCaString(),
+                icon = Icons.TwoTone.Delete,
+                state = OperationDisplay.State.Cancelling,
+                startedAt = Clock.System.now(),
+            ),
+            onRowClick = {},
+            onActionClick = {},
+            isBarExpanded = true,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OperationEntryRow(
+            operation = OperationDisplay(
+                id = Operation.Id(),
+                title = "Copy operation".toCaString(),
+                description = "Copying to backup folder".toCaString(),
+                icon = Icons.TwoTone.Delete,
+                state = OperationDisplay.State.Cancelling,
+                startedAt = Clock.System.now(),
+            ),
+            onRowClick = {},
+            onActionClick = {},
+            isBarExpanded = false,
+        )
+    }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationsBar.kt
@@ -141,15 +141,18 @@ fun OperationsBar(
                     !isExpanded -> {
                         // When collapsed, prioritize operations needing attention
                         val waitingOps = operations.filter { it.state is OperationDisplay.State.Waiting }
-                        val runningOps = operations.filter { it.state is OperationDisplay.State.Running }
+                        val ongoingOps = operations.filter {
+                            it.state is OperationDisplay.State.Running || it.state is OperationDisplay.State.Cancelling
+                        }
                         when {
                             // Priority 1: Waiting operations (require user input, blocking)
                             waitingOps.isNotEmpty() -> {
                                 if (waitingOps.size > 1) waitingOps.reversed() else waitingOps
                             }
-                            // Priority 2: Running operations
-                            runningOps.isNotEmpty() -> {
-                                if (runningOps.size > 1) runningOps.reversed() else runningOps
+                            // Priority 2: Ongoing operations, cancelling included: the row the user
+                            // just cancelled must not vanish while the work unwinds.
+                            ongoingOps.isNotEmpty() -> {
+                                if (ongoingOps.size > 1) ongoingOps.reversed() else ongoingOps
                             }
                             // Fallback: Most recently started operation
                             else -> {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBar.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBar.kt
@@ -40,6 +40,7 @@ fun FloatingBarScope.WorkspaceOperationsFloatingBar(
         when (op.state) {
             is OperationDisplay.State.Queued,
             is OperationDisplay.State.Running,
+            is OperationDisplay.State.Cancelling,
             is OperationDisplay.State.Waiting -> true
 
             is OperationDisplay.State.Completed,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationOverviewSection.kt
@@ -117,6 +117,7 @@ private fun OperationOverviewGrid(
             is OperationDisplay.State.Queued -> stringResource(R.string.operations_state_queued)
             is OperationDisplay.State.Running -> stringResource(R.string.operations_state_running)
             is OperationDisplay.State.Waiting -> stringResource(R.string.operations_state_waiting)
+            is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
             is OperationDisplay.State.Completed -> stringResource(R.string.operations_state_successful)
             is OperationDisplay.State.Failed -> stringResource(R.string.operations_state_failed)
             is OperationDisplay.State.Cancelled -> stringResource(R.string.operations_state_cancelled)
@@ -137,6 +138,7 @@ private fun OperationOverviewGrid(
         durationValue = when (operation.state) {
             is OperationDisplay.State.Queued -> stringResource(R.string.operations_details_duration_not_started)
             is OperationDisplay.State.Running,
+            is OperationDisplay.State.Cancelling,
             is OperationDisplay.State.Waiting -> formatDuration(Clock.System.now() - operation.startedAt)
             is OperationDisplay.State.Completed -> formatDuration(operation.state.completedAt - operation.startedAt)
             is OperationDisplay.State.Failed -> formatDuration(operation.state.completedAt - operation.startedAt)

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="operations_state_successful">Successful</string>
     <string name="operations_state_failed">Failed</string>
     <string name="operations_state_cancelled">Canceled</string>
+    <string name="operations_state_cancelling">Canceling…</string>
     <string name="operations_cancel_operation">Cancel operation</string>
     <string name="operations_cancel_dialog_title">Cancel operation?</string>
     <string name="operations_cancel_dialog_message">Are you sure you want to cancel this operation?</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationsManagerTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/operations/OperationsManagerTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -235,4 +236,50 @@ class OperationsManagerTest : BaseTest() {
         managed.claimCompletionEmission() shouldBe true
         managed.claimCompletionEmission() shouldBe false
     }
+
+    @Test
+    fun `a cancel is announced before the operation has finished unwinding`() = runTest {
+        val manager = create()
+        val managed = manager.submitManaged(FakeOperation(workspaceId))
+        runCurrent()
+
+        managed.cancelRequested.value shouldBe false
+
+        managed.cancel()
+
+        managed.cancelRequested.value shouldBe true
+    }
+
+    @Test
+    fun `an operation cancelled while queued can no longer be cancelled`() = runTest {
+        // Deliberately never started: a started operation reaches Completed through the flow's own
+        // onCompletion, which makes canCancel false regardless of the cancel request.
+        val managed = ManagedOperation(
+            id = Operation.Id(),
+            operation = FakeOperation(workspaceId),
+            parentScope = backgroundScope,
+        )
+        managed.state.value.shouldBeInstanceOf<Operation.State.Queued>()
+        managed.canCancel shouldBe true
+
+        managed.cancel()
+
+        managed.canCancel shouldBe false
+    }
+
+    @Test
+    fun `an operation cancelled before its collector runs still reaches a terminal state`() =
+        runTest {
+            // Standard, not unconfined: an unconfined dispatcher runs the collector eagerly and the
+            // flow's own onCompletion would publish the terminal state instead.
+            val manager = OperationsManager(TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+            val managed = manager.submitManaged(FakeOperation(workspaceId))
+
+            manager.cancel(managed.id)
+            runCurrent()
+
+            val state = managed.state.value.shouldBeInstanceOf<Operation.State.Completed>()
+            state.error.shouldBeInstanceOf<CancellationException>()
+            manager.stateObservers.keys.shouldBeEmpty()
+        }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationDisplayTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/OperationDisplayTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.workspace.ui.operations
 
 import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.progress.Progress
 import eu.darken.butler.workspace.core.operations.ManagedOperation
 import eu.darken.butler.workspace.core.operations.Operation
 import io.kotest.matchers.nulls.shouldBeNull
@@ -24,10 +25,11 @@ class OperationDisplayTest : BaseTest() {
         override val error = failure
     }
 
-    private fun managedOp(opState: Operation.State): ManagedOperation {
+    private fun managedOp(opState: Operation.State, cancelRequested: Boolean = false): ManagedOperation {
         val op = mockk<ManagedOperation>()
         every { op.id } returns Operation.Id()
         every { op.state } returns MutableStateFlow(opState)
+        every { op.cancelRequested } returns MutableStateFlow(cancelRequested)
         every { op.canCancel } returns false
         every { op.metadata } returns mockk {
             every { icon } returns mockk()
@@ -61,5 +63,28 @@ class OperationDisplayTest : BaseTest() {
         val display = managedOp(completed(IOException("No space left"))).toDisplayModel()
 
         display.state.shouldBeInstanceOf<OperationDisplay.State.Failed>()
+    }
+
+    @Test
+    fun `a run whose cancel is still unwinding is cancelling`() {
+        val active = object : Operation.State.Active {
+            override val startedAt = Clock.System.now()
+            override val primaryProgress = Progress.Data()
+            override val secondaryProgress: Progress.Data? = null
+        }
+
+        val display = managedOp(active, cancelRequested = true).toDisplayModel()
+
+        display.state.shouldBeInstanceOf<OperationDisplay.State.Cancelling>()
+    }
+
+    @Test
+    fun `a run that finished unwinding is cancelled, not cancelling`() {
+        val display = managedOp(
+            completed(CancellationException("The user cancelled the copy")),
+            cancelRequested = true,
+        ).toDisplayModel()
+
+        display.state.shouldBeInstanceOf<OperationDisplay.State.Cancelled>()
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBarTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/bar/WorkspaceOperationsFloatingBarTest.kt
@@ -250,6 +250,39 @@ class WorkspaceOperationsFloatingBarTest : ComposeTest() {
         emitted shouldBe listOf(OperationsBarAction.ClearCompleted)
     }
 
+    /** Pressing cancel a second time does nothing, so the affordance must not stay offered. */
+    @Test
+    fun `a cancelling operation offers no cancel action`() {
+        setBar {
+            listOf(operation(FIRST_TITLE, OperationDisplay.State.Cancelling))
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(WorkspaceR.string.operations_cancel_operation))
+            .assertDoesNotExist()
+    }
+
+    /**
+     * The collapsed bar picks its rows independently of the sort order, so a second running
+     * operation must not push the row the user just cancelled out of view.
+     */
+    @Test
+    fun `a collapsed bar keeps a cancelling operation beside a running one`() {
+        setBar(initialExpanded = false) {
+            listOf(
+                operation(FIRST_TITLE, OperationDisplay.State.Cancelling, startedAt = defaultStartedAt),
+                operation(SECOND_TITLE, running(SECOND_TITLE), startedAt = defaultStartedAt + 1.minutes),
+            )
+        }
+
+        composeTestRule.onNodeWithText(FIRST_TITLE).assertIsDisplayed()
+        composeTestRule.onNodeWithText(SECOND_TITLE).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(context.getString(WorkspaceR.string.operations_state_cancelling))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("$FIRST_TITLE details").assertDoesNotExist()
+    }
+
     companion object {
         private const val KEY = "operations"
         private const val FIRST_TITLE = "Copying files"

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/page/WorkspacePageChromeTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/page/WorkspacePageChromeTest.kt
@@ -50,10 +50,14 @@ class WorkspacePageChromeTest : BaseTest() {
         override val issue = issue
     }
 
-    private fun managedOp(stateFlow: MutableStateFlow<Operation.State>): ManagedOperation {
+    private fun managedOp(
+        stateFlow: MutableStateFlow<Operation.State>,
+        cancelRequestedFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    ): ManagedOperation {
         val op = mockk<ManagedOperation>()
         every { op.id } returns Operation.Id()
         every { op.state } returns stateFlow
+        every { op.cancelRequested } returns cancelRequestedFlow
         every { op.canCancel } returns true
         every { op.metadata } returns mockk {
             every { origin } returns Operation.Metadata.Origin.Explorer(workspaceId)
@@ -286,6 +290,31 @@ class WorkspacePageChromeTest : BaseTest() {
         runCurrent()
 
         emissions.last().operations.single().state.shouldBeInstanceOf<OperationDisplay.State.Waiting>()
+        collector.cancel()
+    }
+
+    @Test
+    fun `operations re-emits when only the cancel request changes`() = runTest {
+        val stateFlow = MutableStateFlow<Operation.State>(
+            Operation.State.Queued(startedAt = Clock.System.now()),
+        )
+        val cancelRequestedFlow = MutableStateFlow(false)
+        val operationsManager = mockk<OperationsManager>().apply {
+            every { operations } returns MutableStateFlow(listOf(managedOp(stateFlow, cancelRequestedFlow)))
+            every { completedOperations } returns MutableSharedFlow()
+        }
+        val chrome = backgroundScope.chrome(operationsManager)
+
+        val emissions = mutableListOf<OperationsDisplayState>()
+        val collector = chrome.operations.onEach { emissions.add(it) }.launchIn(backgroundScope)
+        runCurrent()
+
+        emissions.last().operations.single().state shouldBe OperationDisplay.State.Queued
+
+        cancelRequestedFlow.value = true
+        runCurrent()
+
+        emissions.last().operations.single().state shouldBe OperationDisplay.State.Cancelling
         collector.cancel()
     }
 

--- a/app/src/main/java/eu/darken/butler/main/core/operations/fgs/OperationFgsCoordinator.kt
+++ b/app/src/main/java/eu/darken/butler/main/core/operations/fgs/OperationFgsCoordinator.kt
@@ -173,8 +173,17 @@ class OperationFgsCoordinator @Inject constructor(
         for (op in ongoing) {
             seen += op.id
             val slot = slots.getOrPut(op.id) { OpSlot(nextId(), nextId()) }
-            when (op.state.value) {
-                is Operation.State.Waiting -> {
+            when {
+                // A cancel requested from Waiting must not keep the attention notification: its
+                // title, reason and conflict-resolution intent all describe a wait that is over.
+                op.cancelRequested.value -> {
+                    notificationManager.notify(
+                        slot.progressId,
+                        notifications.buildProgress(slot.progressId, op, op.state.value),
+                    )
+                    notificationManager.cancel(slot.attentionId)
+                }
+                op.state.value is Operation.State.Waiting -> {
                     notificationManager.notify(slot.attentionId, notifications.buildAttention(slot.attentionId, op))
                     notificationManager.cancel(slot.progressId)
                 }

--- a/app/src/main/java/eu/darken/butler/main/core/operations/fgs/OperationNotifications.kt
+++ b/app/src/main/java/eu/darken/butler/main/core/operations/fgs/OperationNotifications.kt
@@ -87,6 +87,9 @@ class OperationNotifications @Inject constructor(
         when {
             operation.cancelRequested.value -> {
                 builder.setContentText(context.getString(R.string.ops_notification_state_cancelling))
+                builder.setStyle(
+                    NotificationCompat.BigTextStyle().bigText(operation.metadata.description.get(context)),
+                )
                 builder.setProgress(0, 0, true)
             }
             state is Operation.State.Active -> {

--- a/app/src/main/java/eu/darken/butler/main/core/operations/fgs/OperationNotifications.kt
+++ b/app/src/main/java/eu/darken/butler/main/core/operations/fgs/OperationNotifications.kt
@@ -84,8 +84,12 @@ class OperationNotifications @Inject constructor(
             .setOnlyAlertOnce(true)
             .setContentIntent(focusWorkspaceIntent(notificationId, operation))
 
-        when (state) {
-            is Operation.State.Active -> {
+        when {
+            operation.cancelRequested.value -> {
+                builder.setContentText(context.getString(R.string.ops_notification_state_cancelling))
+                builder.setProgress(0, 0, true)
+            }
+            state is Operation.State.Active -> {
                 // The title is per-kind ("Copy operation"), so with several operations running
                 // it cannot tell them apart. The metadata description names what is being moved
                 // and where, which is what makes a row identifiable, and what makes its Cancel

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -492,6 +492,7 @@
         <item quantity="other">%1$d file operations running</item>
     </plurals>
     <string name="ops_notification_state_queued">Queued…</string>
+    <string name="ops_notification_state_cancelling">Canceling…</string>
     <string name="ops_notification_state_attention_title">Action required</string>
     <string name="ops_notification_state_attention_text">A conflict needs your attention — tap to resolve</string>
     <string name="ops_notification_result_failed_title">Operation failed</string>

--- a/app/src/test/java/eu/darken/butler/main/core/operations/fgs/OperationFgsCoordinatorTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/core/operations/fgs/OperationFgsCoordinatorTest.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
 import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.issue.Issue
 import eu.darken.butler.workspace.core.operations.CompletedOperationSnapshot
 import eu.darken.butler.workspace.core.operations.ManagedOperation
 import eu.darken.butler.workspace.core.operations.Operation
@@ -74,10 +75,19 @@ class OperationFgsCoordinatorTest : BaseTest() {
         state: Operation.State,
         id: Operation.Id = Operation.Id(),
         cancellable: Boolean = true,
+        cancelRequestedFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
     ): ManagedOperation = mockk {
         every { this@mockk.id } returns id
         every { this@mockk.state } returns MutableStateFlow(state)
+        every { cancelRequested } returns cancelRequestedFlow
         every { canCancel } returns cancellable
+    }
+
+    private fun waitingState() = object : Operation.State.Waiting {
+        override val startedAt = t0
+        override val waitingSince = t0
+        override val reason = "conflict".toCaString()
+        override val issue: Issue = mockk(relaxed = true)
     }
 
     private fun completedState(error: Throwable? = null) = object : Operation.State.Completed {
@@ -221,5 +231,30 @@ class OperationFgsCoordinatorTest : BaseTest() {
         testScope.advanceUntilIdle()
 
         verify { notificationManager.cancel(id) }
+    }
+
+    /**
+     * The attention notification's title, reason and content intent all describe a wait the user
+     * has just called off, so it must give way to the progress notification.
+     */
+    @Test
+    fun `cancelling a waiting operation replaces its attention notification with progress`() {
+        val attentionId = slot<Int>()
+        every { notifications.buildAttention(capture(attentionId), any()) } returns mockk(relaxed = true)
+
+        startCoordinator()
+        coordinator.onAppBackgrounded()
+        testScope.advanceUntilIdle()
+
+        val cancelRequested = MutableStateFlow(false)
+        opsFlow.value = listOf(managedOp(waitingState(), cancelRequestedFlow = cancelRequested))
+        testScope.advanceUntilIdle()
+        val postedAttentionId = attentionId.captured
+
+        cancelRequested.value = true
+        testScope.advanceUntilIdle()
+
+        verify { notifications.buildProgress(any(), any(), any()) }
+        verify { notificationManager.cancel(postedAttentionId) }
     }
 }

--- a/app/src/test/java/eu/darken/butler/main/core/operations/fgs/OperationNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/butler/main/core/operations/fgs/OperationNotificationsTest.kt
@@ -1,0 +1,95 @@
+package eu.darken.butler.main.core.operations.fgs
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.progress.Progress
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.operations.ManagedOperation
+import eu.darken.butler.workspace.core.operations.Operation
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import kotlin.time.Instant
+
+/**
+ * Builds real platform notifications, so it needs a Robolectric context and lives in :app where
+ * the notification's content intents resolve against the app manifest.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OperationNotificationsTest : BaseTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val t0 = Instant.fromEpochMilliseconds(0)
+
+    private val description = "Copying 5 files to Download"
+
+    private fun createNotifications(): OperationNotifications = OperationNotifications(
+        context = context,
+        notificationManager = context.getSystemService(NotificationManager::class.java)!!,
+    ).also { it.setupChannels() }
+
+    private fun activeState(): Operation.State.Active = object : Operation.State.Active {
+        override val startedAt = t0
+        override val primaryProgress = Progress.Data(count = Progress.Count.Percent(1, 2))
+        override val secondaryProgress: Progress.Data? = null
+    }
+
+    private fun opMetadata(): Operation.Metadata = mockk(relaxed = true) {
+        every { origin } returns Operation.Metadata.Origin.Explorer(Workspace.Id())
+        every { title } returns "Copy operation".toCaString()
+        every { this@mockk.description } returns this@OperationNotificationsTest.description.toCaString()
+    }
+
+    private fun managedOp(
+        state: Operation.State,
+        cancelRequested: Boolean,
+    ): ManagedOperation = mockk {
+        every { this@mockk.id } returns Operation.Id()
+        every { this@mockk.state } returns MutableStateFlow(state)
+        every { this@mockk.cancelRequested } returns MutableStateFlow(cancelRequested)
+        // A cancel-requested operation can no longer be cancelled again.
+        every { canCancel } returns !cancelRequested
+        every { metadata } returns opMetadata()
+    }
+
+    /** Control: the description reaches the notification while the operation is simply running. */
+    @Test
+    fun `an active operation carries its description`() {
+        val notification = createNotifications().buildProgress(
+            notificationId = 1,
+            operation = managedOp(activeState(), cancelRequested = false),
+            state = activeState(),
+        )
+
+        notification.extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() shouldBe description
+        notification.extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() shouldBe description
+    }
+
+    /**
+     * The title is per-kind ("Copy operation"), so with two operations of the same kind running,
+     * dropping the description leaves the user unable to tell which one is cancelling.
+     */
+    @Test
+    fun `a cancel-requested operation still carries its description`() {
+        val notification = createNotifications().buildProgress(
+            notificationId = 2,
+            operation = managedOp(activeState(), cancelRequested = true),
+            state = activeState(),
+        )
+
+        notification.extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() shouldBe
+            context.getString(R.string.ops_notification_state_cancelling)
+        notification.extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString() shouldBe description
+    }
+}


### PR DESCRIPTION
## What changed

Cancelling a file operation now shows that it is cancelling. Before, pressing cancel on a long-running operation — a copy to a network share, for instance — produced no error, no change to the row, and no sign that anything had happened. The operation kept showing its old progress and the cancel button stayed active, so the same operation could be cancelled over and over with no visible effect, until the underlying work eventually finished unwinding on its own.

The operation now switches to a "Canceling…" state as soon as cancel is pressed, with an indeterminate progress bar, and its cancel button is withdrawn. That applies everywhere an operation is shown: the operations bar (collapsed and expanded), the operation details sheet, and the foreground-service notification while the app is in the background.

Two related problems are fixed alongside it:

- An operation cancelled before it started running kept offering a cancel button that did nothing, and in a narrow timing window could be left showing "Queued" indefinitely while keeping the foreground service alive.
- In the Saver, the operation details sheet's Cancel button closed the dialog without cancelling anything at all.

## Technical Context

- Root cause: `ManagedOperation.cancel()` only cancelled the coroutine scope and published no state at all. The operations list recomposes only when some `ManagedOperation.state` emits, so nothing re-rendered between the cancel request and the work actually unwinding — which on an SMB share can be a 30-second blocking write.
- The cancel marker is a separate `StateFlow` rather than a new `Operation.State` variant. `onEach { _state.emit(state) }` writes whatever `perform()` produces, so a state already past the collector's cancellation check could overwrite a marker written into `_state` and flip the row back to Running. A flow `perform()` never writes cannot lose that race.
- `toDisplayModel()` tests the terminal `Completed` state before the cancel request, so an operation that has finished unwinding is never re-described as still cancelling.
- `job.invokeOnCompletion` now publishes a terminal state when cancellation lands before the collector body starts. The flow's own `onCompletion` is unreachable in that window, so `_state` would otherwise stay `Queued` forever, holding its state observer open and the foreground service with it.
- Worth close review: the collapsed operations bar selects its visible rows with its own filters rather than the sort comparator, so the new state had to be added there separately — otherwise a just-cancelled row vanishes from the bar whenever another operation is running.

Deliberately not included: shortening the unwind window itself on SMB. Nothing establishes how long it actually is, and an `ensureActive()` in the copy loop cannot interrupt a write already blocked inside `requestBlocking`, which is not wrapped in `runInterruptible`.
