### PR TITLE
IO: Fix the operation graph starting partway across the plot

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PathOperationProgressTracker.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PathOperationProgressTracker.kt
@@ -26,7 +26,16 @@ class PathOperationProgressTracker(
     var totalItems = 0
     var itemsProcessed = 0
     var totalBytes = 0L
+
+    /** Bytes actually moved. */
     var processedBytes = 0L
+
+    /**
+     * Work accounted for: [processedBytes] plus the size of every item that completed without
+     * moving a byte. The performance graph plots this, throughput is measured from [processedBytes].
+     */
+    var accountedBytes = 0L
+        private set
 
     // Current file progress
     var currentFileSize = 0L
@@ -45,6 +54,7 @@ class PathOperationProgressTracker(
 
     private var lastSampleTime: Instant? = null
     private var lastSampleBytes = 0L
+    private var lastSampleAccounted = 0L
     private var lastSampleItems = 0
 
     /**
@@ -66,6 +76,7 @@ class PathOperationProgressTracker(
     fun updateFileProgress(bytes: Long) {
         currentFileBytes += bytes
         processedBytes += bytes
+        accountedBytes += bytes
     }
 
     /**
@@ -76,6 +87,7 @@ class PathOperationProgressTracker(
         val remaining = currentFileSize - currentFileBytes
         if (remaining > 0) {
             processedBytes += remaining
+            accountedBytes += remaining
         }
 
         currentFileSize = 0L
@@ -98,6 +110,35 @@ class PathOperationProgressTracker(
     fun completeItem(bytes: Long) {
         itemsProcessed++
         processedBytes += bytes
+        accountedBytes += bytes
+    }
+
+    /**
+     * Marks an item complete that transferred no bytes: a created directory, a skipped file, a
+     * subtree renamed in one call. Its size counts as work accounted for so the performance graph's
+     * x advances with it, but not as bytes moved.
+     */
+    fun skipItem(size: Long) {
+        val remaining = size - currentFileBytes
+        if (remaining > 0) accountedBytes += remaining
+        currentFileSize = 0L
+        currentFileBytes = 0L
+        currentFileStartTime = null
+        itemsProcessed++
+    }
+
+    /** A retried transfer restarts at byte zero; drop the abandoned attempt's bytes. */
+    fun restartFile() {
+        processedBytes -= currentFileBytes
+        accountedBytes -= currentFileBytes
+        currentFileBytes = 0L
+        // The abandoned attempt is not progress: rebase the sample marks so the next sample
+        // measures the retry alone rather than a negative delta.
+        lastSampleBytes = processedBytes
+        lastSampleAccounted = accountedBytes
+        lastSampleItems = itemsProcessed
+        lastSampleTime = clock.now()
+        currentFileStartTime = clock.now()
     }
 
     /**
@@ -109,6 +150,7 @@ class PathOperationProgressTracker(
         itemsProcessed = 0
         totalBytes = 0L
         processedBytes = 0L
+        accountedBytes = 0L
         currentFileSize = 0L
         currentFileBytes = 0L
         currentFileStartTime = null
@@ -116,6 +158,7 @@ class PathOperationProgressTracker(
         performanceHistory = PerformanceHistory()
         lastSampleTime = null
         lastSampleBytes = 0L
+        lastSampleAccounted = 0L
         lastSampleItems = 0
     }
 
@@ -158,14 +201,16 @@ class PathOperationProgressTracker(
     private fun recordPerformanceSample(now: Instant) {
         val lastTime = lastSampleTime
         val lastBytes = lastSampleBytes
+        val lastAccounted = lastSampleAccounted
         val lastItems = lastSampleItems
 
         // Calculate deltas
         val bytesDelta = processedBytes - lastBytes
+        val accountedDelta = accountedBytes - lastAccounted
         val itemsDelta = itemsProcessed - lastItems
 
         // Only skip if no progress has been made
-        if (bytesDelta == 0L && itemsDelta == 0) {
+        if (bytesDelta == 0L && accountedDelta == 0L && itemsDelta == 0) {
             lastSampleTime = now
             return
         }
@@ -224,6 +269,7 @@ class PathOperationProgressTracker(
             itemsPerSecond = itemsPerSecond,
             totalBytesProcessed = processedBytes,
             totalItemsProcessed = itemsProcessed,
+            totalBytesAccounted = accountedBytes,
         )
 
         performanceHistory = performanceHistory.addSample(
@@ -234,6 +280,7 @@ class PathOperationProgressTracker(
 
         lastSampleTime = now
         lastSampleBytes = processedBytes
+        lastSampleAccounted = accountedBytes
         lastSampleItems = itemsProcessed
     }
 
@@ -246,6 +293,7 @@ class PathOperationProgressTracker(
             itemsProcessed = itemsProcessed,
             totalBytes = totalBytes,
             processedBytes = processedBytes,
+            accountedBytes = accountedBytes,
             currentFileSize = currentFileSize,
             currentFileBytes = currentFileBytes,
             currentFileStartTime = currentFileStartTime
@@ -260,6 +308,7 @@ class PathOperationProgressTracker(
         val itemsProcessed: Int,
         val totalBytes: Long,
         val processedBytes: Long,
+        val accountedBytes: Long,
         val currentFileSize: Long,
         val currentFileBytes: Long,
         val currentFileStartTime: Instant?

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
@@ -11,6 +11,10 @@ import kotlin.time.Instant
 
 /**
  * Single performance sample captured at a point in time.
+ *
+ * [totalBytesProcessed] is bytes actually moved, [totalBytesAccounted] is work accounted for: those
+ * bytes plus the size of every item that completed without moving one (a created directory, a
+ * skipped file). The graph plots the latter, throughput is measured from the former.
  */
 @Serializable
 data class PerformanceSample(
@@ -20,6 +24,7 @@ data class PerformanceSample(
     val itemsPerSecond: Float,
     val totalBytesProcessed: Long,
     val totalItemsProcessed: Int,
+    val totalBytesAccounted: Long = totalBytesProcessed,
 )
 
 /**
@@ -148,7 +153,7 @@ data class PerformanceHistory(
             val percentage = if (useItems) {
                 (sample.totalItemsProcessed.toDouble() / totalItems) * 100.0
             } else {
-                (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
+                (sample.totalBytesAccounted.toDouble() / totalBytes) * 100.0
             }
             // Clamp percentage to [0.0, 100.0] and ensure bucket index is [0, NUM_BUCKETS - 1]
             val clampedPercentage = percentage.coerceIn(0.0, 100.0)

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathCopy.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathCopy.kt
@@ -101,6 +101,11 @@ internal class GenericPathCopy<
     private val skipped = linkedSetOf<SPL>()
     private var totalBytesTransferred = 0L
 
+    // Last values an Active state actually carried, so the terminal report can skip a no-op emission
+    private var lastEmittedItems = -1
+    private var lastEmittedProcessed = -1L
+    private var lastEmittedAccounted = -1L
+
     // Shared components
     private val progressTracker = PathOperationProgressTracker(clock = progressClock)
     private val issueResolver = PathOperationIssueResolver(onIssue)
@@ -127,6 +132,8 @@ internal class GenericPathCopy<
     // Scan tracking
     private var scanItemsRemaining = 0
     private val completedScans = mutableSetOf<SP>()
+    // A source only ever contributes to the totals once, however often a failed scan is retried
+    private val registeredScans = mutableSetOf<SP>()
     // Track followed symlink aliases so recursive scans can detect alias cycles.
     private val resolvedSymlinkAliases = mutableMapOf<String, String>()
 
@@ -219,6 +226,7 @@ internal class GenericPathCopy<
         }
 
         // Process work queue
+        var lastProcessed: Pair<SPL, DP>? = null
         while (workQueue.isNotEmpty() && currentCoroutineContext().isActive) {
             when (val item = workQueue.removeFirst()) {
                 is WorkItem.ScanSource<*> -> {
@@ -235,28 +243,43 @@ internal class GenericPathCopy<
 
                 is WorkItem.CopyFile<*, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processCopyFile(item as WorkItem.CopyFile<SP, SPL, DP>) { send(it) }
+                    val copyItem = item as WorkItem.CopyFile<SP, SPL, DP>
+                    processCopyFile(copyItem) { send(it) }
+                    lastProcessed = copyItem.sourceLookup to copyItem.destination
                 }
 
                 is WorkItem.CreateDirectory<*, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processCreateDirectory(item as WorkItem.CreateDirectory<SP, SPL, DP>)
+                    val dirItem = item as WorkItem.CreateDirectory<SP, SPL, DP>
+                    processCreateDirectory(dirItem) { send(it) }
+                    lastProcessed = dirItem.sourceLookup to dirItem.destination
                 }
 
                 is WorkItem.BatchCopySubtree<*, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processBatchCopySubtree(item as WorkItem.BatchCopySubtree<SP, SPL, DP>) { send(it) }
+                    val batchItem = item as WorkItem.BatchCopySubtree<SP, SPL, DP>
+                    processBatchCopySubtree(batchItem) { send(it) }
+                    lastProcessed = batchItem.sourceLookup to batchItem.destination
                 }
 
                 is WorkItem.ResolveConflict<*, *, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processResolveConflict(item as WorkItem.ResolveConflict<SP, SPL, DP, DPL>)
+                    val conflictItem = item as WorkItem.ResolveConflict<SP, SPL, DP, DPL>
+                    processResolveConflict(conflictItem) { send(it) }
+                    lastProcessed = conflictItem.sourceLookup to conflictItem.destination
                 }
             }
         }
 
         // Record final 100% sample before completing
         progressTracker.shouldReportProgress(force = true)
+        // Completed carries no progress data, so counters that advanced past the last emission
+        // (e.g. a trailing burst of skips inside the throttle window) need one last Active state
+        val finalSnapshot = progressTracker.createSnapshot()
+        val advanced = finalSnapshot.itemsProcessed != lastEmittedItems ||
+            finalSnapshot.processedBytes != lastEmittedProcessed ||
+            finalSnapshot.accountedBytes != lastEmittedAccounted
+        if (advanced) lastProcessed?.let { (lookup, dest) -> reportProgress(lookup, dest) { send(it) } }
 
         // For same-type operations (SP=DP), copied is Set<Pair<SP, DP>> which equals Set<Pair<SP, SP>>
         // For cross-type, this won't compile - cross-type operations should use their own result type
@@ -319,8 +342,10 @@ internal class GenericPathCopy<
         when (effectiveLookup.fileType) {
             FileType.FILE, FileType.SYMBOLIC_LINK -> {
                 // SYMBOLIC_LINK only when followSymlinks=false (otherwise resolved above)
-                progressTracker.totalItems++
-                progressTracker.totalBytes += effectiveLookup.size ?: 0L
+                if (registeredScans.add(item.source)) {
+                    progressTracker.totalItems++
+                    progressTracker.totalBytes += effectiveLookup.size ?: 0L
+                }
                 workQueue.addLast(WorkItem.CopyFile(effectiveLookup, destPath, item.topLevelSource))
 
                 // Report scan progress with throttling
@@ -333,8 +358,10 @@ internal class GenericPathCopy<
             }
 
             FileType.DIRECTORY -> {
-                progressTracker.totalItems++
-                progressTracker.totalBytes += effectiveLookup.size ?: 0L
+                if (registeredScans.add(item.source)) {
+                    progressTracker.totalItems++
+                    progressTracker.totalBytes += effectiveLookup.size ?: 0L
+                }
 
                 // Report scan progress with throttling
                 if (progressTracker.shouldReportProgress()) {
@@ -449,7 +476,8 @@ internal class GenericPathCopy<
         if (isDescendantOfSkippedDir(item.sourceLookup.lookedUp)) {
             log(TAG, VERBOSE) { "Skipping file - parent directory was skipped" }
             skipped.add(item.sourceLookup)
-            progressTracker.completeItem()
+            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+            reportItemProgress(item.sourceLookup, item.destination, emit)
             return
         }
 
@@ -491,7 +519,7 @@ internal class GenericPathCopy<
 
                 is TransferStrategy.TransferResult.Skipped -> {
                     skipped.add(item.sourceLookup)
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(item.sourceLookup.size ?: 0L)
                 }
             }
 
@@ -503,19 +531,25 @@ internal class GenericPathCopy<
             log(TAG, VERBOSE) { "File collision detected: $adjustedDest" }
             val destLookup = destOps.lookup(adjustedDest, LookupOptions.BASE)
             handleFileConflict(item, adjustedDest, destLookup)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             handleCopyError(e, item)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         }
     }
 
-    private suspend fun processCreateDirectory(item: WorkItem.CreateDirectory<SP, SPL, DP>) {
+    private suspend fun processCreateDirectory(
+        item: WorkItem.CreateDirectory<SP, SPL, DP>,
+        emit: suspend (CopyAction.State<SP, SPL, DP, DPL>) -> Unit
+    ) {
         // Skip if parent directory was skipped
         if (isDescendantOfSkippedDir(item.sourceLookup.lookedUp)) {
             log(TAG, VERBOSE) { "Skipping directory - parent directory was skipped" }
             skipped.add(item.sourceLookup)
-            progressTracker.completeItem()
+            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+            reportItemProgress(item.sourceLookup, item.destination, emit)
             return
         }
 
@@ -528,6 +562,7 @@ internal class GenericPathCopy<
         if (destLookup.fileType != FileType.UNKNOWN) {
             log(TAG, VERBOSE) { "Directory collision detected: $adjustedDest" }
             handleDirectoryConflict(item, adjustedDest, destLookup)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
             return
         }
 
@@ -548,18 +583,21 @@ internal class GenericPathCopy<
                         ?: destOps.lookup(result.destination, LookupOptions.BASE)
                     copied.add(item.sourceLookup to destLookup)
                     totalBytesTransferred += result.bytesTransferred
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(item.sourceLookup.size ?: 0L)
                 }
 
                 is TransferStrategy.TransferResult.Skipped -> {
                     skipped.add(item.sourceLookup)
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(item.sourceLookup.size ?: 0L)
                 }
             }
+
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             handleDirectoryError(e, item)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         }
     }
 
@@ -570,7 +608,8 @@ internal class GenericPathCopy<
         if (isDescendantOfSkippedDir(item.sourceLookup.lookedUp)) {
             log(TAG, VERBOSE) { "Skipping batch subtree - parent directory was skipped" }
             skipped.add(item.sourceLookup)
-            progressTracker.completeItem()
+            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+            reportItemProgress(item.sourceLookup, item.destination, emit)
             return
         }
 
@@ -583,6 +622,7 @@ internal class GenericPathCopy<
             return
         }
 
+        var forwardedBatchProgress = false
         try {
             ensureBatchDestinationParent(destinationRoot)
             ensureBatchDestinationAbsent(destinationRoot)
@@ -593,7 +633,11 @@ internal class GenericPathCopy<
                 onIssue = onIssue,
             ).collect { state ->
                 when (state) {
-                    is CopyAction.State.Active -> emitBatchProgress(state, emit)
+                    is CopyAction.State.Active -> {
+                        emitBatchProgress(state, emit)
+                        forwardedBatchProgress = true
+                    }
+
                     is CopyAction.State.Completed -> {
                         @Suppress("UNCHECKED_CAST")
                         copied.addAll(state.copied as Set<Pair<SPL, APathLookup<DP>>>)
@@ -602,7 +646,17 @@ internal class GenericPathCopy<
                         totalBytesTransferred += state.copiedBytes
                         try {
                             normalizeOwnershipIfNeeded(item.ownershipFixup, destinationRoot, item.sourceRoute)
-                            progressTracker.completeItem()
+                            // Only the subtree root is in totalBytes, its children were never scanned
+                            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+                            // The forwarded batch state is the newest progress the UI has, and it carries the
+                            // nested operation's history. Adopt the tracker's counters as emitted so the
+                            // terminal state check doesn't overwrite it with our own coarser progress.
+                            if (forwardedBatchProgress) {
+                                val snapshot = progressTracker.createSnapshot()
+                                lastEmittedItems = snapshot.itemsProcessed
+                                lastEmittedProcessed = snapshot.processedBytes
+                                lastEmittedAccounted = snapshot.accountedBytes
+                            }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: OwnershipNormalizationException) {
@@ -732,7 +786,10 @@ internal class GenericPathCopy<
         )
     }
 
-    private suspend fun processResolveConflict(item: WorkItem.ResolveConflict<SP, SPL, DP, DPL>) {
+    private suspend fun processResolveConflict(
+        item: WorkItem.ResolveConflict<SP, SPL, DP, DPL>,
+        emit: suspend (CopyAction.State<SP, SPL, DP, DPL>) -> Unit
+    ) {
         val canMerge = item.originalItem is WorkItem.CreateDirectory<*, *, *> &&
             item.destLookup.fileType == FileType.DIRECTORY
 
@@ -785,6 +842,8 @@ internal class GenericPathCopy<
             },
             onRenameDestination = { workQueue.addFirst(item.originalItem) }
         )
+
+        reportItemProgress(item.sourceLookup, item.destination, emit)
     }
 
     private fun calculateDestinationPath(source: SP, topLevelSource: SP): DP {
@@ -820,6 +879,7 @@ internal class GenericPathCopy<
             onSkip = {
                 skipped.add(it)
                 skippedSourceDirs.add(it.lookedUp)
+                if (originalItem.source in registeredScans) progressTracker.skipItem(it.size ?: 0L)
             },
             onRetry = { workQueue.addFirst(originalItem) },
             onIssue = onIssue,
@@ -835,7 +895,10 @@ internal class GenericPathCopy<
             issueResolver = issueResolver,
             progressTracker = progressTracker,
             onSkip = { skipped.add(it) },
-            onRetry = { workQueue.addFirst(originalItem) },
+            onRetry = {
+                progressTracker.restartFile()
+                workQueue.addFirst(originalItem)
+            },
             canRetry = true,
             onIssue = onIssue,
             tag = TAG
@@ -924,12 +987,26 @@ internal class GenericPathCopy<
         )
     }
 
+    /**
+     * Throttled progress report for a completion that moved no bytes.
+     */
+    private suspend fun reportItemProgress(
+        lookup: SPL,
+        destination: DP,
+        emit: suspend (CopyAction.State<SP, SPL, DP, DPL>) -> Unit
+    ) {
+        if (progressTracker.shouldReportProgress()) reportProgress(lookup, destination, emit)
+    }
+
     private suspend fun reportProgress(
         lookup: SPL,
         destLookup: DP,
         emit: suspend (CopyAction.State<SP, SPL, DP, DPL>) -> Unit
     ) {
         val snapshot = progressTracker.createSnapshot()
+        lastEmittedItems = snapshot.itemsProcessed
+        lastEmittedProcessed = snapshot.processedBytes
+        lastEmittedAccounted = snapshot.accountedBytes
 
         @Suppress("UNCHECKED_CAST")
         emit(

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathMove.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathMove.kt
@@ -88,6 +88,11 @@ internal class GenericPathMove<
     private val skipped = linkedSetOf<SPL>()
     private var totalBytesTransferred = 0L
 
+    // Last values an Active state actually carried, so the terminal report can skip a no-op emission
+    private var lastEmittedItems = -1
+    private var lastEmittedProcessed = -1L
+    private var lastEmittedAccounted = -1L
+
     // Shared components
     private val progressTracker = PathOperationProgressTracker(clock = progressClock)
     private val issueResolver = PathOperationIssueResolver(onIssue)
@@ -116,6 +121,8 @@ internal class GenericPathMove<
     // Scan tracking
     private var scanItemsRemaining = 0
     private val completedScans = mutableSetOf<SP>()
+    // A source only ever contributes to the totals once, however often a failed scan is retried
+    private val registeredScans = mutableSetOf<SP>()
 
     // Destination state
     private var destinationExistedAsDirectory = false
@@ -256,6 +263,7 @@ internal class GenericPathMove<
         }
 
         // Process work queue
+        var lastProcessed: Pair<SPL, DP>? = null
         while (workQueue.isNotEmpty() && currentCoroutineContext().isActive) {
             when (val item = workQueue.removeFirst()) {
                 is WorkItem.ScanSource<*> -> {
@@ -272,22 +280,30 @@ internal class GenericPathMove<
 
                 is WorkItem.MoveFile<*, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processMoveFile(item as WorkItem.MoveFile<SP, SPL, DP>) { send(it) }
+                    val moveItem = item as WorkItem.MoveFile<SP, SPL, DP>
+                    processMoveFile(moveItem) { send(it) }
+                    lastProcessed = moveItem.sourceLookup to moveItem.destination
                 }
 
                 is WorkItem.CreateDirectory<*, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processCreateDirectory(item as WorkItem.CreateDirectory<SP, SPL, DP>)
+                    val dirItem = item as WorkItem.CreateDirectory<SP, SPL, DP>
+                    processCreateDirectory(dirItem) { send(it) }
+                    lastProcessed = dirItem.sourceLookup to dirItem.destination
                 }
 
                 is WorkItem.BatchMoveSubtree<*, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processBatchMoveSubtree(item as WorkItem.BatchMoveSubtree<SP, SPL, DP>) { send(it) }
+                    val batchItem = item as WorkItem.BatchMoveSubtree<SP, SPL, DP>
+                    processBatchMoveSubtree(batchItem) { send(it) }
+                    lastProcessed = batchItem.sourceLookup to batchItem.destination
                 }
 
                 is WorkItem.ResolveConflict<*, *, *, *> -> {
                     @Suppress("UNCHECKED_CAST")
-                    processResolveConflict(item as WorkItem.ResolveConflict<SP, SPL, DP, DPL>)
+                    val conflictItem = item as WorkItem.ResolveConflict<SP, SPL, DP, DPL>
+                    processResolveConflict(conflictItem) { send(it) }
+                    lastProcessed = conflictItem.sourceLookup to conflictItem.destination
                 }
             }
         }
@@ -297,6 +313,13 @@ internal class GenericPathMove<
 
         // Record final 100% sample before completing
         progressTracker.shouldReportProgress(force = true)
+        // Completed carries no progress data, so counters that advanced past the last emission
+        // (e.g. a trailing burst of skips inside the throttle window) need one last Active state
+        val finalSnapshot = progressTracker.createSnapshot()
+        val advanced = finalSnapshot.itemsProcessed != lastEmittedItems ||
+            finalSnapshot.processedBytes != lastEmittedProcessed ||
+            finalSnapshot.accountedBytes != lastEmittedAccounted
+        if (advanced) lastProcessed?.let { (lookup, dest) -> reportProgress(lookup, dest) { send(it) } }
 
         send(
             MoveAction.State.Completed(
@@ -345,8 +368,10 @@ internal class GenericPathMove<
 
         when (lookup.fileType) {
             FileType.FILE, FileType.SYMBOLIC_LINK -> {
-                progressTracker.totalItems++
-                progressTracker.totalBytes += lookup.size ?: 0L
+                if (registeredScans.add(item.source)) {
+                    progressTracker.totalItems++
+                    progressTracker.totalBytes += lookup.size ?: 0L
+                }
                 workQueue.addLast(WorkItem.MoveFile(lookup, destPath, item.topLevelSource))
 
                 // Report scan progress with throttling
@@ -359,8 +384,10 @@ internal class GenericPathMove<
             }
 
             FileType.DIRECTORY -> {
-                progressTracker.totalItems++
-                progressTracker.totalBytes += lookup.size ?: 0L
+                if (registeredScans.add(item.source)) {
+                    progressTracker.totalItems++
+                    progressTracker.totalBytes += lookup.size ?: 0L
+                }
 
                 // Report scan progress with throttling
                 if (progressTracker.shouldReportProgress()) {
@@ -405,7 +432,7 @@ internal class GenericPathMove<
                                 is AtomicMoveResult.Success -> {
                                     // Atomic move succeeded - moved in one operation
                                     moved.add(lookup to atomicMoveResult.destLookup)
-                                    progressTracker.completeItem()
+                                    progressTracker.skipItem(lookup.size ?: 0L)
 
                                     // Report progress
                                     if (progressTracker.shouldReportProgress()) {
@@ -512,7 +539,8 @@ internal class GenericPathMove<
         if (isDescendantOfSkippedDir(item.sourceLookup.lookedUp)) {
             log(TAG, VERBOSE) { "Skipping file - parent directory was skipped" }
             skipped.add(item.sourceLookup)
-            progressTracker.completeItem()
+            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+            reportItemProgress(item.sourceLookup, item.destination, emit)
             return
         }
 
@@ -524,6 +552,7 @@ internal class GenericPathMove<
         val destLookup = destOps.lookup(adjustedDest, LookupOptions.BASE.copy(fallbackToUnknown = true))
         if (destLookup.fileType != FileType.UNKNOWN) {
             handleFileConflict(item, adjustedDest, destLookup)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
             return
         }
 
@@ -561,7 +590,7 @@ internal class GenericPathMove<
 
                 is TransferStrategy.TransferResult.Skipped -> {
                     skipped.add(item.sourceLookup)
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(item.sourceLookup.size ?: 0L)
                 }
             }
 
@@ -573,15 +602,20 @@ internal class GenericPathMove<
             throw e
         } catch (e: Exception) {
             handleMoveError(e, item)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         }
     }
 
-    private suspend fun processCreateDirectory(item: WorkItem.CreateDirectory<SP, SPL, DP>) {
+    private suspend fun processCreateDirectory(
+        item: WorkItem.CreateDirectory<SP, SPL, DP>,
+        emit: suspend (MoveAction.State<SP, SPL, DP, DPL>) -> Unit
+    ) {
         if (isDescendantOfSkippedDir(item.sourceLookup.lookedUp)) {
             log(TAG, VERBOSE) { "Skipping directory - parent was skipped" }
             skipped.add(item.sourceLookup)
             skippedSourceDirs.add(item.sourceLookup.lookedUp)
-            progressTracker.completeItem()
+            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+            reportItemProgress(item.sourceLookup, item.destination, emit)
             return
         }
 
@@ -593,6 +627,7 @@ internal class GenericPathMove<
         val destLookup = destOps.lookup(adjustedDest, LookupOptions.BASE.copy(fallbackToUnknown = true))
         if (destLookup.fileType != FileType.UNKNOWN) {
             handleDirectoryConflict(item, adjustedDest, destLookup)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
             return
         }
 
@@ -613,18 +648,21 @@ internal class GenericPathMove<
                         ?: destOps.lookup(result.destination, LookupOptions.BASE)
                     moved.add(item.sourceLookup to destLookup)
                     totalBytesTransferred += result.bytesTransferred
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(item.sourceLookup.size ?: 0L)
                 }
 
                 is TransferStrategy.TransferResult.Skipped -> {
                     skipped.add(item.sourceLookup)
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(item.sourceLookup.size ?: 0L)
                 }
             }
+
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             handleDirectoryError(e, item)
+            reportItemProgress(item.sourceLookup, adjustedDest, emit)
         }
     }
 
@@ -636,7 +674,8 @@ internal class GenericPathMove<
             log(TAG, VERBOSE) { "Skipping batch subtree - parent was skipped" }
             skipped.add(item.sourceLookup)
             skippedSourceDirs.add(item.sourceLookup.lookedUp)
-            progressTracker.completeItem()
+            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+            reportItemProgress(item.sourceLookup, item.destination, emit)
             return
         }
 
@@ -649,6 +688,7 @@ internal class GenericPathMove<
             return
         }
 
+        var forwardedBatchProgress = false
         try {
             ensureBatchDestinationParent(destinationRoot)
             ensureBatchDestinationAbsent(destinationRoot)
@@ -659,7 +699,11 @@ internal class GenericPathMove<
                 onIssue = onIssue,
             ).collect { state ->
                 when (state) {
-                    is MoveAction.State.Active -> emitBatchProgress(state, emit)
+                    is MoveAction.State.Active -> {
+                        emitBatchProgress(state, emit)
+                        forwardedBatchProgress = true
+                    }
+
                     is MoveAction.State.Completed -> {
                         @Suppress("UNCHECKED_CAST")
                         moved.addAll(state.movedFiles as Set<Pair<SPL, APathLookup<DP>>>)
@@ -668,7 +712,17 @@ internal class GenericPathMove<
                         totalBytesTransferred += state.bytesMoved
                         try {
                             normalizeOwnershipIfNeeded(item.ownershipFixup, destinationRoot, item.sourceRoute)
-                            progressTracker.completeItem()
+                            // Only the subtree root is in totalBytes, its children were never scanned
+                            progressTracker.skipItem(item.sourceLookup.size ?: 0L)
+                            // The forwarded batch state is the newest progress the UI has, and it carries the
+                            // nested operation's history. Adopt the tracker's counters as emitted so the
+                            // terminal state check doesn't overwrite it with our own coarser progress.
+                            if (forwardedBatchProgress) {
+                                val snapshot = progressTracker.createSnapshot()
+                                lastEmittedItems = snapshot.itemsProcessed
+                                lastEmittedProcessed = snapshot.processedBytes
+                                lastEmittedAccounted = snapshot.accountedBytes
+                            }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: OwnershipNormalizationException) {
@@ -840,7 +894,10 @@ internal class GenericPathMove<
         )
     }
 
-    private suspend fun processResolveConflict(item: WorkItem.ResolveConflict<SP, SPL, DP, DPL>) {
+    private suspend fun processResolveConflict(
+        item: WorkItem.ResolveConflict<SP, SPL, DP, DPL>,
+        emit: suspend (MoveAction.State<SP, SPL, DP, DPL>) -> Unit
+    ) {
         val canMerge = item.originalItem is WorkItem.CreateDirectory<*, *, *> &&
             item.destLookup.fileType == FileType.DIRECTORY
 
@@ -887,6 +944,8 @@ internal class GenericPathMove<
             },
             onRenameDestination = { workQueue.addFirst(item.originalItem) }
         )
+
+        reportItemProgress(item.sourceLookup, item.destination, emit)
     }
 
     private fun calculateDestinationPath(source: SP, topLevelSource: SP): DP {
@@ -922,6 +981,7 @@ internal class GenericPathMove<
             onSkip = {
                 skipped.add(it)
                 skippedSourceDirs.add(it.lookedUp)
+                if (originalItem.source in registeredScans) progressTracker.skipItem(it.size ?: 0L)
             },
             onRetry = { workQueue.addFirst(originalItem) },
             onIssue = onIssue,
@@ -937,7 +997,10 @@ internal class GenericPathMove<
             issueResolver = issueResolver,
             progressTracker = progressTracker,
             onSkip = { skipped.add(it) },
-            onRetry = { workQueue.addFirst(originalItem) },
+            onRetry = {
+                progressTracker.restartFile()
+                workQueue.addFirst(originalItem)
+            },
             canRetry = true,
             onIssue = onIssue,
             tag = TAG
@@ -1041,12 +1104,26 @@ internal class GenericPathMove<
         )
     }
 
+    /**
+     * Throttled progress report for a completion that moved no bytes.
+     */
+    private suspend fun reportItemProgress(
+        lookup: SPL,
+        destination: DP,
+        emit: suspend (MoveAction.State<SP, SPL, DP, DPL>) -> Unit
+    ) {
+        if (progressTracker.shouldReportProgress()) reportProgress(lookup, destination, emit)
+    }
+
     private suspend fun reportProgress(
         lookup: SPL,
         destination: DP,
         emit: suspend (MoveAction.State<SP, SPL, DP, DPL>) -> Unit
     ) {
         val snapshot = progressTracker.createSnapshot()
+        lastEmittedItems = snapshot.itemsProcessed
+        lastEmittedProcessed = snapshot.processedBytes
+        lastEmittedAccounted = snapshot.accountedBytes
 
         emit(
             MoveAction.State.Active(

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/TransferConflictResolver.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/TransferConflictResolver.kt
@@ -103,7 +103,7 @@ class TransferConflictResolver<
         if (issueResolver.skipAllPathExists) {
             log(tag, INFO) { "Skipping (apply-to-all): $destination" }
             onSkip(sourceLookup)
-            progressTracker.completeItem()
+            progressTracker.skipItem(sourceLookup.size ?: 0L)
             return ApplyToAllResult.Resolved
         }
 
@@ -121,6 +121,7 @@ class TransferConflictResolver<
         if (onMerge != null && destLookup.fileType == FileType.DIRECTORY && issueResolver.mergeAllPathExists) {
             log(tag, INFO) { "Merging directory (apply-to-all): $destination" }
             onMerge()
+            progressTracker.skipItem(sourceLookup.size ?: 0L)
             return ApplyToAllResult.Resolved
         }
 
@@ -229,6 +230,7 @@ class TransferConflictResolver<
         if (destLookup.fileType == FileType.DIRECTORY && onIssue == null) {
             log(tag, VERBOSE) { "Directory already exists, auto-merging: $destination" }
             onMerge()
+            progressTracker.skipItem(sourceLookup.size ?: 0L)
             return
         }
 
@@ -280,7 +282,7 @@ class TransferConflictResolver<
             is PathActionIssue.PathAlreadyExists.Resolution.Skip -> {
                 val isDirectory = canMerge // canMerge is true only for directory conflicts
                 onSkip(sourceLookup, isDirectory)
-                progressTracker.completeItem()
+                progressTracker.skipItem(sourceLookup.size ?: 0L)
             }
 
             is PathActionIssue.PathAlreadyExists.Resolution.Overwrite -> {
@@ -291,7 +293,7 @@ class TransferConflictResolver<
 
             is PathActionIssue.PathAlreadyExists.Resolution.Merge -> {
                 onMerge()
-                progressTracker.completeItem()
+                progressTracker.skipItem(sourceLookup.size ?: 0L)
             }
 
             is PathActionIssue.PathAlreadyExists.Resolution.RenameSource -> {

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/TransferErrorHandler.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/TransferErrorHandler.kt
@@ -157,19 +157,20 @@ class TransferErrorHandler {
                         onRetry()
                     } else {
                         onSkip(sourceLookup)
-                        progressTracker.completeItem()
+                        progressTracker.skipItem(sourceLookup.size ?: 0L)
                     }
                 }
                 else -> {
                     onSkip(sourceLookup)
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(sourceLookup.size ?: 0L)
                 }
             }
             return
         }
 
         // Fast path: Check "apply to all" flags
-        if (checkApplyToAllErrorFlags(error, sourceLookup, issueResolver, onSkip, progressTracker::completeItem, tag)) {
+        val onComplete = { progressTracker.skipItem(sourceLookup.size ?: 0L) }
+        if (checkApplyToAllErrorFlags(error, sourceLookup, issueResolver, onSkip, onComplete, tag)) {
             return
         }
 
@@ -210,7 +211,7 @@ class TransferErrorHandler {
             is PathActionIssue.UnknownError.Resolution.Skip -> {
                 log(tag, INFO) { "User chose to skip: ${sourceLookup.lookedUp}" }
                 onSkip(sourceLookup)
-                progressTracker.completeItem()
+                progressTracker.skipItem(sourceLookup.size ?: 0L)
             }
 
             is PathActionIssue.UnknownError.Resolution.Retry -> {
@@ -220,7 +221,7 @@ class TransferErrorHandler {
                 } else {
                     log(tag, WARN) { "Retry requested but not supported, skipping: ${sourceLookup.lookedUp}" }
                     onSkip(sourceLookup)
-                    progressTracker.completeItem()
+                    progressTracker.skipItem(sourceLookup.size ?: 0L)
                 }
             }
 

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PathOperationProgressTrackerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PathOperationProgressTrackerTest.kt
@@ -303,6 +303,151 @@ class PathOperationProgressTrackerTest : BaseTest() {
     }
 
     @Test
+    fun `skipItem credits accounted bytes but not processed bytes`() {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalItems = 2
+        tracker.totalBytes = 1000L
+
+        tracker.skipItem(size = 400L)
+
+        tracker.itemsProcessed shouldBe 1
+        tracker.processedBytes shouldBe 0L
+        tracker.accountedBytes shouldBe 400L
+    }
+
+    @Test
+    fun `skipItem after a partial transfer credits only the remainder`() {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalBytes = 1000L
+
+        tracker.startFile(size = 500L)
+        tracker.updateFileProgress(bytes = 200L)
+        tracker.skipItem(size = 500L)
+
+        tracker.processedBytes shouldBe 200L
+        tracker.accountedBytes shouldBe 500L
+    }
+
+    @Test
+    fun `skipItem clears the per-file state so the next file reports its own size`() {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalBytes = 11_000_000L
+
+        tracker.startFile(size = 10_000_000L)
+        tracker.skipItem(size = 10_000_000L)
+
+        tracker.currentFileSize shouldBe 0L
+
+        tracker.startFile(size = 1_000_000L)
+        tracker.updateFileProgress(bytes = 1_000_000L)
+        tracker.completeFile()
+
+        tracker.processedBytes shouldBe 1_000_000L
+    }
+
+    @Test
+    fun `restartFile drops the abandoned attempt's bytes from both counters`() {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalBytes = 1000L
+
+        tracker.startFile(size = 500L)
+        tracker.updateFileProgress(bytes = 300L)
+        tracker.restartFile()
+
+        tracker.processedBytes shouldBe 0L
+        tracker.accountedBytes shouldBe 0L
+        tracker.currentFileBytes shouldBe 0L
+        // The size survives, the re-queued item must not start a new file
+        tracker.currentFileSize shouldBe 500L
+
+        tracker.updateFileProgress(bytes = 500L)
+        tracker.completeFile()
+
+        tracker.processedBytes shouldBe 500L
+    }
+
+    @Test
+    fun `a sample records when only accounted bytes advanced`() {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalItems = 2
+        tracker.totalBytes = 1000L
+
+        tracker.startFile(size = 400L)
+        tracker.updateFileProgress(bytes = 400L)
+        tracker.completeFile()
+        tracker.completeItem()
+        tracker.shouldReportProgress(force = true)
+
+        // A directory is created: no bytes move, but its size is work accounted for
+        tracker.skipItem(size = 600L)
+        tracker.shouldReportProgress(force = true)
+
+        val sample = tracker.performanceHistory.samples.last()
+        sample.totalBytesProcessed shouldBe 400L
+        sample.totalBytesAccounted shouldBe 1000L
+    }
+
+    @Test
+    fun `a restarted transfer never samples a negative speed`() {
+        val clock = TestClock()
+        val tracker = PathOperationProgressTracker(clock = clock)
+        tracker.totalItems = 1
+        tracker.totalBytes = 300_000L
+
+        // A first attempt gets part of the way and is sampled
+        tracker.startFile(size = 300_000L)
+        tracker.updateFileProgress(bytes = 200_000L)
+        clock += 1.seconds
+        tracker.shouldReportProgress(force = true)
+
+        // The attempt is abandoned, the transfer restarts at byte zero
+        tracker.restartFile()
+        clock += 1.seconds
+        tracker.updateFileProgress(bytes = 50_000L)
+        tracker.shouldReportProgress(force = true)
+
+        // Then - throughput is never reported as flowing backwards
+        tracker.performanceHistory.samples
+            .map { it.bytesPerSecond }
+            .filter { it < 0L } shouldBe emptyList<Long>()
+    }
+
+    @Test
+    fun `a restart does not inflate the item rate with the items before it`() {
+        val clock = TestClock()
+        val tracker = PathOperationProgressTracker(progressReportInterval = 10.seconds, clock = clock)
+        tracker.totalItems = 5
+        tracker.totalBytes = 5000L
+
+        // A first item completes and is sampled, so the sample marks sit at one item
+        tracker.startFile(size = 1000L)
+        tracker.updateFileProgress(bytes = 1000L)
+        tracker.completeFile()
+        tracker.completeItem()
+        tracker.shouldReportProgress(force = true)
+
+        // Three more items complete inside the throttle window, so none of them is sampled
+        repeat(3) {
+            clock += 1.seconds
+            tracker.skipItem(size = 1000L)
+            tracker.shouldReportProgress() shouldBe false
+        }
+        tracker.itemsProcessed shouldBe 4
+
+        // A transfer is abandoned and restarts, which rebases the sample marks
+        tracker.startFile(size = 1000L)
+        tracker.updateFileProgress(bytes = 400L)
+        tracker.restartFile()
+
+        // 10ms later the retry reports, with no item having completed since the restart
+        clock += 10.milliseconds
+        tracker.shouldReportProgress(force = true)
+
+        // Then - the item rate measures the restart window, not the items completed before it
+        tracker.performanceHistory.samples.last().itemsPerSecond shouldBe 0f
+    }
+
+    @Test
     fun `multiple files tracked correctly`() {
         val tracker = PathOperationProgressTracker()
         tracker.totalItems = 3

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
@@ -907,6 +907,40 @@ class PerformanceHistoryTest : BaseTest() {
     }
 
     @Test
+    fun `bucketing follows accounted bytes rather than transferred bytes`() {
+        val startTime = Instant.fromEpochMilliseconds(1000)
+        var history = PerformanceHistory()
+        val totalBytes = 1_500_000_000L
+
+        // Nothing is ever transferred, every item completes by being created or skipped
+        repeat(1500) { i ->
+            history = history.addSample(
+                PerformanceSample(
+                    timestamp = startTime + (i * 10).milliseconds,
+                    bytesPerSecond = 0L,
+                    itemsPerSecond = 10f,
+                    totalBytesProcessed = 0L,
+                    totalItemsProcessed = i + 1,
+                    totalBytesAccounted = (i + 1) * (totalBytes / 1500),
+                ),
+                totalBytes = totalBytes,
+                totalItems = 0  // Items = 0, so use bytes
+            )
+        }
+
+        val buckets = history.samples.groupBy { sample ->
+            val percentage = (sample.totalBytesAccounted.toDouble() / totalBytes) * 100.0
+            (percentage / 5.0).toInt().coerceIn(0, 19)
+        }
+
+        buckets.keys.size shouldBe 20
+        buckets.keys.min() shouldBe 0
+        buckets.keys.max() shouldBe 19
+        // Bucketing on transferred bytes would have crammed all of these into bucket 0
+        history.samples.all { it.totalBytesProcessed == 0L } shouldBe true
+    }
+
+    @Test
     fun `item-based operation uses items for percentage`() {
         val startTime = Instant.fromEpochMilliseconds(1000)
         var history = PerformanceHistory()

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/operations/GenericPathCopyIssueTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/operations/GenericPathCopyIssueTest.kt
@@ -1,21 +1,30 @@
 package eu.darken.butler.common.files.operations
 
 import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.LookupOptions
 import eu.darken.butler.common.files.actions.CopyAction
 import eu.darken.butler.common.files.actions.PathActionIssue
 import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.routing.AccessIntent
+import eu.darken.butler.common.files.local.routing.AccessMode
+import eu.darken.butler.common.files.local.routing.IntentAwareFileSystemOps
 import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.progress.Progress
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.TestClock
 import testhelpers.firstPath
 import testhelpers.shouldBePaths
 import testhelpers.shouldContainPath
@@ -658,5 +667,278 @@ class GenericPathCopyIssueTest : BaseTest() {
         mockOps.getFileContent("/dest/parent/child.txt") shouldBe "content".toByteArray()
         result.copied.size shouldBe 2 // parent + child.txt
         result.skipped.size shouldBe 0
+    }
+
+    // ============ PROGRESS ACCOUNTING ============
+
+    /** Every progress throttle window has elapsed, so each report site actually emits. */
+    private fun tickingClock() = TestClock(autoAdvance = 1.seconds)
+
+    private fun List<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>.counters() =
+        mapNotNull { it.primaryProgress.count as? Progress.Count.Counter }
+
+    @Test
+    fun `a skipped scan error accounts the directory it already counted`() = runTest {
+        // Given - a directory whose listing fails, plus a sibling file that copies normally
+        mockOps.addMockDir("/source/parent")
+        mockOps.addMockFile("/source/parent/child.txt", "content".toByteArray())
+        mockOps.addMockFile("/source/after.txt", "after".toByteArray())
+        mockOps.addMockDir("/dest")
+
+        mockOps.setFailListFiles(1, { SecurityException("Permission denied") })
+
+        val states = mutableListOf<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>()
+
+        setOf(LocalPath.build("/source/parent"), LocalPath.build("/source/after.txt")).copyGeneric(
+            destination = LocalPath.build("/dest"),
+            sourceOps = mockOps,
+            destOps = mockOps,
+            strategy = strategy,
+            progressClock = tickingClock(),
+            onIssue = { issue ->
+                when (issue) {
+                    is PathActionIssue.UnknownError -> PathActionIssue.UnknownError.Resolution.Skip()
+                    is PathActionIssue.InsufficientPermission -> PathActionIssue.InsufficientPermission.Resolution.Skip()
+                    else -> throw AssertionError("Unexpected issue: $issue")
+                }
+            }
+        ).onEach { if (it is CopyAction.State.Active) states.add(it) }.last()
+
+        // Then - the skipped directory counts towards the items it was already counted in
+        val counter = states.counters().last()
+        counter.max shouldBe 2L
+        counter.current shouldBe 2L
+    }
+
+    @Test
+    fun `a retried scan does not count its directory twice`() = runTest {
+        // Given - a directory whose first listing fails and is retried
+        mockOps.addMockDir("/source/parent")
+        mockOps.addMockFile("/source/parent/child.txt", "content".toByteArray())
+        mockOps.addMockDir("/dest")
+
+        mockOps.setFailListFiles(1, { SecurityException("Permission denied") })
+
+        var retryInvoked = false
+        val states = mutableListOf<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>()
+
+        setOf(LocalPath.build("/source/parent")).copyGeneric(
+            destination = LocalPath.build("/dest"),
+            sourceOps = mockOps,
+            destOps = mockOps,
+            strategy = strategy,
+            progressClock = tickingClock(),
+            onIssue = { issue ->
+                when (issue) {
+                    is PathActionIssue.UnknownError -> {
+                        retryInvoked = true
+                        PathActionIssue.UnknownError.Resolution.Retry
+                    }
+                    else -> throw AssertionError("Unexpected issue: $issue")
+                }
+            }
+        ).onEach { if (it is CopyAction.State.Active) states.add(it) }.last()
+
+        // Then - the directory and its child, not the directory twice
+        retryInvoked shouldBe true
+        states.counters().maxOf { it.max } shouldBe 2L
+    }
+
+    @Test
+    fun `a retried transfer counts the file's bytes once`() = runTest {
+        // Given - a file whose first attempt dies after part of it was written
+        val content = ByteArray(300_000) { (it % 251).toByte() }
+        mockOps.addMockFile("/source/file.bin", content)
+        mockOps.addMockDir("/dest")
+
+        mockOps.setFailWriteAfter(count = 1, afterBytes = 100_000L)
+
+        val states = mutableListOf<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>()
+
+        setOf(LocalPath.build("/source/file.bin")).copyGeneric(
+            destination = LocalPath.build("/dest"),
+            sourceOps = mockOps,
+            destOps = mockOps,
+            strategy = strategy,
+            progressClock = tickingClock(),
+            onIssue = { issue ->
+                when (issue) {
+                    is PathActionIssue.UnknownError -> PathActionIssue.UnknownError.Resolution.Retry
+                    // The failed attempt left a partial file behind
+                    is PathActionIssue.PathAlreadyExists -> PathActionIssue.PathAlreadyExists.Resolution.Overwrite()
+                    else -> throw AssertionError("Unexpected issue: $issue")
+                }
+            }
+        ).onEach { if (it is CopyAction.State.Active) states.add(it) }.last()
+
+        // Then - the abandoned attempt's bytes are not counted a second time
+        mockOps.getFileContent("/dest/file.bin") shouldBe content
+        states.last().copiedBytes shouldBe content.size.toLong()
+    }
+
+    @Test
+    fun `a skip-heavy run reports progress as it goes`() = runTest {
+        // Given - the destination folder already exists and is merged, and every source file
+        // already exists inside it
+        mockOps.addMockDir("/source/folder")
+        mockOps.addMockDir("/dest")
+        mockOps.addMockDir("/dest/folder")
+        (1..12).forEach { i ->
+            val content = ByteArray(i * 10_000) { 'a'.code.toByte() }
+            mockOps.addMockFile("/source/folder/file$i.txt", content)
+            mockOps.addMockFile("/dest/folder/file$i.txt", "old".toByteArray())
+        }
+
+        val states = mutableListOf<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>()
+
+        setOf(LocalPath.build("/source/folder")).copyGeneric(
+            destination = LocalPath.build("/dest"),
+            sourceOps = mockOps,
+            destOps = mockOps,
+            strategy = strategy,
+            progressClock = tickingClock(),
+            onIssue = { issue ->
+                when (issue) {
+                    is PathActionIssue.PathAlreadyExists -> {
+                        if (issue.destination.fileType == FileType.DIRECTORY) {
+                            PathActionIssue.PathAlreadyExists.Resolution.Merge()
+                        } else {
+                            PathActionIssue.PathAlreadyExists.Resolution.Skip(applyToAll = true)
+                        }
+                    }
+
+                    else -> throw AssertionError("Unexpected issue: $issue")
+                }
+            }
+        ).onEach { if (it is CopyAction.State.Active) states.add(it) }.last()
+
+        // Then - the accounted work climbs across the run instead of jumping at the end
+        val history = states.mapNotNull { it.primaryProgress.extra as? PerformanceHistory }.last()
+        history.samples.map { it.totalBytesAccounted }.distinct().size shouldBeGreaterThan 5
+        history.samples.all { it.totalBytesProcessed == 0L } shouldBe true
+    }
+
+    @Test
+    fun `a source skipped before it was counted does not overshoot the item total`() = runTest {
+        // Given - a directory whose only child cannot be planned for writing at the destination
+        val ops = PlanAwareMockOps()
+        ops.addMockDir("/source/parent")
+        ops.addMockFile("/source/parent/blocked.txt", "content".toByteArray())
+        ops.addMockDir("/dest")
+        ops.failPlanning("/dest/parent/blocked.txt") { SecurityException("Permission denied") }
+
+        val states = mutableListOf<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>()
+
+        setOf(LocalPath.build("/source/parent")).copyGeneric(
+            destination = LocalPath.build("/dest"),
+            sourceOps = ops,
+            destOps = ops,
+            strategy = strategy,
+            progressClock = tickingClock(),
+            onIssue = { issue ->
+                when (issue) {
+                    is PathActionIssue.InsufficientPermission -> PathActionIssue.InsufficientPermission.Resolution.Skip()
+                    is PathActionIssue.UnknownError -> PathActionIssue.UnknownError.Resolution.Skip()
+                    else -> throw AssertionError("Unexpected issue: $issue")
+                }
+            }
+        ).onEach { if (it is CopyAction.State.Active) states.add(it) }.last()
+
+        // Then - no report claims more items done than the scan ever counted
+        states.counters()
+            .filter { it.current > it.max }
+            .map { "${it.current}/${it.max}" } shouldBe emptyList<String>()
+    }
+
+    @Test
+    fun `the last item resolved through a conflict prompt is reported as done`() = runTest {
+        // Given - a folder whose last-processed file already exists at the destination.
+        // Children are queued in reverse, so the child added first is the last work item processed.
+        mockOps.addMockDir("/source/folder")
+        mockOps.addMockFile("/source/folder/conflicting.txt", "new".toByteArray())
+        mockOps.addMockFile("/source/folder/plain.txt", "plain".toByteArray())
+        mockOps.addMockDir("/dest")
+        mockOps.addMockDir("/dest/folder")
+        mockOps.addMockFile("/dest/folder/conflicting.txt", "old".toByteArray())
+
+        val states = mutableListOf<CopyAction.State.Active<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>>()
+        val prompted = mutableListOf<String>()
+
+        setOf(LocalPath.build("/source/folder")).copyGeneric(
+            destination = LocalPath.build("/dest"),
+            sourceOps = mockOps,
+            destOps = mockOps,
+            strategy = strategy,
+            progressClock = tickingClock(),
+            onIssue = { issue ->
+                when (issue) {
+                    is PathActionIssue.PathAlreadyExists -> {
+                        prompted.add(issue.destination.lookedUp.path)
+                        if (issue.destination.fileType == FileType.DIRECTORY) {
+                            PathActionIssue.PathAlreadyExists.Resolution.Merge()
+                        } else {
+                            // Without applyToAll this runs the prompt path, not the apply-to-all shortcut
+                            PathActionIssue.PathAlreadyExists.Resolution.Skip()
+                        }
+                    }
+
+                    else -> throw AssertionError("Unexpected issue: $issue")
+                }
+            }
+        ).onEach { if (it is CopyAction.State.Active) states.add(it) }.last()
+
+        // The prompt only fires from the conflict-resolution work item, so this pins the path taken
+        prompted shouldBe listOf("/dest/folder", "/dest/folder/conflicting.txt")
+
+        // Then - the last reported counter has every item accounted for
+        val counter = states.counters().last()
+        counter.current shouldBe counter.max
+    }
+
+    /**
+     * [MockFileSystemOps] plus the intent-aware hooks the scan reaches for. `ensurePlanned` is a
+     * no-op on plain ops, so an access-planning failure has no other way in.
+     */
+    private class PlanAwareMockOps : MockFileSystemOps<LocalPath, LocalPathLookup>(
+        { path, type, size, modifiedAt, permissions, ownership, createdAt ->
+            LocalPathLookup(
+                lookedUp = path,
+                fileType = type,
+                size = size,
+                modifiedAt = modifiedAt ?: kotlin.time.Instant.fromEpochMilliseconds(0),
+                target = null,
+                ownership = ownership,
+                permissions = permissions,
+                createdAt = createdAt,
+            )
+        },
+    ), IntentAwareFileSystemOps<LocalPath, LocalPathLookup> {
+
+        private val planFailures = mutableMapOf<String, () -> Exception>()
+
+        fun failPlanning(path: String, exceptionFactory: () -> Exception) {
+            planFailures[path] = exceptionFactory
+        }
+
+        override suspend fun lookup(path: LocalPath, intent: AccessIntent, options: LookupOptions): LocalPathLookup =
+            lookup(path, options)
+
+        override suspend fun lookupFiles(
+            path: LocalPath,
+            intent: AccessIntent,
+            options: LookupOptions,
+        ): List<LocalPathLookup> = lookupFiles(path, options)
+
+        override suspend fun ensurePlanned(path: LocalPath, intent: AccessIntent) {
+            planFailures[path.path]?.let { throw it() }
+        }
+
+        override suspend fun modeOf(path: LocalPath, intent: AccessIntent): AccessMode = AccessMode.DIRECT
+
+        override fun proactiveChildren(parent: LocalPath): Set<LocalPath> = emptySet()
+
+        override suspend fun installLogicalAlias(alias: LocalPath, resolved: LocalPath, intent: AccessIntent) = Unit
+
+        override fun unknownLookup(path: LocalPath, error: Exception): LocalPathLookup? = null
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/operations/GenericPathRoutedBatchTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/operations/GenericPathRoutedBatchTest.kt
@@ -3,6 +3,10 @@ package eu.darken.butler.common.files.operations
 import eu.darken.butler.common.files.FileSystemOps
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.LookupOptions
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
+import eu.darken.butler.common.files.local.operations.core.PerformanceSample
+import eu.darken.butler.common.progress.Progress
 import eu.darken.butler.common.files.actions.CopyAction
 import eu.darken.butler.common.files.actions.DeleteAction
 import eu.darken.butler.common.files.actions.MoveAction
@@ -37,6 +41,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -370,6 +375,68 @@ class GenericPathRoutedBatchTest : BaseTest() {
         }
     }
 
+    @Test
+    fun `batch subtree as final work item keeps its detailed history in the last emitted state`() = runTest {
+        val source = p("/src")
+        val destination = p("/dst")
+        val destinationRoot = p("/dst/src")
+        val sourceLookup = lookup(source, FileType.DIRECTORY)
+        val destinationLookup = lookup(destinationRoot, FileType.DIRECTORY)
+        val batchSamples = 12
+        val batch = HistoryEmittingBatchOps(sourceLookup, destinationLookup, batchSamples)
+
+        val rootOps = mockk<FileSystemOps<LocalPath, LocalPathLookup>>(relaxed = true) {
+            coEvery { lookup(source, any<LookupOptions>()) } returns sourceLookup
+        }
+        val directOps = mockk<FileSystemOps<LocalPath, LocalPathLookup>>(relaxed = true) {
+            coEvery { lookup(destination, any<LookupOptions>()) } returns lookup(destination, FileType.DIRECTORY)
+            coEvery { lookup(destinationRoot, any<LookupOptions>()) } returns LocalPathLookup.unknown(destinationRoot)
+            coEvery { createDir(destination, createParents = true) } returns Unit
+        }
+        val caps = CapabilitySnapshot.fixed(hasRoot = true, hasAdb = false)
+        val policy = mockk<LocalPathRoutingPolicy> {
+            coEvery { classify(source, AccessIntent.Read, caps) } returns RouteDecision.Allowed(AccessMode.ROOT)
+            coEvery { classify(destination, AccessIntent.Write, caps) } returns RouteDecision.Allowed(AccessMode.DIRECT)
+            coEvery { classify(destinationRoot, AccessIntent.Write, caps) } returns RouteDecision.Allowed(AccessMode.DIRECT)
+            every { proactiveChildren(any()) } returns emptySet()
+            coEvery { batchEligibility(any()) } returns BatchEligibility.Eligible(
+                mode = AccessMode.ROOT,
+                destinationModeOverride = null,
+                ownershipFixup = OwnershipFixup.None,
+            )
+        }
+        val factory = mockk<ModeSessionFactory> {
+            coEvery { open(AccessMode.ROOT) } returns ModeSession(AccessMode.ROOT, rootOps, batch, null)
+            coEvery { open(AccessMode.DIRECT) } returns ModeSession(AccessMode.DIRECT, directOps, null, null)
+        }
+        val registry = ModeSessionRegistry(factory)
+        val router = StaticLocalRouteRouter(policy, caps, registry)
+        val sourceOps = RoutedLocalFileSystemOps(router, AccessIntent.Read)
+        val destOps = RoutedLocalFileSystemOps(router, AccessIntent.Write)
+
+        try {
+            val states = setOf(source).copyGeneric(
+                destination = destination,
+                sourceOps = sourceOps,
+                destOps = destOps,
+                strategy = GenericCrossTypeCopyStrategy(),
+                onIssue = { PathActionIssue.UnknownError.Resolution.Skip() }
+            ).toList()
+
+            val actives = states.filterIsInstance<CopyAction.State.Active<*, *, *, *>>()
+
+            // Sanity: the nested batch really did emit a plottable history
+            actives.mapNotNull { it.primaryProgress.extra as? PerformanceHistory }
+                .maxOf { it.samples.size } shouldBe batchSamples
+
+            // The state the UI keeps as "last progress" must still carry that history
+            val lastHistory = actives.last().primaryProgress.extra as? PerformanceHistory
+            (lastHistory?.samples?.size ?: 0) shouldBe batchSamples
+        } finally {
+            registry.close()
+        }
+    }
+
     private fun p(path: String): LocalPath = LocalPath.build(path)
 
     private fun lookup(path: LocalPath, fileType: FileType): LocalPathLookup = LocalPathLookup(
@@ -452,6 +519,76 @@ class GenericPathRoutedBatchTest : BaseTest() {
             copyCalls++
             return flow { throw IOException("simulated batch failure") }
         }
+
+        override suspend fun moveSubtreeExact(
+            sourceRoot: LocalPath,
+            destinationRoot: LocalPath,
+            options: MoveAction.Options,
+            onIssue: (suspend (PathActionIssue) -> PathActionIssue.Resolution)?,
+        ): Flow<MoveAction.State<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>> = emptyFlow()
+
+        override suspend fun deleteSubtree(
+            root: LocalPath,
+            options: DeleteAction.Options<LocalPath>,
+        ): Flow<DeleteAction.State<LocalPath, LocalPathLookup>> = emptyFlow()
+    }
+
+    /**
+     * Mimics a nested batch backend that reports its own detailed progress: each Active state
+     * carries a PerformanceHistory one sample longer than the previous one.
+     */
+    private class HistoryEmittingBatchOps(
+        private val sourceLookup: LocalPathLookup,
+        private val destinationLookup: LocalPathLookup,
+        private val sampleCount: Int,
+    ) : ClientBatchOps {
+
+        override suspend fun copySubtreeExact(
+            sourceRoot: LocalPath,
+            destinationRoot: LocalPath,
+            options: CopyAction.Options,
+            onIssue: (suspend (PathActionIssue) -> PathActionIssue.Resolution)?,
+        ): Flow<CopyAction.State<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>> = flow {
+            (1..sampleCount).forEach { step ->
+                emit(
+                    CopyAction.State.Active(
+                        currentSource = sourceLookup,
+                        currentDestination = destinationLookup.lookedUp,
+                        primaryProgress = Progress.Data(
+                            primary = "batch".toCaString(),
+                            secondary = "batch".toCaString(),
+                            count = Progress.Count.Counter(step, sampleCount),
+                            extra = history(step),
+                        ),
+                        copiedBytes = step.toLong(),
+                        totalBytes = sampleCount.toLong(),
+                    )
+                )
+            }
+            emit(
+                CopyAction.State.Completed(
+                    copied = setOf(sourceLookup to destinationLookup),
+                    skipped = emptySet(),
+                    copiedBytes = sampleCount.toLong(),
+                )
+            )
+        }
+
+        private fun history(samples: Int) = PerformanceHistory(
+            samples = (1..samples).map { index ->
+                PerformanceSample(
+                    timestamp = Instant.fromEpochMilliseconds(index.toLong()),
+                    bytesPerSecond = 1L,
+                    itemsPerSecond = 1f,
+                    totalBytesProcessed = index.toLong(),
+                    totalItemsProcessed = index,
+                    totalBytesAccounted = index.toLong(),
+                )
+            },
+            startTime = Instant.fromEpochMilliseconds(0),
+            totalBytes = sampleCount.toLong(),
+            totalItems = sampleCount,
+        )
 
         override suspend fun moveSubtreeExact(
             sourceRoot: LocalPath,

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/operations/MockFileSystemOps.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/operations/MockFileSystemOps.kt
@@ -146,6 +146,9 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
     private var failCreateFileException: (() -> Exception)? = null
     private var failListFilesCount = 0
     private var failListFilesException: (() -> Exception)? = null
+    private var failWriteCount = 0
+    private var failWriteAfterBytes = 0L
+    private var failWriteException: (() -> Exception)? = null
 
     suspend fun lookup(path: P) = lookup(path, LookupOptions.BASE)
 
@@ -389,7 +392,35 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
             ByteArray(0)
         }
 
+        val failAfterBytes = if (failWriteCount > 0) {
+            failWriteCount--
+            failWriteAfterBytes
+        } else {
+            null
+        }
+
         return object : ByteArrayOutputStream() {
+
+            private var written = 0L
+
+            override fun write(b: Int) {
+                failIfPastLimit(1L)
+                super.write(b)
+            }
+
+            override fun write(b: ByteArray, off: Int, len: Int) {
+                failIfPastLimit(len.toLong())
+                super.write(b, off, len)
+            }
+
+            private fun failIfPastLimit(incoming: Long) {
+                val limit = failAfterBytes ?: return
+                written += incoming
+                if (written > limit) {
+                    throw failWriteException?.invoke() ?: java.io.IOException("Injected failure")
+                }
+            }
+
             override fun close() {
                 super.close()
                 val newContent = if (append) {
@@ -688,6 +719,20 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
     /**
      * Configure listFiles to fail the next N times with specified exception.
      */
+    /**
+     * Fails the next [count] output streams once more than [afterBytes] have been written to them,
+     * leaving a partially transferred destination behind.
+     */
+    fun setFailWriteAfter(
+        count: Int,
+        afterBytes: Long,
+        exceptionFactory: () -> Exception = { java.io.IOException("Temporary failure") },
+    ) {
+        failWriteCount = count
+        failWriteAfterBytes = afterBytes
+        failWriteException = exceptionFactory
+    }
+
     fun setFailListFiles(count: Int, exceptionFactory: () -> Exception = { SecurityException("Permission denied") }) {
         failListFilesCount = count
         failListFilesException = exceptionFactory
@@ -709,6 +754,9 @@ open class MockFileSystemOps<P : APath<P>, PL : APathLookup<P>>(
         failCreateFileException = null
         failListFilesCount = 0
         failListFilesException = null
+        failWriteCount = 0
+        failWriteAfterBytes = 0L
+        failWriteException = null
     }
 
     /**

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/operations/TransferConflictResolverTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/operations/TransferConflictResolverTest.kt
@@ -69,6 +69,79 @@ class TransferConflictResolverTest : BaseTest() {
         onRenameDestination = onRenameDestination,
     )
 
+    private fun trackingResolver(
+        tracker: PathOperationProgressTracker,
+        issueResolver: PathOperationIssueResolver,
+    ) = TransferConflictResolver<LocalPath, LocalPathLookup, LocalPath, LocalPathLookup>(
+        destOps = destOps,
+        issueResolver = issueResolver,
+        progressTracker = tracker,
+        tag = "test",
+    )
+
+    @Test
+    fun `merge-all directory conflict advances progress exactly once`() = runTest2 {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalItems = 2
+        val issueResolver = PathOperationIssueResolver(
+            onIssue = { PathActionIssue.PathAlreadyExists.Resolution.Merge(applyToAll = true) },
+        )
+        val conflictResolver = trackingResolver(tracker, issueResolver)
+        val sourceLookup = lookupOf(sourcePath, isDir = true)
+        val destLookup = lookupOf(destination, isDir = true)
+
+        // The first conflict goes through the user and arms merge-all
+        conflictResolver.processResolveConflict(
+            sourceLookup = sourceLookup,
+            destination = destination,
+            destLookup = destLookup,
+            canMerge = true,
+            onSkip = { _, _ -> },
+            onOverwrite = {},
+            onMerge = {},
+            onRenameSource = {},
+            onRenameDestination = {},
+        )
+
+        tracker.itemsProcessed shouldBe 1
+
+        // The second is resolved by the flag alone, without reaching the user
+        conflictResolver.handleDirectoryConflict(
+            sourceLookup = sourceLookup,
+            destination = destination,
+            destLookup = destLookup,
+            onSkip = { _, _ -> },
+            onRename = {},
+            onMerge = {},
+            onOverwrite = {},
+            onResolveConflict = { throw AssertionError("merge-all should have resolved this") },
+            onIssue = issueResolver.onIssue,
+        )
+
+        tracker.itemsProcessed shouldBe 2
+    }
+
+    @Test
+    fun `auto-merged directory conflict advances progress`() = runTest2 {
+        val tracker = PathOperationProgressTracker()
+        tracker.totalItems = 1
+        val conflictResolver = trackingResolver(tracker, PathOperationIssueResolver(onIssue = null))
+
+        conflictResolver.handleDirectoryConflict(
+            sourceLookup = lookupOf(sourcePath, isDir = true),
+            destination = destination,
+            destLookup = lookupOf(destination, isDir = true),
+            onSkip = { _, _ -> },
+            onRename = {},
+            onMerge = {},
+            onOverwrite = {},
+            onResolveConflict = { throw AssertionError("auto-merge should have resolved this") },
+            onIssue = null,
+        )
+
+        tracker.itemsProcessed shouldBe 1
+    }
+
     @Test
     fun `overwrite with successful delete continues`() = runTest2 {
         val (conflictResolver, _) = resolver(PathActionIssue.PathAlreadyExists.Resolution.Overwrite())

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -2,7 +2,6 @@ package eu.darken.butler.workspace.ui.operations.details
 
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.files.local.operations.core.PerformanceSample
-import kotlin.math.max
 import kotlin.math.round
 
 enum class ByteSpeedUnit(val divisor: Double) {
@@ -40,11 +39,16 @@ data class PerformanceGraphData(
             // Without either total there is no x domain, every percentage would divide by zero
             if (history.totalBytes == 0L && history.totalItems == 0) return null
 
+            // Plotting against accounted bytes needs a domain that actually moves, otherwise the
+            // whole run collapses onto one x and nothing is plottable
+            val useByteAxis = history.totalBytes > 0L &&
+                history.samples.map { history.byteProgressOf(it) }.distinct().size >= 2
+
             val samples = mutableListOf<PerformanceSample>()
             val progress = mutableListOf<Float>()
 
             history.samples.forEach { sample ->
-                val x = history.progressOf(sample)
+                val x = history.progressOf(sample, useByteAxis)
                 if (progress.isEmpty() || x - progress.last() >= PROGRESS_STEP) {
                     samples.add(sample)
                     progress.add(x)
@@ -54,7 +58,7 @@ data class PerformanceGraphData(
             // The final state matters even when it didn't advance enough to pass the filter
             val finalSample = history.samples.last()
             if (samples.last() !== finalSample) {
-                val finalX = history.progressOf(finalSample)
+                val finalX = history.progressOf(finalSample, useByteAxis)
                 when {
                     finalX == progress.last() -> {
                         samples[samples.lastIndex] = finalSample
@@ -100,25 +104,35 @@ data class PerformanceGraphData(
         }
 
         /**
+         * Share of the accounted work a sample carries, rounded to 0.5 steps.
+         *
+         * This is the axis candidate before the terminal clause in [progressOf], so it says whether
+         * accounted bytes move at all.
+         */
+        private fun PerformanceHistory.byteProgressOf(sample: PerformanceSample): Float =
+            roundToStep((sample.totalBytesAccounted.toFloat() / totalBytes.toFloat()) * 100f)
+
+        /**
          * Completion percentage of a sample, rounded to 0.5 steps.
          *
-         * Bytes and items are unified via max() so that operations where one metric stalls, e.g. a
-         * copy that skips items, still reach 100%.
+         * On the byte axis a sample that has processed every item is pinned to 100%, so rounding
+         * shortfalls and items that finish without accounting their full size still terminate.
          */
-        private fun PerformanceHistory.progressOf(sample: PerformanceSample): Float {
-            val bytesPercentage = if (totalBytes > 0L) {
-                (sample.totalBytesProcessed.toFloat() / totalBytes.toFloat()) * 100f
-            } else {
-                0f
+        private fun PerformanceHistory.progressOf(sample: PerformanceSample, useByteAxis: Boolean): Float {
+            val raw = when {
+                !useByteAxis -> if (totalItems > 0) {
+                    (sample.totalItemsProcessed.toFloat() / totalItems.toFloat()) * 100f
+                } else {
+                    0f
+                }
+
+                totalItems > 0 && sample.totalItemsProcessed >= totalItems -> 100f
+                else -> (sample.totalBytesAccounted.toFloat() / totalBytes.toFloat()) * 100f
             }
-            val itemsPercentage = if (totalItems > 0) {
-                (sample.totalItemsProcessed.toFloat() / totalItems.toFloat()) * 100f
-            } else {
-                0f
-            }
-            val raw = max(bytesPercentage.coerceIn(0f, 100f), itemsPercentage.coerceIn(0f, 100f))
-            return round(raw * 2) / 2f
+            return roundToStep(raw)
         }
+
+        private fun roundToStep(percentage: Float): Float = round(percentage.coerceIn(0f, 100f) * 2) / 2f
 
         private fun unitFor(maxBytesPerSecond: Long): ByteSpeedUnit = when {
             maxBytesPerSecond < 1_000L -> ByteSpeedUnit.B_S

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
@@ -25,12 +25,14 @@ class PerformanceGraphDataTest : BaseTest() {
         itemsPerSecond: Float = 0f,
         totalBytesProcessed: Long = 0L,
         totalItemsProcessed: Int = 0,
+        totalBytesAccounted: Long = totalBytesProcessed,
     ) = PerformanceSample(
         timestamp = startTime + (index * 100).milliseconds,
         bytesPerSecond = bytesPerSecond,
         itemsPerSecond = itemsPerSecond,
         totalBytesProcessed = totalBytesProcessed,
         totalItemsProcessed = totalItemsProcessed,
+        totalBytesAccounted = totalBytesAccounted,
     )
 
     private fun history(
@@ -264,6 +266,114 @@ class PerformanceGraphDataTest : BaseTest() {
 
         data.progress shouldBe data.progress.distinct()
         data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+    }
+
+    @Test
+    fun `a directory completing before any bytes move keeps the plot at the left edge`() {
+        // An 8 item folder copy: the destination directory is created first, then the files stream
+        val directorySize = 4_096L
+        val history = history(
+            samples = (0 until 20).map { i ->
+                val transferred = (i + 1) * 5_000_000L
+                sample(
+                    index = i,
+                    bytesPerSecond = 5_000_000L,
+                    itemsPerSecond = 0.3f,
+                    totalBytesProcessed = transferred,
+                    totalItemsProcessed = 1 + i / 3,
+                    totalBytesAccounted = transferred + directorySize,
+                )
+            },
+            totalBytes = 1_000_000_000L,
+            totalItems = 8,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        // 5 MB of 1 GB, not the 12.5% one of eight items would claim
+        data.progress.first() shouldBe 0.5f
+        data.progress.max() shouldBe 10f
+    }
+
+    @Test
+    fun `early transfer positions survive the progress filter`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                val transferred = (i + 1) * 5_000_000L
+                sample(
+                    index = i,
+                    bytesPerSecond = 5_000_000L,
+                    itemsPerSecond = 0f,
+                    totalBytesProcessed = transferred,
+                    totalItemsProcessed = 1,  // Still inside the first file
+                    totalBytesAccounted = transferred + 4_096L,
+                )
+            },
+            totalBytes = 1_000_000_000L,
+            totalItems = 8,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress shouldBe (1..20).map { it * 0.5f }
+    }
+
+    @Test
+    fun `progress reaches 100 percent when the final item completes below the byte total`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(
+                    index = i,
+                    bytesPerSecond = 25_000_000L,
+                    itemsPerSecond = 0.5f,
+                    // Half the announced bytes never move, the rest of the items were skipped
+                    totalBytesProcessed = (i + 1) * 25_000_000L,
+                    totalItemsProcessed = if (i == 19) 10 else i / 2,
+                )
+            },
+            totalBytes = 1_000_000_000L,
+            totalItems = 10,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress.last() shouldBe 100f
+    }
+
+    @Test
+    fun `an operation whose accounted bytes never move plots against items`() {
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
+            },
+            totalBytes = 1_000_000_000L,  // Announced up front, then nothing is accounted against it
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress shouldBe (1..20).map { it * 5f }
+    }
+
+    @Test
+    fun `a stray byte does not collapse an item graph`() {
+        val history = history(
+            samples = (0 until 11).map { i ->
+                sample(
+                    index = i,
+                    itemsPerSecond = 5f,
+                    // The last sample accounts a byte count that still rounds to 0%
+                    totalBytesProcessed = if (i == 10) 1_000L else 0L,
+                    totalItemsProcessed = i + 1,
+                )
+            },
+            totalBytes = 1_000_000_000L,
+            totalItems = 20,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.progress shouldBe (1..11).map { it * 5f }
     }
 
     // ============ FILTERING ============


### PR DESCRIPTION
## What changed

The performance graph on an operation's detail sheet used to start partway across the plot, leaving an empty band on the left and squashing the first minutes of a transfer onto a single point. Copying a folder with 8 items started the curve an eighth of the way in; the fewer the items, the wider the gap.

The graph now begins where the transfer does, and the early part of a long copy is visible as a curve instead of a vertical edge.

Fixing it meant correcting how operations count their own progress, so several related problems went with it:

- Merging a folder into an existing one left those folders uncounted, so the item counter could never reach its total.
- Skipping a file left the next file's progress bar showing the previous file's size, and credited bytes that were never copied.
- Retrying a failed transfer counted the abandoned attempt's bytes a second time, and retrying a failed folder scan counted that folder twice.
- Skipping a lot of files in a row, or answering a conflict prompt on the last item, left the graph frozen and the counter one short until the operation ended.
- A copy or move that had to be skipped before it was counted could push the counter past its own total, which pinned the graph at 100% while the operation was still running.

## Technical Context

- Root cause: the graph's x axis was `max(bytesPercentage, itemsPercentage)`. A folder copy queues the destination directory ahead of the files it contains, and creating it completes an item without moving a byte, so the item term advanced x for work nothing had been plotted against.
- Driving the axis from bytes alone was considered and rejected: every byte-less completion leaves the item's size in `totalBytes` but never adds it to `processedBytes`, so a copy that skips most of its files would have compressed the whole curve into the left edge instead — the same defect at the other end.
- The tracker now keeps `accountedBytes` (transferred bytes plus the size of every item that completes transferring nothing) beside `processedBytes` (bytes actually moved). The graph plots the former; the sheet's "copied bytes" readout keeps the latter, so neither number has to lie for the other's benefit.
- `PerformanceSample` gained `totalBytesAccounted` as its last parameter with a default, which needs no migration: the type is only ever held in memory on the operation report — no database column, no type converter, no IPC conversion.
- Worth close review: the terminal progress emission at the end of each `execute()`. It exists so a trailing burst of skips reaches the UI, and it is guarded against firing when nothing advanced and against displacing the detailed history that a batched root or ADB transfer forwards from its nested operation.
