### PR TITLE
Workspace: Fix the speed graph not appearing during large copies

### DIFF
--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
@@ -1006,6 +1006,33 @@ class PerformanceHistoryTest : BaseTest() {
         }
     }
 
+    @Test
+    fun `a totals-free history keeps its most recent window after compaction`() {
+        val startTime = Instant.fromEpochMilliseconds(1000)
+        var history = PerformanceHistory()
+
+        repeat(1001) { i ->
+            history = history.addSample(
+                PerformanceSample(
+                    timestamp = startTime + (i * 250).milliseconds,
+                    bytesPerSecond = 1_000_000L,
+                    itemsPerSecond = 10f,
+                    totalBytesProcessed = 0L,
+                    totalItemsProcessed = 0,
+                ),
+                totalBytes = 0L,  // No total to calculate percentage
+                totalItems = 0,
+            )
+        }
+
+        // Everything before the window is dropped while startTime stays put, so consumers plotting
+        // against elapsed time see a window that begins long after the operation started
+        history.samples shouldHaveSize 800
+        history.samples.first().timestamp shouldBe startTime + (201 * 250).milliseconds
+        history.samples.last().timestamp shouldBe startTime + (1000 * 250).milliseconds
+        history.startTime shouldBe startTime
+    }
+
     // ============ EDGE CASES ============
 
     @Test

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -57,6 +57,9 @@ import kotlin.time.Duration.Companion.milliseconds
 
 private val TAG = logTag("PerformanceGraph")
 
+/** Upper bound on the x values the bottom axis enumerates per draw. */
+private const val MAX_AXIS_STEPS = 200
+
 
 @Composable
 fun OperationPerformanceGraph(
@@ -70,10 +73,10 @@ fun OperationPerformanceGraph(
     val modelProducer = remember(byteSpeeds != null) { CartesianChartModelProducer() }
 
     LaunchedEffect(graphData) {
-        log(TAG, DEBUG) { "Plotting ${graphData.progress.size} points" }
+        log(TAG, DEBUG) { "Plotting ${graphData.elapsedSeconds.size} points" }
         modelProducer.runTransaction {
-            if (byteSpeeds != null) lineSeries { series(x = graphData.progress, y = byteSpeeds) }
-            lineSeries { series(x = graphData.progress, y = graphData.itemSpeeds) }
+            if (byteSpeeds != null) lineSeries { series(x = graphData.elapsedSeconds, y = byteSpeeds) }
+            lineSeries { series(x = graphData.elapsedSeconds, y = graphData.itemSpeeds) }
         }
     }
 
@@ -181,6 +184,10 @@ fun OperationPerformanceGraph(
                         guideline = null,  // Hide grid lines
                         tick = null,  // Hide tick marks
                     ),
+                    // Without a step the axis would enumerate one value per grid point of a long operation
+                    getXStep = { model ->
+                        (model.width / MAX_AXIS_STEPS).coerceAtLeast(PLOT_STEP_SECONDS.toDouble())
+                    },
                 ),
                 modelProducer = modelProducer,
                 zoomState = rememberVicoZoomState(
@@ -246,10 +253,6 @@ private fun speedRangeProvider(rangeMaxY: Double) = object : CartesianLayerRange
     override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double = 0.0
 
     override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double = rangeMaxY
-
-    override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore): Double = 0.0
-
-    override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore): Double = 100.0
 }
 
 /** Slow axes need decimals, fast ones would only repeat the same rounded label. */

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -2,8 +2,8 @@ package eu.darken.butler.workspace.ui.operations.details
 
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.files.local.operations.core.PerformanceSample
-import kotlin.math.max
 import kotlin.math.round
+import kotlin.time.Instant
 
 enum class ByteSpeedUnit(val divisor: Double) {
     B_S(1.0),
@@ -12,16 +12,20 @@ enum class ByteSpeedUnit(val divisor: Double) {
     GB_S(1_000_000_000.0),
 }
 
+/** Grid the x values are snapped to, in seconds. */
+internal const val PLOT_STEP_SECONDS = 0.5f
+
 /**
  * Plot-ready series for [OperationPerformanceGraph].
  *
- * All series share the [progress] x values, which are completion percentages rounded to 0.5 steps.
+ * All series share the [elapsedSeconds] x values, seconds since the operation started, snapped to
+ * [PLOT_STEP_SECONDS] steps.
  *
  * [recentBytesPerSecond] and [recentItemsPerSecond] are averages over the raw history, not over the
  * decimated and smoothed series, so they stay the speeds the operation actually reported last.
  */
 data class PerformanceGraphData(
-    val progress: List<Float>,
+    val elapsedSeconds: List<Float>,
     val byteSpeeds: List<Float>?,
     val itemSpeeds: List<Float>,
     val byteUnit: ByteSpeedUnit?,
@@ -32,52 +36,39 @@ data class PerformanceGraphData(
 ) {
 
     companion object {
-        private const val PROGRESS_STEP = 0.5f
         private const val SMOOTHING_WINDOW = 10
 
         fun from(history: PerformanceHistory): PerformanceGraphData? {
             if (!history.canShowGraph) return null
-            // Without either total there is no x domain, every percentage would divide by zero
-            if (history.totalBytes == 0L && history.totalItems == 0) return null
+
+            val origin = history.startTime ?: history.samples.first().timestamp
 
             val samples = mutableListOf<PerformanceSample>()
-            val progress = mutableListOf<Float>()
+            val elapsedSeconds = mutableListOf<Float>()
 
             history.samples.forEach { sample ->
-                val x = history.progressOf(sample)
-                if (progress.isEmpty() || x - progress.last() >= PROGRESS_STEP) {
+                val x = elapsedSecondsOf(sample, origin)
+                if (elapsedSeconds.isEmpty() || x > elapsedSeconds.last()) {
                     samples.add(sample)
-                    progress.add(x)
+                    elapsedSeconds.add(x)
                 }
             }
 
-            // The final state matters even when it didn't advance enough to pass the filter
+            // The final state matters even when it didn't reach the next grid step
             val finalSample = history.samples.last()
             if (samples.last() !== finalSample) {
-                val finalX = history.progressOf(finalSample)
-                when {
-                    finalX == progress.last() -> {
-                        samples[samples.lastIndex] = finalSample
-                        progress[progress.lastIndex] = finalX
-                    }
-                    // Defensive: non-monotonic sample order (e.g. a wall-clock jump) can move the final sample back onto steps already plotted
-                    finalX < progress.last() -> {
-                        while (progress.isNotEmpty() && progress.last() >= finalX) {
-                            samples.removeAt(samples.lastIndex)
-                            progress.removeAt(progress.lastIndex)
-                        }
-                        samples.add(finalSample)
-                        progress.add(finalX)
-                    }
-                    else -> {
-                        samples.add(finalSample)
-                        progress.add(finalX)
-                    }
+                val finalX = elapsedSecondsOf(finalSample, origin)
+                if (finalX > elapsedSeconds.last()) {
+                    samples.add(finalSample)
+                    elapsedSeconds.add(finalX)
+                } else {
+                    // Keeping the plotted x also covers a wall-clock jump moving the final sample back
+                    samples[samples.lastIndex] = finalSample
                 }
             }
 
-            // A flat x domain (e.g. an all-skipped operation) has nothing to plot against
-            if (progress.distinct().size < 2) return null
+            // Distinct by construction, so this only fires when fewer than two samples survived
+            if (elapsedSeconds.distinct().size < 2) return null
 
             val hasByteData = history.samples.any { it.bytesPerSecond > 0L || it.totalBytesProcessed > 0L }
             val byteUnit = if (hasByteData) unitFor(samples.maxOf { it.bytesPerSecond }) else null
@@ -88,7 +79,7 @@ data class PerformanceGraphData(
             val itemSpeeds = samples.map { it.itemsPerSecond.toDouble() }.trailingAverage()
 
             return PerformanceGraphData(
-                progress = progress,
+                elapsedSeconds = elapsedSeconds,
                 byteSpeeds = byteSpeeds,
                 itemSpeeds = itemSpeeds,
                 byteUnit = byteUnit,
@@ -100,24 +91,15 @@ data class PerformanceGraphData(
         }
 
         /**
-         * Completion percentage of a sample, rounded to 0.5 steps.
+         * Seconds since [origin], snapped to [PLOT_STEP_SECONDS] steps.
          *
-         * Bytes and items are unified via max() so that operations where one metric stalls, e.g. a
-         * copy that skips items, still reach 100%.
+         * The fixed grid keeps the chart's x step exact, bounds how many x values the axis
+         * enumerates per draw, and makes a sample's inclusion depend only on earlier samples, so
+         * points already plotted are never re-placed.
          */
-        private fun PerformanceHistory.progressOf(sample: PerformanceSample): Float {
-            val bytesPercentage = if (totalBytes > 0L) {
-                (sample.totalBytesProcessed.toFloat() / totalBytes.toFloat()) * 100f
-            } else {
-                0f
-            }
-            val itemsPercentage = if (totalItems > 0) {
-                (sample.totalItemsProcessed.toFloat() / totalItems.toFloat()) * 100f
-            } else {
-                0f
-            }
-            val raw = max(bytesPercentage.coerceIn(0f, 100f), itemsPercentage.coerceIn(0f, 100f))
-            return round(raw * 2) / 2f
+        private fun elapsedSecondsOf(sample: PerformanceSample, origin: Instant): Float {
+            val raw = (sample.timestamp - origin).inWholeMilliseconds / 1000f
+            return (round(raw / PLOT_STEP_SECONDS) * PLOT_STEP_SECONDS).coerceAtLeast(0f)
         }
 
         private fun unitFor(maxBytesPerSecond: Long): ByteSpeedUnit = when {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
@@ -48,11 +48,13 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
         totalBytes: Long = 1_000_000_000L,
         totalItems: Int = 20,
         spacing: Duration = 250.milliseconds,
+        jitter: Duration = Duration.ZERO,
         advancing: Boolean = true,
     ) = PerformanceHistory(
         samples = (0 until sampleCount).map { i ->
             PerformanceSample(
-                timestamp = startTime + spacing * i,
+                // Wall-clock sampling doesn't land on exact steps, jitter models that
+                timestamp = startTime + spacing * i + (if (i % 2 == 0) Duration.ZERO else jitter),
                 bytesPerSecond = 50_000_000L,
                 itemsPerSecond = 5f,
                 totalBytesProcessed = if (advancing) i * 50_000_000L else 0L,
@@ -132,7 +134,7 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     fun `real graph renders for a byte and item history`() {
         composeTestRule.setContent {
             PreviewWrapper {
-                OperationPerformanceGraphSection(operation = operation(running(history())))
+                OperationPerformanceGraphSection(operation = operation(running(history(jitter = (-1).milliseconds))))
             }
         }
 
@@ -220,11 +222,12 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     }
 
     @Test
-    fun `a running operation stuck on one progress step is still collecting`() {
+    fun `a running operation with a pinned progress counter shows the graph`() {
         setSection(running(history(totalItems = 0, advancing = false)))
 
         composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
-        composeTestRule.onNodeWithText(collectingText).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+        composeTestRule.onNodeWithText(collectingText).assertDoesNotExist()
     }
 
     @Test
@@ -236,11 +239,12 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     }
 
     @Test
-    fun `a completed operation without totals has insufficient data`() {
+    fun `a completed operation without totals shows the graph`() {
         setSection(completed(history(totalBytes = 0L, totalItems = 0)))
 
         composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
-        composeTestRule.onNodeWithText(insufficientText).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+        composeTestRule.onNodeWithText(insufficientText).assertDoesNotExist()
     }
 
     @Test

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
@@ -134,11 +134,12 @@ class PerformanceGraphDataTest : BaseTest() {
         data.byteSpeeds shouldBe null
         data.byteUnit shouldBe null
         data.maxByteSpeed shouldBe 0.0
-        data.progress shouldBe (0 until 20).map { it * 5f }
+        // 20 samples 100ms apart cover 1.9s, so five grid points
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f, 1.5f, 2f)
     }
 
     @Test
-    fun `unknown size transfer keeps its byte series and plots against items`() {
+    fun `unknown size transfer keeps its byte series`() {
         val history = history(
             samples = (0 until 20).map { i ->
                 sample(
@@ -156,30 +157,33 @@ class PerformanceGraphDataTest : BaseTest() {
         val data = PerformanceGraphData.from(history).shouldNotBeNull()
 
         data.byteUnit shouldBe ByteSpeedUnit.MB_S
-        data.byteSpeeds.shouldNotBeNull() shouldHaveSize 20
-        data.progress shouldBe (0 until 20).map { it * 5f }
+        data.byteSpeeds.shouldNotBeNull() shouldHaveSize 5
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f, 1.5f, 2f)
     }
 
     // ============ NO GRAPH ============
 
     @Test
-    fun `history without totals has no x domain`() {
+    fun `a history without totals plots against elapsed time`() {
         val history = history(
             samples = (0 until 20).map { i ->
                 sample(index = i, bytesPerSecond = 1_000_000L, itemsPerSecond = 5f)
             },
         )
 
-        PerformanceGraphData.from(history) shouldBe null
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f, 1.5f, 2f)
+        data.byteUnit shouldBe ByteSpeedUnit.MB_S
     }
 
     @Test
-    fun `flat progress is not plottable`() {
+    fun `samples that all carry the same instant are not plottable`() {
         val history = history(
             samples = (0 until 20).map { i ->
-                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = 0)
+                sample(index = 0, itemsPerSecond = 5f, totalItemsProcessed = i)
             },
-            totalItems = 100,
+            totalItems = 20,
         )
 
         PerformanceGraphData.from(history) shouldBe null
@@ -200,52 +204,77 @@ class PerformanceGraphDataTest : BaseTest() {
     // ============ X DOMAIN ============
 
     @Test
-    fun `skipped items still let progress reach 100 percent`() {
+    fun `a pinned item counter no longer suppresses the chart`() {
+        // Copying 8 large files to a slow target: one item done, bytes crawling
         val history = history(
             samples = (0 until 20).map { i ->
                 sample(
                     index = i,
-                    bytesPerSecond = 1_000L,
-                    itemsPerSecond = 2f,
-                    // Bytes stall at 10%: the remaining items were skipped
-                    totalBytesProcessed = minOf(i, 2) * 50_000L,
-                    totalItemsProcessed = i + 1,
+                    bytesPerSecond = 2_000_000L,
+                    itemsPerSecond = 0.01f,
+                    totalBytesProcessed = 1_300_000_000L + i * 200_000L,
+                    totalItemsProcessed = 1,
                 )
             },
-            totalBytes = 1_000_000L,
+            totalBytes = 16_222_522_748L,
+            totalItems = 8,
+        )
+
+        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+
+        data.elapsedSeconds.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+    }
+
+    @Test
+    fun `elapsed x spans the operation's duration, not its completion fraction`() {
+        // One sample per second, ending at 95% completion
+        val history = history(
+            samples = (0 until 20).map { i ->
+                sample(index = i * 10, itemsPerSecond = 1f, totalItemsProcessed = i)
+            },
             totalItems = 20,
         )
 
         val data = PerformanceGraphData.from(history).shouldNotBeNull()
 
-        data.progress.last() shouldBe 100f
+        data.elapsedSeconds shouldBe (0 until 20).map { it.toFloat() }
     }
 
     @Test
-    fun `progress beyond the total is clamped to 100 percent`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 2f,
-                    // The last few samples report more than the total
-                    totalBytesProcessed = (i + 1) * 100_000L,
-                    totalItemsProcessed = i,
-                )
-            },
-            totalBytes = 1_000_000L,
-            totalItems = 20,
-        )
+    fun `x values stay on the plot grid`() {
+        // Wall-clock sampling produces 249/251ms deltas, not exact quarter seconds
+        var offsetMs = 0
+        val samples = (0 until 20).map { i ->
+            val sample = PerformanceSample(
+                timestamp = startTime + offsetMs.milliseconds,
+                bytesPerSecond = 1_000_000L,
+                itemsPerSecond = 5f,
+                totalBytesProcessed = i * 1_000_000L,
+                totalItemsProcessed = i,
+            )
+            offsetMs += if (i % 2 == 0) 249 else 251
+            sample
+        }
 
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+        val data = PerformanceGraphData.from(history(samples, totalItems = 20)).shouldNotBeNull()
 
-        data.progress.max() shouldBe 100f
-        data.progress.last() shouldBe 100f
+        data.elapsedSeconds.forEach { (it % PLOT_STEP_SECONDS) shouldBe 0f }
+        data.elapsedSeconds.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
     }
 
     @Test
-    fun `single large file still advances along the byte axis`() {
+    fun `a sample stamped before the start time is clamped to zero`() {
+        val samples = listOf(sample(index = -5, itemsPerSecond = 5f)) +
+            (0 until 19).map { i -> sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i) }
+
+        val data = PerformanceGraphData.from(history(samples, totalItems = 20)).shouldNotBeNull()
+
+        data.elapsedSeconds.first() shouldBe 0f
+        data.elapsedSeconds.forEach { (it >= 0f) shouldBe true }
+    }
+
+    @Test
+    fun `a single large file still advances along the time axis`() {
         val history = history(
             samples = (0 until 20).map { i ->
                 sample(
@@ -262,57 +291,82 @@ class PerformanceGraphDataTest : BaseTest() {
 
         val data = PerformanceGraphData.from(history).shouldNotBeNull()
 
-        data.progress shouldBe data.progress.distinct()
-        data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+        data.elapsedSeconds shouldBe data.elapsedSeconds.distinct()
+        data.elapsedSeconds.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
     }
 
     // ============ FILTERING ============
 
     @Test
-    fun `samples are kept once progress advanced half a percent`() {
-        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
+    fun `samples are kept once they land on the next grid step`() {
+        // 100ms apart, so most samples round onto the grid step of their predecessor
         val samples = (0 until 10).map { i ->
             sample(index = i, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i + 1)
         }
         val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
 
-        data.progress shouldBe listOf(0f, 0.5f, 1f)
-        // The final sample replaced the entry that shared its 1.0% step: (10 + 30 + 100) / 3
-        data.itemSpeeds.last() shouldBe (46.667f plusOrMinus 0.01f)
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f)
+        // The final sample replaced the entry that shared its 1.0s step: (10 + 40 + 100) / 3
+        data.itemSpeeds.last() shouldBe (50f plusOrMinus 0.01f)
     }
 
     @Test
-    fun `a final sample below earlier progress truncates back to it`() {
+    fun `the plotted points only grow as samples arrive`() {
+        val samples = (0 until 24).map { i ->
+            sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i)
+        }
+
+        val earlier = PerformanceGraphData.from(history(samples.dropLast(1), totalItems = 24)).shouldNotBeNull()
+        val later = PerformanceGraphData.from(history(samples, totalItems = 24)).shouldNotBeNull()
+
+        later.elapsedSeconds.take(earlier.elapsedSeconds.size) shouldBe earlier.elapsedSeconds
+        later.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f, 1.5f, 2f, 2.5f)
+    }
+
+    @Test
+    fun `a final sample stamped before the last plotted point replaces it`() {
         val samples = (0 until 10).map { i ->
             sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
-        } + sample(index = 10, itemsPerSecond = 5f, totalItemsProcessed = 4)  // Progress reported lower
+        } + sample(index = 2, itemsPerSecond = 5f, totalItemsProcessed = 4)  // Timestamped in the past
 
         val data = PerformanceGraphData.from(history(samples, totalItems = 10)).shouldNotBeNull()
 
-        data.progress shouldBe listOf(10f, 20f, 30f, 40f)
-        data.progress shouldBe data.progress.distinct()
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f)
+        data.itemSpeeds shouldHaveSize 3
     }
 
     @Test
     fun `a final sample above the last kept step is appended`() {
-        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
         val samples = (0 until 11).map { i ->
             sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
-        } + sample(index = 11, itemsPerSecond = 5f, totalItemsProcessed = 100)  // A batch of items landed at once
+        } + sample(index = 40, itemsPerSecond = 5f, totalItemsProcessed = 12)  // Sampling stalled for 3s
 
-        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
+        val data = PerformanceGraphData.from(history(samples, totalItems = 20)).shouldNotBeNull()
 
-        data.progress shouldBe listOf(0f, 0.5f, 1f, 10f)
-        data.progress shouldBe data.progress.distinct()
-        data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f, 4f)
+        data.elapsedSeconds.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+    }
+
+    @Test
+    fun `a wall-clock rollback on the final sample does not break x ordering`() {
+        val samples = (0 until 10).map { i ->
+            sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
+        } + sample(index = 4, itemsPerSecond = 50f, totalItemsProcessed = 11)  // Clock jumped backwards
+
+        val data = PerformanceGraphData.from(history(samples, totalItems = 20)).shouldNotBeNull()
+
+        data.elapsedSeconds.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+        // The rolled back sample took over the last plotted point: (5 + 5 + 50) / 3
+        data.itemSpeeds.last() shouldBe (20f plusOrMinus 0.01f)
     }
 
     // ============ SMOOTHING ============
 
     @Test
     fun `smoothing only averages over preceding samples`() {
+        // 500ms apart, so every sample lands on its own grid step
         val samples = (0 until 15).map { i ->
-            sample(index = i, itemsPerSecond = (i + 1).toFloat(), totalItemsProcessed = i + 1)
+            sample(index = i * 5, itemsPerSecond = (i + 1).toFloat(), totalItemsProcessed = i + 1)
         }
 
         val data = PerformanceGraphData.from(history(samples, totalItems = 15)).shouldNotBeNull()
@@ -372,7 +426,7 @@ class PerformanceGraphDataTest : BaseTest() {
 
     @Test
     fun `recent speeds ignore the filtering and smoothing of the series`() {
-        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
+        // 100ms apart, so most samples round onto the grid step of their predecessor
         val samples = (0 until 10).map { i ->
             sample(index = i, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i + 1)
         }


### PR DESCRIPTION
## What changed

During a large copy the performance graph could sit on "Collecting performance data…" for minutes on end, even though speed was being measured the whole time. When it finally did appear, the curve was squeezed into a narrow strip with most of the chart left empty.

The graph now plots speed against elapsed time. It shows up within the first few seconds of an operation and fills the width of the chart from then on.

## Technical Context

- Root cause: the x value was the operation's completion percentage, `max(bytes%, items%)`. A coarse item counter dominates fine-grained byte progress and holds x flat, and a series whose x values are all identical was suppressed outright. Copying 8 large files to a slow target with one file finished pinned x at 12.5% until bytes overtook that mark, which took minutes.
- x is now elapsed seconds snapped to a fixed 0.5 s grid. The grid is load-bearing rather than cosmetic: Vico derives the chart's x step from the GCD of the x deltas and asserts that x carries at most four decimal places, so raw millisecond timestamps would have pushed per-frame axis enumeration into the thousands and eventually thrown. `getXStep` is now passed explicitly for the same reason, capping enumeration regardless of how long an operation runs.
- Both x-range overrides are gone, not only the `getMaxX = 100.0` that caused the squeeze. Anchoring the minimum at zero is unsafe under a time axis: a history with no totals keeps only its most recent 800 samples while its start time stays put, which would strand the curve at the right-hand edge instead of the left.
- Dropping the "no totals" guard is a deliberate behaviour change. That guard existed to avoid dividing by zero in the percentage; with no percentage on the axis, such an operation now draws a graph instead of reporting insufficient data.
- Worth a close read: the final-sample handling in `PerformanceGraphData.from`. When the last sample's timestamp ties or moves backwards it replaces the last plotted point rather than repositioning it, which is what keeps x strictly increasing across a wall-clock jump.
