### PR TITLE
Workspace: Keep the operation details sheet from jumping as the estimate changes

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationCombinedProgressSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationCombinedProgressSection.kt
@@ -136,8 +136,11 @@ private fun OperationProgressDisplay(
 
                 // Secondary text
                 if (progressData.secondary != CaString.EMPTY) {
+                    // Speed/ETA text changes length constantly, a two line floor keeps the sheet
+                    // from shifting on every progress update.
                     Text(
                         text = progressData.secondary.asComposable(),
+                        minLines = 2,
                         style = if (isPrimary) {
                             MaterialTheme.typography.bodyMedium
                         } else {
@@ -202,6 +205,27 @@ private fun OperationProgressDisplay(
                     overflow = TextOverflow.MiddleEllipsis,
                 )
             }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun OperationCombinedProgressSectionShortMetricsPreview() {
+    PreviewWrapper {
+        Box(modifier = Modifier.width(320.dp)) {
+            OperationCombinedProgressSection(
+                primaryProgress = Progress.Data(
+                    primary = "Copying items".toCaString(),
+                    secondary = "6.5 MB/s".toCaString(),
+                    count = Progress.Count.Counter(4, 5),
+                ),
+                secondaryProgress = Progress.Data(
+                    primary = "report.pdf".toCaString(),
+                    secondary = "7.1 MB/s".toCaString(),
+                    count = Progress.Count.Size(25_000_000, 118_000_000),
+                ),
+            )
         }
     }
 }


### PR DESCRIPTION
## What changed

The progress section of the operation details sheet no longer shifts around while an operation
runs. The line showing transfer speed and time remaining changes length constantly (a short
"6.5 MB/s" one moment, "12 MB/s • 3 items/s • 5 minutes 12 seconds remaining." the next), and every
time it grew past one line everything below it moved down and back up again. That line now always
reserves the height of two lines, so the rest of the sheet stays put.

## Technical Context

- The speed/ETA text in `OperationProgressDisplay` was the only height-variable element in the
  section: the title, the count and the progress bar are all pinned to one line or a fixed height.
  It got a `minLines = 2` floor in both the primary and the secondary progress block.
- No `maxLines`, deliberately. When no speed is known yet the same slot falls back to the full
  source path, which can legitimately need three lines, and large font scales need the room too.
  A hard cap would ellipsize those; the floor removes the common one-to-two-line jump without
  hiding anything.
- The floating operations bar renders the same string but already clamps it to a single line, so
  the bar rows are untouched by this.
- The alternative of shortening the ETA format itself (`DurationFormat.COMPACT`, "5m 12s") was
  considered and left out: it changes visible text in the bar as well, which is a separate call.
