### PR TITLE
Workspace: Show operation speed over time instead of completion

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistory.kt
@@ -7,6 +7,7 @@ import eu.darken.butler.common.serialization.InstantSerializer
 import kotlinx.serialization.Serializable
 import kotlin.math.roundToInt
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 /**
@@ -28,16 +29,16 @@ data class PerformanceSample(
 )
 
 /**
- * Historical performance data with adaptive sampling for memory efficiency.
+ * Historical performance data with time-based retention for memory efficiency.
  *
  * Sampling Strategy:
- * - Hard cap: 1000 samples. Exceeding it triggers a compaction.
- * - Compaction target: 800 samples, so the next compaction is ~200 adds away instead of every add.
- * - Percentage-based bucketing: Divides 0-100% progress into 5% buckets (20 total)
- * - Compaction keeps 800/20 = 40 samples per bucket, endpoint-inclusive so first and last survive
- * - Supports both byte-based (copy/move) and item-based (delete) operations
- * - Uses totalBytes for percentage if available, otherwise uses totalItems
- * - Ensures graph coverage across full 0-100% even with rapid sampling (many small files)
+ * - Hard cap: [MAX_SAMPLES] samples. Exceeding it triggers a compaction.
+ * - The last [RECENT_WINDOW] is kept verbatim, so the live graph has every sample it plots.
+ * - A forced-sampling burst inside that window is thinned to [RECENT_TARGET], leaving the newest
+ *   [PROTECTED_TAIL] samples untouched for [getRecentBytesPerSecond] and [getRecentItemsPerSecond].
+ * - Everything older is spread over [OVERVIEW_BUCKETS] equal-duration buckets, each thinned to
+ *   [SAMPLES_PER_OVERVIEW_BUCKET] evenly spaced samples, endpoint-inclusive so bucket ends survive.
+ * - Worst case retained is 741 samples, well under [COMPACT_TARGET], so compaction stays amortized.
  */
 @Serializable
 data class PerformanceHistory(
@@ -59,7 +60,7 @@ data class PerformanceHistory(
         get() = samples.size >= 10
 
     /**
-     * Add a new sample with adaptive downsampling for old data.
+     * Add a new sample, compacting older data once the cap is crossed.
      */
     fun addSample(sample: PerformanceSample, totalBytes: Long = 0L, totalItems: Int = 0): PerformanceHistory {
         log(
@@ -67,7 +68,7 @@ data class PerformanceHistory(
             DEBUG
         ) { "Adding sample. Current: ${samples.size} → New: ${samples.size + 1}, Speed: ${sample.bytesPerSecond / 1_000_000f} MB/s" }
 
-        // The totals this add carries can grow during scanning, bucketing has to use the new ones
+        // The totals this add carries can grow during scanning
         val nextTotalBytes = maxOf(this.totalBytes, totalBytes)
         val nextTotalItems = maxOf(this.totalItems, totalItems)
 
@@ -75,9 +76,8 @@ data class PerformanceHistory(
             if (allSamples.size <= MAX_SAMPLES) {
                 allSamples
             } else {
-                // Apply adaptive sampling: keep recent, downsample old
-                log(TAG, DEBUG) { "Applying adaptive sampling" }
-                adaptiveSample(allSamples, nextTotalBytes, nextTotalItems)
+                log(TAG, DEBUG) { "Compacting samples" }
+                compact(allSamples)
             }
         }
 
@@ -132,50 +132,66 @@ data class PerformanceHistory(
             samples.last().timestamp - startTime
         }
 
-    private fun adaptiveSample(
-        allSamples: List<PerformanceSample>,
-        totalBytes: Long,
-        totalItems: Int,
-    ): List<PerformanceSample> {
-        // Determine which metric to use for percentage calculation
-        val useItems = totalBytes == 0L && totalItems > 0
+    /**
+     * Keep the last [RECENT_WINDOW] verbatim and thin everything older into an overview.
+     */
+    private fun compact(allSamples: List<PerformanceSample>): List<PerformanceSample> {
+        // Recording order, not timestamps: the origin of the operation and the samples the progress
+        // bar's speed and ETA read are defined by when they arrived, whatever the clock did to them
+        // Matching on [startTime] relies on the sort below being stable: after a backwards clock jump
+        // another sample can share the origin's timestamp, and only stability keeps the origin first
+        val origin = allSamples.firstOrNull { it.timestamp == startTime } ?: allSamples.first()
+        val protectedTail = allSamples.takeLast(PROTECTED_TAIL)
 
-        if (totalBytes == 0L && totalItems == 0) {
-            // Can't determine percentage without either metric, fallback to keeping last N
-            return allSamples.takeLast(COMPACT_TARGET).sortedBy { it.timestamp }
+        // A clock that jumped backwards leaves the newest timestamp somewhere in the middle, and
+        // every bound below reads an end of the list
+        val ordered = allSamples.sortedBy { it.timestamp }
+        val cutoff = ordered.last().timestamp - RECENT_WINDOW
+        val compactable = ordered - protectedTail.toSet()
+        val older = compactable.filter { it.timestamp < cutoff }
+        val recent = compactable.filter { it.timestamp >= cutoff }
+
+        // Only forced sampling can outpace the report interval enough to reach this
+        val recentBudget = RECENT_TARGET - PROTECTED_TAIL
+        val thinnedRecent = if (recent.size > recentBudget) {
+            evenlySpaced(recent, recentBudget)
+        } else {
+            recent
         }
 
-        // Percentage-based downsampling: ensure samples distributed across 0-100% range
-        val bucketSize = 100.0 / NUM_BUCKETS
-        val samplesPerBucket = (COMPACT_TARGET / NUM_BUCKETS).coerceAtLeast(1)
-
-        val buckets = allSamples.groupBy { sample ->
-            val percentage = if (useItems) {
-                (sample.totalItemsProcessed.toDouble() / totalItems) * 100.0
-            } else {
-                (sample.totalBytesAccounted.toDouble() / totalBytes) * 100.0
-            }
-            // Clamp percentage to [0.0, 100.0] and ensure bucket index is [0, NUM_BUCKETS - 1]
-            val clampedPercentage = percentage.coerceIn(0.0, 100.0)
-            minOf(NUM_BUCKETS - 1, (clampedPercentage / bucketSize).toInt())
-        }
-
-        // Downsample each bucket, endpoint-inclusive so both ends of a bucket survive
-        val downsampledSamples = buckets.flatMap { (_, samplesInBucket) ->
-            when {
-                samplesInBucket.size <= samplesPerBucket -> samplesInBucket
-                samplesPerBucket == 1 -> listOf(samplesInBucket.last())
-                else -> {
-                    val lastIndex = samplesInBucket.size - 1
-                    (0 until samplesPerBucket)
-                        .map { i -> ((i.toDouble() * lastIndex) / (samplesPerBucket - 1)).roundToInt() }
-                        .distinct()
-                        .map { samplesInBucket[it] }
+        val overview = if (older.isEmpty()) {
+            emptyList()
+        } else {
+            val bucketStart = older.first().timestamp
+            val span = older.last().timestamp - bucketStart
+            older
+                .groupBy { sample ->
+                    if (span == Duration.ZERO) {
+                        0
+                    } else {
+                        val position = (sample.timestamp - bucketStart) / span
+                        (position * OVERVIEW_BUCKETS).toInt().coerceIn(0, OVERVIEW_BUCKETS - 1)
+                    }
                 }
-            }
-        }.sortedBy { it.timestamp }  // Maintain chronological order
+                .flatMap { (_, samplesInBucket) -> evenlySpaced(samplesInBucket, SAMPLES_PER_OVERVIEW_BUCKET) }
+        }
 
-        return downsampledSamples
+        return (listOf(origin) + overview + thinnedRecent + protectedTail).distinct().sortedBy { it.timestamp }
+    }
+
+    /**
+     * Thin [source] to [target] entries, endpoint-inclusive so both ends survive.
+     */
+    private fun evenlySpaced(source: List<PerformanceSample>, target: Int): List<PerformanceSample> = when {
+        source.size <= target -> source
+        target <= 1 -> listOf(source.last())
+        else -> {
+            val lastIndex = source.size - 1
+            (0 until target)
+                .map { i -> ((i.toDouble() * lastIndex) / (target - 1)).roundToInt() }
+                .distinct()
+                .map { source[it] }
+        }
     }
 
     override fun toString(): String {
@@ -183,9 +199,20 @@ data class PerformanceHistory(
     }
 
     companion object {
-        private const val MAX_SAMPLES = 1000
-        private const val COMPACT_TARGET = 800
-        private const val NUM_BUCKETS = 20
+        internal const val MAX_SAMPLES = 1000
+        internal const val COMPACT_TARGET = 800
+
+        /** How much of the tail the live graph plots, and therefore may not be thinned. */
+        internal val RECENT_WINDOW = 120.seconds
+        internal const val RECENT_TARGET = 500
+
+        /**
+         * Twice the default window of [getRecentBytesPerSecond] and [getRecentItemsPerSecond], whose
+         * results reach the user as the progress bar's speed and ETA.
+         */
+        internal const val PROTECTED_TAIL = 60
+        internal const val OVERVIEW_BUCKETS = 60
+        internal const val SAMPLES_PER_OVERVIEW_BUCKET = 4
         private val TAG = logTag("PerformanceHistory")
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/files/local/operations/core/PerformanceHistoryTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeLessThan
@@ -11,22 +12,44 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 /**
- * Tests for PerformanceHistory - performance tracking with adaptive sampling.
+ * Tests for PerformanceHistory - performance tracking with time-based retention.
  *
  * Critical tests verify:
- * - Sample distribution across 0-100% range after downsampling
- * - Early samples (0-5%) are retained
- * - Late samples (95-100%) are retained
+ * - Samples inside the recent window survive compaction verbatim
+ * - Older samples are thinned evenly and stay chronological
+ * - The first and the last sample are always retained
  * - Total samples never exceed MAX_SAMPLES (1000)
- * - Percentage > 100% is handled correctly
- * - Chronological ordering is maintained
  */
 class PerformanceHistoryTest : BaseTest() {
+
+    /** The most a compaction can leave behind: a full recent tail plus a full overview. */
+    private val retentionBound = PerformanceHistory.RECENT_TARGET +
+        PerformanceHistory.OVERVIEW_BUCKETS * PerformanceHistory.SAMPLES_PER_OVERVIEW_BUCKET + 1
+
+    private fun samples(
+        count: Int,
+        spacing: Duration,
+        startTime: Instant = Instant.fromEpochMilliseconds(1000),
+    ) = (0 until count).map { i ->
+        PerformanceSample(
+            timestamp = startTime + spacing * i,
+            bytesPerSecond = (i + 1) * 1_000_000L,
+            itemsPerSecond = (i + 1).toFloat(),
+            totalBytesProcessed = (i + 1) * 1_000L,
+            totalItemsProcessed = i + 1,
+        )
+    }
+
+    private fun historyOf(samples: List<PerformanceSample>, totalBytes: Long = 0L, totalItems: Int = 0) =
+        samples.fold(PerformanceHistory()) { history, sample ->
+            history.addSample(sample, totalBytes = totalBytes, totalItems = totalItems)
+        }
 
     // ============ BASIC FUNCTIONALITY ============
 
@@ -421,7 +444,7 @@ class PerformanceHistoryTest : BaseTest() {
         recentSpeed shouldBe overallSpeed
     }
 
-    // ============ NO DOWNSAMPLING (UNDER LIMIT) ============
+    // ============ NO COMPACTION (UNDER LIMIT) ============
 
     @Test
     fun `500 samples do not trigger downsampling`() {
@@ -495,7 +518,7 @@ class PerformanceHistoryTest : BaseTest() {
         }
     }
 
-    // ============ CRITICAL DOWNSAMPLING TESTS ============
+    // ============ CRITICAL COMPACTION TESTS ============
 
     @Test
     fun `1500 samples trigger downsampling to under 1000`() {
@@ -522,173 +545,69 @@ class PerformanceHistoryTest : BaseTest() {
     }
 
     @Test
-    fun `distribution across 0-100 percent is maintained after downsampling`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_500_000_000L
+    fun `samples inside the recent window survive compaction verbatim`() {
+        val added = samples(count = 1001, spacing = 250.milliseconds)
+        val history = historyOf(added, totalBytes = 1_001_000L, totalItems = 1001)
 
-        // Create 1500 samples evenly distributed from 0% to 100%
-        repeat(1500) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 1500),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 1500
-            )
-        }
+        val cutoff = added.last().timestamp - PerformanceHistory.RECENT_WINDOW
+        val expected = added.filter { it.timestamp >= cutoff }
 
-        // Verify we have samples in each 5% bucket (20 buckets total)
-        val buckets = history.samples.groupBy { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            (percentage / 5.0).toInt().coerceIn(0, 19)
-        }
-
-        // All 20 buckets should have at least one sample
-        buckets.keys.size shouldBe 20
-        buckets.keys.min() shouldBe 0
-        buckets.keys.max() shouldBe 19
+        expected shouldHaveSize 481
+        history.samples.filter { it.timestamp >= cutoff } shouldBe expected
+        history.samples shouldHaveSize 721
     }
 
     @Test
-    fun `early samples (0-5 percent) are retained after downsampling`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 2_000_000_000L
+    fun `the first sample survives repeated compactions`() {
+        val added = samples(count = 5000, spacing = 250.milliseconds)
+        val history = historyOf(added, totalBytes = 5_000_000L, totalItems = 5000)
 
-        // Create 2000 samples
-        repeat(2000) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 2000),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 2000
-            )
-        }
-
-        // Find samples in 0-5% range
-        val earlySamples = history.samples.filter { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            percentage < 5.0
-        }
-
-        earlySamples.size shouldBeGreaterThan 0
-        println("Early samples (0-5%): ${earlySamples.size}")
+        history.samples.first() shouldBe added.first()
+        history.samples.size shouldBeLessThanOrEqual PerformanceHistory.MAX_SAMPLES
     }
 
     @Test
-    fun `late samples (95-100 percent) are retained after downsampling`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 2_000_000_000L
+    fun `the newest samples survive compaction untouched`() {
+        val added = samples(count = 2000, spacing = 250.milliseconds)
+        val history = historyOf(added, totalBytes = 2_000_000L, totalItems = 2000)
 
-        // Create 2000 samples
-        repeat(2000) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 2000),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 2000
-            )
-        }
-
-        // Find samples in 95-100% range
-        val lateSamples = history.samples.filter { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            percentage >= 95.0
-        }
-
-        lateSamples.size shouldBeGreaterThan 0
-        println("Late samples (95-100%): ${lateSamples.size}")
+        history.samples.takeLast(100) shouldBe added.takeLast(100)
     }
 
     @Test
-    fun `mid-range samples (40-60 percent) are retained after downsampling`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 2_000_000_000L
+    fun `older samples are thinned but stay chronological`() {
+        val added = samples(count = 1001, spacing = 250.milliseconds)
+        val history = historyOf(added, totalBytes = 1_001_000L, totalItems = 1001)
 
-        // Create 2000 samples
-        repeat(2000) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 2000),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 2000
-            )
+        val cutoff = added.last().timestamp - PerformanceHistory.RECENT_WINDOW
+        val older = history.samples.filter { it.timestamp < cutoff }
+
+        older shouldHaveSize 240
+        older.size shouldBeLessThan added.count { it.timestamp < cutoff }
+        older.first() shouldBe added.first()
+        history.samples.zipWithNext().forEach { (prev, next) ->
+            (prev.timestamp < next.timestamp) shouldBe true
         }
-
-        // Find samples in 40-60% range
-        val midSamples = history.samples.filter { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            percentage in 40.0..60.0
-        }
-
-        midSamples.size shouldBeGreaterThan 0
-        println("Mid samples (40-60%): ${midSamples.size}")
     }
 
     @Test
-    fun `percentage over 100 is clamped correctly`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_000_000L
+    fun `older samples are evenly spaced within their bucket`() {
+        val added = samples(count = 1001, spacing = 250.milliseconds)
+        val history = historyOf(added, totalBytes = 1_001_000L, totalItems = 1001)
 
-        // Add 1100 samples, with the last 100 exceeding totalBytes (simulating measurement errors)
-        repeat(1100) { i ->
-            val bytesProcessed = if (i < 1000) {
-                (i + 1) * (totalBytes / 1000)
-            } else {
-                // Exceed totalBytes - these should be clamped to 100%
-                totalBytes + ((i - 1000 + 1) * 10_000L)
-            }
+        val cutoff = added.last().timestamp - PerformanceHistory.RECENT_WINDOW
+        val older = history.samples.filter { it.timestamp < cutoff }
+        val span = older.last().timestamp - older.first().timestamp
 
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = bytesProcessed,
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 1100
-            )
+        val buckets = older.groupBy { sample ->
+            val position = (sample.timestamp - older.first().timestamp) / span
+            (position * PerformanceHistory.OVERVIEW_BUCKETS)
+                .toInt()
+                .coerceAtMost(PerformanceHistory.OVERVIEW_BUCKETS - 1)
         }
 
-        // Should not crash and should stay under limit
-        history.samples.size shouldBeLessThanOrEqual 1000
-
-        // Verify all samples with >100% are in the last bucket
-        val samplesOver100 = history.samples.filter { sample ->
-            sample.totalBytesProcessed > totalBytes
-        }
-        println("Samples over 100%: ${samplesOver100.size}")
-
-        // All should be treated as 100% (bucket 19)
-        samplesOver100.forEach { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            percentage shouldBeGreaterThan 100.0  // Raw percentage exceeds 100
-        }
+        buckets.keys shouldHaveSize PerformanceHistory.OVERVIEW_BUCKETS
+        buckets.values.forEach { it shouldHaveSize PerformanceHistory.SAMPLES_PER_OVERVIEW_BUCKET }
     }
 
     @Test
@@ -746,278 +665,94 @@ class PerformanceHistoryTest : BaseTest() {
     }
 
     @Test
-    fun `even bucket distribution - no bucket dominates`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 2_000_000_000L
-
-        fun addSample(i: Int) {
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 2000),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 2000
-            )
+    fun `every sampling cadence compacts inside the retention bound`() {
+        // One add past the cap, so each case is measured right after a compaction
+        val sizes = listOf(10.milliseconds, 250.milliseconds, 1.seconds).map { spacing ->
+            historyOf(samples(count = 1001, spacing = spacing)).samples.size
         }
 
-        // The bound only holds right after a compaction, mid-amortization there are up to ~200
-        // uncompacted trailing samples that all land in the same bucket
-        repeat(1001) { addSample(it) }
-
-        val buckets = history.samples.groupBy { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            (percentage / 5.0).toInt().coerceIn(0, 19)
-        }
-
-        val avgSamplesPerBucket = history.samples.size.toDouble() / 20
-
-        buckets.values.forEach { samplesInBucket ->
-            samplesInBucket.size shouldBeLessThanOrEqual (avgSamplesPerBucket * 2).toInt()
-        }
-
-        println("Bucket distribution: ${buckets.mapValues { it.value.size }}")
-
-        // The cap still holds while amortizing towards the next compaction
-        (1001 until 2000).forEach { addSample(it) }
-        history.samples.size shouldBeLessThanOrEqual 1000
+        // A fast cadence fits entirely inside the recent window, a slow one spills into the overview
+        sizes shouldBe listOf(500, 721, 361)
+        sizes.forEach { it shouldBeLessThanOrEqual retentionBound }
     }
 
     @Test
-    fun `compaction is amortized - one compaction lands on the target`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_001_000_000L
+    fun `compaction is amortized - one compaction leaves room to grow`() {
+        val history = historyOf(samples(count = 1001, spacing = 10.milliseconds))
 
-        repeat(1001) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 1001),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 1001
-            )
-        }
-
-        history.samples shouldHaveSize 800
+        history.samples shouldHaveSize 500
+        history.samples.size shouldBeLessThanOrEqual PerformanceHistory.COMPACT_TARGET
     }
 
     @Test
     fun `final sample survives compaction`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_001_000_000L
-        lateinit var lastSample: PerformanceSample
+        val added = samples(count = 1001, spacing = 10.milliseconds)
+        val history = historyOf(added, totalBytes = 1_001_000L, totalItems = 1001)
 
-        // Even distribution puts 50+ samples into every bucket, so every bucket gets downsampled
-        repeat(1001) { i ->
-            lastSample = PerformanceSample(
-                timestamp = startTime + (i * 10).milliseconds,
-                bytesPerSecond = 1_000_000L,
-                itemsPerSecond = 10f,
-                totalBytesProcessed = (i + 1) * (totalBytes / 1001),
-                totalItemsProcessed = i + 1
-            )
-            history = history.addSample(lastSample, totalBytes = totalBytes, totalItems = 1001)
-        }
-
-        history.samples.last() shouldBe lastSample
+        history.samples.last() shouldBe added.last()
     }
 
     @Test
-    fun `totals jumping on the cap-crossing add drive bucket assignment`() {
+    fun `compaction ignores the totals an add carries`() {
+        val added = samples(count = 1001, spacing = 10.milliseconds)
+        var history = PerformanceHistory()
+
+        // The totals only become known while the operation runs, retention must not depend on them
+        added.dropLast(1).forEach { history = history.addSample(it, totalBytes = 0L, totalItems = 1000) }
+        history = history.addSample(added.last(), totalBytes = 0L, totalItems = 10_000)
+
+        history.totalItems shouldBe 10_000
+        history.samples shouldHaveSize 500
+        history.samples.first() shouldBe added.first()
+        history.samples.last() shouldBe added.last()
+    }
+
+    // ============ RETENTION IS INDEPENDENT OF THE TOTALS ============
+
+    @Test
+    fun `a history with neither total compacts identically to one with totals`() {
+        val added = samples(count = 1200, spacing = 10.milliseconds)
+
+        val byteBased = historyOf(added, totalBytes = 1_200_000L, totalItems = 0)
+        val itemBased = historyOf(added, totalBytes = 0L, totalItems = 1200)
+        val mixed = historyOf(added, totalBytes = 1_200_000L, totalItems = 1200)
+        val neither = historyOf(added, totalBytes = 0L, totalItems = 0)
+
+        // 1001 adds compact to 500, the remaining 199 adds accumulate on top
+        byteBased.samples shouldHaveSize 699
+        itemBased.samples shouldBe byteBased.samples
+        mixed.samples shouldBe byteBased.samples
+        neither.samples shouldBe byteBased.samples
+    }
+
+    @Test
+    fun `samples that never transferred a byte are retained like any other`() {
         val startTime = Instant.fromEpochMilliseconds(1000)
         var history = PerformanceHistory()
 
-        // 1000 samples that look complete under the old total of 1000 items
-        repeat(1000) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 0L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = 0L,
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = 0L,
-                totalItems = 1000
-            )
-        }
-
-        // The add that crosses the cap discovers 9000 more items
-        history = history.addSample(
+        // Nothing is ever transferred, every item completes by being created or skipped
+        val added = (0 until 1001).map { i ->
             PerformanceSample(
-                timestamp = startTime + 10_010.milliseconds,
+                timestamp = startTime + (i * 10).milliseconds,
                 bytesPerSecond = 0L,
                 itemsPerSecond = 10f,
                 totalBytesProcessed = 0L,
-                totalItemsProcessed = 1001
-            ),
-            totalBytes = 0L,
-            totalItems = 10_000
-        )
-
-        history.totalItems shouldBe 10_000
-
-        // Under the new denominator everything sits below 11%, so only the first three buckets
-        // are populated: 40 + 40 + 2. Stale totals would have spread them over all 20 buckets.
-        history.samples shouldHaveSize 82
-
-        history.samples.forEach { sample ->
-            val percentage = (sample.totalItemsProcessed.toDouble() / history.totalItems) * 100.0
-            (percentage / 5.0).toInt() shouldBeLessThanOrEqual 2
-        }
-
-        history.samples.first().totalItemsProcessed shouldBe 1
-        history.samples.last().totalItemsProcessed shouldBe 1001
-    }
-
-    // ============ BYTE-BASED VS ITEM-BASED OPERATIONS ============
-
-    @Test
-    fun `byte-based operation uses bytes for percentage`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_000_000L
-
-        repeat(1200) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 1200),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 0  // Items = 0, so use bytes
+                totalItemsProcessed = i + 1,
+                totalBytesAccounted = (i + 1) * 1_000L,
             )
         }
+        added.forEach { history = history.addSample(it, totalBytes = 1_001_000L, totalItems = 0) }
 
-        history.samples.size shouldBeLessThanOrEqual 1000
-        history.samples.size shouldBeGreaterThan 0
-    }
-
-    @Test
-    fun `bucketing follows accounted bytes rather than transferred bytes`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_500_000_000L
-
-        // Nothing is ever transferred, every item completes by being created or skipped
-        repeat(1500) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 0L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = 0L,
-                    totalItemsProcessed = i + 1,
-                    totalBytesAccounted = (i + 1) * (totalBytes / 1500),
-                ),
-                totalBytes = totalBytes,
-                totalItems = 0  // Items = 0, so use bytes
-            )
-        }
-
-        val buckets = history.samples.groupBy { sample ->
-            val percentage = (sample.totalBytesAccounted.toDouble() / totalBytes) * 100.0
-            (percentage / 5.0).toInt().coerceIn(0, 19)
-        }
-
-        buckets.keys.size shouldBe 20
-        buckets.keys.min() shouldBe 0
-        buckets.keys.max() shouldBe 19
-        // Bucketing on transferred bytes would have crammed all of these into bucket 0
+        history.samples shouldHaveSize 500
+        history.samples.takeLast(60) shouldBe added.takeLast(60)
         history.samples.all { it.totalBytesProcessed == 0L } shouldBe true
     }
 
     @Test
-    fun `item-based operation uses items for percentage`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalItems = 1200
-
-        repeat(1200) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 0L,  // No bytes
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = 0L,
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = 0L,  // Bytes = 0, so use items
-                totalItems = totalItems
-            )
-        }
-
-        history.samples.size shouldBeLessThanOrEqual 1000
-        history.samples.size shouldBeGreaterThan 0
-    }
-
-    @Test
-    fun `mixed operation prefers bytes when both available`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_000_000L
-        val totalItems = 100
-
-        repeat(1200) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = (i + 1) * (totalBytes / 1200),
-                    totalItemsProcessed = (i + 1) * (totalItems / 1200)
-                ),
-                totalBytes = totalBytes,
-                totalItems = totalItems
-            )
-        }
-
-        history.samples.size shouldBeLessThanOrEqual 1000
-        history.samples.size shouldBeGreaterThan 0
-    }
-
-    @Test
-    fun `fallback when neither bytes nor items available`() {
+    fun `compaction sorts samples recorded out of order`() {
         val startTime = Instant.fromEpochMilliseconds(1000)
         var history = PerformanceHistory()
 
-        repeat(1200) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = 0L,
-                    totalItemsProcessed = 0
-                ),
-                totalBytes = 0L,  // No total to calculate percentage
-                totalItems = 0
-            )
-        }
-
-        // Should fallback to takeLast(800): add 1001 compacts, the remaining 199 adds accumulate
-        history.samples.size shouldBe 999
-    }
-
-    @Test
-    fun `fallback compaction keeps chronological order`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-
-        // Stop at the first compaction, later adds would append past the sorted block again
         repeat(1001) { i ->
             // Every tenth sample is recorded out of insertion order
             val offsetMs = if (i % 10 == 0) (i * 10) - 25 else i * 10
@@ -1029,15 +764,103 @@ class PerformanceHistoryTest : BaseTest() {
                     totalBytesProcessed = 0L,
                     totalItemsProcessed = 0
                 ),
-                totalBytes = 0L,  // No total to calculate percentage
+                totalBytes = 0L,
                 totalItems = 0
             )
         }
 
-        history.samples shouldHaveSize 800
+        history.samples shouldHaveSize 500
         history.samples.zipWithNext().forEach { (prev, next) ->
             (prev.timestamp <= next.timestamp) shouldBe true
         }
+    }
+
+    @Test
+    fun `a backwards clock jump still compacts within the cap`() {
+        val base = Instant.fromEpochMilliseconds(1000)
+        // The clock rewinds a minute right after the first sample, then runs forward again
+        val stamps = listOf(base) +
+            (0 until 500).map { i -> base - 60.seconds + (i * 120).milliseconds } +
+            (0 until 500).map { i -> base + 1500.milliseconds + (i * 250).milliseconds }
+        val added = stamps.mapIndexed { i, timestamp ->
+            PerformanceSample(
+                timestamp = timestamp,
+                bytesPerSecond = (i + 1) * 1_000_000L,
+                itemsPerSecond = (i + 1).toFloat(),
+                totalBytesProcessed = (i + 1) * 1_000L,
+                totalItemsProcessed = i + 1,
+            )
+        }
+
+        val history = historyOf(added)
+
+        history.samples.size shouldBeLessThanOrEqual PerformanceHistory.MAX_SAMPLES
+    }
+
+    @Test
+    fun `the first recorded sample survives a backwards clock jump`() {
+        val base = Instant.fromEpochMilliseconds(1_000_000)
+        // The clock rewinds a minute right after the first sample, then a forced burst runs forward
+        val stamps = listOf(base) + (0 until 1000).map { i -> base - 60.seconds + (i * 120).milliseconds }
+        val added = stamps.mapIndexed { i, timestamp ->
+            PerformanceSample(
+                timestamp = timestamp,
+                bytesPerSecond = (i + 1) * 1_000_000L,
+                itemsPerSecond = (i + 1).toFloat(),
+                totalBytesProcessed = (i + 1) * 1_000L,
+                totalItemsProcessed = i + 1,
+            )
+        }
+
+        val history = historyOf(added)
+
+        // The operation's origin point, wherever the clock put its timestamp
+        val origin = added.first()
+        history.samples.firstOrNull { it.bytesPerSecond == origin.bytesPerSecond } shouldBe origin
+    }
+
+    @Test
+    fun `the first recorded sample survives a second compaction after a backwards clock jump`() {
+        val base = Instant.fromEpochMilliseconds(1_000_000)
+        // Same rewind, but the burst runs long enough to compact twice
+        val stamps = listOf(base) + (0 until 1500).map { i -> base - 60.seconds + (i * 120).milliseconds }
+        val added = stamps.mapIndexed { i, timestamp ->
+            PerformanceSample(
+                timestamp = timestamp,
+                bytesPerSecond = (i + 1) * 1_000_000L,
+                itemsPerSecond = (i + 1).toFloat(),
+                totalBytesProcessed = (i + 1) * 1_000L,
+                totalItemsProcessed = i + 1,
+            )
+        }
+
+        val history = historyOf(added)
+
+        // The operation's origin point, wherever the clock put its timestamp
+        val origin = added.first()
+        history.samples.firstOrNull { it.bytesPerSecond == origin.bytesPerSecond } shouldBe origin
+    }
+
+    @Test
+    fun `a forced sampling burst keeps its newest sample after a backwards clock jump`() {
+        val base = Instant.fromEpochMilliseconds(1_000_000)
+        // The clock rewinds during the burst, so the newest sample no longer has the newest timestamp
+        val stamps = (0 until 1000).map { i -> base + (i * 100).milliseconds } + (base + 60_050.milliseconds)
+        val added = stamps.mapIndexed { i, timestamp ->
+            PerformanceSample(
+                timestamp = timestamp,
+                bytesPerSecond = (i + 1) * 1_000_000L,
+                itemsPerSecond = (i + 1).toFloat(),
+                totalBytesProcessed = (i + 1) * 1_000L,
+                totalItemsProcessed = i + 1,
+            )
+        }
+
+        val history = historyOf(added)
+
+        // Whatever the clock did, this is what the progress bar's speed and ETA just measured
+        val newest = added.last()
+        history.samples.firstOrNull { it.bytesPerSecond == newest.bytesPerSecond } shouldBe newest
     }
 
     // ============ EDGE CASES ============
@@ -1263,31 +1086,23 @@ class PerformanceHistoryTest : BaseTest() {
     }
 
     @Test
-    fun `percentage calculation uses latest totals not first totals`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
+    fun `a growing span coarsens the overview rather than dropping the tail`() {
+        val shortRun = historyOf(samples(count = 2000, spacing = 250.milliseconds))
+        val longRun = historyOf(samples(count = 5000, spacing = 250.milliseconds))
 
-        // Simulate discovering files during scanning
-        // First sample: Only 1000 files discovered, processed 500
-        history = history.addSample(
-            PerformanceSample(startTime, 1_000_000L, 10f, 500_000L, 500),
-            totalBytes = 1_000_000L,
-            totalItems = 1000
-        )
+        fun tailAndOverview(history: PerformanceHistory): Pair<Int, Int> {
+            val cutoff = history.samples.last().timestamp - PerformanceHistory.RECENT_WINDOW
+            return history.samples.count { it.timestamp >= cutoff } to
+                history.samples.count { it.timestamp < cutoff }
+        }
 
-        // This looks like 50% complete (500/1000)
+        val (shortTail, shortOverview) = tailAndOverview(shortRun)
+        val (longTail, longOverview) = tailAndOverview(longRun)
 
-        // Second sample: Now 9000 files total discovered, still only processed 500
-        history = history.addSample(
-            PerformanceSample(startTime + 100.milliseconds, 1_000_000L, 10f, 500_000L, 500),
-            totalBytes = 9_000_000L,
-            totalItems = 9000
-        )
-
-        // Now it's only ~5.5% complete (500/9000), not 50%!
-        history.totalItems shouldBe 9000
-        val percentage = (500.0 / history.totalItems) * 100.0
-        percentage shouldBeLessThan 10.0  // Should be much less than 50%
+        // The recent window holds the same samples either way, only the overview thins out
+        shortTail shouldBe 481
+        longTail shouldBe 481
+        longOverview shouldBeLessThan shortOverview
     }
 
     @Test
@@ -1356,33 +1171,28 @@ class PerformanceHistoryTest : BaseTest() {
     }
 
     @Test
-    fun `downsampling uses latest totals for bucketing`() {
+    fun `growing totals do not change what compaction retains`() {
         val startTime = Instant.fromEpochMilliseconds(1000)
         var history = PerformanceHistory()
 
-        // Add 1500 samples with increasing totals (simulates long scanning phase)
-        repeat(1500) { i ->
-            // Totals grow linearly as scanning progresses
-            val currentTotal = 1000 + (i * 5)  // Starts at 1000, ends at 8500
-            val processed = i + 1
-
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 10).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = processed * 1000L,
-                    totalItemsProcessed = processed
-                ),
-                totalBytes = currentTotal * 1000L,
-                totalItems = currentTotal
+        val added = (0 until 1500).map { i ->
+            PerformanceSample(
+                timestamp = startTime + (i * 10).milliseconds,
+                bytesPerSecond = 1_000_000L,
+                itemsPerSecond = 10f,
+                totalBytesProcessed = (i + 1) * 1000L,
+                totalItemsProcessed = i + 1
             )
         }
+        // Totals grow linearly as scanning progresses
+        added.forEachIndexed { i, sample ->
+            val currentTotal = 1000 + (i * 5)
+            history = history.addSample(sample, totalBytes = currentTotal * 1000L, totalItems = currentTotal)
+        }
 
-        // Should downsample to ≤ 1000
-        history.samples.size shouldBeLessThanOrEqual 1000
+        history.samples.size shouldBeLessThanOrEqual PerformanceHistory.MAX_SAMPLES
+        history.samples shouldBe historyOf(added).samples
 
-        // Verify it used the FINAL total (8500) not the first total (1000) for bucketing
         history.totalItems shouldBe 8495  // Last total: 1000 + (1499 * 5)
         history.totalBytes shouldBe 8_495_000L
     }
@@ -1409,49 +1219,17 @@ class PerformanceHistoryTest : BaseTest() {
     }
 
     @Test
-    fun `last bucket (95-100 percent) is populated when operation completes`() {
-        val startTime = Instant.fromEpochMilliseconds(1000)
-        var history = PerformanceHistory()
-        val totalBytes = 1_000_000L
+    fun `a forced sampling burst keeps its newest samples untouched`() {
+        val added = samples(count = 1001, spacing = 1.milliseconds)
+        val uncompacted = PerformanceHistory(samples = added, startTime = added.first().timestamp)
+        val history = historyOf(added, totalBytes = 1_001_000L, totalItems = 1001)
 
-        // Add samples up to 95%
-        repeat(95) { i ->
-            history = history.addSample(
-                PerformanceSample(
-                    timestamp = startTime + (i * 100).milliseconds,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 10f,
-                    totalBytesProcessed = ((i + 1) * 10_000L),
-                    totalItemsProcessed = i + 1
-                ),
-                totalBytes = totalBytes,
-                totalItems = 100
-            )
-        }
+        history.samples shouldHaveSize PerformanceHistory.RECENT_TARGET
+        history.samples.takeLast(PerformanceHistory.PROTECTED_TAIL) shouldBe
+            added.takeLast(PerformanceHistory.PROTECTED_TAIL)
 
-        // Add final 100% sample
-        history = history.addSample(
-            PerformanceSample(
-                timestamp = startTime + 100.seconds,
-                bytesPerSecond = 1_000_000L,
-                itemsPerSecond = 10f,
-                totalBytesProcessed = totalBytes,
-                totalItemsProcessed = 100
-            ),
-            totalBytes = totalBytes,
-            totalItems = 100
-        )
-
-        // Find samples in 95-100% range (bucket 19)
-        val finalBucketSamples = history.samples.filter { sample ->
-            val percentage = (sample.totalBytesProcessed.toDouble() / totalBytes) * 100.0
-            percentage >= 95.0
-        }
-
-        finalBucketSamples.size shouldBeGreaterThan 0
-
-        // Verify 100% sample exists
-        val completeSample = history.samples.last()
-        completeSample.totalBytesProcessed shouldBe totalBytes
+        // The progress bar's speed and ETA read these, thinning under them would change a shown number
+        history.getRecentBytesPerSecond() shouldBe uncompacted.getRecentBytesPerSecond()
+        history.getRecentItemsPerSecond() shouldBe uncompacted.getRecentItemsPerSecond()
     }
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraph.kt
@@ -36,6 +36,7 @@ import com.patrykandpatrick.vico.core.cartesian.Zoom
 import com.patrykandpatrick.vico.core.cartesian.axis.Axis
 import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModel
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
@@ -55,8 +56,30 @@ import eu.darken.butler.common.formatItemSpeed
 import eu.darken.butler.workspace.R
 import java.util.Locale
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 private val TAG = logTag("PerformanceGraph")
+
+/** Bounds how many labels the bottom axis enumerates on a multi-minute range. */
+private const val MAX_AXIS_STEPS = 200
+
+/**
+ * The window bounds travel with the data: a transaction whose series are unchanged is dropped by the
+ * model producer, and only a transaction that reaches it recomputes the chart's ranges.
+ */
+internal val X_START = ExtraStore.Key<Float>()
+internal val X_END = ExtraStore.Key<Float>()
+
+internal suspend fun CartesianChartModelProducer.plotGraphData(graphData: PerformanceGraphData) {
+    runTransaction {
+        if (graphData.byteSpeeds != null) lineSeries { series(x = graphData.elapsedSeconds, y = graphData.byteSpeeds) }
+        lineSeries { series(x = graphData.elapsedSeconds, y = graphData.itemSpeeds) }
+        extras {
+            it[X_START] = graphData.xStart
+            it[X_END] = graphData.xEnd
+        }
+    }
+}
 
 
 @Composable
@@ -71,11 +94,8 @@ fun OperationPerformanceGraph(
     val modelProducer = remember(byteSpeeds != null) { CartesianChartModelProducer() }
 
     LaunchedEffect(graphData) {
-        log(TAG, DEBUG) { "Plotting ${graphData.progress.size} points" }
-        modelProducer.runTransaction {
-            if (byteSpeeds != null) lineSeries { series(x = graphData.progress, y = byteSpeeds) }
-            lineSeries { series(x = graphData.progress, y = graphData.itemSpeeds) }
-        }
+        log(TAG, DEBUG) { "Plotting ${graphData.elapsedSeconds.size} points" }
+        modelProducer.plotGraphData(graphData)
     }
 
     Column(
@@ -166,6 +186,12 @@ fun OperationPerformanceGraph(
                 null
             }
 
+            // Vico's default step is the greatest common divisor of the x deltas, which throws on
+            // time values, and the bottom axis enumerates its labels even without drawing them
+            val getXStep = remember(graphData.xStart, graphData.xEnd) {
+                xStepProvider((graphData.xEnd - graphData.xStart) / MAX_AXIS_STEPS)
+            }
+
             // Keyed like the producer above so a mode flip pairs a fresh host with the fresh producer
             key(byteSpeeds != null) {
                 CartesianChartHost(
@@ -184,6 +210,7 @@ fun OperationPerformanceGraph(
                             guideline = null,  // Hide grid lines
                             tick = null,  // Hide tick marks
                         ),
+                        getXStep = getXStep,
                     ),
                     modelProducer = modelProducer,
                     zoomState = rememberVicoZoomState(
@@ -214,8 +241,30 @@ fun OperationPerformanceGraph(
                     .align(Alignment.TopEnd)
                     .offset(x = (-48).dp, y = 16.dp),
             )
+
+            // How much time the plot covers, bottom-start so it clears both speed readouts
+            graphData.windowSpanSeconds?.let { span ->
+                SpeedChip(
+                    text = windowSpanLabel(span),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .offset(x = 48.dp, y = (-8).dp),
+                )
+            }
         }
     }
+}
+
+/** The window grows for its first two minutes, so the span is shown rather than a fixed label. */
+@Composable
+private fun windowSpanLabel(spanSeconds: Int): String = when {
+    spanSeconds >= 60 && spanSeconds % 60 == 0 -> stringResource(
+        R.string.workspace_operation_performance_window_minutes,
+        spanSeconds / 60,
+    )
+
+    else -> stringResource(R.string.workspace_operation_performance_window_seconds, spanSeconds)
 }
 
 @Composable
@@ -247,14 +296,22 @@ private val ByteSpeedUnit.labelRes: Int
 
 private fun axisMax(maxValue: Double): Double = if (maxValue == 0.0) 1.0 else maxValue * 1.20
 
-private fun speedRangeProvider(rangeMaxY: Double) = object : CartesianLayerRangeProvider {
+internal fun speedRangeProvider(rangeMaxY: Double) = object : CartesianLayerRangeProvider {
     override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double = 0.0
 
     override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double = rangeMaxY
 
-    override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore): Double = 0.0
+    override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore): Double =
+        extraStore[X_START].toDouble()
 
-    override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore): Double = 100.0
+    override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore): Double =
+        extraStore[X_END].toDouble()
+}
+
+/** The range is the bound, not the model width, so an early frame with few points is bounded too. */
+private fun xStepProvider(stepSeconds: Float): (CartesianChartModel) -> Double {
+    val step = stepSeconds.toDouble().coerceAtLeast(PerformanceGraphData.PLOT_STEP_SECONDS.toDouble())
+    return { step }
 }
 
 /** Slow axes need decimals, fast ones would only repeat the same rounded label. */
@@ -269,14 +326,12 @@ private fun speedValueFormatter(maxY: Double) = CartesianValueFormatter { _, val
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun OperationPerformanceGraphHalfDataPreview() {
-    // 50% completion with varying speeds (many small files scenario)
+private fun OperationPerformanceGraphShortOverviewPreview() {
+    // A 12 second transfer of many small files, seen after it completed
     val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
-        val totalBytes = 1_000_000_000L
 
         val samples = (0..50).map { i ->
-            val progress = i / 100f
             val speed = (150_000_000 + (kotlin.math.sin(i * 0.3) * 100_000_000)).toLong()
             // Items/s varies independently - simulates many small files
             val items = (15.0 + (kotlin.math.sin(i * 0.5) * 10.0)).coerceAtLeast(5.0).toFloat()
@@ -284,18 +339,13 @@ private fun OperationPerformanceGraphHalfDataPreview() {
                 timestamp = baseTime + (i * 250).milliseconds,
                 bytesPerSecond = speed.coerceAtLeast(50_000_000),
                 itemsPerSecond = items,
-                totalBytesProcessed = (totalBytes * progress).toLong(),
-                totalItemsProcessed = (progress * 1000).toInt(),
+                totalBytesProcessed = i * 40_000_000L,
+                totalItemsProcessed = i * 10,
             )
         }
 
-        val history = PerformanceHistory(
-            samples = samples,
-            startTime = baseTime,
-            totalBytes = totalBytes,
-            totalItems = 1000,
-        )
-        PerformanceGraphData.from(history)
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.OVERVIEW, samples.last().timestamp)
     } ?: return
     OperationPerformanceGraph(graphData = graphData)
 }
@@ -303,14 +353,12 @@ private fun OperationPerformanceGraphHalfDataPreview() {
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun OperationPerformanceGraphFullDataPreview() {
-    // 100% completion with varying speeds (mixed file sizes scenario)
+private fun OperationPerformanceGraphOverviewPreview() {
+    // A completed transfer of mixed file sizes over 25 seconds
     val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
-        val totalBytes = 1_000_000_000L
 
         val samples = (0..100).map { i ->
-            val progress = i / 100f
             val speed = (200_000_000 + (kotlin.math.sin(i * 0.2) * 150_000_000)).toLong()
             // Items/s shows different pattern - starts high (small files), drops (large files), rises again
             val items = when {
@@ -322,18 +370,13 @@ private fun OperationPerformanceGraphFullDataPreview() {
                 timestamp = baseTime + (i * 250).milliseconds,
                 bytesPerSecond = speed.coerceAtLeast(50_000_000),
                 itemsPerSecond = items,
-                totalBytesProcessed = (totalBytes * progress).toLong(),
-                totalItemsProcessed = (progress * 1000).toInt(),
+                totalBytesProcessed = i * 50_000_000L,
+                totalItemsProcessed = i * 10,
             )
         }
 
-        val history = PerformanceHistory(
-            samples = samples,
-            startTime = baseTime,
-            totalBytes = totalBytes,
-            totalItems = 1000,
-        )
-        PerformanceGraphData.from(history)
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.OVERVIEW, samples.last().timestamp)
     } ?: return
     OperationPerformanceGraph(graphData = graphData)
 }
@@ -345,7 +388,6 @@ private fun OperationPerformanceGraphItemsOnlyPreview() {
     // Deleting 500 empty files: no bytes anywhere, only the items axis has data
     val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
-        val totalItems = 500
 
         val samples = (0..100).map { i ->
             val items = (40.0 + (kotlin.math.sin(i * 0.35) * 15.0)).coerceAtLeast(10.0).toFloat()
@@ -354,16 +396,12 @@ private fun OperationPerformanceGraphItemsOnlyPreview() {
                 bytesPerSecond = 0L,
                 itemsPerSecond = items,
                 totalBytesProcessed = 0L,
-                totalItemsProcessed = (totalItems * (i / 100f)).toInt(),
+                totalItemsProcessed = i * 5,
             )
         }
 
-        val history = PerformanceHistory(
-            samples = samples,
-            startTime = baseTime,
-            totalItems = totalItems,
-        )
-        PerformanceGraphData.from(history)
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.OVERVIEW, samples.last().timestamp)
     } ?: return
     OperationPerformanceGraph(graphData = graphData)
 }
@@ -375,27 +413,95 @@ private fun OperationPerformanceGraphSingleFilePreview() {
     // A single large file: the item count never moves, item speed stays below 1/s
     val graphData = remember {
         val baseTime = kotlin.time.Clock.System.now()
-        val totalBytes = 4_000_000_000L
 
         val samples = (0..100).map { i ->
-            val progress = i / 100f
             val speed = (80_000_000 + (kotlin.math.sin(i * 0.25) * 20_000_000)).toLong()
             PerformanceSample(
                 timestamp = baseTime + (i * 500).milliseconds,
                 bytesPerSecond = speed,
                 itemsPerSecond = 0.02f,
-                totalBytesProcessed = (totalBytes * progress).toLong(),
+                totalBytesProcessed = i * 40_000_000L,
                 totalItemsProcessed = 0,
             )
         }
 
-        val history = PerformanceHistory(
-            samples = samples,
-            startTime = baseTime,
-            totalBytes = totalBytes,
-            totalItems = 1,
-        )
-        PerformanceGraphData.from(history)
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.OVERVIEW, samples.last().timestamp)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationPerformanceGraphGrowingWindowPreview() {
+    // 15 seconds in, the window is still growing so the curve fills the width without sliding
+    val graphData = remember {
+        val baseTime = kotlin.time.Clock.System.now()
+
+        val samples = (0..60).map { i ->
+            val speed = (120_000_000 + (kotlin.math.sin(i * 0.4) * 60_000_000)).toLong()
+            PerformanceSample(
+                timestamp = baseTime + (i * 250).milliseconds,
+                bytesPerSecond = speed,
+                itemsPerSecond = (6.0 + (kotlin.math.sin(i * 0.6) * 3.0)).toFloat(),
+                totalBytesProcessed = i * 30_000_000L,
+                totalItemsProcessed = i * 2,
+            )
+        }
+
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.LIVE, baseTime + 15.seconds)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationPerformanceGraphSlidingWindowPreview() {
+    // Five minutes in, the window holds the last two minutes and the early samples are cropped away
+    val graphData = remember {
+        val baseTime = kotlin.time.Clock.System.now()
+
+        val samples = (0..600).map { i ->
+            val speed = (90_000_000 + (kotlin.math.sin(i * 0.05) * 70_000_000)).toLong()
+            PerformanceSample(
+                timestamp = baseTime + (i * 500).milliseconds,
+                bytesPerSecond = speed,
+                itemsPerSecond = (4.0 + (kotlin.math.sin(i * 0.08) * 2.0)).toFloat(),
+                totalBytesProcessed = i * 45_000_000L,
+                totalItemsProcessed = i * 2,
+            )
+        }
+
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.LIVE, baseTime + 300.seconds)
+    } ?: return
+    OperationPerformanceGraph(graphData = graphData)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun OperationPerformanceGraphStalledWindowPreview() {
+    // A blocked transfer: the right edge keeps advancing while the line stops at its last sample
+    val graphData = remember {
+        val baseTime = kotlin.time.Clock.System.now()
+
+        val samples = (0..80).map { i ->
+            val speed = (60_000_000 - (i * 500_000L)).coerceAtLeast(1_000_000L)
+            PerformanceSample(
+                timestamp = baseTime + (i * 250).milliseconds,
+                bytesPerSecond = speed,
+                itemsPerSecond = 1.5f,
+                totalBytesProcessed = i * 15_000_000L,
+                totalItemsProcessed = i,
+            )
+        }
+
+        val history = PerformanceHistory(samples = samples, startTime = baseTime)
+        PerformanceGraphData.from(history, PerformanceGraphScope.LIVE, baseTime + 90.seconds)
     } ?: return
     OperationPerformanceGraph(graphData = graphData)
 }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSection.kt
@@ -11,6 +11,8 @@ import androidx.compose.material.icons.twotone.ContentCopy
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,12 +30,15 @@ import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import kotlinx.coroutines.delay
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
 
 @Composable
 internal fun OperationPerformanceGraphSection(
     operation: OperationDisplay,
+    clock: Clock = Clock.System,
     graphContent: @Composable (PerformanceGraphData) -> Unit = { OperationPerformanceGraph(graphData = it) },
 ) {
     OperationSection(
@@ -42,13 +47,37 @@ internal fun OperationPerformanceGraphSection(
     ) {
         // Inside the section: building the series walks the whole history, and a collapsed section
         // never composes this lambda.
-        val graphState = remember(operation.state) { performanceGraphStateOf(operation) }
+        val state = operation.state
+        val initialNow = when (state) {
+            is OperationDisplay.State.Running -> clock.now()
+            // A finished operation covers a fixed span, a clock would only make it unpredictable
+            else -> state.performanceHistoryOrNull?.samples?.lastOrNull()?.timestamp ?: clock.now()
+        }
+        // A stalled operation reports no samples at all, so the live window has to advance on its own
+        val now by produceState(initialNow, state, clock) {
+            if (state !is OperationDisplay.State.Running) return@produceState
+            while (true) {
+                delay(TICK_INTERVAL)
+                value = clock.now()
+            }
+        }
+        val graphState = remember(state, now) { performanceGraphStateOf(operation, now) }
         when (graphState) {
             is PerformanceGraphState.Plottable -> ProGate { graphContent(graphState.data) }
             is PerformanceGraphState.Unavailable -> PerformanceGraphUnavailableInfo(reason = graphState.reason)
         }
     }
 }
+
+private val TICK_INTERVAL = 500.milliseconds
+
+/** The history a state carries, if its kind carries one at all. */
+private val OperationDisplay.State.performanceHistoryOrNull: PerformanceHistory?
+    get() = when (this) {
+        is OperationDisplay.State.Running -> performanceHistory
+        is OperationDisplay.State.Completed -> performanceHistory
+        else -> null
+    }
 
 internal sealed interface PerformanceGraphState {
     data class Plottable(val data: PerformanceGraphData) : PerformanceGraphState
@@ -66,17 +95,18 @@ internal enum class PerformanceGraphUnavailability {
  * Whether [operation] has something to plot, and if not, which explanation fits its state.
  *
  * A running operation is always [PerformanceGraphUnavailability.COLLECTING], whatever kept the
- * series empty: no history yet, too few samples, or progress that hasn't moved. All three can still
- * turn into a graph while it runs.
+ * series empty: no history yet, or too few samples. Both can still turn into a graph while it runs.
  */
-internal fun performanceGraphStateOf(operation: OperationDisplay): PerformanceGraphState {
-    val history = when (val state = operation.state) {
-        is OperationDisplay.State.Running -> state.performanceHistory
-        is OperationDisplay.State.Completed -> state.performanceHistory
-        else -> null
+internal fun performanceGraphStateOf(operation: OperationDisplay, now: Instant): PerformanceGraphState {
+    val history = operation.state.performanceHistoryOrNull
+
+    // A running operation follows its recent window, a finished one is shown in full
+    val scope = when (operation.state) {
+        is OperationDisplay.State.Running -> PerformanceGraphScope.LIVE
+        else -> PerformanceGraphScope.OVERVIEW
     }
 
-    val data = history?.let { PerformanceGraphData.from(it) }
+    val data = history?.let { PerformanceGraphData.from(it, scope, now) }
     if (data != null) return PerformanceGraphState.Plottable(data)
 
     val reason = when (operation.state) {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphData.kt
@@ -3,6 +3,9 @@ package eu.darken.butler.workspace.ui.operations.details
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import kotlin.math.round
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 enum class ByteSpeedUnit(val divisor: Double) {
     B_S(1.0),
@@ -12,15 +15,30 @@ enum class ByteSpeedUnit(val divisor: Double) {
 }
 
 /**
+ * Which stretch of an operation the graph covers.
+ *
+ * [LIVE] follows the most recent [PerformanceGraphData.RECENT_WINDOW_SECONDS], [OVERVIEW] spans the
+ * whole sampled transfer.
+ */
+enum class PerformanceGraphScope {
+    LIVE,
+    OVERVIEW,
+}
+
+/**
  * Plot-ready series for [OperationPerformanceGraph].
  *
- * All series share the [progress] x values, which are completion percentages rounded to 0.5 steps.
+ * All series share the [elapsedSeconds] x values, which are seconds since the first recorded sample
+ * rounded to 0.5 s steps. [xStart] and [xEnd] are the axis bounds, and may reach past the newest
+ * sample while an operation stalls.
+ *
+ * [windowSpanSeconds] is the length of the live window, null for a completed operation.
  *
  * [recentBytesPerSecond] and [recentItemsPerSecond] are averages over the raw history, not over the
  * decimated and smoothed series, so they stay the speeds the operation actually reported last.
  */
 data class PerformanceGraphData(
-    val progress: List<Float>,
+    val elapsedSeconds: List<Float>,
     val byteSpeeds: List<Float>?,
     val itemSpeeds: List<Float>,
     val byteUnit: ByteSpeedUnit?,
@@ -28,71 +46,89 @@ data class PerformanceGraphData(
     val maxItemSpeed: Double,
     val recentBytesPerSecond: Long,
     val recentItemsPerSecond: Float,
+    val xStart: Float,
+    val xEnd: Float,
+    val windowSpanSeconds: Int?,
 ) {
 
     companion object {
-        private const val PROGRESS_STEP = 0.5f
-        private const val SMOOTHING_WINDOW = 10
+        /** Read by [OperationPerformanceGraph] as the floor for the chart's x step. */
+        internal const val PLOT_STEP_SECONDS = 0.5f
+        internal const val RECENT_WINDOW_SECONDS = 120f
+        private val SMOOTHING_DURATION = 2.seconds
 
-        fun from(history: PerformanceHistory): PerformanceGraphData? {
+        fun from(
+            history: PerformanceHistory,
+            scope: PerformanceGraphScope,
+            now: Instant,
+        ): PerformanceGraphData? {
             if (!history.canShowGraph) return null
-            // Without either total there is no x domain, every percentage would divide by zero
-            if (history.totalBytes == 0L && history.totalItems == 0) return null
 
-            // Plotting against accounted bytes needs a domain that actually moves, otherwise the
-            // whole run collapses onto one x and nothing is plottable
-            val useByteAxis = history.totalBytes > 0L &&
-                history.samples.map { history.byteProgressOf(it) }.distinct().size >= 2
+            val samples = history.samples
+            // The axis spans the sampled transfer: nothing is recorded until progress moves, so an
+            // operation's own start would prepend its scanning phase as blank space
+            val origin = history.startTime ?: samples.first().timestamp
 
-            val samples = mutableListOf<PerformanceSample>()
-            val progress = mutableListOf<Float>()
+            val elapsed = mutableListOf<Float>()
+            samples.forEach { sample ->
+                val x = roundToStep((sample.timestamp - origin).inWholeMilliseconds / 1000f).coerceAtLeast(0f)
+                // A wall-clock jump backwards must not delete curve that was already measured
+                elapsed.add(if (elapsed.isEmpty()) x else maxOf(x, elapsed.last()))
+            }
 
-            history.samples.forEach { sample ->
-                val x = history.progressOf(sample, useByteAxis)
-                if (progress.isEmpty() || x - progress.last() >= PROGRESS_STEP) {
-                    samples.add(sample)
-                    progress.add(x)
-                }
+            val smoothedBytes = samples.trailingAverage { it.bytesPerSecond.toDouble() }
+            val smoothedItems = samples.trailingAverage { it.itemsPerSecond.toDouble() }
+
+            val lastX = elapsed.last()
+            val xEnd = when (scope) {
+                PerformanceGraphScope.LIVE -> ((now - origin).inWholeMilliseconds / 1000f).coerceAtLeast(lastX)
+                PerformanceGraphScope.OVERVIEW -> lastX
+            }
+            val xStart = when (scope) {
+                PerformanceGraphScope.LIVE -> (xEnd - RECENT_WINDOW_SECONDS).coerceAtLeast(0f)
+                PerformanceGraphScope.OVERVIEW -> 0f
+            }
+            val windowSpanSeconds = when (scope) {
+                PerformanceGraphScope.LIVE -> (xEnd - xStart).roundToInt()
+                PerformanceGraphScope.OVERVIEW -> null
+            }
+
+            // Selecting over the whole history first makes the x values distinct by construction, so
+            // cropping them cannot merge the two points the chart needs into one plot step
+            val selected = mutableListOf<Int>()
+            for (i in elapsed.indices) {
+                if (selected.isEmpty() || elapsed[i] > elapsed[selected.last()]) selected.add(i)
             }
 
             // The final state matters even when it didn't advance enough to pass the filter
-            val finalSample = history.samples.last()
-            if (samples.last() !== finalSample) {
-                val finalX = history.progressOf(finalSample, useByteAxis)
-                when {
-                    finalX == progress.last() -> {
-                        samples[samples.lastIndex] = finalSample
-                        progress[progress.lastIndex] = finalX
-                    }
-                    // Defensive: non-monotonic sample order (e.g. a wall-clock jump) can move the final sample back onto steps already plotted
-                    finalX < progress.last() -> {
-                        while (progress.isNotEmpty() && progress.last() >= finalX) {
-                            samples.removeAt(samples.lastIndex)
-                            progress.removeAt(progress.lastIndex)
-                        }
-                        samples.add(finalSample)
-                        progress.add(finalX)
-                    }
-                    else -> {
-                        samples.add(finalSample)
-                        progress.add(finalX)
-                    }
+            if (selected.last() != elapsed.lastIndex) selected[selected.lastIndex] = elapsed.lastIndex
+
+            val cropStart = when (scope) {
+                PerformanceGraphScope.LIVE -> {
+                    // One point before the window, so the line enters from the left edge
+                    val firstInWindow = selected.indexOfFirst { elapsed[it] >= xStart }
+                    val cropped = if (firstInWindow < 0) selected.size else (firstInWindow - 1).coerceAtLeast(0)
+                    // A stall longer than the window pushes every sample out of it, the chart stays
+                    if (selected.lastIndex - cropped >= 1) cropped else (selected.lastIndex - 1).coerceAtLeast(0)
                 }
+
+                PerformanceGraphScope.OVERVIEW -> 0
             }
 
-            // A flat x domain (e.g. an all-skipped operation) has nothing to plot against
-            if (progress.distinct().size < 2) return null
+            val plotted = selected.drop(cropStart)
+            val xValues = plotted.map { elapsed[it] }
 
-            val hasByteData = history.samples.any { it.bytesPerSecond > 0L || it.totalBytesProcessed > 0L }
-            val byteUnit = if (hasByteData) unitFor(samples.maxOf { it.bytesPerSecond }) else null
+            if (xValues.size < 2) return null
 
-            val byteSpeeds = byteUnit?.let { unit ->
-                samples.map { it.bytesPerSecond / unit.divisor }.trailingAverage()
-            }
-            val itemSpeeds = samples.map { it.itemsPerSecond.toDouble() }.trailingAverage()
+            val hasByteData = samples.any { it.bytesPerSecond > 0L || it.totalBytesProcessed > 0L }
+            // The y range comes from the plotted points, so the unit has to follow the same population
+            val byteUnit = if (hasByteData) unitFor(plotted.maxOf { samples[it].bytesPerSecond }) else null
+
+            val byteSpeeds = byteUnit?.let { unit -> plotted.map { (smoothedBytes[it] / unit.divisor).toFloat() } }
+            val itemSpeeds = plotted.map { smoothedItems[it].toFloat() }
 
             return PerformanceGraphData(
-                progress = progress,
+                elapsedSeconds = xValues,
                 byteSpeeds = byteSpeeds,
                 itemSpeeds = itemSpeeds,
                 byteUnit = byteUnit,
@@ -100,39 +136,13 @@ data class PerformanceGraphData(
                 maxItemSpeed = itemSpeeds.max().toDouble(),
                 recentBytesPerSecond = history.getRecentBytesPerSecond(),
                 recentItemsPerSecond = history.getRecentItemsPerSecond(),
+                xStart = xStart,
+                xEnd = xEnd,
+                windowSpanSeconds = windowSpanSeconds,
             )
         }
 
-        /**
-         * Share of the accounted work a sample carries, rounded to 0.5 steps.
-         *
-         * This is the axis candidate before the terminal clause in [progressOf], so it says whether
-         * accounted bytes move at all.
-         */
-        private fun PerformanceHistory.byteProgressOf(sample: PerformanceSample): Float =
-            roundToStep((sample.totalBytesAccounted.toFloat() / totalBytes.toFloat()) * 100f)
-
-        /**
-         * Completion percentage of a sample, rounded to 0.5 steps.
-         *
-         * On the byte axis a sample that has processed every item is pinned to 100%, so rounding
-         * shortfalls and items that finish without accounting their full size still terminate.
-         */
-        private fun PerformanceHistory.progressOf(sample: PerformanceSample, useByteAxis: Boolean): Float {
-            val raw = when {
-                !useByteAxis -> if (totalItems > 0) {
-                    (sample.totalItemsProcessed.toFloat() / totalItems.toFloat()) * 100f
-                } else {
-                    0f
-                }
-
-                totalItems > 0 && sample.totalItemsProcessed >= totalItems -> 100f
-                else -> (sample.totalBytesAccounted.toFloat() / totalBytes.toFloat()) * 100f
-            }
-            return roundToStep(raw)
-        }
-
-        private fun roundToStep(percentage: Float): Float = round(percentage.coerceIn(0f, 100f) * 2) / 2f
+        private fun roundToStep(seconds: Float): Float = round(seconds / PLOT_STEP_SECONDS) * PLOT_STEP_SECONDS
 
         private fun unitFor(maxBytesPerSecond: Long): ByteSpeedUnit = when {
             maxBytesPerSecond < 1_000L -> ByteSpeedUnit.B_S
@@ -142,15 +152,23 @@ data class PerformanceGraphData(
         }
 
         /**
-         * Moving average over the current and the previous [window] - 1 values.
+         * Moving average over the samples within [SMOOTHING_DURATION] before each one.
          *
-         * Trailing, not centered: a point may never be smoothed by values that come after it.
+         * Trailing, not centered: a point may never be smoothed by values that come after it. The
+         * index guard matters as much as the timestamp one, two samples can share a timestamp and a
+         * later one must not change what an earlier one already plotted.
          */
-        private fun List<Double>.trailingAverage(window: Int = SMOOTHING_WINDOW): List<Float> = indices.map { i ->
-            val start = maxOf(0, i - window + 1)
-            var sum = 0.0
-            for (j in start..i) sum += this[j]
-            (sum / (i - start + 1)).toFloat()
-        }
+        private fun List<PerformanceSample>.trailingAverage(value: (PerformanceSample) -> Double): List<Double> =
+            indices.map { i ->
+                val windowStart = this[i].timestamp - SMOOTHING_DURATION
+                var sum = 0.0
+                var count = 0
+                for (j in i downTo 0) {
+                    if (this[j].timestamp <= windowStart) continue
+                    sum += value(this[j])
+                    count++
+                }
+                sum / count
+            }
     }
 }

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -279,6 +279,8 @@
     <string name="workspace_operation_performance_unavailable_collecting">Collecting performance data…</string>
     <string name="workspace_operation_performance_unavailable_insufficient">There isn\'t enough performance data from this operation to plot a graph.</string>
     <string name="workspace_operation_performance_unavailable_not_available">Performance data isn\'t available for this operation.</string>
+    <string name="workspace_operation_performance_window_seconds">Last %1$d s</string>
+    <string name="workspace_operation_performance_window_minutes">Last %1$d min</string>
     <string name="workspace_operation_performance_unit_bytes">B/s</string>
     <string name="workspace_operation_performance_unit_kilobytes">kB/s</string>
     <string name="workspace_operation_performance_unit_megabytes">MB/s</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphSectionTest.kt
@@ -19,12 +19,17 @@ import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.operations.Operation
 import eu.darken.butler.workspace.ui.operations.OperationDisplay
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.Test
 import testhelpers.ComposeTest
 import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class OperationPerformanceGraphSectionTest : ComposeTest() {
@@ -42,6 +47,11 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     private val notAvailableText = context.getString(R.string.workspace_operation_performance_unavailable_not_available)
 
     private val startTime = Instant.fromEpochMilliseconds(1000)
+
+    /** These histories sit at the Unix epoch, a real clock would put them decades in the past. */
+    private class TestClock(var instant: Instant) : Clock {
+        override fun now(): Instant = instant
+    }
 
     private fun history(
         sampleCount: Int = 20,
@@ -66,7 +76,7 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
 
     private fun operation(state: OperationDisplay.State) = OperationDisplay(
         id = Operation.Id(),
-        startedAt = Clock.System.now(),
+        startedAt = startTime,
         icon = Icons.TwoTone.ContentCopy,
         title = "Copying files".toCaString(),
         description = "3 of 10".toCaString(),
@@ -94,11 +104,12 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
 
     private fun cancelled() = OperationDisplay.State.Cancelled(completedAt = startTime, report = null)
 
-    private fun setSection(state: OperationDisplay.State) {
+    private fun setSection(state: OperationDisplay.State, clock: Clock = TestClock(startTime + 30.seconds)) {
         composeTestRule.setContent {
             PreviewWrapper {
                 OperationPerformanceGraphSection(
                     operation = operation(state),
+                    clock = clock,
                     graphContent = { Text(text = "graph", modifier = Modifier.testTag(graphTag)) },
                 )
             }
@@ -130,9 +141,10 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
 
     @Test
     fun `real graph renders for a byte and item history`() {
+        val clock = TestClock(startTime + 30.seconds)
         composeTestRule.setContent {
             PreviewWrapper {
-                OperationPerformanceGraphSection(operation = operation(running(history())))
+                OperationPerformanceGraphSection(operation = operation(running(history())), clock = clock)
             }
         }
 
@@ -220,11 +232,14 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     }
 
     @Test
-    fun `a running operation stuck on one progress step is still collecting`() {
+    fun `a running operation whose progress is stuck is still plotted`() {
         setSection(running(history(totalItems = 0, advancing = false)))
 
         composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
-        composeTestRule.onNodeWithText(collectingText).assertIsDisplayed()
+
+        // Time keeps moving even when progress doesn't, so a stuck operation shows a flat line
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+        composeTestRule.onNodeWithText(collectingText).assertDoesNotExist()
     }
 
     @Test
@@ -236,11 +251,13 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
     }
 
     @Test
-    fun `a completed operation without totals has insufficient data`() {
+    fun `a completed operation without totals is still plotted`() {
         setSection(completed(history(totalBytes = 0L, totalItems = 0)))
 
         composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
-        composeTestRule.onNodeWithText(insufficientText).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+        composeTestRule.onNodeWithText(insufficientText).assertDoesNotExist()
     }
 
     @Test
@@ -281,5 +298,70 @@ class OperationPerformanceGraphSectionTest : ComposeTest() {
 
         composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
         composeTestRule.onNodeWithText(notAvailableText).assertIsDisplayed()
+    }
+
+    // ============ SCOPE SELECTION ============
+
+    private fun captureGraphData(
+        state: OperationDisplay.State,
+        clock: Clock,
+        captured: (PerformanceGraphData) -> Unit,
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraphSection(
+                    operation = operation(state),
+                    clock = clock,
+                    graphContent = {
+                        captured(it)
+                        Text(text = "graph", modifier = Modifier.testTag(graphTag))
+                    },
+                )
+            }
+        }
+        composeTestRule.onNodeWithContentDescription(expandLabel).performClick()
+        // The expanded body composes a frame after the click, wait for it or nothing was captured
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a running operation is plotted against its live window`() {
+        var data: PerformanceGraphData? = null
+        captureGraphData(running(history()), TestClock(startTime + 30.seconds)) { data = it }
+
+        val plotted = data.shouldNotBeNull()
+        plotted.windowSpanSeconds shouldNotBe null
+        plotted.xEnd shouldBe 30f
+    }
+
+    @Test
+    fun `a completed operation is plotted as an overview`() {
+        var data: PerformanceGraphData? = null
+        // A clock an hour ahead: a completed operation is a fixed span and must ignore it
+        captureGraphData(completed(history()), TestClock(startTime + 1.hours)) { data = it }
+
+        val plotted = data.shouldNotBeNull()
+        plotted.windowSpanSeconds shouldBe null
+        plotted.xStart shouldBe 0f
+        plotted.xEnd shouldBe 5f
+    }
+
+    @Test
+    fun `the live window advances while the operation runs`() {
+        val clock = TestClock(startTime + 30.seconds)
+        var data: PerformanceGraphData? = null
+        captureGraphData(running(history()), clock) { data = it }
+
+        data.shouldNotBeNull().xEnd shouldBe 30f
+
+        clock.instant = startTime + 40.seconds
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.mainClock.advanceTimeBy(600)
+        composeTestRule.mainClock.autoAdvance = true
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
+
+        // No sample arrived, only the ticker moved the right edge
+        data.shouldNotBeNull().xEnd shouldBe 40f
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/OperationPerformanceGraphTest.kt
@@ -12,11 +12,12 @@ import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import eu.darken.butler.common.formatByteSpeed
+import eu.darken.butler.workspace.R
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.ComposeTest
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class OperationPerformanceGraphTest : ComposeTest() {
@@ -32,7 +33,7 @@ class OperationPerformanceGraphTest : ComposeTest() {
     private fun history(withBytes: Boolean) = PerformanceHistory(
         samples = (0 until 20).map { i ->
             PerformanceSample(
-                timestamp = startTime + 250.milliseconds * i,
+                timestamp = startTime + 1.seconds * i,
                 bytesPerSecond = if (withBytes) bytesPerSecond else 0L,
                 itemsPerSecond = 5f,
                 totalBytesProcessed = if (withBytes) i * bytesPerSecond else 0L,
@@ -40,11 +41,10 @@ class OperationPerformanceGraphTest : ComposeTest() {
             )
         },
         startTime = startTime,
-        totalBytes = if (withBytes) 1_000_000_000L else 0L,
-        totalItems = 20,
     )
 
-    private fun graphData(withBytes: Boolean) = PerformanceGraphData.from(history(withBytes))!!
+    private fun graphData(withBytes: Boolean, scope: PerformanceGraphScope = PerformanceGraphScope.OVERVIEW) =
+        PerformanceGraphData.from(history(withBytes), scope, startTime + 30.seconds)!!
 
     @Test
     fun `byte data appearing mid operation keeps the graph composed`() {
@@ -71,5 +71,35 @@ class OperationPerformanceGraphTest : ComposeTest() {
 
         composeTestRule.onNodeWithTag(graphTag).assertIsDisplayed()
         composeTestRule.onNodeWithText(formatByteSpeed(context, bytesPerSecond)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a live window is labelled with the span it covers`() {
+        val live = graphData(withBytes = true, scope = PerformanceGraphScope.LIVE)
+        live.windowSpanSeconds shouldBe 30
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraph(modifier = Modifier.testTag(graphTag), graphData = live)
+            }
+        }
+
+        val label = context.getString(R.string.workspace_operation_performance_window_seconds, 30)
+        composeTestRule.onNodeWithText(label).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a completed overview carries no window label`() {
+        val overview = graphData(withBytes = true)
+        overview.windowSpanSeconds shouldBe null
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                OperationPerformanceGraph(modifier = Modifier.testTag(graphTag), graphData = overview)
+            }
+        }
+
+        val label = context.getString(R.string.workspace_operation_performance_window_seconds, 30)
+        composeTestRule.onNodeWithText(label).assertDoesNotExist()
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphDataTest.kt
@@ -3,13 +3,13 @@ package eu.darken.butler.workspace.ui.operations.details
 import eu.darken.butler.common.files.local.operations.core.PerformanceHistory
 import eu.darken.butler.common.files.local.operations.core.PerformanceSample
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.floats.plusOrMinus
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 /**
@@ -17,54 +17,219 @@ import kotlin.time.Instant
  */
 class PerformanceGraphDataTest : BaseTest() {
 
-    private val startTime = Instant.fromEpochMilliseconds(1000)
+    private val startTime = Instant.fromEpochMilliseconds(1_000_000)
 
     private fun sample(
-        index: Int,
+        atMillis: Long,
         bytesPerSecond: Long = 0L,
         itemsPerSecond: Float = 0f,
         totalBytesProcessed: Long = 0L,
         totalItemsProcessed: Int = 0,
-        totalBytesAccounted: Long = totalBytesProcessed,
     ) = PerformanceSample(
-        timestamp = startTime + (index * 100).milliseconds,
+        timestamp = startTime + atMillis.milliseconds,
         bytesPerSecond = bytesPerSecond,
         itemsPerSecond = itemsPerSecond,
         totalBytesProcessed = totalBytesProcessed,
         totalItemsProcessed = totalItemsProcessed,
-        totalBytesAccounted = totalBytesAccounted,
     )
 
-    private fun history(
-        samples: List<PerformanceSample>,
-        totalBytes: Long = 0L,
-        totalItems: Int = 0,
-    ) = PerformanceHistory(
+    private fun history(samples: List<PerformanceSample>) = PerformanceHistory(
         samples = samples,
         startTime = startTime,
-        totalBytes = totalBytes,
-        totalItems = totalItems,
     )
+
+    /** [count] samples one second apart, the cadence at which every sample gets its own x. */
+    private fun secondly(
+        count: Int,
+        bytesPerSecond: (Int) -> Long = { 0L },
+        itemsPerSecond: (Int) -> Float = { 1f },
+    ) = (0 until count).map { i ->
+        sample(
+            atMillis = i * 1000L,
+            bytesPerSecond = bytesPerSecond(i),
+            itemsPerSecond = itemsPerSecond(i),
+            totalBytesProcessed = i * 1_000_000L,
+            totalItemsProcessed = i,
+        )
+    }
+
+    private fun overviewOf(samples: List<PerformanceSample>) = PerformanceGraphData.from(
+        history = history(samples),
+        scope = PerformanceGraphScope.OVERVIEW,
+        now = samples.last().timestamp,
+    )
+
+    private fun liveOf(samples: List<PerformanceSample>, nowMillis: Long) = PerformanceGraphData.from(
+        history = history(samples),
+        scope = PerformanceGraphScope.LIVE,
+        now = startTime + nowMillis.milliseconds,
+    )
+
+    // ============ TIME AXIS ============
+
+    @Test
+    fun `x values snap to the half second grid under sampling jitter`() {
+        // The tracker reports every 250ms give or take a few, nothing may land between the steps
+        val samples = (0 until 20).map { i ->
+            val jitter = if (i % 2 == 0) 0L else 249L
+            sample(atMillis = (i / 2) * 500L + jitter, itemsPerSecond = 5f, totalItemsProcessed = i)
+        }
+
+        val data = overviewOf(samples).shouldNotBeNull()
+
+        data.elapsedSeconds shouldBe (0 until 10).map { it * 0.5f }
+    }
+
+    @Test
+    fun `a sample stamped before the start clamps to zero`() {
+        val samples = listOf(sample(atMillis = -500L, itemsPerSecond = 1f)) + secondly(count = 15)
+
+        val data = overviewOf(samples).shouldNotBeNull()
+
+        data.elapsedSeconds.first() shouldBe 0f
+    }
+
+    @Test
+    fun `a wall clock rollback keeps every earlier point`() {
+        val before = secondly(count = 15)
+        // The clock jumps twelve seconds back, later samples carry timestamps already plotted
+        val after = before + listOf(
+            sample(atMillis = 2_000L, itemsPerSecond = 1f),
+            sample(atMillis = 2_500L, itemsPerSecond = 1f),
+            sample(atMillis = 3_000L, itemsPerSecond = 1f),
+        )
+
+        val plain = overviewOf(before).shouldNotBeNull()
+        val rolledBack = overviewOf(after).shouldNotBeNull()
+
+        rolledBack.elapsedSeconds shouldBe plain.elapsedSeconds
+        rolledBack.elapsedSeconds.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
+    }
+
+    @Test
+    fun `the plotted prefix is stable as samples arrive`() {
+        val samples = secondly(count = 15, itemsPerSecond = { (it + 1).toFloat() })
+
+        val early = overviewOf(samples.take(12)).shouldNotBeNull()
+        val later = overviewOf(samples).shouldNotBeNull()
+
+        later.elapsedSeconds.take(12) shouldBe early.elapsedSeconds
+        later.itemSpeeds.take(12) shouldBe early.itemSpeeds
+    }
+
+    @Test
+    fun `a final sample sharing the last step replaces it`() {
+        // 100ms apart, so ten samples collapse onto three plot steps
+        val samples = (0 until 10).map { i ->
+            sample(atMillis = i * 100L, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i)
+        }
+
+        val data = overviewOf(samples).shouldNotBeNull()
+
+        data.elapsedSeconds shouldBe listOf(0f, 0.5f, 1f)
+        // The final sample took the place of the one that shared its step: (10 + 20 + … + 100) / 10
+        data.itemSpeeds.last() shouldBe (55f plusOrMinus 0.001f)
+    }
+
+    // ============ SMOOTHING ============
+
+    @Test
+    fun `smoothing averages over the preceding two seconds`() {
+        val samples = secondly(count = 15, itemsPerSecond = { (it + 1).toFloat() })
+
+        val data = overviewOf(samples).shouldNotBeNull()
+
+        data.itemSpeeds shouldHaveSize 15
+        // A one second cadence puts two samples in the window, the first point only knows itself
+        data.itemSpeeds[0] shouldBe (1f plusOrMinus 0.001f)
+        data.itemSpeeds[3] shouldBe (3.5f plusOrMinus 0.001f)
+        data.itemSpeeds.last() shouldBe (14.5f plusOrMinus 0.001f)
+        data.maxItemSpeed shouldBe 14.5
+    }
+
+    @Test
+    fun `two samples sharing a timestamp cannot change the earlier one`() {
+        val samples = secondly(count = 15, itemsPerSecond = { 10f })
+        val withDuplicate = samples.take(6) +
+            sample(atMillis = 5_000L, itemsPerSecond = 1_000f) +
+            samples.drop(6)
+
+        val plain = overviewOf(samples).shouldNotBeNull()
+        val duplicated = overviewOf(withDuplicate).shouldNotBeNull()
+
+        duplicated.elapsedSeconds shouldBe plain.elapsedSeconds
+        duplicated.itemSpeeds.take(6) shouldBe plain.itemSpeeds.take(6)
+    }
+
+    // ============ LIVE WINDOW ============
+
+    @Test
+    fun `a live window under two minutes starts at zero and reports its elapsed time`() {
+        val data = liveOf(secondly(count = 20), nowMillis = 30_000L).shouldNotBeNull()
+
+        data.xStart shouldBe 0f
+        data.xEnd shouldBe 30f
+        data.windowSpanSeconds shouldBe 30
+        data.elapsedSeconds shouldHaveSize 20
+    }
+
+    @Test
+    fun `a live window past two minutes slides and keeps one point before it`() {
+        val data = liveOf(secondly(count = 201), nowMillis = 200_000L).shouldNotBeNull()
+
+        data.xStart shouldBe 80f
+        data.xEnd shouldBe 200f
+        data.windowSpanSeconds shouldBe 120
+        // The point before the window keeps the line entering from the left edge
+        data.elapsedSeconds.first() shouldBe 79f
+        data.elapsedSeconds.last() shouldBe 200f
+    }
+
+    @Test
+    fun `a stall longer than the window still plots and still tracks now`() {
+        val data = liveOf(secondly(count = 20), nowMillis = 400_000L).shouldNotBeNull()
+
+        // Every sample is older than the window, dropping them would blank the graph mid stall
+        data.elapsedSeconds shouldBe listOf(18f, 19f)
+        data.xEnd shouldBe 400f
+        data.windowSpanSeconds shouldBe 120
+    }
+
+    @Test
+    fun `a stall still plots when the last two samples share a plot step`() {
+        // The final pair is 250ms apart, so both snap onto the same 9.5s step
+        val samples = secondly(count = 9) + listOf(
+            sample(atMillis = 9_300L, itemsPerSecond = 1f, totalItemsProcessed = 9),
+            sample(atMillis = 9_550L, itemsPerSecond = 1f, totalItemsProcessed = 10),
+        )
+
+        liveOf(samples, nowMillis = 200_000L).shouldNotBeNull()
+    }
+
+    @Test
+    fun `an overview spans the whole transfer without a window span`() {
+        val data = overviewOf(secondly(count = 20)).shouldNotBeNull()
+
+        data.xStart shouldBe 0f
+        data.xEnd shouldBe 19f
+        data.windowSpanSeconds shouldBe null
+    }
+
+    @Test
+    fun `the range never ends before the newest sample`() {
+        // A clock that lags behind the samples must not crop the newest point away
+        val data = liveOf(secondly(count = 20), nowMillis = 0L).shouldNotBeNull()
+
+        data.xEnd shouldBe 19f
+    }
 
     // ============ BYTE UNIT SELECTION ============
 
     @Test
     fun `slow transfer is scaled into kilobytes per second`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 500_000L,
-                    itemsPerSecond = 4f,
-                    totalBytesProcessed = i * 500_000L,
-                    totalItemsProcessed = i,
-                )
-            },
-            totalBytes = 10_000_000L,
-            totalItems = 20,
-        )
+        val samples = secondly(count = 20, bytesPerSecond = { 500_000L }, itemsPerSecond = { 4f })
 
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+        val data = overviewOf(samples).shouldNotBeNull()
 
         data.byteUnit shouldBe ByteSpeedUnit.KB_S
         data.byteSpeeds.shouldNotBeNull().forEach { it shouldBe 500f }
@@ -74,19 +239,8 @@ class PerformanceGraphDataTest : BaseTest() {
     @Test
     fun `byte unit is selected from the fastest sample`() {
         fun unitFor(bytesPerSecond: Long): ByteSpeedUnit? {
-            val history = history(
-                samples = (0 until 20).map { i ->
-                    sample(
-                        index = i,
-                        bytesPerSecond = bytesPerSecond,
-                        itemsPerSecond = 1f,
-                        totalBytesProcessed = i * 10L,
-                        totalItemsProcessed = i,
-                    )
-                },
-                totalItems = 20,
-            )
-            return PerformanceGraphData.from(history).shouldNotBeNull().byteUnit
+            val samples = secondly(count = 20, bytesPerSecond = { bytesPerSecond })
+            return overviewOf(samples).shouldNotBeNull().byteUnit
         }
 
         unitFor(999L) shouldBe ByteSpeedUnit.B_S
@@ -98,362 +252,102 @@ class PerformanceGraphDataTest : BaseTest() {
     }
 
     @Test
-    fun `bytes moved without a measured speed still get a byte series`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 0L,
-                    itemsPerSecond = 2f,
-                    totalBytesProcessed = i * 100_000L,
-                    totalItemsProcessed = i,
-                )
-            },
-            totalBytes = 2_000_000L,
-            totalItems = 20,
+    fun `the byte unit follows the plotted window`() {
+        // A fast burst up front, then a long slow tail
+        fun burstThenTail(count: Int) = secondly(
+            count = count,
+            bytesPerSecond = { if (it < 20) 2_000_000_000L else 5_000_000L },
         )
 
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+        val early = liveOf(burstThenTail(30), nowMillis = 29_000L).shouldNotBeNull()
+        val late = liveOf(burstThenTail(220), nowMillis = 219_000L).shouldNotBeNull()
+
+        early.byteUnit shouldBe ByteSpeedUnit.GB_S
+        // The burst scrolled out of the window, so the axis relabels
+        late.byteUnit shouldBe ByteSpeedUnit.MB_S
+    }
+
+    @Test
+    fun `bytes moved without a measured speed still get a byte series`() {
+        val samples = secondly(count = 20, itemsPerSecond = { 2f })
+
+        val data = overviewOf(samples).shouldNotBeNull()
 
         data.byteUnit shouldBe ByteSpeedUnit.B_S
         data.byteSpeeds.shouldNotBeNull().forEach { it shouldBe 0f }
         data.maxByteSpeed shouldBe 0.0
     }
 
-    // ============ SERIES PRESENCE ============
-
     @Test
-    fun `item only operation has no byte series`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i)
-            },
-            totalItems = 20,
-        )
+    fun `an item only operation has no byte series`() {
+        val samples = (0 until 20).map { i ->
+            sample(atMillis = i * 1000L, itemsPerSecond = 5f, totalItemsProcessed = i)
+        }
 
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+        val data = overviewOf(samples).shouldNotBeNull()
 
         data.byteSpeeds shouldBe null
         data.byteUnit shouldBe null
         data.maxByteSpeed shouldBe 0.0
-        data.progress shouldBe (0 until 20).map { it * 5f }
     }
 
     @Test
-    fun `unknown size transfer keeps its byte series and plots against items`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 4_000_000L,
-                    itemsPerSecond = 2f,
-                    totalBytesProcessed = i * 4_000_000L,
-                    totalItemsProcessed = i,
-                )
-            },
-            totalBytes = 0L,  // Size unknown up front, e.g. a stream copy
-            totalItems = 20,
-        )
+    fun `a byteless window keeps the byte series of the full history`() {
+        // Byte data anywhere in the history keeps both axes, a window without it must not flip modes
+        val samples = (0 until 220).map { i ->
+            sample(
+                atMillis = i * 1000L,
+                bytesPerSecond = if (i < 20) 1_000_000L else 0L,
+                itemsPerSecond = 5f,
+                totalItemsProcessed = i,
+            )
+        }
 
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
+        val data = liveOf(samples, nowMillis = 219_000L).shouldNotBeNull()
 
-        data.byteUnit shouldBe ByteSpeedUnit.MB_S
-        data.byteSpeeds.shouldNotBeNull() shouldHaveSize 20
-        data.progress shouldBe (0 until 20).map { it * 5f }
+        data.byteSpeeds.shouldNotBeNull().forEach { it shouldBe 0f }
     }
 
     // ============ NO GRAPH ============
 
     @Test
-    fun `history without totals has no x domain`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(index = i, bytesPerSecond = 1_000_000L, itemsPerSecond = 5f)
-            },
-        )
-
-        PerformanceGraphData.from(history) shouldBe null
-    }
-
-    @Test
-    fun `flat progress is not plottable`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = 0)
-            },
-            totalItems = 100,
-        )
-
-        PerformanceGraphData.from(history) shouldBe null
-    }
-
-    @Test
     fun `too few samples produce no data`() {
-        val history = history(
-            samples = (0 until 9).map { i ->
-                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i)
-            },
-            totalItems = 9,
-        )
+        val samples = secondly(count = 9)
 
-        PerformanceGraphData.from(history) shouldBe null
-    }
-
-    // ============ X DOMAIN ============
-
-    @Test
-    fun `skipped items still let progress reach 100 percent`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 1_000L,
-                    itemsPerSecond = 2f,
-                    // Bytes stall at 10%: the remaining items were skipped
-                    totalBytesProcessed = minOf(i, 2) * 50_000L,
-                    totalItemsProcessed = i + 1,
-                )
-            },
-            totalBytes = 1_000_000L,
-            totalItems = 20,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress.last() shouldBe 100f
+        PerformanceGraphData.from(history(samples), PerformanceGraphScope.OVERVIEW, startTime) shouldBe null
     }
 
     @Test
-    fun `progress beyond the total is clamped to 100 percent`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 1_000_000L,
-                    itemsPerSecond = 2f,
-                    // The last few samples report more than the total
-                    totalBytesProcessed = (i + 1) * 100_000L,
-                    totalItemsProcessed = i,
-                )
-            },
-            totalBytes = 1_000_000L,
-            totalItems = 20,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress.max() shouldBe 100f
-        data.progress.last() shouldBe 100f
-    }
-
-    @Test
-    fun `single large file still advances along the byte axis`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 50_000_000L,
-                    itemsPerSecond = 0.05f,
-                    totalBytesProcessed = i * 50_000_000L,
-                    totalItemsProcessed = 0,  // The single file is only counted once it is done
-                )
-            },
-            totalBytes = 1_000_000_000L,
-            totalItems = 1,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress shouldBe data.progress.distinct()
-        data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
-    }
-
-    @Test
-    fun `a directory completing before any bytes move keeps the plot at the left edge`() {
-        // An 8 item folder copy: the destination directory is created first, then the files stream
-        val directorySize = 4_096L
-        val history = history(
-            samples = (0 until 20).map { i ->
-                val transferred = (i + 1) * 5_000_000L
-                sample(
-                    index = i,
-                    bytesPerSecond = 5_000_000L,
-                    itemsPerSecond = 0.3f,
-                    totalBytesProcessed = transferred,
-                    totalItemsProcessed = 1 + i / 3,
-                    totalBytesAccounted = transferred + directorySize,
-                )
-            },
-            totalBytes = 1_000_000_000L,
-            totalItems = 8,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        // 5 MB of 1 GB, not the 12.5% one of eight items would claim
-        data.progress.first() shouldBe 0.5f
-        data.progress.max() shouldBe 10f
-    }
-
-    @Test
-    fun `early transfer positions survive the progress filter`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                val transferred = (i + 1) * 5_000_000L
-                sample(
-                    index = i,
-                    bytesPerSecond = 5_000_000L,
-                    itemsPerSecond = 0f,
-                    totalBytesProcessed = transferred,
-                    totalItemsProcessed = 1,  // Still inside the first file
-                    totalBytesAccounted = transferred + 4_096L,
-                )
-            },
-            totalBytes = 1_000_000_000L,
-            totalItems = 8,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress shouldBe (1..20).map { it * 0.5f }
-    }
-
-    @Test
-    fun `progress reaches 100 percent when the final item completes below the byte total`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(
-                    index = i,
-                    bytesPerSecond = 25_000_000L,
-                    itemsPerSecond = 0.5f,
-                    // Half the announced bytes never move, the rest of the items were skipped
-                    totalBytesProcessed = (i + 1) * 25_000_000L,
-                    totalItemsProcessed = if (i == 19) 10 else i / 2,
-                )
-            },
-            totalBytes = 1_000_000_000L,
-            totalItems = 10,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress.last() shouldBe 100f
-    }
-
-    @Test
-    fun `an operation whose accounted bytes never move plots against items`() {
-        val history = history(
-            samples = (0 until 20).map { i ->
-                sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
-            },
-            totalBytes = 1_000_000_000L,  // Announced up front, then nothing is accounted against it
-            totalItems = 20,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress shouldBe (1..20).map { it * 5f }
-    }
-
-    @Test
-    fun `a stray byte does not collapse an item graph`() {
-        val history = history(
-            samples = (0 until 11).map { i ->
-                sample(
-                    index = i,
-                    itemsPerSecond = 5f,
-                    // The last sample accounts a byte count that still rounds to 0%
-                    totalBytesProcessed = if (i == 10) 1_000L else 0L,
-                    totalItemsProcessed = i + 1,
-                )
-            },
-            totalBytes = 1_000_000_000L,
-            totalItems = 20,
-        )
-
-        val data = PerformanceGraphData.from(history).shouldNotBeNull()
-
-        data.progress shouldBe (1..11).map { it * 5f }
-    }
-
-    // ============ FILTERING ============
-
-    @Test
-    fun `samples are kept once progress advanced half a percent`() {
-        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
-        val samples = (0 until 10).map { i ->
-            sample(index = i, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i + 1)
-        }
-        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
-
-        data.progress shouldBe listOf(0f, 0.5f, 1f)
-        // The final sample replaced the entry that shared its 1.0% step: (10 + 30 + 100) / 3
-        data.itemSpeeds.last() shouldBe (46.667f plusOrMinus 0.01f)
-    }
-
-    @Test
-    fun `a final sample below earlier progress truncates back to it`() {
-        val samples = (0 until 10).map { i ->
-            sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
-        } + sample(index = 10, itemsPerSecond = 5f, totalItemsProcessed = 4)  // Progress reported lower
-
-        val data = PerformanceGraphData.from(history(samples, totalItems = 10)).shouldNotBeNull()
-
-        data.progress shouldBe listOf(10f, 20f, 30f, 40f)
-        data.progress shouldBe data.progress.distinct()
-    }
-
-    @Test
-    fun `a final sample above the last kept step is appended`() {
-        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
-        val samples = (0 until 11).map { i ->
-            sample(index = i, itemsPerSecond = 5f, totalItemsProcessed = i + 1)
-        } + sample(index = 11, itemsPerSecond = 5f, totalItemsProcessed = 100)  // A batch of items landed at once
-
-        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
-
-        data.progress shouldBe listOf(0f, 0.5f, 1f, 10f)
-        data.progress shouldBe data.progress.distinct()
-        data.progress.zipWithNext().forEach { (previous, next) -> (next > previous) shouldBe true }
-    }
-
-    // ============ SMOOTHING ============
-
-    @Test
-    fun `smoothing only averages over preceding samples`() {
-        val samples = (0 until 15).map { i ->
-            sample(index = i, itemsPerSecond = (i + 1).toFloat(), totalItemsProcessed = i + 1)
+    fun `an operation that never advanced is still plottable against time`() {
+        val samples = (0 until 20).map { i ->
+            sample(atMillis = i * 1000L, itemsPerSecond = 5f, totalItemsProcessed = 0)
         }
 
-        val data = PerformanceGraphData.from(history(samples, totalItems = 15)).shouldNotBeNull()
+        val data = overviewOf(samples).shouldNotBeNull()
 
-        data.itemSpeeds shouldHaveSize 15
-        // Partial window at the start: (1 + 2 + 3 + 4) / 4
-        data.itemSpeeds[3] shouldBe (2.5f plusOrMinus 0.001f)
-        // Full trailing window of 10: (4 + 5 + … + 13) / 10
-        data.itemSpeeds[12] shouldBe (8.5f plusOrMinus 0.001f)
-        // The last point knows nothing beyond itself: (6 + 7 + … + 15) / 10
-        data.itemSpeeds.last() shouldBe (10.5f plusOrMinus 0.001f)
-        data.maxItemSpeed shouldBe (10.5 plusOrMinus 0.001)
+        data.elapsedSeconds shouldBe (0 until 20).map { it.toFloat() }
+    }
+
+    @Test
+    fun `samples recorded within one plot step are not plottable`() {
+        val samples = (0 until 20).map { i ->
+            sample(atMillis = i.toLong(), itemsPerSecond = 5f, totalItemsProcessed = i)
+        }
+
+        overviewOf(samples) shouldBe null
     }
 
     // ============ RECENT SPEEDS ============
 
     @Test
     fun `recent speeds average the raw samples`() {
-        val samples = (0 until 20).map { i ->
-            sample(
-                index = i,
-                bytesPerSecond = (i + 1) * 1_000_000L,
-                itemsPerSecond = (i + 1).toFloat(),
-                totalBytesProcessed = i * 1_000_000L,
-                totalItemsProcessed = i,
-            )
-        }
+        val samples = secondly(
+            count = 20,
+            bytesPerSecond = { (it + 1) * 1_000_000L },
+            itemsPerSecond = { (it + 1).toFloat() },
+        )
 
-        val data = PerformanceGraphData
-            .from(history(samples, totalBytes = 20_000_000L, totalItems = 20))
-            .shouldNotBeNull()
+        val data = overviewOf(samples).shouldNotBeNull()
 
         // (1 + 2 + … + 20) / 20 = 10.5
         data.recentBytesPerSecond shouldBe 10_500_000L
@@ -462,19 +356,13 @@ class PerformanceGraphDataTest : BaseTest() {
 
     @Test
     fun `recent speeds only cover the last 30 samples`() {
-        val samples = (0 until 40).map { i ->
-            sample(
-                index = i,
-                bytesPerSecond = if (i < 10) 500_000_000L else 1_000_000L,
-                itemsPerSecond = if (i < 10) 100f else 2f,
-                totalBytesProcessed = i * 1_000_000L,
-                totalItemsProcessed = i,
-            )
-        }
+        val samples = secondly(
+            count = 40,
+            bytesPerSecond = { if (it < 10) 500_000_000L else 1_000_000L },
+            itemsPerSecond = { if (it < 10) 100f else 2f },
+        )
 
-        val data = PerformanceGraphData
-            .from(history(samples, totalBytes = 40_000_000L, totalItems = 40))
-            .shouldNotBeNull()
+        val data = overviewOf(samples).shouldNotBeNull()
 
         data.recentBytesPerSecond shouldBe 1_000_000L
         data.recentItemsPerSecond shouldBe (2f plusOrMinus 0.001f)
@@ -482,15 +370,57 @@ class PerformanceGraphDataTest : BaseTest() {
 
     @Test
     fun `recent speeds ignore the filtering and smoothing of the series`() {
-        // 1 of 1000 items per sample, so most samples round onto the same 0.5% step
+        // 100ms apart, so ten samples collapse onto three plot steps
         val samples = (0 until 10).map { i ->
-            sample(index = i, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i + 1)
+            sample(atMillis = i * 100L, itemsPerSecond = (i + 1) * 10f, totalItemsProcessed = i)
         }
 
-        val data = PerformanceGraphData.from(history(samples, totalItems = 1000)).shouldNotBeNull()
+        val data = overviewOf(samples).shouldNotBeNull()
 
         data.itemSpeeds shouldHaveSize 3
         // (10 + 20 + … + 100) / 10, over every sample rather than the three plotted points
         data.recentItemsPerSecond shouldBe (55f plusOrMinus 0.001f)
+    }
+
+    // ============ CROPPING ============
+
+    @Test
+    fun `the live window crops the samples that scrolled out`() {
+        val samples = secondly(count = 201)
+
+        val cropped = liveOf(samples, nowMillis = 200_000L).shouldNotBeNull()
+        val full = overviewOf(samples).shouldNotBeNull()
+
+        cropped.elapsedSeconds shouldHaveSize 122
+        full.elapsedSeconds shouldHaveSize 201
+        cropped.elapsedSeconds shouldBe full.elapsedSeconds.takeLast(122)
+    }
+
+    @Test
+    fun `a window shorter than the samples still smooths from before its edge`() {
+        val samples = secondly(count = 201, itemsPerSecond = { (it + 1).toFloat() })
+
+        val cropped = liveOf(samples, nowMillis = 200_000L).shouldNotBeNull()
+        val full = overviewOf(samples).shouldNotBeNull()
+
+        // Smoothing runs over the raw history, so a cropped point keeps the value it always had
+        cropped.itemSpeeds shouldBe full.itemSpeeds.takeLast(122)
+    }
+
+    @Test
+    fun `the smoothing window is measured in time, not in samples`() {
+        val dense = (0 until 20).map { i ->
+            sample(atMillis = i * 500L, itemsPerSecond = if (i == 0) 100f else 0f)
+        }
+
+        val data = PerformanceGraphData.from(
+            history = history(dense),
+            scope = PerformanceGraphScope.OVERVIEW,
+            now = startTime + 10.seconds,
+        ).shouldNotBeNull()
+
+        // Four samples still hold the 100/s spike, the fifth is a full two seconds past it
+        data.itemSpeeds[3] shouldBe (25f plusOrMinus 0.001f)
+        data.itemSpeeds[4] shouldBe (0f plusOrMinus 0.001f)
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphRangeSlideTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/operations/details/PerformanceGraphRangeSlideTest.kt
@@ -1,0 +1,178 @@
+package eu.darken.butler.workspace.ui.operations.details
+
+import com.patrykandpatrick.vico.core.cartesian.CartesianChart
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartRanges
+import com.patrykandpatrick.vico.core.cartesian.data.MutableCartesianChartRanges
+import com.patrykandpatrick.vico.core.cartesian.data.toImmutable
+import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
+import com.patrykandpatrick.vico.core.common.Fill
+import com.patrykandpatrick.vico.core.common.data.MutableExtraStore
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * Drives [plotGraphData] and [speedRangeProvider] the way [OperationPerformanceGraph] does while an
+ * operation stalls: the ticker hands the chart a new x window while the sampler has recorded nothing
+ * new, so the series in the transaction are unchanged.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class, sdk = [34])
+class PerformanceGraphRangeSlideTest : BaseTest() {
+
+    private fun graphData(
+        elapsedSeconds: List<Float>,
+        byteSpeeds: List<Float>,
+        itemSpeeds: List<Float>,
+        xStart: Float,
+        xEnd: Float,
+    ) = PerformanceGraphData(
+        elapsedSeconds = elapsedSeconds,
+        byteSpeeds = byteSpeeds,
+        itemSpeeds = itemSpeeds,
+        byteUnit = ByteSpeedUnit.MB_S,
+        maxByteSpeed = byteSpeeds.max().toDouble(),
+        maxItemSpeed = itemSpeeds.max().toDouble(),
+        recentBytesPerSecond = 12_000_000L,
+        recentItemsPerSecond = itemSpeeds.last(),
+        xStart = xStart,
+        xEnd = xEnd,
+        windowSpanSeconds = (xEnd - xStart).toInt(),
+    )
+
+    private fun layer(rangeMaxY: Double) = LineCartesianLayer(
+        lineProvider = LineCartesianLayer.LineProvider.series(
+            LineCartesianLayer.Line(LineCartesianLayer.LineFill.single(Fill(0xFF0000FF.toInt()))),
+        ),
+        rangeProvider = speedRangeProvider(rangeMaxY),
+    )
+
+    /** Layer order matches the series order [plotGraphData] writes: bytes first, then items. */
+    private fun chartFor(graphData: PerformanceGraphData) = CartesianChart(
+        layer(graphData.maxByteSpeed),
+        layer(graphData.maxItemSpeed),
+        getXStep = { 1.0 },
+    )
+
+    /** Mirrors `collectAsState`: one registration per chart id, always calling the newest chart. */
+    private class Host(
+        private val producer: CartesianChartModelProducer,
+        initialChart: CartesianChart,
+    ) {
+        var chart: CartesianChart = initialChart
+        val rangesFromChart = mutableListOf<Pair<Double, Double>>()
+        val rangesAtHost = mutableListOf<Pair<Double, Double>>()
+
+        val failures = mutableListOf<Throwable>()
+        private val scope = CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.Default +
+                CoroutineExceptionHandler { _, e -> synchronized(failures) { failures += e } },
+        )
+        private val animationJobs = mutableListOf<Job>()
+        private val hostExtraStore = MutableExtraStore()
+        private val ranges = MutableCartesianChartRanges()
+
+        suspend fun register() {
+            producer.registerForUpdates(
+                key = chart.id,
+                cancelAnimation = {},
+                startAnimation = { transformModel ->
+                    synchronized(animationJobs) {
+                        animationJobs += scope.launch { transformModel(chart.id, 1f) }
+                    }
+                },
+                prepareForTransformation = { model, extraStore, chartRanges ->
+                    chart.prepareForTransformation(model, extraStore, chartRanges)
+                },
+                transform = { extraStore, fraction -> chart.transform(extraStore, fraction) },
+                hostExtraStore = hostExtraStore,
+                updateRanges = { model ->
+                    ranges.reset()
+                    if (model != null) {
+                        chart.updateRanges(ranges, model)
+                        rangesFromChart += ranges.minX to ranges.maxX
+                        ranges.toImmutable()
+                    } else {
+                        CartesianChartRanges.Empty
+                    }
+                },
+                onUpdate = { _, chartRanges, _ ->
+                    // `CartesianChartRanges.Empty` throws on every getter; the real host stores it as-is
+                    if (chartRanges !== CartesianChartRanges.Empty) {
+                        rangesAtHost += chartRanges.minX to chartRanges.maxX
+                    }
+                },
+            )
+            settle()
+        }
+
+        suspend fun settle() {
+            val pending = synchronized(animationJobs) { animationJobs.toList().also { animationJobs.clear() } }
+            pending.joinAll()
+        }
+    }
+
+    private val elapsedSeconds = listOf(10f, 20f, 30f)
+    private val byteSpeeds = listOf(4f, 6f, 5f)
+    private val itemSpeeds = listOf(1f, 2f, 3f)
+
+    @Test
+    fun `a sliding x window with unchanged samples reaches the chart`() = runBlocking<Unit> {
+        val first = graphData(elapsedSeconds, byteSpeeds, itemSpeeds, xStart = 0f, xEnd = 60f)
+        val producer = CartesianChartModelProducer()
+        val host = Host(producer, chartFor(first))
+        host.register()
+
+        producer.plotGraphData(first)
+        host.settle()
+
+        // The ticker fires: same samples, window moved on by 30 seconds
+        val second = graphData(elapsedSeconds, byteSpeeds, itemSpeeds, xStart = 30f, xEnd = 90f)
+        producer.plotGraphData(second)
+        host.settle()
+
+        host.failures shouldBe emptyList()
+        host.rangesFromChart shouldBe listOf(0.0 to 60.0, 30.0 to 90.0)
+        host.rangesAtHost.last() shouldBe (30.0 to 90.0)
+    }
+
+    /** Control: the same harness does observe a second update when the samples themselves change. */
+    @Test
+    fun `a new sample reaches the chart`() = runBlocking<Unit> {
+        val first = graphData(elapsedSeconds, byteSpeeds, itemSpeeds, xStart = 0f, xEnd = 60f)
+        val producer = CartesianChartModelProducer()
+        val host = Host(producer, chartFor(first))
+        host.register()
+
+        producer.plotGraphData(first)
+        host.settle()
+
+        val second = graphData(
+            elapsedSeconds = elapsedSeconds + 40f,
+            byteSpeeds = byteSpeeds + 7f,
+            itemSpeeds = itemSpeeds + 4f,
+            xStart = 30f,
+            xEnd = 90f,
+        )
+        producer.plotGraphData(second)
+        host.settle()
+
+        host.failures shouldBe emptyList()
+        host.rangesFromChart shouldBe listOf(0.0 to 60.0, 30.0 to 90.0)
+        host.rangesAtHost.last() shouldBe (30.0 to 90.0)
+    }
+}


### PR DESCRIPTION
## What changed

The performance graph in an operation's details used to plot speed against how much of the work was done, on a fixed 0-100 scale. That made it hard to read: everything you actually want from a throughput chart is about time. Whether the speed is steady, falling, stalling or recovering. A ten second stall completes no work, so it took up no space on the chart at all, and the one moment worth looking at was the one that got erased.

The graph now plots speed against elapsed time. While an operation runs it shows the recent past: the view grows from the start and then follows along, holding the last two minutes, with a small label saying how much time is on screen. The curve always fills the width, so a copy that has been running for eight seconds gets a full eight second graph rather than a sliver in the corner. Once the operation finishes, the graph shows the whole transfer at once.

Speeds are also kept differently now. The old approach thinned out samples evenly across the *progress* of an operation, which meant a long slow stretch got thinned the hardest, even though a slow stretch is exactly what you open this chart to look at. Recent speeds are now kept in full and older ones are summarised by time, so the shape of a slow patch survives.

One limit worth knowing: if an operation stalls inside a single large file transfer, the graph cannot show a flat line at zero, because nothing is measured while it is blocked. The stall shows up as a wide gap with a low reading after it rather than a flat floor.

## Technical Context

- The retention change in `PerformanceHistory` is a prerequisite, not a side effect. Percentage bucketing thinned each 5% bucket to 40 samples across its whole duration, including the newest, so a live window could not be recovered by cropping graph-side. Retention now keeps the last 120s verbatim, never thins the newest 60 samples (`getRecentBytesPerSecond`/`getRecentItemsPerSecond` feed the progress bar's speed and ETA), and spreads older data over 60 time buckets. Worst case retained is unchanged at 741 under the 1000 cap.
- `compact()` sorts for its timestamp bounds but takes the origin and the protected tail in *recording* order, because a backwards clock jump makes those different samples. Selecting the origin by `startTime` relies on `sortedBy` being stable; there is a comment at the site saying so.
- The window bounds travel in the chart transaction's `ExtraStore` rather than being captured in the range provider. Vico drops a transaction whose series are unchanged, and chart ranges are recomputed only inside that update path, so a ticker changing only the range would never reach the chart. Worth a close look: `PerformanceGraphRangeSlideTest` guards exactly this, and its second test is a control that must keep passing.
- The x axis spans the sampled transfer rather than the operation's wall clock start. Nothing is recorded until progress moves, so using `startedAt` would render the scanning phase as blank space asserting zero throughput.
- `PerformanceHistory` and `PathOperationProgressTracker` are hand-synced with SD Maid SE. This changes the former substantially and leaves the latter untouched.
