### PR TITLE
Workspace: Stop the joke loading message flickering during file operations

### DIFF
--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/CopyOperationEventConversion.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/CopyOperationEventConversion.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.local.ipc
 
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.actions.CopyAction
@@ -89,6 +90,7 @@ fun CopyOperationEvent.toCopyActionState(): CopyAction.State<LocalPath, LocalPat
                 ),
                 secondaryProgress = Progress.Data(
                     primary = currentSource.lookedUp.name.toCaString(),
+                    secondary = CaString.EMPTY,
                     count = Progress.Count.Size(
                         current = currentFileBytes,
                         max = currentFileSize,

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/DeleteOperationEventConversion.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/DeleteOperationEventConversion.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.local.ipc
 
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.actions.DeleteAction
@@ -84,6 +85,7 @@ fun DeleteOperationEvent.toDeleteActionState(): DeleteAction.State<LocalPath, Lo
                 ),
                 secondaryProgress = Progress.Data(
                     primary = currentPath.lookedUp.name.toCaString(),
+                    secondary = CaString.EMPTY,
                     count = Progress.Count.Size(
                         current = currentSize,
                         max = totalSize,

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/MoveOperationEventConversion.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/local/ipc/MoveOperationEventConversion.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.common.files.local.ipc
 
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.actions.MoveAction
@@ -91,6 +92,7 @@ fun MoveOperationEvent.toMoveActionState(): MoveAction.State<LocalPath, LocalPat
                 ),
                 secondaryProgress = Progress.Data(
                     primary = currentSource.lookedUp.name.toCaString(),
+                    secondary = CaString.EMPTY,
                     count = Progress.Count.Size(
                         current = currentFileBytes,
                         max = currentFileSize,

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathCopy.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathCopy.kt
@@ -1024,6 +1024,7 @@ internal class GenericPathCopy<
                 ),
                 secondaryProgress = eu.darken.butler.common.progress.Progress.Data(
                     primary = lookup.lookedUp.name.toCaString(),
+                    secondary = eu.darken.butler.common.ca.CaString.EMPTY,
                     count = eu.darken.butler.common.progress.Progress.Count.Size(
                         current = snapshot.currentFileBytes,
                         max = snapshot.currentFileSize

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathDelete.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathDelete.kt
@@ -488,6 +488,7 @@ internal class GenericPathDelete<P : APath<P>, PL : APathLookup<P>>(
                 ),
                 secondaryProgress = eu.darken.butler.common.progress.Progress.Data(
                     primary = lookup.lookedUp.name.toCaString(),
+                    secondary = eu.darken.butler.common.ca.CaString.EMPTY,
                     count = eu.darken.butler.common.progress.Progress.Count.Size(
                         current = lookup.size ?: 0L,
                         max = lookup.size ?: 0L

--- a/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathMove.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/files/operations/GenericPathMove.kt
@@ -1140,6 +1140,7 @@ internal class GenericPathMove<
                 ),
                 secondaryProgress = eu.darken.butler.common.progress.Progress.Data(
                     primary = lookup.lookedUp.name.toCaString(),
+                    secondary = eu.darken.butler.common.ca.CaString.EMPTY,
                     count = eu.darken.butler.common.progress.Progress.Count.Size(
                         current = snapshot.currentFileBytes,
                         max = snapshot.currentFileSize

--- a/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/operations/PackageActionOperation.kt
+++ b/app-workspace-apps/src/main/java/eu/darken/butler/apps/core/operations/PackageActionOperation.kt
@@ -16,6 +16,7 @@ import eu.darken.butler.apps.core.AppSizeCache
 import eu.darken.butler.common.ElevatedAccessUnavailableException
 import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.icons.Snowflake
 import eu.darken.butler.common.compose.icons.SnowflakeOff
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
@@ -125,7 +126,7 @@ class PackageActionOperation @AssistedInject constructor(
                 val label = caString {
                     "${command.target.label.get(it)} · ${entry.className.substringAfterLast('.')}"
                 }
-                send(activeState(startedAt, label, index, command.entries.size))
+                send(activeState(startedAt, label, command.target.installId.pkgId.name, index, command.entries.size))
                 outcomes += runTarget(label, command.target.installId.pkgId.name) {
                     pkgOps.changeComponentState(
                         entry.packageName.toPkgId(),
@@ -136,7 +137,7 @@ class PackageActionOperation @AssistedInject constructor(
             }
 
             else -> command.targets.forEachIndexed { index, target ->
-                send(activeState(startedAt, target.label, index, command.targets.size))
+                send(activeState(startedAt, target.label, target.installId.pkgId.name, index, command.targets.size))
                 outcomes += when (command) {
                     is PackageCommand.Enable -> runTarget(target.label, target.installId.pkgId.name) {
                         pkgOps.changePackageState(target.installId.pkgId, enabled = true)
@@ -159,7 +160,7 @@ class PackageActionOperation @AssistedInject constructor(
                         viaSystemDialog = command.viaSystemDialog,
                         onWaiting = { issue -> send(WaitingState(startedAt = startedAt, issue = issue)) },
                         onResumed = {
-                            send(activeState(startedAt, target.label, index, command.targets.size))
+                            send(activeState(startedAt, target.label, target.installId.pkgId.name, index, command.targets.size))
                         },
                     )
 
@@ -200,10 +201,19 @@ class PackageActionOperation @AssistedInject constructor(
         )
     }
 
-    private fun activeState(startedAt: Instant, label: CaString, index: Int, total: Int) = ActiveState(
+    private fun activeState(
+        startedAt: Instant,
+        label: CaString,
+        pkgName: String,
+        index: Int,
+        total: Int,
+    ) = ActiveState(
         startedAt = startedAt,
         primaryProgress = Progress.Data(
             primary = label,
+            // A package with no resolvable app label falls back to its own id, which would then
+            // fill both progress lines with the same text.
+            secondary = caString { if (label.get(it) == pkgName) "" else pkgName },
             count = Progress.Count.Counter(index, total),
         ),
     )

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateLargeFilesOperation.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateLargeFilesOperation.kt
@@ -79,10 +79,12 @@ class GenerateLargeFilesOperation @AssistedInject constructor(
                         startedAt = operationContext.startedAt,
                         primaryProgress = Progress.Data(
                             primary = R.string.developer_operation_large_files_creating.toCaString(fileName),
+                            secondary = targetDir.userReadablePath,
                             count = Progress.Count.Counter(index.toLong(), sizes.size.toLong()),
                         ),
                         secondaryProgress = Progress.Data(
                             primary = fileName.toCaString(),
+                            secondary = CaString.EMPTY,
                             count = Progress.Count.Size(bytesWritten, totalBytes),
                         ),
                     )

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateNestedStructureOperation.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateNestedStructureOperation.kt
@@ -92,10 +92,12 @@ class GenerateNestedStructureOperation @AssistedInject constructor(
                             startedAt = operationContext.startedAt,
                             primaryProgress = Progress.Data(
                                 primary = R.string.developer_operation_nested_creating.toCaString(subDir.name),
+                                secondary = targetDir.userReadablePath,
                                 count = Progress.Count.Counter(dirsCreated.toLong(), totalDirs.toLong()),
                             ),
                             secondaryProgress = Progress.Data(
                                 primary = R.string.developer_operation_nested_files_created.toCaString(filesCreated),
+                                secondary = CaString.EMPTY,
                                 count = Progress.Count.Percent(dirsCreated.toLong(), totalDirs.toLong()),
                             ),
                         )
@@ -110,6 +112,7 @@ class GenerateNestedStructureOperation @AssistedInject constructor(
                     startedAt = operationContext.startedAt,
                     primaryProgress = Progress.Data(
                         primary = R.string.developer_operation_nested_starting.toCaString(),
+                        secondary = targetDir.userReadablePath,
                         count = Progress.Count.Counter(0, totalDirs.toLong()),
                     ),
                 )

--- a/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateTextFilesOperation.kt
+++ b/app-workspace-developer/src/main/java/eu/darken/butler/developer/core/operations/GenerateTextFilesOperation.kt
@@ -77,10 +77,12 @@ class GenerateTextFilesOperation @AssistedInject constructor(
                         startedAt = operationContext.startedAt,
                         primaryProgress = Progress.Data(
                             primary = R.string.developer_operation_text_files_creating.toCaString(fileName),
+                            secondary = targetDir.userReadablePath,
                             count = Progress.Count.Counter(index.toLong(), sizes.size.toLong()),
                         ),
                         secondaryProgress = Progress.Data(
                             primary = fileName.toCaString(),
+                            secondary = CaString.EMPTY,
                             count = Progress.Count.Size(bytesWritten, totalBytes),
                         ),
                     )
@@ -92,10 +94,12 @@ class GenerateTextFilesOperation @AssistedInject constructor(
                             startedAt = operationContext.startedAt,
                             primaryProgress = Progress.Data(
                                 primary = R.string.developer_operation_text_files_creating.toCaString(fileName),
+                                secondary = targetDir.userReadablePath,
                                 count = Progress.Count.Counter(index.toLong(), sizes.size.toLong()),
                             ),
                             secondaryProgress = Progress.Data(
                                 primary = fileName.toCaString(),
+                                secondary = CaString.EMPTY,
                                 count = Progress.Count.Size(bytesWritten + fileProgress, totalBytes),
                             ),
                         )

--- a/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/DocumentBuffer.kt
+++ b/app-workspace-editor/src/main/java/eu/darken/butler/editor/core/engine/DocumentBuffer.kt
@@ -3,6 +3,7 @@ package eu.darken.butler.editor.core.engine
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
@@ -208,6 +209,7 @@ class DocumentBuffer @AssistedInject constructor(
                     onProgress?.invoke(
                         Progress.Data(
                             primary = R.string.editor_progress_opening.toCaString(),
+                            secondary = CaString.EMPTY,
                             count = Progress.Count.Size(bytesIndexed, logicalSize),
                         ),
                     )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/CompressOperation.kt
@@ -159,6 +159,7 @@ class CompressOperation @AssistedInject constructor(
                 stateActive = stateActive.copy(
                     primaryProgress = Progress.Data(
                         primary = entry.name.toCaString(),
+                        secondary = outputPath.userReadablePath,
                         count = Progress.Count.Counter(current = processed.toLong(), max = fileCount.toLong()),
                     ),
                 )

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/DownloadLocalCopyOperation.kt
@@ -132,6 +132,7 @@ class DownloadLocalCopyOperation @AssistedInject constructor(
                             stateActive = stateActive.copy(
                                 primaryProgress = Progress.Data(
                                     primary = command.source.userReadableName,
+                                    secondary = command.destinationDir.userReadablePath,
                                     count = sourceSize
                                         ?.let { Progress.Count.Size(current = count, max = it) }
                                         ?: Progress.Count.Indeterminate(),

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperation.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/operations/ExtractOperation.kt
@@ -149,6 +149,7 @@ class ExtractOperation @AssistedInject constructor(
                 stateActive = stateActive.copy(
                     primaryProgress = Progress.Data(
                         primary = outcome.destPath.userReadableName,
+                        secondary = command.archive.userReadablePath,
                         count = Progress.Count.Size(current = processedBytes, max = totalBytes),
                     ),
                 )
@@ -251,6 +252,7 @@ class ExtractOperation @AssistedInject constructor(
                     stateActive.copy(
                         primaryProgress = Progress.Data(
                             primary = (currentEntry ?: command.archive.name).toCaString(),
+                            secondary = command.archive.userReadablePath,
                             count = total
                                 ?.let { Progress.Count.Size(current = read, max = it) }
                                 ?: Progress.Count.Indeterminate(),

--- a/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesOperation.kt
+++ b/app-workspace-saver/src/main/java/eu/darken/butler/saver/core/operations/SaveFilesOperation.kt
@@ -434,24 +434,22 @@ class SaveFilesOperation @AssistedInject constructor(
 
         val primaryProgress = Progress.Data(
             primary = caString { "${snapshot.itemsProcessed + 1} / ${snapshot.totalItems}" },
+            secondary = metrics.overall ?: CaString.EMPTY,
             count = Progress.Count.Counter(
                 current = snapshot.itemsProcessed + 1,
                 max = snapshot.totalItems,
             ),
             extra = perfHistory,
-        ).let { progress ->
-            metrics.overall?.let { progress.copy(secondary = it) } ?: progress
-        }
+        )
 
         val secondaryProgress = Progress.Data(
             primary = currentSource.filename.toCaString(),
+            secondary = metrics.currentFile ?: CaString.EMPTY,
             count = Progress.Count.Size(
                 current = snapshot.currentFileBytes,
                 max = snapshot.currentFileSize,
             ),
-        ).let { progress ->
-            metrics.currentFile?.let { progress.copy(secondary = it) } ?: progress
-        }
+        )
 
         return State.Active(
             startedAt = operationContext.startedAt,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/CoreDeleteExecutor.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/operations/CoreDeleteExecutor.kt
@@ -1,6 +1,7 @@
 package eu.darken.butler.workspace.core.operations
 
 import android.text.format.Formatter
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.caString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.datastore.value
@@ -410,6 +411,7 @@ class CoreDeleteExecutor @Inject constructor(
         // Build secondary progress showing current file
         val secondaryProgress = Progress.Data(
             primary = trashState.currentItem.lookedUp.name.toCaString(),
+            secondary = CaString.EMPTY,
             count = if (trashState.totalBytesEstimate > 0) {
                 Progress.Count.Size(
                     current = trashState.bytesMovedSoFar,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/bar/OperationEntryRow.kt
@@ -102,7 +102,15 @@ fun OperationEntryRow(
                 }
 
                 // Row 2: Icon + secondary text (result icon for finished ops, info icon for running ops)
-                if (showSecondaryText) {
+                val secondaryText = when (operation.state) {
+                    is OperationDisplay.State.Running -> operation.state.primaryProgress.secondary.asComposable()
+                    is OperationDisplay.State.Completed -> operation.state.summary.asComposable()
+                    is OperationDisplay.State.Failed -> operation.state.summary.asComposable()
+                    is OperationDisplay.State.Waiting -> operation.state.reason.asComposable()
+                    is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
+                    else -> operation.description.asComposable()
+                }
+                if (showSecondaryText && secondaryText.isNotEmpty()) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
@@ -127,15 +135,6 @@ fun OperationEntryRow(
                             tint = rowTint,
                         )
                         Spacer(modifier = Modifier.width(6.dp))
-
-                        val secondaryText = when (operation.state) {
-                            is OperationDisplay.State.Running -> operation.state.primaryProgress.secondary.asComposable()
-                            is OperationDisplay.State.Completed -> operation.state.summary.asComposable()
-                            is OperationDisplay.State.Failed -> operation.state.summary.asComposable()
-                            is OperationDisplay.State.Waiting -> operation.state.reason.asComposable()
-                            is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
-                            else -> operation.description.asComposable()
-                        }
 
                         Text(
                             text = secondaryText,
@@ -298,14 +297,14 @@ fun OperationEntryRow(
                     overflow = TextOverflow.Ellipsis,
                 )
 
-                if (showSecondaryText) {
-                    val secondaryText = when (operation.state) {
-                        is OperationDisplay.State.Running -> operation.state.primaryProgress.secondary.asComposable()
-                        is OperationDisplay.State.Completed -> operation.state.summary.asComposable()
-                        is OperationDisplay.State.Waiting -> operation.state.reason.asComposable()
-                        is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
-                        else -> operation.description.asComposable()
-                    }
+                val secondaryText = when (operation.state) {
+                    is OperationDisplay.State.Running -> operation.state.primaryProgress.secondary.asComposable()
+                    is OperationDisplay.State.Completed -> operation.state.summary.asComposable()
+                    is OperationDisplay.State.Waiting -> operation.state.reason.asComposable()
+                    is OperationDisplay.State.Cancelling -> stringResource(R.string.operations_state_cancelling)
+                    else -> operation.description.asComposable()
+                }
+                if (showSecondaryText && secondaryText.isNotEmpty()) {
                     Text(
                         text = secondaryText,
                         style = MaterialTheme.typography.bodySmall,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationCombinedProgressSection.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/operations/details/OperationCombinedProgressSection.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -135,11 +134,12 @@ private fun OperationProgressDisplay(
                 )
 
                 // Secondary text
-                if (progressData.secondary != CaString.EMPTY) {
+                val secondaryText = progressData.secondary.asComposable()
+                if (secondaryText.isNotEmpty()) {
                     // Speed/ETA text changes length constantly, a two line floor keeps the sheet
                     // from shifting on every progress update.
                     Text(
-                        text = progressData.secondary.asComposable(),
+                        text = secondaryText,
                         minLines = 2,
                         style = if (isPrimary) {
                             MaterialTheme.typography.bodyMedium


### PR DESCRIPTION
## What changed

Copying a folder full of small files used to show a different funny loading message on the progress line for every single file, so the second line of the operation flickered through jokes instead of telling you anything. The same flicker showed up when moving, deleting, moving to trash, compressing, extracting, downloading a local copy, saving files, running app actions, and opening a large file in the editor.

Those lines are now quiet, or carry something useful instead. Where a progress row already showed the current item's name, the second line now shows the operation's context that stays put for the whole run: the archive being written or read, the folder a download is going to, the package id of the app being acted on, and the storage path the developer test data generators are writing to. The generators run once per configured target path, and until now nothing on screen said which one was active.

The funny messages themselves are unchanged and still appear where they were meant to, on the workspace init screen and the editor loading overlay.

## Technical Context

- Root cause: `Progress.Data.secondary` defaults to `easterEggProgressMsg`, a `val` whose getter calls `(0..14).random()`. Every construction that omits `secondary` silently draws a new joke, and the sites in this diff build a fresh `Progress.Data` per item instead of `copy()`-ing the previous one. The default itself is deliberately left alone.
- The copy path is the worst case and the reported one: `GenericPathCopy.reportProgress` is called with `shouldReportProgress(force = true)` after every completed file, bypassing the 250 ms throttle, and `CopyOperation`'s `metrics.currentFile ?: secondaryProgress.secondary` fallback lands on the joke because `buildTransferProgressMetrics` measures elapsed time in whole milliseconds, so a sub-millisecond file gives a speed of 0.
- Out of scope by choice: sites that show one joke per navigation (the Explorer location loaders) or one pinned joke per operation (`RestoreOperation`, `CreateOperation`, `CreateTextFileOperation`, and the bare `Progress.Data()` state defaults). Those are a different problem — a joke that never changes rather than one that flickers.
- Two renderers needed a guard to match. `OperationEntryRow` drew its secondary `Text` unconditionally, which would now leave a blank line and an orphaned info icon whenever `SaveFilesOperation` has no throughput metrics yet. `OperationCombinedProgressSection` guarded on `!= CaString.EMPTY`, an identity check that any empty-content `CaString` slips past into a `Text` with `minLines = 2`.
- Worth a close look: `PackageActionOperation.activeState()` gained a `pkgName` parameter, so check that each of its three call sites passes the package id belonging to the label beside it. It emits an empty secondary when the two resolve equal, because `NormalPkg.label` falls back to the package id when the launcher label can't be resolved.
