### PR TITLE
General: [verification only, do not merge] Robolectric SDK jar cache

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,5 +1,14 @@
 name: 'Common project setup'
 description: 'Setup the base project'
+inputs:
+  robolectric-cache-scope:
+    description: >
+      Cache scope for Robolectric's Android SDK jars. Jobs that run Robolectric tests pass a
+      name and must invoke ./.github/actions/robolectric-cache-save after their test step;
+      an empty value skips the cache entirely. Scopes needing different SDK levels get
+      different names so one does not restore the other's set.
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -39,3 +48,40 @@ runs:
         key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', '**/gradle-wrapper.properties', 'buildSrc/**/*.kt') }}
         restore-keys: |
           ${{ runner.os }}-gradle-caches-
+
+    - name: Resolve Robolectric cache key
+      if: inputs.robolectric-cache-scope != ''
+      id: robolectric-key
+      shell: bash
+      run: |
+        version=$(sed -n 's/^robolectric[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' gradle/libs.versions.toml | head -n1)
+        if [ -z "$version" ]; then
+          echo "::error::Could not read the robolectric version from gradle/libs.versions.toml"
+          exit 1
+        fi
+        prefix="${RUNNER_OS}-robolectric-sdks-${{ inputs.robolectric-cache-scope }}-${version}-"
+        echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+        echo "ROBOLECTRIC_CACHE_PREFIX=$prefix" >> "$GITHUB_ENV"
+
+    - name: Restore Robolectric Android SDK jars
+      if: inputs.robolectric-cache-scope != ''
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      with:
+        path: ~/.m2/repository/org/robolectric
+        key: ${{ steps.robolectric-key.outputs.prefix }}
+        restore-keys: ${{ steps.robolectric-key.outputs.prefix }}
+
+    - name: Record restored Robolectric jars
+      if: inputs.robolectric-cache-scope != ''
+      shell: bash
+      run: |
+        dir="$HOME/.m2/repository/org/robolectric"
+        echo "Robolectric jars present after restore:"
+        if [ -d "$dir" ]; then
+          (cd "$dir" && find . -name '*.jar' | sort | sed 's/^/  /')
+          fingerprint=$(cd "$dir" && find . -name '*.jar' | sort | sha256sum | cut -d' ' -f1)
+        else
+          echo "  (none)"
+          fingerprint=empty
+        fi
+        echo "ROBOLECTRIC_INVENTORY_BEFORE=$fingerprint" >> "$GITHUB_ENV"

--- a/.github/actions/robolectric-cache-save/action.yml
+++ b/.github/actions/robolectric-cache-save/action.yml
@@ -1,0 +1,40 @@
+name: 'Save Robolectric SDK jars'
+description: >
+  Saves Robolectric's downloaded Android SDK jars when, and only when, the job added one the
+  restored cache entry lacked. Pairs with common-setup's robolectric-cache-scope input; run
+  it after the step that executes Robolectric tests.
+runs:
+  using: "composite"
+  steps:
+    - name: Inspect Robolectric jars
+      id: inventory
+      shell: bash
+      run: |
+        if [ -z "${ROBOLECTRIC_CACHE_PREFIX:-}" ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        dir="$HOME/.m2/repository/org/robolectric"
+        echo "Robolectric jars present after tests:"
+        if [ -d "$dir" ]; then
+          (cd "$dir" && find . -name '*.jar' | sort | sed 's/^/  /')
+          fingerprint=$(cd "$dir" && find . -name '*.jar' | sort | sha256sum | cut -d' ' -f1)
+        else
+          echo "  (none)"
+          fingerprint=empty
+        fi
+        if [ "$fingerprint" = "${ROBOLECTRIC_INVENTORY_BEFORE:-}" ]; then
+          echo "Unchanged since restore; not saving."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "New jars downloaded; saving a fuller cache entry."
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "key=${ROBOLECTRIC_CACHE_PREFIX}${fingerprint}-$(cat /proc/sys/kernel/random/uuid)" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Save Robolectric Android SDK jars
+      if: steps.inventory.outputs.changed == 'true'
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      with:
+        path: ~/.m2/repository/org/robolectric
+        key: ${{ steps.inventory.outputs.key }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -46,6 +46,8 @@ jobs:
           persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
+        with:
+          robolectric-cache-scope: ${{ matrix.flavor == 'Foss' && 'saf-test-provider' || '' }}
 
       - name: Build modules
         run: ./gradlew ${{ matrix.module }}:assemble${{ matrix.flavor }}${{ matrix.variant }}
@@ -53,6 +55,10 @@ jobs:
       - name: Build and test SAF test provider
         if: matrix.flavor == 'Foss'
         run: ./gradlew :saf-test-provider:assembleDebug :saf-test-provider:testDebugUnitTest
+
+      - name: Save Robolectric SDK jars
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/robolectric-cache-save
 
   test-modules:
     name: Unit tests
@@ -72,9 +78,15 @@ jobs:
           persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
+        with:
+          robolectric-cache-scope: modules
 
       - name: Test modules
         run: ./gradlew ${{ matrix.flavor }}${{ matrix.variant }}UnitTest
+
+      - name: Save Robolectric SDK jars
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/robolectric-cache-save
 
       - name: Verify Room schemas are committed
         run: |

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and test SAF test provider
         if: matrix.flavor == 'Foss'
-        run: ./gradlew :saf-test-provider:assembleDebug :saf-test-provider:testDebugUnitTest
+        run: ./gradlew :saf-test-provider:assembleDebug :saf-test-provider:testDebugUnitTest --rerun --no-build-cache
 
       - name: Save Robolectric SDK jars
         if: ${{ !cancelled() }}
@@ -82,7 +82,7 @@ jobs:
           robolectric-cache-scope: modules
 
       - name: Test modules
-        run: ./gradlew ${{ matrix.flavor }}${{ matrix.variant }}UnitTest
+        run: ./gradlew ${{ matrix.flavor }}${{ matrix.variant }}UnitTest --rerun --no-build-cache
 
       - name: Save Robolectric SDK jars
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Throwaway PR used to verify the Robolectric SDK jar cache behaves as designed before the real PR is opened. **Do not merge.** This branch and PR are deleted once the verification runs are read.