### PR TITLE
General: Stop CI tests failing on a Maven Central outage

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,5 +1,14 @@
 name: 'Common project setup'
 description: 'Setup the base project'
+inputs:
+  robolectric-cache-scope:
+    description: >
+      Cache scope for Robolectric's Android SDK jars. Jobs that run Robolectric tests pass a
+      name and must invoke ./.github/actions/robolectric-cache-save after their test step;
+      an empty value skips the cache entirely. Scopes needing different SDK levels get
+      different names so one does not restore the other's set.
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -39,3 +48,40 @@ runs:
         key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', '**/gradle-wrapper.properties', 'buildSrc/**/*.kt') }}
         restore-keys: |
           ${{ runner.os }}-gradle-caches-
+
+    - name: Resolve Robolectric cache key
+      if: inputs.robolectric-cache-scope != ''
+      id: robolectric-key
+      shell: bash
+      run: |
+        version=$(sed -n 's/^robolectric[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' gradle/libs.versions.toml | head -n1)
+        if [ -z "$version" ]; then
+          echo "::error::Could not read the robolectric version from gradle/libs.versions.toml"
+          exit 1
+        fi
+        prefix="${RUNNER_OS}-robolectric-sdks-${{ inputs.robolectric-cache-scope }}-${version}-"
+        echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+        echo "ROBOLECTRIC_CACHE_PREFIX=$prefix" >> "$GITHUB_ENV"
+
+    - name: Restore Robolectric Android SDK jars
+      if: inputs.robolectric-cache-scope != ''
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      with:
+        path: ~/.m2/repository/org/robolectric
+        key: ${{ steps.robolectric-key.outputs.prefix }}
+        restore-keys: ${{ steps.robolectric-key.outputs.prefix }}
+
+    - name: Record restored Robolectric jars
+      if: inputs.robolectric-cache-scope != ''
+      shell: bash
+      run: |
+        dir="$HOME/.m2/repository/org/robolectric"
+        echo "Robolectric jars present after restore:"
+        if [ -d "$dir" ]; then
+          (cd "$dir" && find . -name '*.jar' | sort | sed 's/^/  /')
+          fingerprint=$(cd "$dir" && find . -name '*.jar' | sort | sha256sum | cut -d' ' -f1)
+        else
+          echo "  (none)"
+          fingerprint=empty
+        fi
+        echo "ROBOLECTRIC_INVENTORY_BEFORE=$fingerprint" >> "$GITHUB_ENV"

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -53,13 +53,15 @@ runs:
       if: inputs.robolectric-cache-scope != ''
       id: robolectric-key
       shell: bash
+      env:
+        ROBOLECTRIC_CACHE_SCOPE: ${{ inputs.robolectric-cache-scope }}
       run: |
         version=$(sed -n 's/^robolectric[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' gradle/libs.versions.toml | head -n1)
         if [ -z "$version" ]; then
           echo "::error::Could not read the robolectric version from gradle/libs.versions.toml"
           exit 1
         fi
-        prefix="${RUNNER_OS}-robolectric-sdks-${{ inputs.robolectric-cache-scope }}-${version}-"
+        prefix="${RUNNER_OS}-robolectric-sdks-${ROBOLECTRIC_CACHE_SCOPE}-${version}-"
         echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
         echo "ROBOLECTRIC_CACHE_PREFIX=$prefix" >> "$GITHUB_ENV"
 

--- a/.github/actions/robolectric-cache-save/action.yml
+++ b/.github/actions/robolectric-cache-save/action.yml
@@ -1,0 +1,40 @@
+name: 'Save Robolectric SDK jars'
+description: >
+  Saves Robolectric's downloaded Android SDK jars when, and only when, the job added one the
+  restored cache entry lacked. Pairs with common-setup's robolectric-cache-scope input; run
+  it after the step that executes Robolectric tests.
+runs:
+  using: "composite"
+  steps:
+    - name: Inspect Robolectric jars
+      id: inventory
+      shell: bash
+      run: |
+        if [ -z "${ROBOLECTRIC_CACHE_PREFIX:-}" ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        dir="$HOME/.m2/repository/org/robolectric"
+        echo "Robolectric jars present after tests:"
+        if [ -d "$dir" ]; then
+          (cd "$dir" && find . -name '*.jar' | sort | sed 's/^/  /')
+          fingerprint=$(cd "$dir" && find . -name '*.jar' | sort | sha256sum | cut -d' ' -f1)
+        else
+          echo "  (none)"
+          fingerprint=empty
+        fi
+        if [ "$fingerprint" = "${ROBOLECTRIC_INVENTORY_BEFORE:-}" ]; then
+          echo "Unchanged since restore; not saving."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "New jars downloaded; saving a fuller cache entry."
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "key=${ROBOLECTRIC_CACHE_PREFIX}${fingerprint}-$(cat /proc/sys/kernel/random/uuid)" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Save Robolectric Android SDK jars
+      if: steps.inventory.outputs.changed == 'true'
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      with:
+        path: ~/.m2/repository/org/robolectric
+        key: ${{ steps.inventory.outputs.key }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -46,6 +46,8 @@ jobs:
           persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
+        with:
+          robolectric-cache-scope: ${{ matrix.flavor == 'Foss' && 'saf-test-provider' || '' }}
 
       - name: Build modules
         run: ./gradlew ${{ matrix.module }}:assemble${{ matrix.flavor }}${{ matrix.variant }}
@@ -53,6 +55,10 @@ jobs:
       - name: Build and test SAF test provider
         if: matrix.flavor == 'Foss'
         run: ./gradlew :saf-test-provider:assembleDebug :saf-test-provider:testDebugUnitTest
+
+      - name: Save Robolectric SDK jars
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/robolectric-cache-save
 
   test-modules:
     name: Unit tests
@@ -72,9 +78,15 @@ jobs:
           persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
+        with:
+          robolectric-cache-scope: modules
 
       - name: Test modules
         run: ./gradlew ${{ matrix.flavor }}${{ matrix.variant }}UnitTest
+
+      - name: Save Robolectric SDK jars
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/robolectric-cache-save
 
       - name: Verify Room schemas are committed
         run: |


### PR DESCRIPTION
## What changed

No user-facing behavior change. CI unit-test jobs are faster and no longer fail on a bad day at Maven Central.

Robolectric downloads the Android framework jar it runs against at test time, and nothing cached that download, so every job fetched it fresh. Run #638 failed when Maven Central rejected one of those requests: two tests reported as failed without either one running. Those jars are now cached on the runners, which also takes roughly 700 MB of downloads out of each unit-test job and 95 MB out of the SAF provider job.

## Technical Context

- Robolectric fetches through its own `MavenArtifactFetcher` into `~/.m2/repository`, which no cache covered and which Gradle's repository configuration does not reach. Three job legs per run are affected: `build-modules` on the Foss leg and both `test-modules` legs.

- Restore is split from save so the save key can be derived from the jars actually present *after* the tests. Test tasks can resolve `FROM-CACHE` without starting a test JVM, so a job only holds the jars whose tests really executed, and a key fixed before the tests would freeze that subset permanently. The key also carries a per-save unique suffix: cache entries can never be rewritten and prefix restore returns the newest match, so without it a run that repairs a partial set computes a key that already exists and can never record the repair.

- Restored jars are not re-verified — Robolectric checks sha512 only on the download path. Cache scoping keeps an ordinary PR from poisoning what `main` or another PR restores, so the marginal risk is low and accepted. Worth knowing if it ever matters: a poisoned entry would survive reverting the source change, so recovery means deleting the cache entries too.

- Worth a close look: the `!cancelled()` gate on the save steps, and giving both `test-modules` legs one shared scope while `saf-test-provider` gets its own. The legs share a scope because they need the same six jars.

- Exercised on a throwaway branch before this PR: forcing every test task to run against a warm cache ran 957 suites with zero jars fetched, and a cold run showed both `test-modules` legs saving concurrently under identical fingerprints, which is what the unique suffix exists to survive.
