### PR TITLE
General: Add native Porter support for ADB access

### DIFF
--- a/app-common-adb/build.gradle.kts
+++ b/app-common-adb/build.gradle.kts
@@ -47,8 +47,7 @@ dependencies {
     addSerialization()
     addIO()
 
-    implementation(libs.shizuku.api)
-    implementation(libs.shizuku.provider)
+    implementation(libs.porter.client)
 
     addTesting()
     testImplementation(project(":app-common-test"))

--- a/app-common-adb/src/main/AndroidManifest.xml
+++ b/app-common-adb/src/main/AndroidManifest.xml
@@ -1,9 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="eu.darken.porter.permission.API_V23" />
+    <uses-permission android:name="moe.shizuku.manager.permission.API_V23" />
+
+    <queries>
+        <package android:name="eu.darken.porter" />
+        <package android:name="moe.shizuku.privileged.api" />
+    </queries>
+
     <application>
         <provider
-            android:name="rikka.shizuku.ShizukuProvider"
+            android:name="eu.darken.porter.client.PorterProvider"
+            android:authorities="${applicationId}.porter"
+            android:enabled="true"
+            android:exported="true"
+            android:multiprocess="false"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+        <provider
+            android:name="eu.darken.porter.client.SelectedShizukuProvider"
             android:authorities="${applicationId}.shizuku"
             android:enabled="true"
             android:exported="true"

--- a/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/AdbBackend.kt
+++ b/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/AdbBackend.kt
@@ -1,0 +1,20 @@
+package eu.darken.butler.common.adb.shizuku
+
+/**
+ * Which privileged manager the ADB link talks to.
+ *
+ * Selected once per process by the client SDK and latched from then on, see
+ * [ShizukuWrapper.activeBackend]. Mirrors the SDK's own backend type so it doesn't leak out of this
+ * module.
+ *
+ * [label] is a product name and deliberately not translated.
+ */
+enum class AdbBackend(val label: String) {
+    PORTER("Porter"),
+    SHIZUKU("Shizuku"),
+    ;
+
+    /** The family this process can NOT talk to, i.e. what an inactive manager belongs to. */
+    val other: AdbBackend
+        get() = if (this == PORTER) SHIZUKU else PORTER
+}

--- a/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapper.kt
@@ -56,18 +56,36 @@ class ShizukuWrapper @Inject constructor(
     }
 
     /**
-     * The manager package behind the backend the SDK actually connects through, or null if that
-     * backend's manager isn't installed.
+     * The backend the client SDK picked for this process.
+     *
+     * Latched by the SDK on first use, so it cannot change while the app runs. AUTO is never handed
+     * out (the SDK always resolves it to a concrete backend first) and is mapped defensively.
+     */
+    suspend fun activeBackend(): AdbBackend = withContext(dispatcherProvider.IO) {
+        when (activeBackendAction()) {
+            PorterClient.Backend.PORTER -> AdbBackend.PORTER
+            PorterClient.Backend.SHIZUKU, PorterClient.Backend.AUTO -> AdbBackend.SHIZUKU
+        }.also { log(TAG) { "activeBackend()=$it" } }
+    }
+
+    /**
+     * Every installed manager belonging to the backend we actually connect through.
      *
      * Deliberately without a cross-backend fallback: naming the other family's manager would claim
      * a connection this process cannot make.
      */
-    suspend fun getManagerPackage(): String? = withContext(dispatcherProvider.IO) {
-        when (activeBackendAction()) {
-            PorterClient.Backend.PORTER -> resolvePermissionOwner(PORTER_PERMISSION)
-            else -> SHIZUKU_PERMISSIONS.firstNotNullOfOrNull { resolvePermissionOwner(it) }
+    suspend fun getActiveManagerPackages(): List<String> {
+        val permissions = when (activeBackend()) {
+            AdbBackend.PORTER -> PORTER_PERMISSIONS
+            AdbBackend.SHIZUKU -> SHIZUKU_PERMISSIONS
+        }
+        return withContext(dispatcherProvider.IO) {
+            permissions.mapNotNull { resolvePermissionOwner(it) }.distinct()
         }
     }
+
+    /** The manager package to treat as *the* ADB manager app, see [getActiveManagerPackages]. */
+    suspend fun getManagerPackage(): String? = getActiveManagerPackages().firstOrNull()
 
     private fun resolvePermissionOwner(permission: String): String? = try {
         context.packageManager
@@ -216,12 +234,15 @@ class ShizukuWrapper @Inject constructor(
 
         private const val SHIZUKU_PLUS_PERMISSION = "af.shizuku.plus.permission.API_V23"
 
-        private val PORTER_PERMISSION = PorterClient.PERMISSION
+        // Kept apart from the Shizuku family on purpose: the Porter manager removes the stock Shizuku
+        // permission rather than declaring it, so a Shizuku-family lookup can never resolve to it,
+        // and the active-backend lookup must not mix the two.
+        private val PORTER_PERMISSIONS = listOf(PorterClient.PERMISSION)
 
         // Prefer the stock permission owner when both permissions are declared.
         private val SHIZUKU_PERMISSIONS = listOf(ShizukuProvider.PERMISSION, SHIZUKU_PLUS_PERMISSION)
 
-        private val MANAGER_PERMISSIONS = listOf(PORTER_PERMISSION) + SHIZUKU_PERMISSIONS
+        private val MANAGER_PERMISSIONS = PORTER_PERMISSIONS + SHIZUKU_PERMISSIONS
 
         /**
          * Combined budget for the two binder round-trips behind [isGranted].

--- a/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapper.kt
@@ -13,6 +13,7 @@ import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.flow.setupCommonEventHandlers
+import eu.darken.porter.client.PorterClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
@@ -34,11 +35,17 @@ class ShizukuWrapper @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) {
 
+    // Same reason as the seams below: PorterClient reads the package manager and latches its answer
+    // in a static, neither of which a JVM unit test can set up. Overridden in tests, never in
+    // production.
+    internal var activeBackendAction: () -> PorterClient.Backend = { PorterClient.getActiveBackend(context) }
+
     /**
-     * Packages that declare a Shizuku manager permission, in [MANAGER_PERMISSIONS] order.
+     * Every installed manager, across both the Porter and the Shizuku permission family, in
+     * [MANAGER_PERMISSIONS] order.
      *
-     * Detects Shizuku via its permissions instead of a fixed package name. The permission names are
-     * shared across Shizuku forks, so this keeps working when a fork hides its package from
+     * Detects a manager via its permissions instead of a fixed package name. The permission names
+     * are shared across Shizuku forks, so this keeps working when a fork hides its package from
      * enumeration ("Hide Shizuku from other apps") or ships under a different package name.
      * Permissions live in a global namespace, so the lookup isn't subject to the package-visibility
      * filtering that hides the app itself. Every name is tried because Shizuku+'s Plus flavor
@@ -48,8 +55,19 @@ class ShizukuWrapper @Inject constructor(
         MANAGER_PERMISSIONS.mapNotNull { resolvePermissionOwner(it) }.distinct()
     }
 
-    /** The manager package to treat as *the* Shizuku app, see [getManagerPackages]. */
-    suspend fun getManagerPackage(): String? = getManagerPackages().firstOrNull()
+    /**
+     * The manager package behind the backend the SDK actually connects through, or null if that
+     * backend's manager isn't installed.
+     *
+     * Deliberately without a cross-backend fallback: naming the other family's manager would claim
+     * a connection this process cannot make.
+     */
+    suspend fun getManagerPackage(): String? = withContext(dispatcherProvider.IO) {
+        when (activeBackendAction()) {
+            PorterClient.Backend.PORTER -> resolvePermissionOwner(PORTER_PERMISSION)
+            else -> SHIZUKU_PERMISSIONS.firstNotNullOfOrNull { resolvePermissionOwner(it) }
+        }
+    }
 
     private fun resolvePermissionOwner(permission: String): String? = try {
         context.packageManager
@@ -198,8 +216,12 @@ class ShizukuWrapper @Inject constructor(
 
         private const val SHIZUKU_PLUS_PERMISSION = "af.shizuku.plus.permission.API_V23"
 
+        private val PORTER_PERMISSION = PorterClient.PERMISSION
+
         // Prefer the stock permission owner when both permissions are declared.
-        private val MANAGER_PERMISSIONS = listOf(ShizukuProvider.PERMISSION, SHIZUKU_PLUS_PERMISSION)
+        private val SHIZUKU_PERMISSIONS = listOf(ShizukuProvider.PERMISSION, SHIZUKU_PLUS_PERMISSION)
+
+        private val MANAGER_PERMISSIONS = listOf(PORTER_PERMISSION) + SHIZUKU_PERMISSIONS
 
         /**
          * Combined budget for the two binder round-trips behind [isGranted].

--- a/app-common-adb/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.pm.PermissionInfo
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.porter.client.PorterClient
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -30,6 +31,7 @@ class ShizukuWrapperTest {
 
     private val stockPermission = "moe.shizuku.manager.permission.API_V23"
     private val plusPermission = "af.shizuku.plus.permission.API_V23"
+    private val porterPermission = "eu.darken.porter.permission.API_V23"
 
     private val dispatcherProvider = object : DispatcherProvider {
         override val IO: CoroutineDispatcher = Dispatchers.Unconfined
@@ -38,9 +40,10 @@ class ShizukuWrapperTest {
     private fun wrapper(
         appScope: CoroutineScope = CoroutineScope(Job() + Dispatchers.Unconfined),
         dispatchers: DispatcherProvider = dispatcherProvider,
+        backend: PorterClient.Backend = PorterClient.Backend.SHIZUKU,
     ): ShizukuWrapper {
         every { context.packageManager } returns packageManager
-        return ShizukuWrapper(context, appScope, dispatchers)
+        return ShizukuWrapper(context, appScope, dispatchers).apply { activeBackendAction = { backend } }
     }
 
     // mockk gives us a real (Objenesis-instantiated) PermissionInfo whose inherited public
@@ -103,6 +106,7 @@ class ShizukuWrapperTest {
 
     @Test
     fun `prefers the stock permission owner when both are defined`() = runTest {
+        undefinePermission(porterPermission)
         definePermission(stockPermission, "moe.shizuku.privileged.api")
         definePermission(plusPermission, "af.shizuku.plus.api")
         val wrapper = wrapper()
@@ -113,6 +117,7 @@ class ShizukuWrapperTest {
 
     @Test
     fun `collapses one app defining both permissions to a single entry`() = runTest {
+        undefinePermission(porterPermission)
         definePermission(stockPermission, "moe.shizuku.privileged.api")
         definePermission(plusPermission, "moe.shizuku.privileged.api")
 
@@ -121,6 +126,7 @@ class ShizukuWrapperTest {
 
     @Test
     fun `getManagerPackages is empty when no permission is defined`() = runTest {
+        undefinePermission(porterPermission)
         undefinePermission(stockPermission)
         undefinePermission(plusPermission)
         val wrapper = wrapper()
@@ -135,6 +141,46 @@ class ShizukuWrapperTest {
         definePermission(plusPermission, "af.shizuku.plus.api")
 
         wrapper().getManagerPackage() shouldBe "af.shizuku.plus.api"
+    }
+
+    @Test
+    fun `the active Porter backend resolves Porter's manager even with Shizuku installed`() = runTest {
+        definePermission(porterPermission, "eu.darken.porter")
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        wrapper(backend = PorterClient.Backend.PORTER).getManagerPackage() shouldBe "eu.darken.porter"
+    }
+
+    @Test
+    fun `the active Shizuku backend resolves Shizuku's manager even with Porter installed`() = runTest {
+        definePermission(porterPermission, "eu.darken.porter")
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+
+        wrapper(backend = PorterClient.Backend.SHIZUKU).getManagerPackage() shouldBe "moe.shizuku.privileged.api"
+    }
+
+    @Test
+    fun `an absent manager for the active backend does not fall back to the other one`() = runTest {
+        undefinePermission(porterPermission)
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        // Naming Shizuku here would claim a connection this process cannot make.
+        wrapper(backend = PorterClient.Backend.PORTER).getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `getManagerPackages spans both permission families`() = runTest {
+        definePermission(porterPermission, "eu.darken.porter")
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        wrapper().getManagerPackages() shouldBe listOf(
+            "eu.darken.porter",
+            "moe.shizuku.privileged.api",
+            "af.shizuku.plus.api",
+        )
     }
 
     @Test

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
@@ -62,8 +62,15 @@ class ShizukuManager @Inject constructor(
         }
         .replayingShare(appScope)
 
-    // The reference package plus every installed app that declares a Shizuku manager permission.
-    suspend fun managerIds(): Set<Pkg.Id> = setOf(PKG_ID) + shizukuWrapper.getManagerPackages().map { it.toPkgId() }
+    // The two reference packages plus every installed app that declares a manager permission.
+    suspend fun managerIds(): Set<Pkg.Id> =
+        setOf(PKG_ID, PORTER_PKG_ID) + shizukuWrapper.getManagerPackages().map { it.toPkgId() }
+
+    /**
+     * Only the managers that are actually installed, unlike [managerIds] which always carries the
+     * reference packages and therefore cannot answer whether anything is installed at all.
+     */
+    suspend fun installedManagerIds(): Set<Pkg.Id> = shizukuWrapper.getManagerPackages().map { it.toPkgId() }.toSet()
 
     val permissionGrantEvents: Flow<ShizukuWrapper.ShizukuPermissionRequest> = shizukuWrapper.permissionGrantEvents
         .setupCommonEventHandlers(TAG) { "grantEvents" }
@@ -135,18 +142,22 @@ class ShizukuManager @Inject constructor(
         }
     }
 
-    // Reference package, also used as a fallback for previews and when nothing is installed.
-    val shizukuPkgId: Pkg.Id
-        get() = PKG_ID
+    // Placeholder for previews and for when nothing is installed. Porter is the manager we target
+    // natively, so it is the one to name when there is no installed manager to name instead.
+    val defaultManagerPkgId: Pkg.Id
+        get() = PORTER_PKG_ID
 
     /**
-     * The installed Shizuku manager's package, resolved via its permission so forks and hidden-mode
-     * installs are handled, or null if Shizuku isn't installed.
+     * The manager package of the backend this process connects through, resolved via that backend's
+     * permission so forks and hidden-mode installs still resolve, or null when that backend's manager
+     * is not installed.
      */
     suspend fun getManagerId(): Pkg.Id? = shizukuWrapper.getManagerPackage()?.toPkgId()
 
     // Not cached: a stale "not installed" result would keep the binder gate (see shizukuBinder) closed
-    // even after Shizuku gets installed, until the next process restart. The lookup is cheap.
+    // even after a manager for the active backend gets installed, and the lookup is cheap. It cannot
+    // help across backends though: the active backend is latched for the process lifetime, so a
+    // manager installed for the other one stays invisible until restart however often we re-probe.
     suspend fun isInstalled(): Boolean {
         val installed = getManagerId() != null
         log(TAG) { "isInstalled(): $installed" }
@@ -241,5 +252,6 @@ class ShizukuManager @Inject constructor(
     companion object {
         private val TAG = logTag("ADB", "Shizuku", "Manager")
         internal val PKG_ID = "moe.shizuku.privileged.api".toPkgId()
+        internal val PORTER_PKG_ID = "eu.darken.porter".toPkgId()
     }
 }

--- a/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/butler/common/adb/shizuku/ShizukuManager.kt
@@ -72,6 +72,22 @@ class ShizukuManager @Inject constructor(
      */
     suspend fun installedManagerIds(): Set<Pkg.Id> = shizukuWrapper.getManagerPackages().map { it.toPkgId() }.toSet()
 
+    /** Installed managers of the active backend's family, see [ShizukuWrapper.getActiveManagerPackages]. */
+    suspend fun activeManagerIds(): Set<Pkg.Id> = shizukuWrapper.getActiveManagerPackages().map { it.toPkgId() }.toSet()
+
+    /**
+     * An installed manager belonging to the OTHER family, i.e. one this process cannot talk to.
+     *
+     * The backend latches at provider init, so a manager installed afterwards stays invisible to
+     * [getManagerId] until the app is fully restarted. This is what lets the UI name it.
+     */
+    suspend fun inactiveFamilyManagerId(): Pkg.Id? {
+        val active = shizukuWrapper.getActiveManagerPackages().toSet()
+        return shizukuWrapper.getManagerPackages().firstOrNull { it !in active }?.toPkgId()
+    }
+
+    suspend fun activeBackend(): AdbBackend = shizukuWrapper.activeBackend()
+
     val permissionGrantEvents: Flow<ShizukuWrapper.ShizukuPermissionRequest> = shizukuWrapper.permissionGrantEvents
         .setupCommonEventHandlers(TAG) { "grantEvents" }
         .replayingShare(appScope)
@@ -142,10 +158,12 @@ class ShizukuManager @Inject constructor(
         }
     }
 
-    // Placeholder for previews and for when nothing is installed. Porter is the manager we target
-    // natively, so it is the one to name when there is no installed manager to name instead.
-    val defaultManagerPkgId: Pkg.Id
-        get() = PORTER_PKG_ID
+    // Placeholder for previews and for when nothing is installed: the reference package of the
+    // backend this process would connect through, so it can't name a family we cannot talk to.
+    suspend fun referenceManagerId(): Pkg.Id = when (activeBackend()) {
+        AdbBackend.PORTER -> PORTER_PKG_ID
+        AdbBackend.SHIZUKU -> PKG_ID
+    }
 
     /**
      * The manager package of the backend this process connects through, resolved via that backend's

--- a/app-common-io/src/main/res/values/strings.xml
+++ b/app-common-io/src/main/res/values/strings.xml
@@ -91,7 +91,7 @@
     <string name="app_uninstall_confirm_pending_reason">Android is waiting for your confirmation</string>
 
     <!-- App uninstall errors -->
-    <string name="app_uninstall_other_user_unsupported">Removing this app for another user needs root or Shizuku</string>
+    <string name="app_uninstall_other_user_unsupported">Removing this app for another user needs root or ADB access</string>
     <string name="app_uninstall_no_result">Android did not report a result</string>
 
     <!-- Service connection errors -->

--- a/app-common-io/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuManagerTest.kt
@@ -254,7 +254,25 @@ class ShizukuManagerTest : BaseTest() {
         )
     }
 
-    @Test fun `the default manager package is Porter`() {
-        manager().defaultManagerPkgId shouldBe ShizukuManager.PORTER_PKG_ID
+    @Test fun `the reference package follows the active backend`() {
+        coEvery { shizukuWrapper.activeBackend() } returns AdbBackend.PORTER
+        runBlocking { manager().referenceManagerId() } shouldBe ShizukuManager.PORTER_PKG_ID
+
+        coEvery { shizukuWrapper.activeBackend() } returns AdbBackend.SHIZUKU
+        runBlocking { manager().referenceManagerId() } shouldBe ShizukuManager.PKG_ID
+    }
+
+    @Test fun `the inactive family manager is the one outside the active backend`() {
+        coEvery { shizukuWrapper.getManagerPackages() } returns listOf("eu.darken.porter", "moe.shizuku.privileged.api")
+        coEvery { shizukuWrapper.getActiveManagerPackages() } returns listOf("moe.shizuku.privileged.api")
+
+        runBlocking { manager().inactiveFamilyManagerId() } shouldBe ShizukuManager.PORTER_PKG_ID
+    }
+
+    @Test fun `there is no inactive family manager when every one is reachable`() {
+        coEvery { shizukuWrapper.getManagerPackages() } returns listOf("moe.shizuku.privileged.api")
+        coEvery { shizukuWrapper.getActiveManagerPackages() } returns listOf("moe.shizuku.privileged.api")
+
+        runBlocking { manager().inactiveFamilyManagerId() } shouldBe null
     }
 }

--- a/app-common-io/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/butler/common/adb/shizuku/ShizukuManagerTest.kt
@@ -206,17 +206,21 @@ class ShizukuManagerTest : BaseTest() {
         state.isTerminalFailure shouldBe true
     }
 
-    @Test fun `managerIds always includes the reference package plus any detected fork`() {
+    @Test fun `managerIds always includes the reference packages plus any detected fork`() {
         val mgr = manager()
 
-        // Nothing installed: just the reference package.
+        // Nothing installed: just the reference packages.
         setShizukuPackage(null)
-        runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID)
+        runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, ShizukuManager.PORTER_PKG_ID)
 
-        // Fork installed under a different package: both the reference and the fork are included.
+        // Fork installed under a different package: both the references and the fork are included.
         val forkPkg = "com.example.shizuku.fork"
         setShizukuPackage(forkPkg)
-        runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, forkPkg.toPkgId())
+        runBlocking { mgr.managerIds() } shouldBe setOf(
+            ShizukuManager.PKG_ID,
+            ShizukuManager.PORTER_PKG_ID,
+            forkPkg.toPkgId(),
+        )
     }
 
     @Test fun `managerIds includes every detected manager package`() {
@@ -225,6 +229,32 @@ class ShizukuManagerTest : BaseTest() {
             "af.shizuku.plus.api",
         )
 
-        runBlocking { manager().managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, "af.shizuku.plus.api".toPkgId())
+        runBlocking { manager().managerIds() } shouldBe setOf(
+            ShizukuManager.PKG_ID,
+            ShizukuManager.PORTER_PKG_ID,
+            "af.shizuku.plus.api".toPkgId(),
+        )
+    }
+
+    @Test fun `installedManagerIds is empty when no manager is installed`() {
+        setShizukuPackage(null)
+
+        runBlocking { manager().installedManagerIds() } shouldBe emptySet()
+    }
+
+    @Test fun `installedManagerIds only reports what was actually resolved`() {
+        coEvery { shizukuWrapper.getManagerPackages() } returns listOf(
+            "eu.darken.porter",
+            "moe.shizuku.privileged.api",
+        )
+
+        runBlocking { manager().installedManagerIds() } shouldBe setOf(
+            ShizukuManager.PORTER_PKG_ID,
+            ShizukuManager.PKG_ID,
+        )
+    }
+
+    @Test fun `the default manager package is Porter`() {
+        manager().defaultManagerPkgId shouldBe ShizukuManager.PORTER_PKG_ID
     }
 }

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -209,10 +209,10 @@
     <string name="general_error_cant_access_msg">Zugriff auf %s nicht möglich.</string>
     <string name="general_error_archive_not_seekable_msg">%s lässt sich nicht direkt durchsuchen: Der verwendete Speicher unterstützt nur sequenzielles Lesen, dieses Archivformat erfordert jedoch wahlfreien Zugriff.</string>
     <string name="general_error_root_unavailable">Root-Zugriff ist nicht verfügbar.</string>
-    <string name="general_error_elevated_access_required">Dieser Vorgang erfordert erweiterte Zugriffsrechte. Konfiguriere Root oder Shizuku in der Einrichtung.</string>
+    <string name="general_error_elevated_access_required">Dieser Vorgang erfordert erweiterte Zugriffsrechte. Konfiguriere Root-Zugriff oder ADB-Zugriff in der Einrichtung.</string>
     <string name="general_error_no_compatible_app_found_msg">Keine passende App für diese Anfrage gefunden.</string>
     <string name="general_error_ipc_deadobject_title">Verbindung zum Dienst verloren</string>
-    <string name="general_error_ipc_deadobject_description">Die Verbindung zu einem wichtigen Dienst (z. B. Magisk, Shizuku oder einem anderen Systemdienst) wurde unerwartet getrennt. Starte Dein Gerät bitte neu. Falls das Problem weiterhin auftritt, suche nach Updates oder melde Dich bei mir, damit ich es beheben kann.</string>
+    <string name="general_error_ipc_deadobject_description">Die Verbindung zu einem wichtigen Dienst (z. B. Magisk oder einem anderen Systemdienst) wurde unerwartet getrennt. Starte Dein Gerät bitte neu. Falls das Problem weiterhin auftritt, suche nach Updates oder melde Dich bei mir, damit ich es beheben kann.</string>
 
     <string name="ui_theme_mode_dark_label">Dunkel</string>
     <string name="ui_theme_mode_light_label">Hell</string>
@@ -227,7 +227,7 @@
 
     <!-- Setup module types -->
     <string name="setup_usagestats_title">Nutzungsstatistiken</string>
-    <string name="setup_shizuku_card_title">Shizuku</string>
+    <string name="setup_shizuku_card_title">ADB-Zugriff</string>
     <string name="setup_root_card_title">Root</string>
     <string name="setup_notification_title">Benachrichtigungszugriff</string>
     <string name="setup_manage_storage_card_title">Externen Speicher verwalten</string>
@@ -287,6 +287,6 @@
     <string name="common_tip_multiple_panes">Nutze mehrere Bereiche, um Dateien nebeneinander zu vergleichen.</string>
     <string name="common_tip_different_folders">Öffne in jedem Bereich einen anderen Ordner, um Dateien einfach zu verwalten.</string>
     <string name="common_tip_switch_layouts">Wechsle die Anordnung der Bereiche in den Tab-Einstellungen.</string>
-    <string name="common_tip_elevated_access">Aktiviere Root oder Shizuku in der Einrichtung für erweiterte Dateivorgänge.</string>
+    <string name="common_tip_elevated_access">Aktiviere Root-Zugriff oder ADB-Zugriff in der Einrichtung für erweiterte Dateivorgänge.</string>
     <string name="common_tip_breadcrumb_home">Halte einen Abschnitt der Pfadleiste im Explorer gedrückt, um ihn als Dein Startverzeichnis festzulegen.</string>
 </resources>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -209,10 +209,10 @@
     <string name="general_error_cant_access_msg">Can\'t access %s.</string>
     <string name="general_error_archive_not_seekable_msg">%s can\'t be browsed directly: the storage it is on only supports sequential reading, but this archive format requires random access.</string>
     <string name="general_error_root_unavailable">Root access is unavailable.</string>
-    <string name="general_error_elevated_access_required">This operation requires elevated access. Configure Root or Shizuku in Setup.</string>
+    <string name="general_error_elevated_access_required">This operation requires elevated access. Configure root or ADB access in Setup.</string>
     <string name="general_error_no_compatible_app_found_msg">No compatible app found to handle this request.</string>
     <string name="general_error_ipc_deadobject_title">Service connection lost</string>
-    <string name="general_error_ipc_deadobject_description">The connection to a critical service (e.g. Magisk, Shizuku, or other system-level services) was unexpectedly lost. Please reboot your device. If the issue persists, check for updates or reach out to me so I can fix it.</string>
+    <string name="general_error_ipc_deadobject_description">The connection to a critical service (e.g. Magisk or another system-level service) was unexpectedly lost. Please reboot your device. If the issue persists, check for updates or reach out to me so I can fix it.</string>
 
     <string name="ui_theme_mode_dark_label">Dark</string>
     <string name="ui_theme_mode_light_label">Light</string>
@@ -227,7 +227,7 @@
 
     <!-- Setup module types -->
     <string name="setup_usagestats_title">Usage stats</string>
-    <string name="setup_shizuku_card_title">Shizuku</string>
+    <string name="setup_shizuku_card_title">ADB access</string>
     <string name="setup_root_card_title">Root</string>
     <string name="setup_notification_title">Notification access</string>
     <string name="setup_manage_storage_card_title">Manage external storage</string>
@@ -287,6 +287,6 @@
     <string name="common_tip_multiple_panes">Use multiple panes to compare files side by side.</string>
     <string name="common_tip_different_folders">Open different folders in each pane for easy file management.</string>
     <string name="common_tip_switch_layouts">Switch between pane layouts in the tab settings manager.</string>
-    <string name="common_tip_elevated_access">Enable root or Shizuku in Setup for advanced file operations.</string>
+    <string name="common_tip_elevated_access">Enable root or ADB access in Setup for advanced file operations.</string>
     <string name="common_tip_breadcrumb_home">Long-press an Explorer breadcrumb to set it as your home directory.</string>
 </resources>

--- a/app-provider-documents/src/main/res/values-de/strings.xml
+++ b/app-provider-documents/src/main/res/values-de/strings.xml
@@ -17,7 +17,7 @@
 
     <!-- Error Messages - Phase 1 -->
     <string name="provider_documents_error_requires_root">Zum Durchsuchen dieses Speicherorts ist Root-Zugriff erforderlich. Aktiviere ihn in den Butler-Einstellungen.</string>
-    <string name="provider_documents_error_requires_adb">Zum Durchsuchen dieses Speicherorts ist ADB-/Shizuku-Zugriff erforderlich. Aktiviere Shizuku in den Butler-Einstellungen.</string>
+    <string name="provider_documents_error_requires_adb">Zum Durchsuchen dieses Speicherorts ist ADB-Zugriff erforderlich. Aktiviere ihn in der Butler-Einrichtung.</string>
     <string name="provider_documents_error_requires_storage">Zum Durchsuchen dieses Speicherorts ist eine Speicherberechtigung erforderlich. Gewähre sie in den Butler-Einstellungen.</string>
     <string name="provider_documents_error_requires_permissions">Zum Durchsuchen dieses Speicherorts sind zusätzliche Berechtigungen erforderlich. Prüfe die Butler-Einstellungen.</string>
     <string name="provider_documents_error_generic">Auf diesen Speicherort kann nicht zugegriffen werden. Prüfe die Zugriffsmöglichkeiten in Butler.</string>

--- a/app-provider-documents/src/main/res/values/strings.xml
+++ b/app-provider-documents/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
 
     <!-- Error Messages - Phase 1 -->
     <string name="provider_documents_error_requires_root">Root access required to browse this location. Enable root access in Butler app settings.</string>
-    <string name="provider_documents_error_requires_adb">ADB/Shizuku access required to browse this location. Enable Shizuku in Butler app settings.</string>
+    <string name="provider_documents_error_requires_adb">ADB access required to browse this location. Enable it in Butler\'s setup.</string>
     <string name="provider_documents_error_requires_storage">Storage permission required to browse this location. Grant storage permission in Butler app settings.</string>
     <string name="provider_documents_error_requires_permissions">Additional permissions required to browse this location. Check Butler app settings.</string>
     <string name="provider_documents_error_generic">Unable to access this location. Check Butler app for access options.</string>

--- a/app-workspace-apps/src/main/res/values-de/strings.xml
+++ b/app-workspace-apps/src/main/res/values-de/strings.xml
@@ -69,8 +69,8 @@
     <string name="apps_path_internal_data_label">Interne Daten</string>
     <string name="apps_path_external_data_label">Externer Speicher</string>
     <string name="apps_path_requires_root_label">Root-Zugriff erforderlich</string>
-    <string name="apps_path_requires_shizuku_label">Shizuku erforderlich</string>
-    <string name="apps_path_requires_root_or_shizuku_label">Root-Zugriff oder Shizuku erforderlich</string>
+    <string name="apps_path_requires_shizuku_label">ADB-Zugriff erforderlich</string>
+    <string name="apps_path_requires_root_or_shizuku_label">Root-Zugriff oder ADB-Zugriff erforderlich</string>
     <string name="apps_path_requires_access_label">Zusätzlicher Zugriff erforderlich</string>
     <string name="apps_storage_breakdown_label">Speicheraufteilung</string>
     <string name="apps_storage_app_label">App</string>
@@ -206,7 +206,7 @@
     <string name="apps_components_copy_package_action">Paketnamen kopieren</string>
     <string name="apps_components_action_enable">Komponente aktivieren</string>
     <string name="apps_components_action_disable">Komponente deaktivieren</string>
-    <string name="apps_components_action_requires_elevated">Root-Zugriff oder Shizuku erforderlich. Zum Einrichten tippen</string>
+    <string name="apps_components_action_requires_elevated">Root-Zugriff oder ADB-Zugriff erforderlich. Zum Einrichten tippen</string>
     <string name="apps_components_confirm_enable_title">Komponenten aktivieren?</string>
     <string name="apps_components_confirm_disable_title">Komponenten deaktivieren?</string>
     <string name="apps_components_confirm_enable_message">Die folgenden Komponenten werden aktiviert:</string>

--- a/app-workspace-apps/src/main/res/values/strings.xml
+++ b/app-workspace-apps/src/main/res/values/strings.xml
@@ -78,8 +78,8 @@
     <string name="apps_path_internal_data_label">Internal data</string>
     <string name="apps_path_external_data_label">External storage</string>
     <string name="apps_path_requires_root_label">Requires root</string>
-    <string name="apps_path_requires_shizuku_label">Requires Shizuku</string>
-    <string name="apps_path_requires_root_or_shizuku_label">Requires root or Shizuku</string>
+    <string name="apps_path_requires_shizuku_label">Requires ADB access</string>
+    <string name="apps_path_requires_root_or_shizuku_label">Requires root or ADB access</string>
     <string name="apps_path_requires_access_label">Requires additional access</string>
     <string name="apps_storage_breakdown_label">Storage Breakdown</string>
     <string name="apps_storage_app_label">Application</string>
@@ -230,7 +230,7 @@
     <string name="apps_components_copy_package_action">Copy package name</string>
     <string name="apps_components_action_enable">Enable component</string>
     <string name="apps_components_action_disable">Disable component</string>
-    <string name="apps_components_action_requires_elevated">Requires root or Shizuku — tap to set up</string>
+    <string name="apps_components_action_requires_elevated">Requires root or ADB access — tap to set up</string>
     <string name="apps_components_confirm_enable_title">Enable components?</string>
     <string name="apps_components_confirm_disable_title">Disable components?</string>
     <string name="apps_components_confirm_enable_message">The following components will be enabled:</string>

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceStoragePathsTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/details/AppDetailsWorkspaceStoragePathsTest.kt
@@ -228,14 +228,14 @@ class AppDetailsWorkspaceStoragePathsTest {
     }
 
     @Test
-    fun `a row that needs root or Shizuku says so`() = runTest {
+    fun `a row that needs root or ADB access says so`() = runTest {
         every { pathPermissionCheck.monitor(match<APath<*>> { it.path == INTERNAL }) } returns flowOf(
             PathRequirements(
                 combos = setOf(setOf(SetupModule.Type.ROOT), setOf(SetupModule.Type.SHIZUKU)),
             )
         )
 
-        pathsOf(createWorkspace()).first().requirement?.get(context) shouldBe "Requires root or Shizuku"
+        pathsOf(createWorkspace()).first().requirement?.get(context) shouldBe "Requires root or ADB access"
     }
 
     /** An existing SAF grant makes the path accessible as it is, so there is nothing to announce. */

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/operations/PackageActionOperationTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/core/operations/PackageActionOperationTest.kt
@@ -155,7 +155,7 @@ class PackageActionOperationTest : BaseTest() {
     fun `a system uninstall refused for another user is a failed target`() = runTest2 {
         coEvery {
             systemUninstaller.uninstall(any(), any(), any())
-        } throws SystemUninstallException("Removing this app for another user needs root or Shizuku")
+        } throws SystemUninstallException("Removing this app for another user needs root or ADB access")
 
         val completed = run(
             PackageCommand.Uninstall(listOf(target("a")), viaSystemDialog = true)

--- a/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/components/ComponentDetailsSheetTest.kt
+++ b/app-workspace-apps/src/test/java/eu/darken/butler/apps/ui/details/components/ComponentDetailsSheetTest.kt
@@ -179,7 +179,7 @@ class ComponentDetailsSheetTest : ComposeTest() {
             onSetupRequested = { setupRequests++ },
         )
 
-        composeTestRule.onNodeWithText("Requires root or Shizuku — tap to set up").assertExists()
+        composeTestRule.onNodeWithText("Requires root or ADB access — tap to set up").assertExists()
         composeTestRule.onNodeWithText("Disable component").performScrollTo().performClick()
 
         setupRequests shouldBe 1

--- a/app-workspace-developer/src/main/res/values-de/strings.xml
+++ b/app-workspace-developer/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="developer_options_root_installed_label">Installiert</string>
     <string name="developer_options_root_available_label">Verfügbar</string>
     <string name="developer_options_root_base_check_label">Basisprüfung</string>
-    <string name="developer_options_shizuku_test_action">Shizuku testen</string>
+    <string name="developer_options_shizuku_test_action">ADB-Zugriff testen</string>
     <string name="developer_options_shizuku_installed_label">Installiert</string>
     <string name="developer_options_shizuku_granted_label">Berechtigung</string>
     <string name="developer_options_shizuku_compatible_label">Kompatibel</string>

--- a/app-workspace-developer/src/main/res/values/strings.xml
+++ b/app-workspace-developer/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="developer_options_root_installed_label">Installed</string>
     <string name="developer_options_root_available_label">Available</string>
     <string name="developer_options_root_base_check_label">Base check</string>
-    <string name="developer_options_shizuku_test_action">Test Shizuku</string>
+    <string name="developer_options_shizuku_test_action">Test ADB access</string>
     <string name="developer_options_shizuku_installed_label">Installed</string>
     <string name="developer_options_shizuku_granted_label">Permission</string>
     <string name="developer_options_shizuku_compatible_label">Compatible</string>

--- a/app-workspace-explorer/src/main/res/values-de/strings.xml
+++ b/app-workspace-explorer/src/main/res/values-de/strings.xml
@@ -559,9 +559,9 @@
 
     <!-- Permission Request Card Explanations -->
     <string name="explorer_permission_saf_workaround_description">Android beschränkt den Zugriff auf diesen Ordner. Verwende die Ordnerauswahl, um Zugriff zu gewähren.</string>
-    <string name="explorer_permission_multiple_options_description">Du kannst mit der Android-Ordnerauswahl Zugriff gewähren oder Root/Shizuku einrichten, um schneller auf alle geschützten Ordner zuzugreifen.</string>
-    <string name="explorer_permission_setup_both_description">Dieser Ordner erfordert erweiterten Zugriff. Installiere und konfiguriere entweder Root oder Shizuku in der Einrichtung.</string>
-    <string name="explorer_permission_setup_shizuku_description">Dieser Ordner erfordert erweiterten Zugriff über Shizuku. Installiere den Shizuku Manager und konfiguriere ihn in der Einrichtung.</string>
+    <string name="explorer_permission_multiple_options_description">Du kannst mit der Android-Ordnerauswahl Zugriff gewähren oder Root-Zugriff bzw. ADB-Zugriff einrichten, um schneller auf alle geschützten Ordner zuzugreifen.</string>
+    <string name="explorer_permission_setup_both_description">Dieser Ordner erfordert erweiterten Zugriff. Richte Root-Zugriff oder ADB-Zugriff in der Einrichtung ein.</string>
+    <string name="explorer_permission_setup_shizuku_description">Dieser Ordner erfordert erweiterten Zugriff über ADB. Konfiguriere ADB-Zugriff in der Einrichtung.</string>
     <string name="explorer_permission_setup_root_description">Dieser Ordner erfordert Root-Zugriff. Konfiguriere Root in der Einrichtung, wenn Dein Gerät gerootet ist.</string>
 
     <string name="explorer_permission_option_picker_title">Storage Access Framework</string>
@@ -569,7 +569,7 @@
     <string name="explorer_permission_option_picker_action">SAF-Auswahl öffnen</string>
 
     <string name="explorer_permission_option_setup_title">Vollzugriff</string>
-    <string name="explorer_permission_option_setup_description">Root oder Shizuku für schnelleren Zugriff auf alle geschützten Ordner konfigurieren.</string>
+    <string name="explorer_permission_option_setup_description">Root-Zugriff oder ADB-Zugriff für schnelleren Zugriff auf alle geschützten Ordner konfigurieren.</string>
     <string name="explorer_permission_option_setup_action">Konfigurieren</string>
 
     <!-- Permission Request Card - Storage Access Option -->

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -601,9 +601,9 @@
 
     <!-- Permission Request Card Explanations -->
     <string name="explorer_permission_saf_workaround_description">Android restricts access to this folder. Use the folder picker to grant access.</string>
-    <string name="explorer_permission_multiple_options_description">You can grant access using Android\'s folder picker or set up Root/Shizuku for faster access to all restricted folders.</string>
-    <string name="explorer_permission_setup_both_description">This folder requires elevated access. Install and configure either Root or Shizuku in setup.</string>
-    <string name="explorer_permission_setup_shizuku_description">This folder requires elevated access via Shizuku. Install Shizuku Manager and configure in setup.</string>
+    <string name="explorer_permission_multiple_options_description">You can grant access using Android\'s folder picker or set up root or ADB access for faster access to all restricted folders.</string>
+    <string name="explorer_permission_setup_both_description">This folder requires elevated access. Set up root or ADB access in setup.</string>
+    <string name="explorer_permission_setup_shizuku_description">This folder requires elevated access via ADB. Configure ADB access in setup.</string>
     <string name="explorer_permission_setup_root_description">This folder requires Root access. Configure Root in setup if your device is rooted.</string>
 
     <string name="explorer_permission_option_picker_title">Storage Access Framework</string>
@@ -611,7 +611,7 @@
     <string name="explorer_permission_option_picker_action">Open SAF picker</string>
 
     <string name="explorer_permission_option_setup_title">Full access</string>
-    <string name="explorer_permission_option_setup_description">Configure Root or Shizuku for faster access to all restricted folders.</string>
+    <string name="explorer_permission_option_setup_description">Configure root or ADB access for faster access to all restricted folders.</string>
     <string name="explorer_permission_option_setup_action">Configure</string>
 
     <!-- Permission Request Card - Storage Access Option -->

--- a/app/src/foss/java/eu/darken/butler/setup/core/shizuku/AdbManagerInstallGuideModule.kt
+++ b/app/src/foss/java/eu/darken/butler/setup/core/shizuku/AdbManagerInstallGuideModule.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.setup.core.shizuku
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import eu.darken.butler.R
+import javax.inject.Singleton
+
+object PorterInstallGuide : AdbManagerInstallGuide {
+    override val labelRes: Int = R.string.setup_adb_install_manager_porter_label
+    override val url: String = "https://porter.darken.eu/setup"
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AdbManagerInstallGuideModule {
+
+    @Provides
+    @Singleton
+    fun guide(): AdbManagerInstallGuide = PorterInstallGuide
+}

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -31,4 +31,6 @@
     <!-- Lines starting with "•" (or "-") render as checkmarked feature rows; lines without a marker
          render as plain footnote text. Keep the markers. -->
     <string name="upgrade_screen_benefits_body">• Unlimited tabs and operations\n• Customize design, feel and look\n• Extra options and features for each tool\n• Early access to new features\n• A motivated developer 🧙\nand more…</string>
+
+    <string name="setup_adb_install_manager_porter_label" translatable="false">Porter</string>
 </resources>

--- a/app/src/gplay/java/eu/darken/butler/setup/core/shizuku/AdbManagerInstallGuideModule.kt
+++ b/app/src/gplay/java/eu/darken/butler/setup/core/shizuku/AdbManagerInstallGuideModule.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.setup.core.shizuku
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import eu.darken.butler.R
+import javax.inject.Singleton
+
+object ShizukuInstallGuide : AdbManagerInstallGuide {
+    override val labelRes: Int = R.string.setup_adb_install_manager_shizuku_label
+    override val url: String = "https://play.google.com/store/apps/details?id=moe.shizuku.privileged.api"
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AdbManagerInstallGuideModule {
+
+    @Provides
+    @Singleton
+    fun guide(): AdbManagerInstallGuide = ShizukuInstallGuide
+}

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -88,4 +88,6 @@
     <!-- Lines starting with "•" (or "-") render as checkmarked feature rows; lines without a marker
          render as plain footnote text. Keep the markers. -->
     <string name="upgrade_screen_benefits_body">• Unlimited tabs and operations\n• Customize design, feel and look\n• Extra options and features for each tool\n• Early access to new features\n• A motivated developer 🧙\nand more…</string>
+
+    <string name="setup_adb_install_manager_shizuku_label" translatable="false">Shizuku</string>
 </resources>

--- a/app/src/main/java/eu/darken/butler/main/ui/settings/acknowledgements/AcknowledgementsScreen.kt
+++ b/app/src/main/java/eu/darken/butler/main/ui/settings/acknowledgements/AcknowledgementsScreen.kt
@@ -156,6 +156,15 @@ fun AcknowledgementsScreen(
 
             item {
                 SettingsBaseItem(
+                    title = stringResource(R.string.acknowledgement_porter_title),
+                    subtitle = stringResource(R.string.acknowledgement_porter_subtitle),
+                    onClick = { onOpenUrl("https://github.com/d4rken-org/porter") }
+                )
+                SettingsDivider()
+            }
+
+            item {
+                SettingsBaseItem(
                     title = stringResource(R.string.acknowledgement_shizuku_title),
                     subtitle = stringResource(R.string.acknowledgement_shizuku_subtitle),
                     onClick = { onOpenUrl("https://github.com/RikkaApps/Shizuku") }

--- a/app/src/main/java/eu/darken/butler/setup/core/SetupManager.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/SetupManager.kt
@@ -1,14 +1,21 @@
 package eu.darken.butler.setup.core
 
+import android.content.Context
 import android.content.Intent
+import androidx.core.net.toUri
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.butler.common.coroutine.AppScope
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.getLaunchIntent
+import eu.darken.butler.common.pkgs.getSettingsIntent
 import eu.darken.butler.setup.core.inventory.InventorySetupModule
 import eu.darken.butler.setup.core.notification.NotificationSetupModule
 import eu.darken.butler.setup.core.root.RootSetupModule
+import eu.darken.butler.setup.core.shizuku.AdbManagerInstallGuide
 import eu.darken.butler.setup.core.shizuku.ShizukuSetupModule
 import eu.darken.butler.setup.core.storage.StorageSetupModule
 import eu.darken.butler.setup.core.usagestats.UsageStatsSetupModule
@@ -30,7 +37,9 @@ import kotlin.time.Instant
 
 @Singleton
 class SetupManager @Inject constructor(
+    @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
+    private val adbManagerInstallGuide: AdbManagerInstallGuide,
     setupModules: Set<@JvmSuppressWildcards SetupModule>,
 ) {
     private val modulesByType: Map<SetupModule.Type, SetupModule> = setupModules.associateBy { it.type }
@@ -134,6 +143,16 @@ class SetupManager @Inject constructor(
                 shizukuModule?.toggleUseShizuku(action.useShizuku)
                     ?: log(TAG, WARN) { "Module for $type is not a ShizukuSetupModule" }
             }
+            is SetupAction.OpenAdbManager -> {
+                // Not every manager exports a launcher entry; its app info page is still somewhere
+                // the user can act.
+                val intent = action.pkgId.getLaunchIntent(context) ?: action.pkgId.getSettingsIntent(context)
+                return PermissionResult(intent = intent)
+            }
+            SetupAction.InstallAdbManager -> {
+                val intent = Intent(Intent.ACTION_VIEW, adbManagerInstallGuide.url.toUri())
+                return PermissionResult(intent = intent)
+            }
         }
         return null
     }
@@ -151,6 +170,8 @@ sealed interface SetupAction {
     data object RequestPermission : SetupAction
     data class ToggleRoot(val useRoot: Boolean?) : SetupAction
     data class ToggleShizuku(val useShizuku: Boolean?) : SetupAction
+    data class OpenAdbManager(val pkgId: Pkg.Id) : SetupAction
+    data object InstallAdbManager : SetupAction
 }
 
 data class PermissionResult(

--- a/app/src/main/java/eu/darken/butler/setup/core/shizuku/AdbManagerInstallGuide.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/shizuku/AdbManagerInstallGuide.kt
@@ -1,0 +1,16 @@
+package eu.darken.butler.setup.core.shizuku
+
+import androidx.annotation.StringRes
+
+/**
+ * Where a user without any ADB access manager is sent to get one.
+ *
+ * Flavor bound: the FOSS build cannot point at Google Play, the Play build cannot point users at a
+ * sideload page.
+ */
+interface AdbManagerInstallGuide {
+    /** Name of the manager app this flavor recommends. */
+    @get:StringRes val labelRes: Int
+
+    val url: String
+}

--- a/app/src/main/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModule.kt
@@ -1,8 +1,10 @@
 package eu.darken.butler.setup.core.shizuku
 
+import android.content.Context
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.butler.common.adb.AdbSettings
@@ -18,6 +20,7 @@ import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.flow.replayingShare
 import eu.darken.butler.common.pkgs.Pkg
+import eu.darken.butler.common.pkgs.getLabel2
 import eu.darken.butler.common.rngString
 import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.setup.core.SetupModule
@@ -43,6 +46,7 @@ import kotlin.time.Instant
 
 @Singleton
 class ShizukuSetupModule @Inject constructor(
+    @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val adbSettings: AdbSettings,
@@ -95,9 +99,11 @@ class ShizukuSetupModule @Inject constructor(
     ) { _, useShizuku, useRoot ->
         val managerId = shizukuManager.getManagerId()
         val baseState = Result(
-            pkg = managerId ?: shizukuManager.shizukuPkgId,
+            pkg = managerId ?: shizukuManager.defaultManagerPkgId,
             useShizuku = useShizuku,
             isInstalled = managerId != null,
+            managerLabel = managerId?.let { context.packageManager.getLabel2(it) },
+            otherManagerInstalled = managerId == null && shizukuManager.installedManagerIds().isNotEmpty(),
             isCompatible = shizukuManager.isCompatible(),
             alsoHasRoot = useRoot,
         )
@@ -184,6 +190,15 @@ class ShizukuSetupModule @Inject constructor(
         val useShizuku: Boolean?,
         val isCompatible: Boolean = false,
         override val isInstalled: Boolean = false,
+        /** Display name of [pkg], null while no manager is installed. */
+        val managerLabel: String? = null,
+        /**
+         * No manager for the backend we connect through, but one for the other backend is installed.
+         *
+         * The backend is resolved once per process, so this state only clears on a restart: nothing
+         * the user does inside the app can make it go away.
+         */
+        val otherManagerInstalled: Boolean = false,
         val basicService: Boolean = false,
         val serviceState: ShizukuServiceState = ShizukuServiceState.NotChecked,
         val alsoHasRoot: Boolean = false,

--- a/app/src/main/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.butler.common.adb.AdbSettings
+import eu.darken.butler.common.adb.shizuku.AdbBackend
 import eu.darken.butler.common.adb.shizuku.ShizukuBaseServiceBinder
 import eu.darken.butler.common.adb.shizuku.ShizukuManager
 import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
@@ -16,14 +17,17 @@ import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.coroutine.runDetachedWithTimeout
 import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.logging.Logging.Priority.WARN
+import eu.darken.butler.common.debug.logging.asLog
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.flow.replayingShare
 import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.getLabel2
+import eu.darken.butler.common.pkgs.getLaunchIntent
 import eu.darken.butler.common.rngString
 import eu.darken.butler.common.root.RootManager
 import eu.darken.butler.setup.core.SetupModule
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -38,6 +42,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -98,12 +103,28 @@ class ShizukuSetupModule @Inject constructor(
         rootManager.useRoot,
     ) { _, useShizuku, useRoot ->
         val managerId = shizukuManager.getManagerId()
+        // The open action launches this package. The detected manager can be Shizuku+'s Compat Hub,
+        // which owns the stock permission but has no launcher activity, so prefer the first manager
+        // of the same family that can actually be opened. Stays inside the active backend: opening
+        // the other family's manager cannot affect the link we are waiting on.
+        val openable = managerId?.let {
+            withContext(dispatcherProvider.IO) {
+                shizukuManager.activeManagerIds().firstOrNull { pkg -> pkg.getLaunchIntent(context) != null }
+            }
+        }
+        val restartRequiredFor = when (managerId) {
+            null -> shizukuManager.inactiveFamilyManagerId()
+            else -> null
+        }
+        val pkg = openable ?: managerId ?: shizukuManager.referenceManagerId()
         val baseState = Result(
-            pkg = managerId ?: shizukuManager.defaultManagerPkgId,
+            pkg = pkg,
             useShizuku = useShizuku,
             isInstalled = managerId != null,
-            managerLabel = managerId?.let { context.packageManager.getLabel2(it) },
-            otherManagerInstalled = managerId == null && shizukuManager.installedManagerIds().isNotEmpty(),
+            managerLabel = if (managerId != null) labelOf(pkg) else null,
+            backend = shizukuManager.activeBackend(),
+            restartRequiredFor = restartRequiredFor,
+            restartRequiredLabel = labelOf(restartRequiredFor),
             isCompatible = shizukuManager.isCompatible(),
             alsoHasRoot = useRoot,
         )
@@ -138,6 +159,22 @@ class ShizukuSetupModule @Inject constructor(
         }
         .onEach { log(TAG) { "New Shizuku setup state: $it" } }
         .replayingShare(appScope)
+
+    // Runs outside the probe's catch below, so it must not throw: getPackageInfo2 only converts
+    // NameNotFoundException, and anything else (a PackageManager binder death, a vendor
+    // SecurityException) would kill the sharing coroutine and take every later subscriber with it.
+    private suspend fun labelOf(pkgId: Pkg.Id?): String? = pkgId?.let {
+        withContext(dispatcherProvider.IO) {
+            try {
+                context.packageManager.getLabel2(it)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "labelOf($it) failed: ${e.asLog()}" }
+                null
+            }
+        }
+    }
 
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
@@ -192,13 +229,16 @@ class ShizukuSetupModule @Inject constructor(
         override val isInstalled: Boolean = false,
         /** Display name of [pkg], null while no manager is installed. */
         val managerLabel: String? = null,
+        val backend: AdbBackend = AdbBackend.SHIZUKU,
         /**
-         * No manager for the backend we connect through, but one for the other backend is installed.
+         * An installed manager of the OTHER family, unreachable until the app is fully restarted.
          *
          * The backend is resolved once per process, so this state only clears on a restart: nothing
-         * the user does inside the app can make it go away.
+         * the user does inside the app can make it go away. Null in every other case.
          */
-        val otherManagerInstalled: Boolean = false,
+        val restartRequiredFor: Pkg.Id? = null,
+        /** What [restartRequiredFor] calls itself; callers fall back to [backend]'s other label. */
+        val restartRequiredLabel: String? = null,
         val basicService: Boolean = false,
         val serviceState: ShizukuServiceState = ShizukuServiceState.NotChecked,
         val alsoHasRoot: Boolean = false,
@@ -206,6 +246,9 @@ class ShizukuSetupModule @Inject constructor(
 
         val ourService: Boolean
             get() = serviceState is ShizukuServiceState.Available
+
+        val otherManagerInstalled: Boolean
+            get() = restartRequiredFor != null
 
         override val type: SetupModule.Type = SetupModule.Type.SHIZUKU
 

--- a/app/src/main/java/eu/darken/butler/setup/ui/SetupScreen.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/SetupScreen.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.setup.ui
 
+import android.content.ActivityNotFoundException
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -38,6 +39,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.darken.butler.R
+import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.log
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.error.ErrorEventHandler
@@ -148,7 +150,18 @@ fun SetupScreenHost(
         vm.permissionRequestEvents.collect { intent ->
             log(TAG) { "Launching permission settings intent" }
             isPermissionSettingsLaunched = true
-            context.startActivity(intent)
+            try {
+                context.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                log(TAG, ERROR) { "No activity to handle $intent" }
+                isPermissionSettingsLaunched = false
+                vm.onPermissionIntentFailed(e)
+            } catch (e: SecurityException) {
+                // A handler that matched the intent can still refuse to be started by us.
+                log(TAG, ERROR) { "Failed to launch $intent due to $e" }
+                isPermissionSettingsLaunched = false
+                vm.onPermissionIntentFailed(e)
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/butler/setup/ui/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/SetupViewModel.kt
@@ -113,6 +113,10 @@ class SetupViewModel @AssistedInject constructor(
         }
     }
 
+    fun onPermissionIntentFailed(error: Throwable) {
+        errorEvents.tryEmit(error)
+    }
+
     fun openHelp(type: SetupModule.Type) = launch {
         log(tag) { "openHelp(type=$type)" }
         val helpUrl = getHelpUrl(type)

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -6,26 +6,43 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Download
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import eu.darken.butler.R
 import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.pkgs.getIcon2
+import eu.darken.butler.common.pkgs.getLabel2
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.setup.core.SetupAction
 import eu.darken.butler.setup.core.SetupItem
 import eu.darken.butler.setup.core.SetupModule
 import eu.darken.butler.setup.core.root.RootServiceState
 import eu.darken.butler.setup.core.root.RootSetupModule
+import eu.darken.butler.setup.core.shizuku.AdbManagerInstallGuide
 import eu.darken.butler.setup.core.shizuku.ShizukuSetupModule
 
 @Composable
@@ -35,6 +52,7 @@ fun RootShizukuActions(
     switchLabel: String
 ) {
     val state = item.state as? SetupModule.State.Current
+    val shizukuState = state as? ShizukuSetupModule.Result
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -53,8 +71,13 @@ fun RootShizukuActions(
                 }
             }
             SetupModule.Type.SHIZUKU -> {
-                val shizukuState = state as? ShizukuSetupModule.Result
                 when {
+                    // Ahead of the useShizuku guard on purpose: the setting defaults to null, so
+                    // someone who installs a manager before ever touching the switch is exactly who
+                    // needs to be told a restart is what makes it count.
+                    shizukuState?.otherManagerInstalled == true ->
+                        stringResource(R.string.setup_adb_restart_required)
+
                     shizukuState?.useShizuku != true -> null
                     !shizukuState.isInstalled -> stringResource(R.string.setup_status_not_installed)
                     !shizukuState.isCompatible -> stringResource(R.string.setup_status_unavailable)
@@ -99,6 +122,18 @@ fun RootShizukuActions(
             }
         }
 
+        // Enabled but not connected is a dead end without a way into the manager app. The restart
+        // hint is the exception: the installed manager stays out of reach until the process restarts,
+        // so neither opening nor installing anything is the remedy.
+        if (shizukuState?.useShizuku == true && !shizukuState.ourService && !shizukuState.otherManagerInstalled) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            AdbManagerAction(
+                state = shizukuState,
+                onExecuteAction = onExecuteAction,
+            )
+        }
+
         Spacer(modifier = Modifier.height(12.dp))
 
         // Switch
@@ -137,6 +172,69 @@ fun RootShizukuActions(
             )
         }
     }
+}
+
+@Composable
+private fun AdbManagerAction(
+    modifier: Modifier = Modifier,
+    state: ShizukuSetupModule.Result,
+    onExecuteAction: (SetupAction) -> Unit,
+) {
+    val context = LocalContext.current
+
+    if (state.isInstalled) {
+        val label = state.managerLabel
+            // Not every Result is built with a package manager behind it.
+            ?: remember(state.pkg) { context.packageManager.getLabel2(state.pkg) }
+            ?: state.pkg.name
+
+        OutlinedButton(
+            modifier = modifier,
+            onClick = { onExecuteAction(SetupAction.OpenAdbManager(state.pkg)) },
+        ) {
+            AsyncImage(
+                model = remember(state.pkg) { context.packageManager.getIcon2(state.pkg) },
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
+            )
+            Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
+            Text(text = stringResource(R.string.setup_adb_open_manager_action, label))
+        }
+    } else {
+        val guide = rememberAdbManagerInstallGuide()
+        val label = guide?.let { stringResource(it.labelRes) } ?: state.pkg.name
+
+        OutlinedButton(
+            modifier = modifier,
+            onClick = { onExecuteAction(SetupAction.InstallAdbManager) },
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Download,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
+            )
+            Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
+            Text(text = stringResource(R.string.setup_adb_install_manager_action, label))
+        }
+    }
+}
+
+@Composable
+private fun rememberAdbManagerInstallGuide(): AdbManagerInstallGuide? {
+    val context = LocalContext.current
+    return remember(context) {
+        runCatching {
+            EntryPointAccessors
+                .fromApplication(context.applicationContext, AdbManagerInstallGuideEntryPoint::class.java)
+                .adbManagerInstallGuide()
+        }.getOrNull()
+    }
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+internal interface AdbManagerInstallGuideEntryPoint {
+    fun adbManagerInstallGuide(): AdbManagerInstallGuide
 }
 
 @Preview2
@@ -233,6 +331,7 @@ private fun ShizukuActionsNotConnectedPreview() {
                 useShizuku = true,
                 isCompatible = true,
                 isInstalled = true,
+                managerLabel = "Shizuku",
                 basicService = false,
                 serviceState = ShizukuServiceState.NotChecked,
                 alsoHasRoot = false,
@@ -257,6 +356,7 @@ private fun ShizukuActionsConnectionFailedPreview() {
                 useShizuku = true,
                 isCompatible = true,
                 isInstalled = true,
+                managerLabel = "Shizuku",
                 // Shizuku answers, but our user service never came up.
                 basicService = true,
                 serviceState = ShizukuServiceState.TimedOut,
@@ -267,5 +367,65 @@ private fun ShizukuActionsConnectionFailedPreview() {
         ),
         onExecuteAction = {},
         switchLabel = "Use Shizuku"
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ShizukuActionsRestartRequiredUnsetPreview() = ShizukuRestartRequiredPreview(useShizuku = null)
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ShizukuActionsRestartRequiredDisabledPreview() = ShizukuRestartRequiredPreview(useShizuku = false)
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ShizukuActionsRestartRequiredEnabledPreview() = ShizukuRestartRequiredPreview(useShizuku = true)
+
+@Composable
+private fun ShizukuRestartRequiredPreview(useShizuku: Boolean?) {
+    RootShizukuActions(
+        item = SetupItem(
+            type = SetupModule.Type.SHIZUKU,
+            state = ShizukuSetupModule.Result(
+                pkg = "eu.darken.porter".toPkgId(),
+                useShizuku = useShizuku,
+                isCompatible = true,
+                // The manager on the device belongs to the backend this process did not latch onto.
+                isInstalled = false,
+                otherManagerInstalled = true,
+                alsoHasRoot = false,
+            ),
+            isRequired = false,
+            priority = 6,
+        ),
+        onExecuteAction = {},
+        switchLabel = "Use ADB access",
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ShizukuActionsNoManagerPreview() {
+    RootShizukuActions(
+        item = SetupItem(
+            type = SetupModule.Type.SHIZUKU,
+            state = ShizukuSetupModule.Result(
+                pkg = "eu.darken.porter".toPkgId(),
+                useShizuku = true,
+                isCompatible = true,
+                isInstalled = false,
+                serviceState = ShizukuServiceState.NotChecked,
+                alsoHasRoot = false,
+            ),
+            isRequired = false,
+            priority = 6,
+        ),
+        onExecuteAction = {},
+        switchLabel = "Use ADB access",
     )
 }

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -77,8 +77,10 @@ fun RootShizukuActions(
                     // Ahead of the useShizuku guard on purpose: the setting defaults to null, so
                     // someone who installs a manager before ever touching the switch is exactly who
                     // needs to be told a restart is what makes it count.
-                    shizukuState?.otherManagerInstalled == true ->
-                        stringResource(R.string.setup_adb_restart_required)
+                    shizukuState?.otherManagerInstalled == true -> stringResource(
+                        R.string.setup_adb_restart_required,
+                        shizukuState.restartRequiredLabel ?: shizukuState.backend.other.label,
+                    )
 
                     shizukuState?.useShizuku != true -> null
                     !shizukuState.isInstalled -> stringResource(R.string.setup_status_not_installed)
@@ -181,14 +183,22 @@ fun RootShizukuActions(
     }
 }
 
-/** Display name of the manager backing [state], null while none is installed. */
+/**
+ * Display name of the manager backing [state], null while none is installed.
+ *
+ * The module resolves this already; the lookup here only covers a Result built without one behind
+ * it (previews, tests). Guarded because it runs on the UI thread and PackageManager can fail with
+ * more than the missing-package case that [getLabel2] already absorbs.
+ */
 @Composable
 private fun rememberManagerLabel(state: ShizukuSetupModule.Result?): String? {
     val context = LocalContext.current
     val installed = state?.takeIf { it.isInstalled }
     val pkg = installed?.pkg
-    val resolved = remember(pkg) { pkg?.let { context.packageManager.getLabel2(it) } }
-    // Not every Result is built with a package manager behind it.
+    val needsLookup = installed != null && installed.managerLabel == null
+    val resolved = remember(pkg, needsLookup) {
+        if (needsLookup) runCatching { context.packageManager.getLabel2(pkg!!) }.getOrNull() else null
+    }
     return installed?.managerLabel ?: resolved ?: pkg?.name
 }
 
@@ -207,7 +217,10 @@ private fun AdbManagerAction(
             onClick = { onExecuteAction(SetupAction.OpenAdbManager(state.pkg)) },
         ) {
             AsyncImage(
-                model = remember(state.pkg) { context.packageManager.getIcon2(state.pkg) },
+                // Same guard as the label: a failed icon load is missing artwork, not a dead card.
+                model = remember(state.pkg) {
+                    runCatching { context.packageManager.getIcon2(state.pkg) }.getOrNull()
+                },
                 contentDescription = null,
                 modifier = Modifier.size(ButtonDefaults.IconSize),
             )
@@ -435,7 +448,8 @@ private fun ShizukuRestartRequiredPreview(useShizuku: Boolean?) {
                 isCompatible = true,
                 // The manager on the device belongs to the backend this process did not latch onto.
                 isInstalled = false,
-                otherManagerInstalled = true,
+                restartRequiredFor = "moe.shizuku.privileged.api".toPkgId(),
+                restartRequiredLabel = "Shizuku",
                 alsoHasRoot = false,
             ),
             isRequired = false,

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dagger.hilt.EntryPoint
@@ -35,7 +34,6 @@ import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
-import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.getIcon2
 import eu.darken.butler.common.pkgs.getLabel2
 import eu.darken.butler.common.pkgs.toPkgId
@@ -122,20 +120,11 @@ fun RootShizukuActions(
                 )
 
                 connectionStatus?.let { status ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        if (shizukuState?.ourService == true && shizukuState.isInstalled) {
-                            ManagerIcon(pkg = shizukuState.pkg, size = 18.dp)
-                        }
-
-                        Text(
-                            text = status,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                        )
-                    }
+                    Text(
+                        text = status,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
                 }
             }
         }
@@ -204,32 +193,24 @@ private fun rememberManagerLabel(state: ShizukuSetupModule.Result?): String? {
 }
 
 @Composable
-private fun ManagerIcon(
-    modifier: Modifier = Modifier,
-    pkg: Pkg.Id,
-    size: Dp,
-) {
-    val context = LocalContext.current
-    AsyncImage(
-        model = remember(pkg) { context.packageManager.getIcon2(pkg) },
-        contentDescription = null,
-        modifier = modifier.size(size),
-    )
-}
-
-@Composable
 private fun AdbManagerAction(
     modifier: Modifier = Modifier,
     state: ShizukuSetupModule.Result,
     label: String?,
     onExecuteAction: (SetupAction) -> Unit,
 ) {
+    val context = LocalContext.current
+
     if (state.isInstalled) {
         OutlinedButton(
             modifier = modifier,
             onClick = { onExecuteAction(SetupAction.OpenAdbManager(state.pkg)) },
         ) {
-            ManagerIcon(pkg = state.pkg, size = ButtonDefaults.IconSize)
+            AsyncImage(
+                model = remember(state.pkg) { context.packageManager.getIcon2(state.pkg) },
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
+            )
             Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
             Text(text = stringResource(R.string.setup_adb_open_manager_action, label ?: state.pkg.name))
         }

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dagger.hilt.EntryPoint
@@ -34,6 +35,7 @@ import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.pkgs.Pkg
 import eu.darken.butler.common.pkgs.getIcon2
 import eu.darken.butler.common.pkgs.getLabel2
 import eu.darken.butler.common.pkgs.toPkgId
@@ -58,6 +60,8 @@ fun RootShizukuActions(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        val managerLabel = rememberManagerLabel(shizukuState)
+
         // Connection status for Root/Shizuku
         val connectionStatus = when (item.type) {
             SetupModule.Type.ROOT -> {
@@ -81,7 +85,12 @@ fun RootShizukuActions(
                     shizukuState?.useShizuku != true -> null
                     !shizukuState.isInstalled -> stringResource(R.string.setup_status_not_installed)
                     !shizukuState.isCompatible -> stringResource(R.string.setup_status_unavailable)
-                    shizukuState.ourService -> stringResource(R.string.setup_status_connected)
+                    // Two managers can be installed at once and only one of them is ever bound, so
+                    // "Connected" alone leaves the user unable to tell which. Falls back to the bare
+                    // wording when the label is missing, which is the Root card's case too.
+                    shizukuState.ourService -> managerLabel?.let {
+                        stringResource(R.string.setup_adb_status_connected_via, it)
+                    } ?: stringResource(R.string.setup_status_connected)
                     // Ahead of basicService: Shizuku itself answering says nothing about our service,
                     // and reporting "Connecting…" for a probe that already gave up is what left this
                     // card spinning forever.
@@ -113,23 +122,32 @@ fun RootShizukuActions(
                 )
 
                 connectionStatus?.let { status ->
-                    Text(
-                        text = status,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        if (shizukuState?.ourService == true && shizukuState.isInstalled) {
+                            ManagerIcon(pkg = shizukuState.pkg, size = 18.dp)
+                        }
+
+                        Text(
+                            text = status,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                        )
+                    }
                 }
             }
         }
 
-        // Enabled but not connected is a dead end without a way into the manager app. The restart
-        // hint is the exception: the installed manager stays out of reach until the process restarts,
-        // so neither opening nor installing anything is the remedy.
-        if (shizukuState?.useShizuku == true && !shizukuState.ourService && !shizukuState.otherManagerInstalled) {
+        // The restart hint is the one enabled state without an action: the installed manager stays out
+        // of reach until the process restarts, so neither opening nor installing anything is a remedy.
+        if (shizukuState?.useShizuku == true && !shizukuState.otherManagerInstalled) {
             Spacer(modifier = Modifier.height(12.dp))
 
             AdbManagerAction(
                 state = shizukuState,
+                label = managerLabel,
                 onExecuteAction = onExecuteAction,
             )
         }
@@ -174,31 +192,46 @@ fun RootShizukuActions(
     }
 }
 
+/** Display name of the manager backing [state], null while none is installed. */
+@Composable
+private fun rememberManagerLabel(state: ShizukuSetupModule.Result?): String? {
+    val context = LocalContext.current
+    val installed = state?.takeIf { it.isInstalled }
+    val pkg = installed?.pkg
+    val resolved = remember(pkg) { pkg?.let { context.packageManager.getLabel2(it) } }
+    // Not every Result is built with a package manager behind it.
+    return installed?.managerLabel ?: resolved ?: pkg?.name
+}
+
+@Composable
+private fun ManagerIcon(
+    modifier: Modifier = Modifier,
+    pkg: Pkg.Id,
+    size: Dp,
+) {
+    val context = LocalContext.current
+    AsyncImage(
+        model = remember(pkg) { context.packageManager.getIcon2(pkg) },
+        contentDescription = null,
+        modifier = modifier.size(size),
+    )
+}
+
 @Composable
 private fun AdbManagerAction(
     modifier: Modifier = Modifier,
     state: ShizukuSetupModule.Result,
+    label: String?,
     onExecuteAction: (SetupAction) -> Unit,
 ) {
-    val context = LocalContext.current
-
     if (state.isInstalled) {
-        val label = state.managerLabel
-            // Not every Result is built with a package manager behind it.
-            ?: remember(state.pkg) { context.packageManager.getLabel2(state.pkg) }
-            ?: state.pkg.name
-
         OutlinedButton(
             modifier = modifier,
             onClick = { onExecuteAction(SetupAction.OpenAdbManager(state.pkg)) },
         ) {
-            AsyncImage(
-                model = remember(state.pkg) { context.packageManager.getIcon2(state.pkg) },
-                contentDescription = null,
-                modifier = Modifier.size(ButtonDefaults.IconSize),
-            )
+            ManagerIcon(pkg = state.pkg, size = ButtonDefaults.IconSize)
             Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
-            Text(text = stringResource(R.string.setup_adb_open_manager_action, label))
+            Text(text = stringResource(R.string.setup_adb_open_manager_action, label ?: state.pkg.name))
         }
     } else {
         val guide = rememberAdbManagerInstallGuide()
@@ -341,6 +374,31 @@ private fun ShizukuActionsNotConnectedPreview() {
         ),
         onExecuteAction = {},
         switchLabel = "Use Shizuku"
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ShizukuActionsConnectedPreview() {
+    RootShizukuActions(
+        item = SetupItem(
+            type = SetupModule.Type.SHIZUKU,
+            state = ShizukuSetupModule.Result(
+                pkg = "eu.darken.porter".toPkgId(),
+                useShizuku = true,
+                isCompatible = true,
+                isInstalled = true,
+                managerLabel = "Porter",
+                basicService = true,
+                serviceState = ShizukuServiceState.Available,
+                alsoHasRoot = false,
+            ),
+            isRequired = false,
+            priority = 6,
+        ),
+        onExecuteAction = {},
+        switchLabel = "Use ADB access",
     )
 }
 

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -35,7 +35,6 @@ import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.pkgs.container.toStub
-import eu.darken.butler.common.pkgs.getLabel2
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.setup.core.SetupAction
 import eu.darken.butler.setup.core.SetupItem
@@ -58,7 +57,7 @@ fun RootShizukuActions(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val managerLabel = rememberManagerLabel(shizukuState)
+        val managerLabel = shizukuState?.managerName
 
         // Connection status for Root/Shizuku
         val connectionStatus = when (item.type) {
@@ -186,21 +185,12 @@ fun RootShizukuActions(
 /**
  * Display name of the manager backing [state], null while none is installed.
  *
- * The module resolves this already; the lookup here only covers a Result built without one behind
- * it (previews, tests). Guarded because it runs on the UI thread and PackageManager can fail with
- * more than the missing-package case that [getLabel2] already absorbs.
+ * Resolution belongs to the module, which does it off the UI thread and absorbs a failing lookup.
+ * All that is left here is the backend's product name for when it came back with nothing: a package
+ * id is not a name to show anybody.
  */
-@Composable
-private fun rememberManagerLabel(state: ShizukuSetupModule.Result?): String? {
-    val context = LocalContext.current
-    val installed = state?.takeIf { it.isInstalled }
-    val pkg = installed?.pkg
-    val needsLookup = installed != null && installed.managerLabel == null
-    val resolved = remember(pkg, needsLookup) {
-        if (needsLookup) runCatching { context.packageManager.getLabel2(pkg!!) }.getOrNull() else null
-    }
-    return installed?.managerLabel ?: resolved ?: pkg?.name
-}
+private val ShizukuSetupModule.Result.managerName: String?
+    get() = takeIf { it.isInstalled }?.let { it.managerLabel ?: it.backend.label }
 
 @Composable
 private fun AdbManagerAction(
@@ -223,11 +213,11 @@ private fun AdbManagerAction(
                 modifier = Modifier.size(ButtonDefaults.IconSize),
             )
             Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
-            Text(text = stringResource(R.string.setup_adb_open_manager_action, label ?: state.pkg.name))
+            Text(text = stringResource(R.string.setup_adb_open_manager_action, label ?: state.backend.label))
         }
     } else {
         val guide = rememberAdbManagerInstallGuide()
-        val label = guide?.let { stringResource(it.labelRes) } ?: state.pkg.name
+        val label = guide?.let { stringResource(it.labelRes) } ?: state.backend.label
 
         OutlinedButton(
             modifier = modifier,

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/RootShizukuActions.kt
@@ -34,7 +34,7 @@ import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
-import eu.darken.butler.common.pkgs.getIcon2
+import eu.darken.butler.common.pkgs.container.toStub
 import eu.darken.butler.common.pkgs.getLabel2
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.setup.core.SetupAction
@@ -209,18 +209,16 @@ private fun AdbManagerAction(
     label: String?,
     onExecuteAction: (SetupAction) -> Unit,
 ) {
-    val context = LocalContext.current
-
     if (state.isInstalled) {
         OutlinedButton(
             modifier = modifier,
             onClick = { onExecuteAction(SetupAction.OpenAdbManager(state.pkg)) },
         ) {
             AsyncImage(
-                // Same guard as the label: a failed icon load is missing artwork, not a dead card.
-                model = remember(state.pkg) {
-                    runCatching { context.packageManager.getIcon2(state.pkg) }.getOrNull()
-                },
+                // Through Coil rather than a PackageManager call in composition: AppIconFetcher does
+                // the lookup off the UI thread behind the IPC funnel and substitutes a default icon
+                // when there is nothing to load.
+                model = remember(state.pkg) { state.pkg.toStub() },
                 contentDescription = null,
                 modifier = Modifier.size(ButtonDefaults.IconSize),
             )

--- a/app/src/main/java/eu/darken/butler/setup/ui/items/SetupHelpers.kt
+++ b/app/src/main/java/eu/darken/butler/setup/ui/items/SetupHelpers.kt
@@ -1,11 +1,12 @@
 package eu.darken.butler.setup.ui.items
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Adb
 import androidx.compose.material.icons.twotone.Inventory
 import androidx.compose.material.icons.twotone.Notifications
-import androidx.compose.material.icons.twotone.Security
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Storage
+import androidx.compose.material.icons.twotone.Tag
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -15,8 +16,8 @@ import eu.darken.butler.R
 import eu.darken.butler.setup.core.SetupModule
 
 fun getSetupIcon(type: SetupModule.Type): ImageVector = when (type) {
-    SetupModule.Type.ROOT -> Icons.TwoTone.Security
-    SetupModule.Type.SHIZUKU -> Icons.TwoTone.Security
+    SetupModule.Type.ROOT -> Icons.TwoTone.Tag
+    SetupModule.Type.SHIZUKU -> Icons.TwoTone.Adb
     SetupModule.Type.NOTIFICATION -> Icons.TwoTone.Notifications
     SetupModule.Type.USAGE_STATS -> Icons.TwoTone.Settings
     SetupModule.Type.STORAGE -> Icons.TwoTone.Storage

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -94,8 +94,8 @@
     <string name="setup_status_connecting">Verbindung wird hergestellt…</string>
     <string name="setup_status_connection_failed">Verbindung fehlgeschlagen</string>
     <string name="setup_status_unavailable">Nicht verfügbar</string>
-    <string name="setup_adb_restart_required">Eine andere App für ADB-Zugriff wurde installiert. Starte Butler neu, um sie zu verwenden.</string>
     <!-- %1$s is the name of the app that provides ADB access, e.g. "Porter" or "Shizuku". -->
+    <string name="setup_adb_restart_required">%1$s ist installiert, aber Butler muss erst vollständig geschlossen und neu geöffnet werden.</string>
     <string name="setup_adb_status_connected_via">Verbunden über %1$s</string>
     <string name="setup_adb_open_manager_action">%1$s öffnen</string>
     <string name="setup_adb_install_manager_action">%1$s installieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,7 +62,7 @@
     <string name="shortcuts_settings_min_dialog_message">Wie oft ein Pfad aufgerufen werden muss, bevor er als Verknüpfung erscheint (1–10)</string>
 
     <string name="setup_usagestats_title">Nutzungsstatistiken</string>
-    <string name="setup_shizuku_card_title">Shizuku</string>
+    <string name="setup_shizuku_card_title">ADB-Zugriff</string>
     <string name="setup_root_card_title">Root</string>
     <string name="setup_notification_title">Benachrichtigungszugriff</string>
     <string name="setup_manage_storage_card_title">Externen Speicher verwalten</string>
@@ -73,7 +73,7 @@
     <string name="setup_help_description">Hilfe</string>
 
     <string name="setup_root_description">Ermöglicht für die erweiterte Dateiverwaltung den Zugriff auf Systemdateien und geschützte Verzeichnisse. Schaltet das volle Potenzial von Butler frei, einschließlich Zugriff auf App-Daten und Systemänderungen. Das Gerät muss gerootet sein.</string>
-    <string name="setup_shizuku_description">Eine Alternative zu Root, die privilegierte Dateivorgänge über eine sichere API ermöglicht. Gewährt ohne klassischen Root-Zugriff Zugriff auf eingeschränkte Verzeichnisse. Die Shizuku-App muss installiert sein und ausgeführt werden.</string>
+    <string name="setup_shizuku_description">Eine Alternative zu Root, die privilegierte Dateivorgänge über eine sichere API ermöglicht. Gewährt ohne klassischen Root-Zugriff Zugriff auf eingeschränkte Verzeichnisse. Porter oder Shizuku muss installiert sein und ausgeführt werden.</string>
     <string name="setup_notification_description">Zeigt Aktualisierungen zu Dateivorgängen, Hintergrundaufgaben und Übertragungsfortschritten. So erfährst Du, wenn Vorgänge abgeschlossen sind oder Fehler auftreten.</string>
     <string name="setup_usagestats_description">Analysiert die Speichernutzung von Apps, um große Dateien zu finden und Speicherplatz effektiv zu verwalten. Alle Daten bleiben auf Deinem Gerät und werden niemals übertragen.</string>
     <string name="setup_storage_description">Vollständiger Zugriff auf den gesamten Gerätespeicher für schnelle Dateivorgänge und Stapelverarbeitung. Ermöglicht eine umfassende Dateiverwaltung ohne wiederholte Berechtigungsabfragen.</string>
@@ -82,7 +82,7 @@
     <string name="setup_grant_access_label">Zugriff gewähren</string>
     <string name="setup_access_granted_label">Zugriff gewährt</string>
     <string name="setup_use_root_label">Root verwenden, falls verfügbar</string>
-    <string name="setup_use_shizuku_label">Shizuku verwenden, falls verfügbar</string>
+    <string name="setup_use_shizuku_label">ADB-Zugriff verwenden, falls verfügbar</string>
 
     <string name="setup_status_checking">Wird geprüft…</string>
     <string name="setup_status_completed">Eingerichtet</string>
@@ -94,6 +94,10 @@
     <string name="setup_status_connecting">Verbindung wird hergestellt…</string>
     <string name="setup_status_connection_failed">Verbindung fehlgeschlagen</string>
     <string name="setup_status_unavailable">Nicht verfügbar</string>
+    <string name="setup_adb_restart_required">Eine andere App für ADB-Zugriff wurde installiert. Starte Butler neu, um sie zu verwenden.</string>
+    <!-- %1$s is the name of the app that provides ADB access, e.g. "Porter" or "Shizuku". -->
+    <string name="setup_adb_open_manager_action">%1$s öffnen</string>
+    <string name="setup_adb_install_manager_action">%1$s installieren</string>
 
     <!-- Debug Log -->
     <string name="debug_notification_channel_label">Debug-Benachrichtigungen</string>
@@ -260,6 +264,8 @@
     <string name="acknowledgement_librootjava_subtitle">Java- und Kotlin-Code als Root ausführen! (APACHE 2.0)</string>
     <string name="acknowledgement_librootkotlinx_title">librootkotlinx</string>
     <string name="acknowledgement_librootkotlinx_subtitle">Root-Kotlin-JVM-Code einfach mit Coroutinen ausführen. (APACHE 2.0)</string>
+    <string name="acknowledgement_porter_title">Porter</string>
+    <string name="acknowledgement_porter_subtitle">Gibt Android-Apps über die Shizuku-APIs ADB-Zugriff, mit optionaler Root-Unterstützung. (APACHE 2.0)</string>
     <string name="acknowledgement_shizuku_title">Shizuku</string>
     <string name="acknowledgement_shizuku_subtitle">System-APIs über einen mit app_process gestarteten Java-Prozess direkt mit ADB- oder Root-Berechtigungen aus normalen Apps verwenden. (APACHE 2.0)</string>
     <string name="acknowledgement_material_design_icons_title">Material Design Icons</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -96,6 +96,7 @@
     <string name="setup_status_unavailable">Nicht verfügbar</string>
     <string name="setup_adb_restart_required">Eine andere App für ADB-Zugriff wurde installiert. Starte Butler neu, um sie zu verwenden.</string>
     <!-- %1$s is the name of the app that provides ADB access, e.g. "Porter" or "Shizuku". -->
+    <string name="setup_adb_status_connected_via">Verbunden über %1$s</string>
     <string name="setup_adb_open_manager_action">%1$s öffnen</string>
     <string name="setup_adb_install_manager_action">%1$s installieren</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,8 +94,8 @@
     <string name="setup_status_connecting">Connecting…</string>
     <string name="setup_status_connection_failed">Connection failed</string>
     <string name="setup_status_unavailable">Unavailable</string>
-    <string name="setup_adb_restart_required">Another ADB access app was installed. Restart Butler to use it.</string>
     <!-- %1$s is the name of the app that provides ADB access, e.g. "Porter" or "Shizuku". -->
+    <string name="setup_adb_restart_required">%1$s is installed, but Butler has to be fully closed and reopened before it can use it.</string>
     <string name="setup_adb_status_connected_via">Connected via %1$s</string>
     <string name="setup_adb_open_manager_action">Open %1$s</string>
     <string name="setup_adb_install_manager_action">Install %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="setup_status_unavailable">Unavailable</string>
     <string name="setup_adb_restart_required">Another ADB access app was installed. Restart Butler to use it.</string>
     <!-- %1$s is the name of the app that provides ADB access, e.g. "Porter" or "Shizuku". -->
+    <string name="setup_adb_status_connected_via">Connected via %1$s</string>
     <string name="setup_adb_open_manager_action">Open %1$s</string>
     <string name="setup_adb_install_manager_action">Install %1$s</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="shortcuts_settings_min_dialog_message">How many times a path must be accessed before appearing as a shortcut (1–10)</string>
 
     <string name="setup_usagestats_title">Usage stats</string>
-    <string name="setup_shizuku_card_title">Shizuku</string>
+    <string name="setup_shizuku_card_title">ADB access</string>
     <string name="setup_root_card_title">Root</string>
     <string name="setup_notification_title">Notification access</string>
     <string name="setup_manage_storage_card_title">Manage external storage</string>
@@ -73,7 +73,7 @@
     <string name="setup_help_description">Help</string>
 
     <string name="setup_root_description">Enables access to system files and protected directories for advanced file management. Unlocks Butler\'s full potential including app data access and system modifications. Device must be rooted.</string>
-    <string name="setup_shizuku_description">Alternative to root that provides privileged file operations through a secure API. Allows access to restricted directories without traditional root. Requires Shizuku app to be installed and running.</string>
+    <string name="setup_shizuku_description">Alternative to root that provides privileged file operations through a secure API. Allows access to restricted directories without traditional root. Requires Porter or Shizuku to be installed and running.</string>
     <string name="setup_notification_description">Shows updates for file operations, background tasks, and transfer progress. Keeps you informed when operations complete or errors occur.</string>
     <string name="setup_usagestats_description">Analyzes app storage usage to identify large files and help manage space effectively. All data stays on your device and is never transmitted.</string>
     <string name="setup_storage_description">Full access to all device storage for fast file operations and batch processing. Enables comprehensive file management without repeated permission prompts.</string>
@@ -82,7 +82,7 @@
     <string name="setup_grant_access_label">Grant access</string>
     <string name="setup_access_granted_label">Access granted</string>
     <string name="setup_use_root_label">Use root if available</string>
-    <string name="setup_use_shizuku_label">Use Shizuku if available</string>
+    <string name="setup_use_shizuku_label">Use ADB access if available</string>
 
     <string name="setup_status_checking">Checking…</string>
     <string name="setup_status_completed">Configured</string>
@@ -94,6 +94,10 @@
     <string name="setup_status_connecting">Connecting…</string>
     <string name="setup_status_connection_failed">Connection failed</string>
     <string name="setup_status_unavailable">Unavailable</string>
+    <string name="setup_adb_restart_required">Another ADB access app was installed. Restart Butler to use it.</string>
+    <!-- %1$s is the name of the app that provides ADB access, e.g. "Porter" or "Shizuku". -->
+    <string name="setup_adb_open_manager_action">Open %1$s</string>
+    <string name="setup_adb_install_manager_action">Install %1$s</string>
 
     <!-- Debug Log -->
     <string name="debug_notification_channel_label">Debug notifications</string>
@@ -260,6 +264,8 @@
     <string name="acknowledgement_librootjava_subtitle">Run Java (and Kotlin) code as root! (APACHE 2.0)</string>
     <string name="acknowledgement_librootkotlinx_title">librootkotlinx</string>
     <string name="acknowledgement_librootkotlinx_subtitle">Run rooted Kotlin JVM code made easy with coroutines. (APACHE 2.0)</string>
+    <string name="acknowledgement_porter_title">Porter</string>
+    <string name="acknowledgement_porter_subtitle">Gives Android apps ADB access through the Shizuku APIs, with optional root support. (APACHE 2.0)</string>
     <string name="acknowledgement_shizuku_title">Shizuku</string>
     <string name="acknowledgement_shizuku_subtitle">Using system APIs directly with adb/root privileges from normal apps through a Java process started with app_process. (APACHE 2.0)</string>
     <string name="acknowledgement_material_design_icons_title">Material Design Icons</string>

--- a/app/src/test/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModuleTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.setup.core.shizuku
 
+import android.content.Context
 import eu.darken.butler.common.adb.AdbSettings
 import eu.darken.butler.common.adb.shizuku.ShizukuBaseServiceBinder
 import eu.darken.butler.common.adb.shizuku.ShizukuManager
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit
 
 class ShizukuSetupModuleTest : BaseTest() {
 
+    private val context: Context = mockk(relaxed = true)
     private val adbSettings: AdbSettings = mockk()
     private val shizukuManager: ShizukuManager = mockk()
     private val rootManager: RootManager = mockk()
@@ -53,10 +55,11 @@ class ShizukuSetupModuleTest : BaseTest() {
         every { adbSettings.useShizuku } returns useShizukuValue
         every { useShizukuValue.flow } returns useShizukuFlow
 
-        every { shizukuManager.shizukuPkgId } returns "moe.shizuku.privileged.api".toPkgId()
+        every { shizukuManager.defaultManagerPkgId } returns "eu.darken.porter".toPkgId()
         every { shizukuManager.shizukuBinder } returns flowOf(null)
         every { shizukuManager.permissionGrantEvents } returns emptyFlow()
         coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
+        coEvery { shizukuManager.installedManagerIds() } returns emptySet()
         coEvery { shizukuManager.isCompatible() } returns true
         coEvery { shizukuManager.isGranted() } returns true
         coEvery { shizukuManager.getServiceState() } coAnswers { probeCount++; ShizukuServiceState.Available }
@@ -71,7 +74,7 @@ class ShizukuSetupModuleTest : BaseTest() {
 
     private fun module(
         dispatchers: DispatcherProvider = TestDispatcherProvider(),
-    ) = ShizukuSetupModule(scope, dispatchers, adbSettings, shizukuManager, rootManager)
+    ) = ShizukuSetupModule(context, scope, dispatchers, adbSettings, shizukuManager, rootManager)
 
     @Test fun `first subscription emits Loading then Result`() {
         val mod = module()
@@ -152,6 +155,38 @@ class ShizukuSetupModuleTest : BaseTest() {
         collector.await { _, _ -> probeCount > before }
 
         probeCount shouldBeGreaterThan before
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `a manager for the other backend is reported as needing a restart`() {
+        // The active backend is latched per process, so its manager being absent while another one is
+        // installed is a state the user cannot leave from inside the app.
+        coEvery { shizukuManager.getManagerId() } returns null
+        coEvery { shizukuManager.installedManagerIds() } returns setOf("eu.darken.porter".toPkgId())
+
+        val mod = module()
+        val collector = mod.state.test(tag = "other", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<ShizukuSetupModule.Result>()
+        result.isInstalled shouldBe false
+        result.otherManagerInstalled shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `no manager at all is not reported as needing a restart`() {
+        coEvery { shizukuManager.getManagerId() } returns null
+        coEvery { shizukuManager.installedManagerIds() } returns emptySet()
+
+        val mod = module()
+        val collector = mod.state.test(tag = "none", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<ShizukuSetupModule.Result>()
+        result.isInstalled shouldBe false
+        result.otherManagerInstalled shouldBe false
 
         runBlocking { collector.cancelAndJoin() }
     }

--- a/app/src/test/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/core/shizuku/ShizukuSetupModuleTest.kt
@@ -1,12 +1,16 @@
 package eu.darken.butler.setup.core.shizuku
 
 import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
 import eu.darken.butler.common.adb.AdbSettings
+import eu.darken.butler.common.adb.shizuku.AdbBackend
 import eu.darken.butler.common.adb.shizuku.ShizukuBaseServiceBinder
 import eu.darken.butler.common.adb.shizuku.ShizukuManager
 import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
 import eu.darken.butler.common.coroutine.DispatcherProvider
 import eu.darken.butler.common.datastore.DataStoreValue
+import eu.darken.butler.common.pkgs.getLaunchIntent
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.common.root.RootManager
 import io.kotest.matchers.ints.shouldBeGreaterThan
@@ -15,6 +19,10 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,12 +39,11 @@ import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.flow.awaitSharingStopped
 import testhelpers.flow.test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class ShizukuSetupModuleTest : BaseTest() {
 
     private val context: Context = mockk(relaxed = true)
+    private val packageManager: PackageManager = mockk(relaxed = true)
     private val adbSettings: AdbSettings = mockk()
     private val shizukuManager: ShizukuManager = mockk()
     private val rootManager: RootManager = mockk()
@@ -52,14 +59,18 @@ class ShizukuSetupModuleTest : BaseTest() {
         useShizukuFlow = MutableStateFlow(true)
         scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
+        every { context.packageManager } returns packageManager
         every { adbSettings.useShizuku } returns useShizukuValue
         every { useShizukuValue.flow } returns useShizukuFlow
 
-        every { shizukuManager.defaultManagerPkgId } returns "eu.darken.porter".toPkgId()
+        coEvery { shizukuManager.referenceManagerId() } returns "eu.darken.porter".toPkgId()
         every { shizukuManager.shizukuBinder } returns flowOf(null)
         every { shizukuManager.permissionGrantEvents } returns emptyFlow()
         coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
         coEvery { shizukuManager.installedManagerIds() } returns emptySet()
+        coEvery { shizukuManager.activeManagerIds() } returns emptySet()
+        coEvery { shizukuManager.inactiveFamilyManagerId() } returns null
+        coEvery { shizukuManager.activeBackend() } returns AdbBackend.SHIZUKU
         coEvery { shizukuManager.isCompatible() } returns true
         coEvery { shizukuManager.isGranted() } returns true
         coEvery { shizukuManager.getServiceState() } coAnswers { probeCount++; ShizukuServiceState.Available }
@@ -163,7 +174,7 @@ class ShizukuSetupModuleTest : BaseTest() {
         // The active backend is latched per process, so its manager being absent while another one is
         // installed is a state the user cannot leave from inside the app.
         coEvery { shizukuManager.getManagerId() } returns null
-        coEvery { shizukuManager.installedManagerIds() } returns setOf("eu.darken.porter".toPkgId())
+        coEvery { shizukuManager.inactiveFamilyManagerId() } returns PORTER
 
         val mod = module()
         val collector = mod.state.test(tag = "other", scope = scope)
@@ -172,13 +183,59 @@ class ShizukuSetupModuleTest : BaseTest() {
         val result = collector.latestValues.last().shouldBeInstanceOf<ShizukuSetupModule.Result>()
         result.isInstalled shouldBe false
         result.otherManagerInstalled shouldBe true
+        result.restartRequiredFor shouldBe PORTER
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    /**
+     * The permission owner can be a manager with no launcher activity (Shizuku+'s Compat Hub owns the
+     * stock permission), so the open target has to be a sibling that can actually be started.
+     */
+    @Test fun `a launchable manager of the same family is preferred as the open target`() {
+        coEvery { shizukuManager.getManagerId() } returns COMPAT_HUB
+        coEvery { shizukuManager.activeManagerIds() } returns setOf(COMPAT_HUB, SHIZUKU_PLUS)
+        mockkStatic("eu.darken.butler.common.pkgs.PkgExtensionsKt")
+        every { COMPAT_HUB.getLaunchIntent(any()) } returns null
+        every { SHIZUKU_PLUS.getLaunchIntent(any()) } returns Intent()
+
+        val mod = module()
+        val collector = mod.state.test(tag = "openable", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<ShizukuSetupModule.Result>()
+        result.isInstalled shouldBe true
+        result.pkg shouldBe SHIZUKU_PLUS
+
+        unmockkStatic("eu.darken.butler.common.pkgs.PkgExtensionsKt")
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    /**
+     * The label lookup runs outside the availability probe's handler, so an exception there would kill
+     * the sharing coroutine and strand every later subscriber on the state it died in.
+     */
+    @Test fun `a failing label lookup does not kill the state flow`() {
+        every { packageManager.getPackageInfo(any<String>(), any<Int>()) } throws RuntimeException("binder died")
+
+        val mod = module()
+        val collector = mod.state.test(tag = "label", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+
+        val result = collector.latestValues.last().shouldBeInstanceOf<ShizukuSetupModule.Result>()
+        result.isInstalled shouldBe true
+        result.managerLabel shouldBe null
+
+        // Still live: a dead sharing coroutine would never serve another value.
+        runBlocking { mod.refresh() }
+        collector.await { values, _ -> values.count { it is ShizukuSetupModule.Result } > 1 }
 
         runBlocking { collector.cancelAndJoin() }
     }
 
     @Test fun `no manager at all is not reported as needing a restart`() {
         coEvery { shizukuManager.getManagerId() } returns null
-        coEvery { shizukuManager.installedManagerIds() } returns emptySet()
+        coEvery { shizukuManager.inactiveFamilyManagerId() } returns null
 
         val mod = module()
         val collector = mod.state.test(tag = "none", scope = scope)
@@ -218,8 +275,10 @@ class ShizukuSetupModuleTest : BaseTest() {
             runBlocking { pingEntered.await() }
             val before = collector.latestValues.count { it is ShizukuSetupModule.Result }
 
-            val result = collector.await(timeout = 10_000) { values, _ ->
-                values.count { it is ShizukuSetupModule.Result } > before
+            // The emission itself has to be the Result: a snapshot-only condition can go true while
+            // await is inspecting the replayed Loading, and then hands that Loading back.
+            val result = collector.await(timeout = 10_000) { values, emission ->
+                emission is ShizukuSetupModule.Result && values.count { it is ShizukuSetupModule.Result } > before
             }
 
             result.shouldBeInstanceOf<ShizukuSetupModule.Result>().basicService shouldBe false
@@ -228,5 +287,11 @@ class ShizukuSetupModuleTest : BaseTest() {
         } finally {
             wedge.countDown()
         }
+    }
+
+    companion object {
+        private val PORTER = "eu.darken.porter".toPkgId()
+        private val COMPAT_HUB = "moe.shizuku.privileged.api".toPkgId()
+        private val SHIZUKU_PLUS = "af.shizuku.plus".toPkgId()
     }
 }

--- a/app/src/test/java/eu/darken/butler/setup/ui/SetupScreenIntentLaunchTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/SetupScreenIntentLaunchTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.butler.setup.ui
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.flow.SingleEventFlow
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.Test
+import org.robolectric.Shadows.shadowOf
+import testhelpers.ComposeTest
+
+/**
+ * The install action puts an external URL on the permission intent route, which until then only
+ * carried settings intents that always resolve. A device without an enabled browser has nothing to
+ * handle it.
+ */
+class SetupScreenIntentLaunchTest : ComposeTest() {
+
+    private val permissionIntents = MutableSharedFlow<Intent>(replay = 1)
+
+    private val vm = mockk<SetupViewModel>(relaxed = true).apply {
+        every { errorEvents } returns SingleEventFlow()
+        every { navEvents } returns SingleEventFlow()
+        every { permissionRequestEvents } returns permissionIntents
+        every { runtimePermissionEvents } returns MutableSharedFlow()
+        every { state } returns emptyFlow()
+    }
+
+    @Test
+    fun `an install intent nothing can handle does not take the screen down`() {
+        // Without this Robolectric swallows every startActivity, resolvable or not
+        shadowOf(ApplicationProvider.getApplicationContext<Application>()).checkActivities(true)
+
+        permissionIntents.tryEmit(Intent(Intent.ACTION_VIEW, "https://porter.darken.eu/setup".toUri()))
+
+        composeTestRule.setContent {
+            PreviewWrapper {
+                SetupScreenHost(vm = vm)
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        verify(exactly = 1) { vm.onPermissionIntentFailed(ofType<ActivityNotFoundException>()) }
+    }
+}

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
@@ -44,7 +44,8 @@ class ShizukuSetupCardActionTest : ComposeTest() {
         pkg: String,
         isInstalled: Boolean,
         serviceState: ShizukuServiceState = ShizukuServiceState.NotChecked,
-        otherManagerInstalled: Boolean = false,
+        restartRequiredFor: String? = null,
+        restartRequiredLabel: String? = null,
     ) {
         composeTestRule.setContent {
             PreviewWrapper {
@@ -56,7 +57,8 @@ class ShizukuSetupCardActionTest : ComposeTest() {
                             useShizuku = true,
                             isCompatible = true,
                             isInstalled = isInstalled,
-                            otherManagerInstalled = otherManagerInstalled,
+                            restartRequiredFor = restartRequiredFor?.toPkgId(),
+                            restartRequiredLabel = restartRequiredLabel,
                             serviceState = serviceState,
                         ),
                         isRequired = false,
@@ -122,13 +124,18 @@ class ShizukuSetupCardActionTest : ComposeTest() {
     fun `a manager for the other backend offers no install action`() {
         installManager()
 
-        render(pkg = DEFAULT_MANAGER_PKG, isInstalled = false, otherManagerInstalled = true)
+        render(
+            pkg = DEFAULT_MANAGER_PKG,
+            isInstalled = false,
+            restartRequiredFor = MANAGER_PKG,
+            restartRequiredLabel = MANAGER_LABEL,
+        )
 
         composeTestRule
             .onAllNodes(hasClickAction() and hasText(INSTALL_WORDING, substring = true, ignoreCase = true))
             .assertCountEquals(0)
         composeTestRule
-            .onNode(hasText(context.getString(R.string.setup_adb_restart_required)))
+            .onNode(hasText(context.getString(R.string.setup_adb_restart_required, MANAGER_LABEL)))
             .assertIsDisplayed()
     }
 

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.R
 import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
@@ -20,8 +22,8 @@ import org.robolectric.Shadows.shadowOf
 import testhelpers.ComposeTest
 
 /**
- * ADB access enabled but not connected is a dead end without an action: the card names a state and
- * offers no way to reach the manager app that would change it.
+ * Whenever ADB access is enabled, the card has to offer a route to the manager app: naming a state
+ * and stopping there is what left a stranded user with nothing to act on.
  */
 class ShizukuSetupCardActionTest : ComposeTest() {
 
@@ -88,16 +90,31 @@ class ShizukuSetupCardActionTest : ComposeTest() {
     }
 
     @Test
-    fun `a connected card offers no manager action`() {
+    fun `a connected card keeps the manager within reach`() {
         installManager()
 
         render(pkg = MANAGER_PKG, isInstalled = true, serviceState = ShizukuServiceState.Available)
 
         composeTestRule
-            .onAllNodes(hasClickAction() and hasText(MANAGER_LABEL, substring = true))
-            .assertCountEquals(0)
+            .onNode(hasClickAction() and hasText(MANAGER_LABEL, substring = true))
+            .assertIsDisplayed()
         composeTestRule
             .onAllNodes(hasClickAction() and hasText(INSTALL_WORDING, substring = true, ignoreCase = true))
+            .assertCountEquals(0)
+    }
+
+    /** Two managers can be installed at once, so "Connected" on its own does not say which one won. */
+    @Test
+    fun `a connected card names the manager it bound to`() {
+        installManager()
+
+        render(pkg = MANAGER_PKG, isInstalled = true, serviceState = ShizukuServiceState.Available)
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.setup_adb_status_connected_via, MANAGER_LABEL))
+            .assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithText(context.getString(R.string.setup_status_connected))
             .assertCountEquals(0)
     }
 

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
@@ -1,0 +1,125 @@
+package eu.darken.butler.setup.ui.items
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.pkgs.toPkgId
+import eu.darken.butler.setup.core.SetupItem
+import eu.darken.butler.setup.core.SetupModule
+import eu.darken.butler.setup.core.shizuku.ShizukuSetupModule
+import org.junit.Test
+import org.robolectric.Shadows.shadowOf
+import testhelpers.ComposeTest
+
+/**
+ * ADB access enabled but not connected is a dead end without an action: the card names a state and
+ * offers no way to reach the manager app that would change it.
+ */
+class ShizukuSetupCardActionTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun installManager() {
+        val info = PackageInfo().apply {
+            packageName = MANAGER_PKG
+            applicationInfo = ApplicationInfo().apply {
+                packageName = MANAGER_PKG
+                nonLocalizedLabel = MANAGER_LABEL
+            }
+        }
+        shadowOf(context.packageManager).installPackage(info)
+    }
+
+    private fun render(
+        pkg: String,
+        isInstalled: Boolean,
+        serviceState: ShizukuServiceState = ShizukuServiceState.NotChecked,
+        otherManagerInstalled: Boolean = false,
+    ) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RootShizukuActions(
+                    item = SetupItem(
+                        type = SetupModule.Type.SHIZUKU,
+                        state = ShizukuSetupModule.Result(
+                            pkg = pkg.toPkgId(),
+                            useShizuku = true,
+                            isCompatible = true,
+                            isInstalled = isInstalled,
+                            otherManagerInstalled = otherManagerInstalled,
+                            serviceState = serviceState,
+                        ),
+                        isRequired = false,
+                        priority = 6,
+                    ),
+                    onExecuteAction = {},
+                    switchLabel = context.getString(R.string.setup_use_shizuku_label),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `an installed manager is offered by name`() {
+        installManager()
+
+        render(pkg = MANAGER_PKG, isInstalled = true)
+
+        composeTestRule
+            .onNode(hasClickAction() and hasText(MANAGER_LABEL, substring = true))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `without a manager the card offers to install one`() {
+        render(pkg = DEFAULT_MANAGER_PKG, isInstalled = false)
+
+        composeTestRule
+            .onNode(hasClickAction() and hasText(INSTALL_WORDING, substring = true, ignoreCase = true))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a connected card offers no manager action`() {
+        installManager()
+
+        render(pkg = MANAGER_PKG, isInstalled = true, serviceState = ShizukuServiceState.Available)
+
+        composeTestRule
+            .onAllNodes(hasClickAction() and hasText(MANAGER_LABEL, substring = true))
+            .assertCountEquals(0)
+        composeTestRule
+            .onAllNodes(hasClickAction() and hasText(INSTALL_WORDING, substring = true, ignoreCase = true))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `a manager for the other backend offers no install action`() {
+        installManager()
+
+        render(pkg = DEFAULT_MANAGER_PKG, isInstalled = false, otherManagerInstalled = true)
+
+        composeTestRule
+            .onAllNodes(hasClickAction() and hasText(INSTALL_WORDING, substring = true, ignoreCase = true))
+            .assertCountEquals(0)
+        composeTestRule
+            .onNode(hasText(context.getString(R.string.setup_adb_restart_required)))
+            .assertIsDisplayed()
+    }
+
+    companion object {
+        private const val MANAGER_PKG = "moe.shizuku.privileged.api"
+        private const val MANAGER_LABEL = "Shizuku"
+        private const val DEFAULT_MANAGER_PKG = "eu.darken.porter"
+
+        private const val INSTALL_WORDING = "install"
+    }
+}

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardActionTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.R
+import eu.darken.butler.common.adb.shizuku.AdbBackend
 import eu.darken.butler.common.adb.shizuku.ShizukuServiceState
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.pkgs.toPkgId
@@ -117,6 +118,19 @@ class ShizukuSetupCardActionTest : ComposeTest() {
             .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(context.getString(R.string.setup_status_connected))
+            .assertCountEquals(0)
+    }
+
+    /** A package id is not a name: an unreadable label falls back to the backend's product name. */
+    @Test
+    fun `an unreadable label falls back to the backend name, never the package id`() {
+        render(pkg = DEFAULT_MANAGER_PKG, isInstalled = true)
+
+        composeTestRule
+            .onNode(hasClickAction() and hasText(AdbBackend.SHIZUKU.label, substring = true))
+            .assertIsDisplayed()
+        composeTestRule
+            .onAllNodes(hasText(DEFAULT_MANAGER_PKG, substring = true))
             .assertCountEquals(0)
     }
 

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardStatusTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.butler.R
+import eu.darken.butler.common.adb.shizuku.AdbBackend
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.pkgs.toPkgId
 import eu.darken.butler.setup.core.SetupItem
@@ -34,7 +35,8 @@ class ShizukuSetupCardStatusTest : ComposeTest() {
                             useShizuku = useShizuku,
                             isCompatible = true,
                             isInstalled = false,
-                            otherManagerInstalled = true,
+                            restartRequiredFor = OTHER_MANAGER.toPkgId(),
+                            restartRequiredLabel = OTHER_LABEL,
                         ),
                         isRequired = false,
                         priority = 6,
@@ -47,8 +49,41 @@ class ShizukuSetupCardStatusTest : ComposeTest() {
     }
 
     private fun assertRestartHintShown() {
-        composeTestRule.onNodeWithText(context.getString(R.string.setup_adb_restart_required)).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.setup_adb_restart_required, OTHER_LABEL))
+            .assertIsDisplayed()
         composeTestRule.onAllNodesWithText(context.getString(R.string.setup_status_not_installed)).assertCountEquals(0)
+    }
+
+    /** Falls back to the other backend's product name, so the hint never renders a bare placeholder. */
+    @Test
+    fun `the hint names the backend when the label cannot be read`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RootShizukuActions(
+                    item = SetupItem(
+                        type = SetupModule.Type.SHIZUKU,
+                        state = ShizukuSetupModule.Result(
+                            pkg = "eu.darken.porter".toPkgId(),
+                            useShizuku = true,
+                            isCompatible = true,
+                            isInstalled = false,
+                            backend = AdbBackend.PORTER,
+                            restartRequiredFor = OTHER_MANAGER.toPkgId(),
+                            restartRequiredLabel = null,
+                        ),
+                        isRequired = false,
+                        priority = 6,
+                    ),
+                    onExecuteAction = {},
+                    switchLabel = context.getString(R.string.setup_use_shizuku_label),
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.setup_adb_restart_required, AdbBackend.SHIZUKU.label))
+            .assertIsDisplayed()
     }
 
     @Test
@@ -70,5 +105,10 @@ class ShizukuSetupCardStatusTest : ComposeTest() {
         renderOtherManagerInstalled(true)
 
         assertRestartHintShown()
+    }
+
+    companion object {
+        private const val OTHER_MANAGER = "moe.shizuku.privileged.api"
+        private const val OTHER_LABEL = "Shizuku"
     }
 }

--- a/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardStatusTest.kt
+++ b/app/src/test/java/eu/darken/butler/setup/ui/items/ShizukuSetupCardStatusTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.butler.setup.ui.items
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.butler.R
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.pkgs.toPkgId
+import eu.darken.butler.setup.core.SetupItem
+import eu.darken.butler.setup.core.SetupModule
+import eu.darken.butler.setup.core.shizuku.ShizukuSetupModule
+import org.junit.Test
+import testhelpers.ComposeTest
+
+/**
+ * The restart hint has to survive every value of the use-ADB switch: it sits ahead of that guard
+ * because the setting still being unset is the most likely way to reach this state.
+ */
+class ShizukuSetupCardStatusTest : ComposeTest() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun renderOtherManagerInstalled(useShizuku: Boolean?) {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                RootShizukuActions(
+                    item = SetupItem(
+                        type = SetupModule.Type.SHIZUKU,
+                        state = ShizukuSetupModule.Result(
+                            pkg = "eu.darken.porter".toPkgId(),
+                            useShizuku = useShizuku,
+                            isCompatible = true,
+                            isInstalled = false,
+                            otherManagerInstalled = true,
+                        ),
+                        isRequired = false,
+                        priority = 6,
+                    ),
+                    onExecuteAction = {},
+                    switchLabel = context.getString(R.string.setup_use_shizuku_label),
+                )
+            }
+        }
+    }
+
+    private fun assertRestartHintShown() {
+        composeTestRule.onNodeWithText(context.getString(R.string.setup_adb_restart_required)).assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(context.getString(R.string.setup_status_not_installed)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the hint shows while the switch was never touched`() {
+        renderOtherManagerInstalled(null)
+
+        assertRestartHintShown()
+    }
+
+    @Test
+    fun `the hint shows while the switch is off`() {
+        renderOtherManagerInstalled(false)
+
+        assertRestartHintShown()
+    }
+
+    @Test
+    fun `the hint shows while the switch is on`() {
+        renderOtherManagerInstalled(true)
+
+        assertRestartHintShown()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ work = "2.11.2"
 billing = "8.3.0"
 play-review = "2.0.2"
 vico = "2.2.0"
-shizuku = "13.1.5"
+porter = "0.1.0"
 semver = "3.0.0"
 reorderable = "3.1.0"
 # Testing (versions used by buildSrc addTesting())
@@ -170,8 +170,7 @@ billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = 
 play-review-core = { module = "com.google.android.play:review", version.ref = "play-review" }
 play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "play-review" }
 vico-compose-m3 = { module = "com.patrykandpatrick.vico:compose-m3", version.ref = "vico" }
-shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
-shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
+porter-client = { module = "com.github.d4rken-org.porter-api:client", version.ref = "porter" }
 semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 screenshot-validation-api = { module = "com.android.tools.screenshot:screenshot-validation-api", version.ref = "screenshot" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,10 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://androidx.dev/snapshots/builds/13610170/artifacts/repository")
         }
+        maven {
+            url = uri("https://jitpack.io")
+            content { includeGroup("com.github.d4rken-org.porter-api") }
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

Butler now works with Porter, not just Shizuku.

Porter is picked up automatically when it's installed, and Butler keeps working with Shizuku otherwise. Nothing to configure, and there's no backend picker to get wrong.

The setup card is now called "ADB access" rather than "Shizuku", and every label, error and tip that named Shizuku now talks about ADB access instead. The card's description still names Porter and Shizuku, because "install an ADB access manager" leaves you with nothing to act on. German translations are updated alongside, and Porter joins Shizuku in the acknowledgements.

The card also stopped being a dead end. When ADB access is on but not connected, it now offers a way forward:

- The manager app is installed: a button with its own icon and name, opening it.
- Nothing installed: an install button, pointing at Porter's setup guide on FOSS builds and Shizuku on Google Play.

And if you install a manager app while Butler is already running, the card says a restart is what makes it count, instead of sitting on "Not installed" forever.

## Technical Context

- The backend is selected by which manager is **installed**, not which one is running, and that choice is latched once per process by the SDK. So a user on Shizuku who also has Porter installed but stopped would silently lose elevated access on upgrade. Found on a real device, not in review. The manager button is the remedy: it names the app Butler actually bound to and opens it. Worth a close look if you want to revisit the no-picker decision.
- `getManagerPackage()` resolves the active backend's manager only, with no cross-backend fallback — naming the other family's manager would advertise a connection the process cannot make.
- `AdbManagerInstallGuide` is the flavor seam for the install destination, bound per source set like `ReviewModule`/`UpdaterModule` already are. The gplay binding is not compiled by the foss validation commands, so `:app:compileGplayDebugKotlin` is the check that covers it.
- Both new actions return a `PermissionResult` intent, the existing route for launching an activity from a setup card. That route previously carried only settings intents, which always resolve; an external URL is the first one whose handler is optional, so the shared launch site is now guarded against `ActivityNotFoundException` and `SecurityException`.
- String IDs are deliberately unchanged — renaming one drops its translations on the next Crowdin sync. Only the English values moved, with German updated by hand.
