### PR TITLE
Workspace: Choose which type new tabs open as

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/Workspace.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/Workspace.kt
@@ -8,6 +8,8 @@ import eu.darken.butler.common.parcel.UuidParceler
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlin.uuid.Uuid
 
 interface Workspace<ArgT : Workspace.Arguments> {
@@ -48,6 +50,7 @@ interface Workspace<ArgT : Workspace.Arguments> {
 
     }
 
+    @Serializable
     enum class Type(
         val isSingleton: Boolean = false,
         /**
@@ -57,19 +60,39 @@ interface Workspace<ArgT : Workspace.Arguments> {
          */
         val isQuotaExempt: Boolean = false,
     ) {
+        @SerialName("TEMPLATES")
         TEMPLATES,
+
+        @SerialName("EXPLORER")
         EXPLORER,
+
+        @SerialName("SEARCHER")
         SEARCHER,
+
+        @SerialName("EDITOR")
         EDITOR,
+
+        @SerialName("APPS")
         APPS,
+
+        @SerialName("APP_DETAILS")
         APP_DETAILS,
+
+        @SerialName("SAVER")
         SAVER,
+
+        @SerialName("DEVELOPER")
         DEVELOPER(isSingleton = true, isQuotaExempt = true),
+
+        @SerialName("HISTORY")
         HISTORY,
+
+        @SerialName("BUG_REPORT")
         BUG_REPORT(isSingleton = true, isQuotaExempt = true),
 
         // Appended last on purpose: the ordinal is part of no persisted format, but keeping the
         // existing order stable avoids churn in anything that reads entries positionally.
+        @SerialName("VIEWER")
         VIEWER,
         ;
     }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceSettings.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceSettings.kt
@@ -36,6 +36,13 @@ class WorkspaceSettings @Inject constructor(
 
     val onDemandWorkspaceCreation = dataStore.createValue("workspace.swipe.ondemand.enabled", true)
 
+    val defaultNewTabType = dataStore.createValue(
+        "workspace.newtab.type.default",
+        Workspace.Type.TEMPLATES,
+        json,
+        onErrorFallbackToDefault = true,
+    )
+
     val livePreview = dataStore.createValue("workspace.preview.live.enabled", true)
 
     val layoutModePortrait = dataStore.createValue("workspace.layout.mode.portrait", WorkspacePanelMode.AUTO, json)
@@ -61,6 +68,7 @@ class WorkspaceSettings @Inject constructor(
         showTipBadgeExplanation,
         swipeGesturesEnabled,
         onDemandWorkspaceCreation,
+        defaultNewTabType,
         livePreview,
         layoutModePortrait,
         layoutModeLandscape,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.runtime.collectAsState
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.icon
-import eu.darken.butler.workspace.core.label
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.layout.LayoutPickerDialog
 import eu.darken.butler.workspace.ui.layout.LayoutPickerOption
@@ -59,6 +58,8 @@ import eu.darken.butler.workspace.ui.layout.label
 import eu.darken.butler.workspace.ui.layout.surface
 import eu.darken.butler.workspace.ui.layout.surfaceValueLabel
 import eu.darken.butler.workspace.ui.layout.toPanelMode
+import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
+import eu.darken.butler.workspace.ui.template.newTabTypeName
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import kotlin.time.Duration
 import eu.darken.butler.common.R as CommonR
@@ -136,7 +137,7 @@ fun WorkspaceSettingsScreen(
                     icon = Icons.TwoTone.AddCircle,
                     title = stringResource(R.string.workspace_settings_newtab_type_title),
                     subtitle = stringResource(R.string.workspace_settings_newtab_type_desc),
-                    value = state.defaultNewTabType.newTabTypeValueLabel(),
+                    value = state.defaultNewTabType.newTabTypeValueLabel(state.newTabCandidates),
                     onClick = { showNewTabTypeDialog = true },
                 )
             }
@@ -339,9 +340,9 @@ fun WorkspaceSettingsScreen(
 }
 
 @Composable
-private fun Workspace.Type.newTabTypeValueLabel(): String = when (this) {
+private fun Workspace.Type.newTabTypeValueLabel(candidates: List<WorkspaceTemplate>): String = when (this) {
     Workspace.Type.TEMPLATES -> stringResource(R.string.workspace_settings_newtab_type_ask)
-    else -> label.get(LocalContext.current)
+    else -> candidates.newTabTypeName(this).get(LocalContext.current)
 }
 
 /** "2 hours", "45 minutes", "1 hour 30 minutes" - hours are dropped when zero, and vice versa. */

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.AddCircle
 import androidx.compose.material.icons.twotone.AdsClick
 import androidx.compose.material.icons.twotone.AutoAwesome
 import androidx.compose.material.icons.twotone.PauseCircle
@@ -28,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
@@ -44,6 +46,9 @@ import eu.darken.butler.common.settings.SettingsSwitchItem
 import eu.darken.butler.common.ui.MinutesDurationInputDialog
 import androidx.compose.runtime.collectAsState
 import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.icon
+import eu.darken.butler.workspace.core.label
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.layout.LayoutPickerDialog
 import eu.darken.butler.workspace.ui.layout.LayoutPickerOption
@@ -64,6 +69,7 @@ fun WorkspaceSettingsScreen(
     onNavigateUp: () -> Unit,
     onToggleSwipeGestures: () -> Unit,
     onToggleOnDemandWorkspaceCreation: () -> Unit,
+    onSetDefaultNewTabType: (Workspace.Type) -> Unit,
     onToggleLivePreview: () -> Unit,
     onSetLayoutModePortrait: (WorkspacePanelMode) -> Unit,
     onSetLayoutModeLandscape: (WorkspacePanelMode) -> Unit,
@@ -73,6 +79,7 @@ fun WorkspaceSettingsScreen(
     onSetAutoPauseIdleTimeout: (Duration) -> Unit,
     onToggleUndoClose: () -> Unit,
 ) {
+    var showNewTabTypeDialog by remember { mutableStateOf(false) }
     var showPortraitDialog by remember { mutableStateOf(false) }
     var showLandscapeDialog by remember { mutableStateOf(false) }
     var showAutoPauseTimeoutDialog by remember { mutableStateOf(false) }
@@ -121,6 +128,16 @@ fun WorkspaceSettingsScreen(
                     checked = state.onDemandWorkspaceCreation,
                     onCheckedChange = { onToggleOnDemandWorkspaceCreation() },
                     enabled = state.swipeGesturesEnabled,
+                )
+            }
+
+            item {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.AddCircle,
+                    title = stringResource(R.string.workspace_settings_newtab_type_title),
+                    subtitle = stringResource(R.string.workspace_settings_newtab_type_desc),
+                    value = state.defaultNewTabType.newTabTypeValueLabel(),
+                    onClick = { showNewTabTypeDialog = true },
                 )
             }
 
@@ -236,6 +253,37 @@ fun WorkspaceSettingsScreen(
         }
     }
 
+    if (showNewTabTypeDialog) {
+        val context = LocalContext.current
+        LayoutPickerDialog(
+            title = stringResource(R.string.workspace_settings_newtab_type_title),
+            options = listOf(
+                LayoutPickerOption(
+                    icon = Workspace.Type.TEMPLATES.icon,
+                    label = stringResource(R.string.workspace_settings_newtab_type_ask),
+                    description = stringResource(R.string.workspace_settings_newtab_type_ask_desc),
+                    selected = state.defaultNewTabType == Workspace.Type.TEMPLATES,
+                    onSelect = {
+                        onSetDefaultNewTabType(Workspace.Type.TEMPLATES)
+                        showNewTabTypeDialog = false
+                    },
+                ),
+            ) + state.newTabCandidates.map { template ->
+                LayoutPickerOption(
+                    icon = template.icon,
+                    label = template.title.get(context),
+                    description = template.subtitle.get(context),
+                    selected = state.defaultNewTabType == template.type,
+                    onSelect = {
+                        onSetDefaultNewTabType(template.type)
+                        showNewTabTypeDialog = false
+                    },
+                )
+            },
+            onDismiss = { showNewTabTypeDialog = false },
+        )
+    }
+
     if (showPortraitDialog) {
         LayoutPickerDialog(
             title = stringResource(R.string.workspace_settings_layout_mode_portrait_title),
@@ -290,6 +338,12 @@ fun WorkspaceSettingsScreen(
     }
 }
 
+@Composable
+private fun Workspace.Type.newTabTypeValueLabel(): String = when (this) {
+    Workspace.Type.TEMPLATES -> stringResource(R.string.workspace_settings_newtab_type_ask)
+    else -> label.get(LocalContext.current)
+}
+
 /** "2 hours", "45 minutes", "1 hour 30 minutes" - hours are dropped when zero, and vice versa. */
 @Composable
 private fun Duration.formatCoarse(): String {
@@ -312,6 +366,7 @@ private fun WorkspaceSettingsScreenPreview() {
         state = WorkspaceSettingsViewModel.State(
             swipeGesturesEnabled = true,
             onDemandWorkspaceCreation = true,
+            defaultNewTabType = Workspace.Type.TEMPLATES,
             livePreview = true,
             layoutModePortrait = WorkspacePanelMode.AUTO,
             layoutModeLandscape = WorkspacePanelMode.AUTO,
@@ -324,6 +379,7 @@ private fun WorkspaceSettingsScreenPreview() {
         onNavigateUp = {},
         onToggleSwipeGestures = {},
         onToggleOnDemandWorkspaceCreation = {},
+        onSetDefaultNewTabType = {},
         onToggleLivePreview = {},
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
@@ -343,6 +399,7 @@ private fun WorkspaceSettingsScreenPinnedLayoutPreview() {
         state = WorkspaceSettingsViewModel.State(
             swipeGesturesEnabled = true,
             onDemandWorkspaceCreation = true,
+            defaultNewTabType = Workspace.Type.TEMPLATES,
             livePreview = true,
             layoutModePortrait = WorkspacePanelMode.DUAL_VERTICAL,
             layoutModeLandscape = WorkspacePanelMode.ADAPTIVE,
@@ -355,6 +412,40 @@ private fun WorkspaceSettingsScreenPinnedLayoutPreview() {
         onNavigateUp = {},
         onToggleSwipeGestures = {},
         onToggleOnDemandWorkspaceCreation = {},
+        onSetDefaultNewTabType = {},
+        onToggleLivePreview = {},
+        onSetLayoutModePortrait = {},
+        onSetLayoutModeLandscape = {},
+        onTogglePaneClickToFocus = {},
+        onToggleSessionRestore = {},
+        onToggleAutoPause = {},
+        onSetAutoPauseIdleTimeout = {},
+        onToggleUndoClose = {},
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun WorkspaceSettingsScreenNewTabTypePreview() {
+    WorkspaceSettingsScreen(
+        state = WorkspaceSettingsViewModel.State(
+            swipeGesturesEnabled = true,
+            onDemandWorkspaceCreation = true,
+            defaultNewTabType = Workspace.Type.EXPLORER,
+            livePreview = true,
+            layoutModePortrait = WorkspacePanelMode.AUTO,
+            layoutModeLandscape = WorkspacePanelMode.AUTO,
+            paneClickToFocus = true,
+            sessionRestoreEnabled = true,
+            undoCloseEnabled = true,
+            sessionWorkspaceCount = 3,
+            sessionDatabaseSizeBytes = 131072,
+        ),
+        onNavigateUp = {},
+        onToggleSwipeGestures = {},
+        onToggleOnDemandWorkspaceCreation = {},
+        onSetDefaultNewTabType = {},
         onToggleLivePreview = {},
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
@@ -379,6 +470,7 @@ fun WorkspaceSettingsScreenHost(vm: WorkspaceSettingsViewModel = hiltViewModel()
             onNavigateUp = { vm.navUp() },
             onToggleSwipeGestures = { vm.toggleSwipeGestures() },
             onToggleOnDemandWorkspaceCreation = { vm.toggleOnDemandWorkspaceCreation() },
+            onSetDefaultNewTabType = { type -> vm.setDefaultNewTabType(type) },
             onToggleLivePreview = { vm.toggleLivePreview() },
             onSetLayoutModePortrait = { mode -> vm.setLayoutModePortrait(mode) },
             onSetLayoutModeLandscape = { mode -> vm.setLayoutModeLandscape(mode) },

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsViewModel.kt
@@ -6,9 +6,14 @@ import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.logging.logTag
 import eu.darken.butler.common.flow.combine
 import eu.darken.butler.common.ui.ViewModel4
+import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.core.session.WorkspaceSessionStorage
+import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
+import eu.darken.butler.workspace.ui.template.availableTemplates
+import eu.darken.butler.workspace.ui.template.newTabCandidates
+import eu.darken.butler.workspace.ui.template.newTabTemplate
 import javax.inject.Inject
 import kotlin.time.Duration
 
@@ -17,11 +22,14 @@ class WorkspaceSettingsViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val workspaceSettings: WorkspaceSettings,
     private val sessionStorage: eu.darken.butler.workspace.core.session.WorkspaceSessionStorage,
+    workspaceTemplates: Set<@JvmSuppressWildcards WorkspaceTemplate>,
 ) : ViewModel4(dispatcherProvider, logTag("Workspace", "Settings", "Screen", "VM")) {
 
     val state = combine(
         workspaceSettings.swipeGesturesEnabled.flow,
         workspaceSettings.onDemandWorkspaceCreation.flow,
+        workspaceSettings.defaultNewTabType.flow,
+        workspaceTemplates.availableTemplates(),
         workspaceSettings.livePreview.flow,
         workspaceSettings.layoutModePortrait.flow,
         workspaceSettings.layoutModeLandscape.flow,
@@ -32,10 +40,14 @@ class WorkspaceSettingsViewModel @Inject constructor(
         workspaceSettings.undoCloseEnabled.flow,
         sessionStorage.getWorkspaceCount(WorkspaceSessionStorage.DEFAULT_SESSION_ID),
         sessionStorage.getDatabaseSizeBytes(WorkspaceSessionStorage.DEFAULT_SESSION_ID),
-    ) { swipeGesturesEnabled, onDemandWorkspaceCreation, livePreview, layoutModePortrait, layoutModeLandscape, paneClickToFocus, sessionRestoreEnabled, autoPauseEnabled, autoPauseIdleTimeout, undoCloseEnabled, sessionWorkspaceCount, sessionDatabaseSizeBytes ->
+    ) { swipeGesturesEnabled, onDemandWorkspaceCreation, defaultNewTabType, templates, livePreview, layoutModePortrait, layoutModeLandscape, paneClickToFocus, sessionRestoreEnabled, autoPauseEnabled, autoPauseIdleTimeout, undoCloseEnabled, sessionWorkspaceCount, sessionDatabaseSizeBytes ->
         State(
             swipeGesturesEnabled = swipeGesturesEnabled,
             onDemandWorkspaceCreation = onDemandWorkspaceCreation,
+            // The effective type, so the row never names one the gesture would not honour. The
+            // stored value stays untouched, a type that becomes available again is restored.
+            defaultNewTabType = templates.newTabTemplate(defaultNewTabType)?.type ?: Workspace.Type.TEMPLATES,
+            newTabCandidates = templates.newTabCandidates(),
             livePreview = livePreview,
             layoutModePortrait = layoutModePortrait,
             layoutModeLandscape = layoutModeLandscape,
@@ -57,6 +69,10 @@ class WorkspaceSettingsViewModel @Inject constructor(
     fun toggleOnDemandWorkspaceCreation() = launch {
         val current = workspaceSettings.onDemandWorkspaceCreation.value()
         workspaceSettings.onDemandWorkspaceCreation.value(!current)
+    }
+
+    fun setDefaultNewTabType(type: Workspace.Type) = launch {
+        workspaceSettings.defaultNewTabType.value(type)
     }
 
     fun toggleLivePreview() = launch {
@@ -102,6 +118,8 @@ class WorkspaceSettingsViewModel @Inject constructor(
     data class State(
         val swipeGesturesEnabled: Boolean,
         val onDemandWorkspaceCreation: Boolean,
+        val defaultNewTabType: Workspace.Type = Workspace.Type.TEMPLATES,
+        val newTabCandidates: List<WorkspaceTemplate> = emptyList(),
         val livePreview: Boolean,
         val layoutModePortrait: WorkspacePanelMode,
         val layoutModeLandscape: WorkspacePanelMode,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensions.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.ui.template
 
+import eu.darken.butler.workspace.core.Workspace
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -24,3 +25,10 @@ fun Collection<WorkspaceTemplate>.availableTemplates(): Flow<List<WorkspaceTempl
                 .sortedWith(compareBy<WorkspaceTemplate> { it.sortOrder }.thenBy { it.type.ordinal })
         }
     }
+
+/** Singleton types are excluded: a second create of one returns AlreadyOpen rather than a new tab. */
+fun List<WorkspaceTemplate>.newTabCandidates(): List<WorkspaceTemplate> = filterNot { it.type.isSingleton }
+
+/** The template a new tab opens as, or null to let the user pick via the templates workspace. */
+fun List<WorkspaceTemplate>.newTabTemplate(stored: Workspace.Type): WorkspaceTemplate? =
+    if (stored == Workspace.Type.TEMPLATES) null else newTabCandidates().firstOrNull { it.type == stored }

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensions.kt
@@ -1,6 +1,8 @@
 package eu.darken.butler.workspace.ui.template
 
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.label
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -32,3 +34,11 @@ fun List<WorkspaceTemplate>.newTabCandidates(): List<WorkspaceTemplate> = filter
 /** The template a new tab opens as, or null to let the user pick via the templates workspace. */
 fun List<WorkspaceTemplate>.newTabTemplate(stored: Workspace.Type): WorkspaceTemplate? =
     if (stored == Workspace.Type.TEMPLATES) null else newTabCandidates().firstOrNull { it.type == stored }
+
+/**
+ * The name the new tab picker offered for a type, so every "new tab type" surface repeats the
+ * wording the user chose from. Types without a template (TEMPLATES itself, singletons) keep the
+ * generic workspace label.
+ */
+fun List<WorkspaceTemplate>.newTabTypeName(stored: Workspace.Type): CaString =
+    newTabTemplate(stored)?.title ?: stored.label

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -355,6 +355,10 @@
     <string name="workspace_settings_swipe_gestures_desc">Swipe left or right to switch between tabs.</string>
     <string name="workspace_settings_ondemand_creation_title">Auto-create tabs</string>
     <string name="workspace_settings_ondemand_creation_desc">Automatically create new tab when swiping past the last tab.</string>
+    <string name="workspace_settings_newtab_type_title">New tab type</string>
+    <string name="workspace_settings_newtab_type_desc">Workspace opened when swiping past the last tab, adding a tab to an empty pane, or creating the first tab.</string>
+    <string name="workspace_settings_newtab_type_ask">Ask every time</string>
+    <string name="workspace_settings_newtab_type_ask_desc">Show the tab type picker for each new tab.</string>
     <string name="workspace_settings_live_preview_title">Live previews</string>
     <string name="workspace_settings_live_preview_desc">Show live tab content in tab manager.</string>
     <string name="workspace_settings_other">Other</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
@@ -43,6 +43,7 @@ class WorkspaceSettingsLayoutTest : ComposeTest() {
                     onNavigateUp = {},
                     onToggleSwipeGestures = {},
                     onToggleOnDemandWorkspaceCreation = {},
+                    onSetDefaultNewTabType = {},
                     onToggleLivePreview = {},
                     onSetLayoutModePortrait = { portraitModes += it },
                     onSetLayoutModeLandscape = {},

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensionsTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensionsTest.kt
@@ -93,6 +93,57 @@ class WorkspaceTemplateExtensionsTest : BaseTest() {
     }
 
     @Test
+    fun `new tab resolves the stored type to its template`() = runTest {
+        val templates = listOf(
+            FakeTemplate(Workspace.Type.EXPLORER, sortOrder = 10),
+            FakeTemplate(Workspace.Type.SEARCHER, sortOrder = 20),
+        )
+
+        val available = templates.availableTemplates().first()
+
+        available.newTabTemplate(Workspace.Type.EXPLORER)?.type shouldBe Workspace.Type.EXPLORER
+        available.newTabTemplate(Workspace.Type.SEARCHER)?.type shouldBe Workspace.Type.SEARCHER
+    }
+
+    @Test
+    fun `new tab falls back to the picker without a resolvable template`() = runTest {
+        val templates = listOf(FakeTemplate(Workspace.Type.EXPLORER, sortOrder = 10))
+
+        val available = templates.availableTemplates().first()
+
+        available.newTabTemplate(Workspace.Type.TEMPLATES) shouldBe null
+        available.newTabTemplate(Workspace.Type.EDITOR) shouldBe null
+        emptyList<WorkspaceTemplate>().newTabTemplate(Workspace.Type.EXPLORER) shouldBe null
+    }
+
+    @Test
+    fun `new tab never resolves to a singleton type`() = runTest {
+        val templates = listOf(
+            FakeTemplate(Workspace.Type.EXPLORER, sortOrder = 10),
+            FakeTemplate(Workspace.Type.DEVELOPER, sortOrder = 100),
+        )
+
+        templates.availableTemplates().first().newTabTemplate(Workspace.Type.DEVELOPER) shouldBe null
+    }
+
+    @Test
+    fun `new tab candidates drop singletons and keep the remaining order`() = runTest {
+        val templates = listOf(
+            FakeTemplate(Workspace.Type.EXPLORER, sortOrder = 10),
+            FakeTemplate(Workspace.Type.DEVELOPER, sortOrder = 20),
+            FakeTemplate(Workspace.Type.SEARCHER, sortOrder = 30),
+            FakeTemplate(Workspace.Type.BUG_REPORT, sortOrder = 40),
+            FakeTemplate(Workspace.Type.HISTORY, sortOrder = 50),
+        )
+
+        templates.availableTemplates().first().newTabCandidates().map { it.type } shouldContainExactly listOf(
+            Workspace.Type.EXPLORER,
+            Workspace.Type.SEARCHER,
+            Workspace.Type.HISTORY,
+        )
+    }
+
+    @Test
     fun `quick create selection respects flag order and template arguments`() = runTest {
         val templates = listOf(
             FakeTemplate(Workspace.Type.HISTORY, sortOrder = 50, isQuickCreate = false),

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensionsTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/template/WorkspaceTemplateExtensionsTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.ui.template
 
+import android.content.Context
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Workspaces
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -7,8 +8,11 @@ import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.workspace.contracts.templates.TemplatesArguments
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.label
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -20,14 +24,19 @@ import testhelpers.BaseTest
 
 class WorkspaceTemplateExtensionsTest : BaseTest() {
 
+    /** String resources resolve to a stable stand-in so labels can be compared without a device. */
+    private val context = mockk<Context>().apply {
+        every { getString(any<Int>()) } answers { "res-${firstArg<Int>()}" }
+    }
+
     private class FakeTemplate(
         override val type: Workspace.Type,
         override val sortOrder: Int,
         override val isQuickCreate: Boolean = false,
         override val availability: Flow<Boolean> = flowOf(true),
+        override val title: CaString = type.name.toCaString(),
     ) : WorkspaceTemplate {
         override val icon: ImageVector = Icons.TwoTone.Workspaces
-        override val title: CaString = type.name.toCaString()
         override val subtitle: CaString = type.name.toCaString()
         override val arguments: Workspace.Arguments = TemplatesArguments.Default()
     }
@@ -124,6 +133,38 @@ class WorkspaceTemplateExtensionsTest : BaseTest() {
         )
 
         templates.availableTemplates().first().newTabTemplate(Workspace.Type.DEVELOPER) shouldBe null
+    }
+
+    @Test
+    fun `new tab type name uses the wording the picker offered`() = runTest {
+        val templates = listOf(
+            FakeTemplate(Workspace.Type.EXPLORER, sortOrder = 10, title = "Explorer".toCaString()),
+            // The template's own wording, which differs from Workspace.Type.SEARCHER.label.
+            FakeTemplate(Workspace.Type.SEARCHER, sortOrder = 20, title = "Search".toCaString()),
+        )
+
+        val available = templates.availableTemplates().first()
+
+        available.newTabTypeName(Workspace.Type.SEARCHER).get(context) shouldBe "Search"
+        available.newTabTypeName(Workspace.Type.EXPLORER).get(context) shouldBe "Explorer"
+    }
+
+    @Test
+    fun `new tab type name falls back to the workspace label without a template`() = runTest {
+        val templates = listOf(
+            FakeTemplate(Workspace.Type.EXPLORER, sortOrder = 10),
+            FakeTemplate(Workspace.Type.DEVELOPER, sortOrder = 100, title = "Developer Tools".toCaString()),
+        )
+
+        val available = templates.availableTemplates().first()
+
+        available.newTabTypeName(Workspace.Type.TEMPLATES).get(context) shouldBe
+            Workspace.Type.TEMPLATES.label.get(context)
+        available.newTabTypeName(Workspace.Type.EDITOR).get(context) shouldBe
+            Workspace.Type.EDITOR.label.get(context)
+        // Singletons are not new tab candidates, so their template title never applies.
+        available.newTabTypeName(Workspace.Type.DEVELOPER).get(context) shouldBe
+            Workspace.Type.DEVELOPER.label.get(context)
     }
 
     @Test

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -29,16 +29,19 @@ import eu.darken.butler.upgrade.UpgradeRepo
 import eu.darken.butler.workspace.contracts.bugreport.BugReportArguments
 import eu.darken.butler.workspace.contracts.explorer.ExplorerArguments
 import eu.darken.butler.workspace.contracts.viewer.ViewerArguments
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.workspace.core.OpenInNewTabsUseCase
 import eu.darken.butler.workspace.core.PendingWorkspaceConfirmation
 import eu.darken.butler.workspace.core.RenderedWorkspaceStacks
 import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.label
 import eu.darken.butler.workspace.core.WorkspaceStackChain
 import eu.darken.butler.workspace.core.WorkspaceStacks
 import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
 import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
 import eu.darken.butler.workspace.ui.template.availableTemplates
 import eu.darken.butler.workspace.ui.template.newTabTemplate
+import eu.darken.butler.workspace.ui.template.newTabTypeName
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceEvent
 import eu.darken.butler.workspace.core.WorkspaceRemote
@@ -408,9 +411,10 @@ class WorkspacesViewModel @Inject constructor(
             motd = motd,
             currentPaneCount = uiState.currentPaneCount,
             isRestoring = restorationState == WorkspaceSessionManager.State.Restoring,
-            // Display only, resolved by the helper the create path uses, so the placeholder card
-            // cannot name a type the swipe would not actually open.
-            newTabType = templates.newTabTemplate(defaultNewTabType)?.type ?: Workspace.Type.TEMPLATES,
+            // Display only, resolved by the helper the create path and the settings picker use, so
+            // the placeholder card cannot name a type the swipe would not actually open, and names
+            // it the way the picker offered it.
+            newTabTypeName = templates.newTabTypeName(defaultNewTabType),
         )
 
         // Asking for a favor is the lowest-priority surface there is: anything that asks the user
@@ -745,7 +749,7 @@ class WorkspacesViewModel @Inject constructor(
         val currentPaneCount: Int = 1,
         val isRestoring: Boolean = false,
         val showReviewCard: Boolean = false,
-        val newTabType: Workspace.Type = Workspace.Type.TEMPLATES,
+        val newTabTypeName: CaString = Workspace.Type.TEMPLATES.label,
     ) {
         val portraitPanelMode: WorkspacePanelMode
             get() = state.portraitPanelMode

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -393,7 +393,9 @@ class WorkspacesViewModel @Inject constructor(
         _managerDialogs,
         reviewState,
         guidedTourController.session,
-    ) { repoState, upgradeInfo, swipeGesturesEnabled, onDemandWorkspaceCreation, paneClickToFocus, uiState, motd, restorationState, dialogs, review, tourSession ->
+        workspaceSettings.defaultNewTabType.flow,
+        workspaceTemplates.availableTemplates(),
+    ) { repoState, upgradeInfo, swipeGesturesEnabled, onDemandWorkspaceCreation, paneClickToFocus, uiState, motd, restorationState, dialogs, review, tourSession, defaultNewTabType, templates ->
         val base = State(
             state = repoState,
             focusedWorkspace = uiState.focusedWorkspaceId,
@@ -406,6 +408,9 @@ class WorkspacesViewModel @Inject constructor(
             motd = motd,
             currentPaneCount = uiState.currentPaneCount,
             isRestoring = restorationState == WorkspaceSessionManager.State.Restoring,
+            // Display only, resolved by the helper the create path uses, so the placeholder card
+            // cannot name a type the swipe would not actually open.
+            newTabType = templates.newTabTemplate(defaultNewTabType)?.type ?: Workspace.Type.TEMPLATES,
         )
 
         // Asking for a favor is the lowest-priority surface there is: anything that asks the user
@@ -740,6 +745,7 @@ class WorkspacesViewModel @Inject constructor(
         val currentPaneCount: Int = 1,
         val isRestoring: Boolean = false,
         val showReviewCard: Boolean = false,
+        val newTabType: Workspace.Type = Workspace.Type.TEMPLATES,
     ) {
         val portraitPanelMode: WorkspacePanelMode
             get() = state.portraitPanelMode

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.butler.common.WebpageTool
 import eu.darken.butler.common.compose.tour.GuidedTourController
 import eu.darken.butler.common.coroutine.DispatcherProvider
+import eu.darken.butler.common.datastore.value
 import eu.darken.butler.common.debug.bugreport.BugReportRepo
 import eu.darken.butler.common.debug.logging.Logging.Priority.*
 import eu.darken.butler.common.debug.logging.asLog
@@ -35,6 +36,9 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceStackChain
 import eu.darken.butler.workspace.core.WorkspaceStacks
 import eu.darken.butler.workspace.ui.WorkspacePageHostEntry
+import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
+import eu.darken.butler.workspace.ui.template.availableTemplates
+import eu.darken.butler.workspace.ui.template.newTabTemplate
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.WorkspaceEvent
 import eu.darken.butler.workspace.core.WorkspaceRemote
@@ -73,7 +77,7 @@ class WorkspacesViewModel @Inject constructor(
     dispatchers: DispatcherProvider,
     upgradeRepo: UpgradeRepo,
     private val workspaceRepo: WorkspaceRepo,
-    workspaceSettings: WorkspaceSettings,
+    private val workspaceSettings: WorkspaceSettings,
     private val savedStateHandle: SavedStateHandle,
     val workspacePageManager: WorkspacePageManager,
     private val sessionManager: WorkspaceSessionManager,
@@ -87,6 +91,7 @@ class WorkspacesViewModel @Inject constructor(
     private val reviewTool: ReviewTool,
     private val guidedTourController: GuidedTourController,
     private val closedStash: ClosedWorkspaceStash,
+    private val workspaceTemplates: Set<@JvmSuppressWildcards WorkspaceTemplate>,
     val pageHosts: Map<Workspace.Type, @JvmSuppressWildcards WorkspacePageHostEntry>,
     val scrollPositions: WorkspaceScrollPositions,
     val barCollapseStates: WorkspaceBarCollapseStates,
@@ -418,6 +423,16 @@ class WorkspacesViewModel @Inject constructor(
         base.copy(showReviewCard = review.shouldAskForReview && isQuiet)
     }.asStateFlow()
 
+    /**
+     * What a new tab opens as: the type the user picked, or the templates picker when they did not
+     * pick one, or picked one that is currently unavailable.
+     */
+    private suspend fun newTabCreateRequest(): WorkspaceAction.Create {
+        val stored = workspaceSettings.defaultNewTabType.value()
+        val template = workspaceTemplates.availableTemplates().first().newTabTemplate(stored)
+        return template?.let { WorkspaceAction.Create(it.type, it.arguments) } ?: WorkspaceAction.Create()
+    }
+
     fun executeScreenAction(action: WorkspaceScreenAction) = launch {
         log(tag) { "executeScreenAction($action)" }
 
@@ -455,7 +470,7 @@ class WorkspacesViewModel @Inject constructor(
             }
             is WorkspaceScreenAction.CreateOnDemand -> {
                 log(tag) { "Creating workspace on-demand" }
-                when (val result = workspaceRepo.execute(WorkspaceAction.Create(type = Workspace.Type.TEMPLATES))) {
+                when (val result = workspaceRepo.execute(newTabCreateRequest())) {
                     is WorkspaceAction.Create.Result.Success -> {
                         log(tag) { "On-demand workspace created: ${result.newId}, focusing it" }
                         workspacePageManager.setLayout(mapOf(0 to result.newId), focusedId = result.newId)
@@ -474,7 +489,7 @@ class WorkspacesViewModel @Inject constructor(
             }
             is WorkspaceScreenAction.CreateForPane -> {
                 log(tag) { "Creating workspace for pane ${action.paneIndex}" }
-                when (val result = workspaceRepo.execute(WorkspaceAction.Create(type = Workspace.Type.TEMPLATES))) {
+                when (val result = workspaceRepo.execute(newTabCreateRequest())) {
                     is WorkspaceAction.Create.Result.Success -> {
                         log(tag) { "Workspace created: ${result.newId}, assigning to pane ${action.paneIndex}" }
                         val selections = workspacePageManager.state.value.selectedWorkspaces +

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -282,7 +282,7 @@ internal fun ClassicWorkspaceContainer(
                         // index while the list changes under the finger.
                         modifier = Modifier.suppressPressesUnless { restState.isRestingOn(page) },
                         isCreating = isPlaceholderPage && creationController.isCreating,
-                        newTabType = state.newTabType,
+                        newTabTypeName = state.newTabTypeName,
                         onClick = { creationController.onPlaceholderClick() },
                     )
                 } else {

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -357,6 +357,7 @@ internal fun ClassicWorkspaceContainer(
                     .paneHorizontalInsetPadding(design.paneEdges)
                     .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Vertical)),
                 isUpgraded = state.isUpgraded,
+                onCreate = { onWorkspaceScreenAction(WorkspaceScreenAction.CreateOnDemand) },
                 isTourTarget = isFirstTabTourTarget,
                 tourRequester = firstTabTourRequester,
             )

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/ClassicWorkspaceContainer.kt
@@ -282,6 +282,7 @@ internal fun ClassicWorkspaceContainer(
                         // index while the list changes under the finger.
                         modifier = Modifier.suppressPressesUnless { restState.isRestingOn(page) },
                         isCreating = isPlaceholderPage && creationController.isCreating,
+                        newTabType = state.newTabType,
                         onClick = { creationController.onPlaceholderClick() },
                     )
                 } else {

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/CreatingWorkspacePlaceholder.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/CreatingWorkspacePlaceholder.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
@@ -35,11 +36,14 @@ import eu.darken.butler.R
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.label
 
 @Composable
 internal fun CreatingWorkspacePlaceholder(
     modifier: Modifier = Modifier,
     isCreating: Boolean = false,
+    newTabType: Workspace.Type = Workspace.Type.TEMPLATES,
     onClick: () -> Unit = {},
 ) {
     Column(
@@ -105,7 +109,7 @@ internal fun CreatingWorkspacePlaceholder(
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = stringResource(eu.darken.butler.workspace.R.string.workspace_templates_label),
+                                text = newTabType.label.get(LocalContext.current),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                             )
@@ -128,12 +132,19 @@ internal fun CreatingWorkspacePlaceholder(
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun CreatingWorkspacePlaceholderPreviewReady() {
-    CreatingWorkspacePlaceholder(isCreating = false)
+    CreatingWorkspacePlaceholder(isCreating = false, newTabType = Workspace.Type.TEMPLATES)
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun CreatingWorkspacePlaceholderPreviewReadyExplorer() {
+    CreatingWorkspacePlaceholder(isCreating = false, newTabType = Workspace.Type.EXPLORER)
 }
 
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun CreatingWorkspacePlaceholderPreviewCreating() {
-    CreatingWorkspacePlaceholder(isCreating = true)
+    CreatingWorkspacePlaceholder(isCreating = true, newTabType = Workspace.Type.TEMPLATES)
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/CreatingWorkspacePlaceholder.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/CreatingWorkspacePlaceholder.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.R
+import eu.darken.butler.common.ca.CaString
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -43,7 +44,7 @@ import eu.darken.butler.workspace.core.label
 internal fun CreatingWorkspacePlaceholder(
     modifier: Modifier = Modifier,
     isCreating: Boolean = false,
-    newTabType: Workspace.Type = Workspace.Type.TEMPLATES,
+    newTabTypeName: CaString = Workspace.Type.TEMPLATES.label,
     onClick: () -> Unit = {},
 ) {
     Column(
@@ -109,7 +110,7 @@ internal fun CreatingWorkspacePlaceholder(
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = newTabType.label.get(LocalContext.current),
+                                text = newTabTypeName.get(LocalContext.current),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                             )
@@ -132,19 +133,19 @@ internal fun CreatingWorkspacePlaceholder(
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun CreatingWorkspacePlaceholderPreviewReady() {
-    CreatingWorkspacePlaceholder(isCreating = false, newTabType = Workspace.Type.TEMPLATES)
+    CreatingWorkspacePlaceholder(isCreating = false, newTabTypeName = Workspace.Type.TEMPLATES.label)
 }
 
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun CreatingWorkspacePlaceholderPreviewReadyExplorer() {
-    CreatingWorkspacePlaceholder(isCreating = false, newTabType = Workspace.Type.EXPLORER)
+    CreatingWorkspacePlaceholder(isCreating = false, newTabTypeName = Workspace.Type.EXPLORER.label)
 }
 
 @Preview2
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun CreatingWorkspacePlaceholderPreviewCreating() {
-    CreatingWorkspacePlaceholder(isCreating = true, newTabType = Workspace.Type.TEMPLATES)
+    CreatingWorkspacePlaceholder(isCreating = true, newTabTypeName = Workspace.Type.TEMPLATES.label)
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/EmptyClassicWorkspaceContent.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/classic/EmptyClassicWorkspaceContent.kt
@@ -39,7 +39,6 @@ import eu.darken.butler.common.compose.ButlerTip
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
 import eu.darken.butler.common.compose.tour.guidedTourTarget
-import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.ui.manager.LocalWorkspaceButtonProvider
 import eu.darken.butler.workspace.ui.workspaces.tour.FirstTabTour
 import kotlin.time.Duration.Companion.seconds
@@ -48,6 +47,7 @@ import kotlin.time.Duration.Companion.seconds
 internal fun EmptyClassicWorkspaceContent(
     modifier: Modifier = Modifier,
     isUpgraded: Boolean,
+    onCreate: () -> Unit,
     isTourTarget: Boolean = false,
     /** Lets the tour scroll the create card into the viewport before its step is published. */
     tourRequester: BringIntoViewRequester? = null,
@@ -105,7 +105,7 @@ internal fun EmptyClassicWorkspaceContent(
 
                 // Create workspace card (primary action)
                 Card(
-                    onClick = { workspaceActionHandler?.executeWorkspaceAction(WorkspaceAction.Create()) },
+                    onClick = onCreate,
                     modifier = Modifier
                         .fillMaxWidth()
                         .then(
@@ -218,6 +218,7 @@ internal fun EmptyClassicWorkspaceContent(
 private fun EmptyWorkspaceContentPreview() {
     EmptyClassicWorkspaceContent(
         isUpgraded = false,
+        onCreate = {},
     )
 }
 
@@ -227,5 +228,6 @@ private fun EmptyWorkspaceContentPreview() {
 private fun EmptyWorkspaceContentUpgradedPreview() {
     EmptyClassicWorkspaceContent(
         isUpgraded = true,
+        onCreate = {},
     )
 }

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
@@ -144,6 +144,7 @@ class WorkspacesViewModelDialogTest : BaseTest() {
             reviewTool = reviewTool,
             guidedTourController = guidedTourController,
             closedStash = ClosedWorkspaceStash(backgroundScope),
+            workspaceTemplates = emptySet(),
             pageHosts = emptyMap(),
             scrollPositions = mockk<WorkspaceScrollPositions>(relaxed = true),
             barCollapseStates = mockk<WorkspaceBarCollapseStates>(relaxed = true),

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelErrorIncidentTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelErrorIncidentTest.kt
@@ -130,6 +130,7 @@ class WorkspacesViewModelErrorIncidentTest : BaseTest() {
             reviewTool = reviewTool,
             guidedTourController = guidedTourController,
             closedStash = ClosedWorkspaceStash(backgroundScope),
+            workspaceTemplates = emptySet(),
             pageHosts = emptyMap(),
             scrollPositions = mockk<WorkspaceScrollPositions>(relaxed = true),
             barCollapseStates = mockk<WorkspaceBarCollapseStates>(relaxed = true),

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelReviewCardTest.kt
@@ -87,6 +87,11 @@ class WorkspacesViewModelReviewCardTest : BaseTest() {
             every { flow } returns flowOf(value)
         }
 
+    private fun typeSetting(value: Workspace.Type): DataStoreValue<Workspace.Type> =
+        mockk<DataStoreValue<Workspace.Type>>(relaxed = true).apply {
+            every { flow } returns flowOf(value)
+        }
+
     private fun workspaceInfo(
         id: Workspace.Id,
         caller: Workspace.Id? = null,
@@ -140,6 +145,7 @@ class WorkspacesViewModelReviewCardTest : BaseTest() {
             every { swipeGesturesEnabled } returns boolSetting(true)
             every { onDemandWorkspaceCreation } returns boolSetting(true)
             every { paneClickToFocus } returns boolSetting(true)
+            every { defaultNewTabType } returns typeSetting(Workspace.Type.TEMPLATES)
         }
         val pageManager = mockk<WorkspacePageManager>(relaxed = true).apply {
             every { state } returns MutableStateFlow(

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelReviewCardTest.kt
@@ -186,6 +186,7 @@ class WorkspacesViewModelReviewCardTest : BaseTest() {
             reviewTool = reviewTool,
             guidedTourController = guidedTourController,
             closedStash = ClosedWorkspaceStash(backgroundScope),
+            workspaceTemplates = emptySet(),
             pageHosts = emptyMap(),
             scrollPositions = mockk<WorkspaceScrollPositions>(relaxed = true),
             barCollapseStates = mockk<WorkspaceBarCollapseStates>(relaxed = true),


### PR DESCRIPTION
## What changed

New tabs always opened the tab-type picker, so anyone who mostly wants the same kind of tab picked it again every time. A "New tab type" setting under Settings → Tabs → Navigation now chooses what a new tab opens as. Leave it on "Ask every time" and nothing changes.

The setting covers the three gesture-shaped ways to make a tab: swiping past the last tab, the "+" in an empty pane, and the create-tab card on the empty screen. The two menu entries labelled "New tab" keep opening the picker, so there is still a one-tap route to choosing a type per tab.

Developer tools and Bug report are not offered as a default. Only one of each can exist, so picking one would make the gesture jump to the existing tab instead of opening a new one.

## Technical Context

- The preference stores a `Workspace.Type` defaulting to `TEMPLATES`, which is exactly what the three call sites hardcoded before. No migration, and no behaviour change for anyone who never opens the setting.
- Resolution returns the `WorkspaceTemplate` rather than a bare type, and the create request carries that template's own `arguments`. `WorkspaceRepo` picks the factory by `type` and `Workspace.Arguments` carries its own `type`, so a type paired with foreign arguments is invalid; going through the template also avoids a second source of truth beside `Type.defaultArguments`.
- Singleton types are filtered in `newTabCandidates()` instead of being handled per call site. A create of an already-open singleton returns `AlreadyOpen`, which leaves the swipe placeholder stuck in `Creating` and lets the empty-pane "+" assign one workspace to two panes. Excluding them at the source keeps pager and pane-assignment code untouched.
- `Workspace.Type` gains `@Serializable` with pinned `@SerialName` values. kotlinx serializes enums by name, so the enum's "the ordinal is part of no persisted format" invariant holds and Room's existing `.name` persistence is unaffected.
- The settings row displays the effective resolved type while leaving the stored value alone, so it can never name a type the gesture would not honour, and a type that becomes unavailable and later returns is restored. Worth a close look: `WorkspaceSettingsViewModel` and `WorkspacesViewModel` must resolve through the same `newTabTemplate()` for that to hold.
