### PR TITLE
Workspace: Show what a folder contains on its grid tile

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/grid/DirectoryGrid.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/items/grid/DirectoryGrid.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.explorer.ui.explorer.items.grid
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Folder
@@ -10,13 +11,16 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewWrapper as ComposePreviewWrapper
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
-import eu.darken.butler.common.files.APath
+import eu.darken.butler.common.compose.TintedAsyncImage
+import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.formatDateTime
 import eu.darken.butler.explorer.ui.explorer.items.ItemDecorations
 import eu.darken.butler.explorer.ui.explorer.items.SizeProportionBar
@@ -30,7 +34,11 @@ import eu.darken.butler.explorer.ui.explorer.items.gridIconSize
 import eu.darken.butler.explorer.ui.explorer.items.showsTileMetadata
 import eu.darken.butler.explorer.ui.explorer.preview.MockDataProvider
 import eu.darken.butler.workspace.ui.preview.FolderPreviewCollage
+import eu.darken.butler.workspace.ui.preview.ProvideFolderPreviews
 import eu.darken.butler.workspace.ui.preview.rememberFolderPreviewChildren
+import kotlinx.coroutines.flow.flowOf
+
+internal const val TEST_TAG_EXPLORER_GRID_THUMBNAIL = "explorer.grid.thumbnail"
 
 /** Default for previews/tests: previews are always considered "settled" (loaded immediately). */
 internal val PREVIEWS_ALWAYS_SETTLED: State<Boolean> = mutableStateOf(true)
@@ -71,7 +79,8 @@ internal fun DirectoryGrid(
         decorations = decorations,
         previewContent = {
             DirectoryPreviewBackground(
-                dir = item.lookup.lookedUp,
+                modifier = Modifier.fillMaxSize(),
+                lookup = item.lookup,
                 previewsSettled = previewsSettled,
             )
         },
@@ -102,7 +111,8 @@ internal fun DirectoryGrid(
 }
 
 /**
- * Folder tile background: a collage of the folder's newest media, or nothing.
+ * Folder tile background: a collage of the folder's newest previewable children, or the folder
+ * glyph.
  *
  * The scroll-driven [previewsSettled] read is isolated here so scroll start/stop recomposes only
  * this child, never the surrounding tile chrome or file tiles.
@@ -110,12 +120,19 @@ internal fun DirectoryGrid(
 @Composable
 private fun DirectoryPreviewBackground(
     modifier: Modifier = Modifier,
-    dir: APath<*>,
+    lookup: APathLookup<*>,
     previewsSettled: State<Boolean>,
 ) {
-    val children = rememberFolderPreviewChildren(dir, loadingEnabled = previewsSettled.value)
+    val children = rememberFolderPreviewChildren(lookup.lookedUp, loadingEnabled = previewsSettled.value)
     if (children.isNotEmpty()) {
         FolderPreviewCollage(modifier = modifier, children = children)
+    } else {
+        TintedAsyncImage(
+            model = lookup,
+            contentDescription = null,
+            modifier = modifier.testTag(TEST_TAG_EXPLORER_GRID_THUMBNAIL),
+            contentScale = ContentScale.Crop,
+        )
     }
 }
 
@@ -226,4 +243,31 @@ private fun DirectoryGridHighlightedPreview() {
         showSelection = false,
         isHighlighted = true,
     )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun DirectoryGridCollagePreview() {
+    ProvideFolderPreviews(
+        {
+            flowOf(
+                listOf(
+                    MockDataProvider.createMockImageFile("sunset.jpg"),
+                    MockDataProvider.createMockImageFile("beach.png"),
+                    MockDataProvider.createMockVideoFile("clip.mp4"),
+                    MockDataProvider.createMockPdfFile("manual.pdf"),
+                ),
+            )
+        },
+    ) {
+        DirectoryGrid(
+            item = MockDataProvider.createMockDirectory("Pictures", 42),
+            density = ExplorerViewStyle.Density.COMFORTABLE,
+            isSelected = false,
+            onToggleSelection = {},
+            onClick = {},
+            showSelection = false,
+        )
+    }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/items/grid/DirectoryGridCollageTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/items/grid/DirectoryGridCollageTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.PreviewWrapper
@@ -56,6 +58,33 @@ class DirectoryGridCollageTest : ComposeTest() {
         }
 
         composeTestRule.onNodeWithTag(TEST_TAG_FOLDER_PREVIEW_COLLAGE, useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun `directory without previewable children renders the folder fallback`() {
+        composeTestRule.setContent {
+            PreviewWrapper {
+                ProvideFolderPreviews({ flowOf(emptyList()) }) {
+                    Box(Modifier.size(200.dp)) {
+                        LookupItemGrid(
+                            item = MockDataProvider.createMockDirectory(name = "Docs"),
+                            density = ExplorerViewStyle.Density.COMFORTABLE,
+                            isSelected = false,
+                            onToggleSelection = {},
+                            onClick = {},
+                            showSelection = false,
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(TEST_TAG_FOLDER_PREVIEW_COLLAGE, useUnmergedTree = true).assertDoesNotExist()
+        // The fallback has to cover the tile; at its intrinsic size it would sit under the top bar.
+        composeTestRule.onNodeWithTag(TEST_TAG_EXPLORER_GRID_THUMBNAIL, useUnmergedTree = true)
+            .assertExists()
+            .assertWidthIsEqualTo(200.dp)
+            .assertHeightIsEqualTo(200.dp)
     }
 
     @Test

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/preview/FolderPreviewResolver.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/preview/FolderPreviewResolver.kt
@@ -43,7 +43,7 @@ import kotlin.time.Instant
 typealias FolderPreviewObserver = (APath<*>) -> Flow<List<APathLookup<*>>>
 
 /**
- * Resolves which media children represent a directory as a grid tile collage.
+ * Resolves which children represent a directory as a grid tile collage.
  *
  * Resolution runs in the collector's scope (scrolling a tile away cancels its lookup), on the IO
  * dispatcher, and is bounded by [semaphore] so scroll thrash can't fan out unbounded listings
@@ -200,13 +200,22 @@ class FolderPreviewResolver @Inject constructor(
                         // The preview fetcher renders exactly-0-byte files as generic icons;
                         // unknown (null) sizes may still decode, so only exclude confirmed-empty.
                         .filter { it.size != 0L }
-                        .filter { MimeInfo.fromFileName(it.name).let { mime -> mime.isImage || mime.isVideo } }
+                        .map { it to MimeInfo.fromFileName(it.name) }
+                        .filter { (_, mime) ->
+                            mime.isImage || mime.isVideo || mime.isPdf || mime.isText || mime.isApk
+                        }
                         .sortedWith(
-                            compareByDescending<APathLookup<*>> { it.modifiedAt ?: Instant.DISTANT_PAST }
-                                .thenBy { it.name }
+                            compareByDescending<Pair<APathLookup<*>, MimeInfo>> {
+                                it.first.modifiedAt ?: Instant.DISTANT_PAST
+                            }.thenBy { it.first.name }
                         )
-                        .take(MAX_PREVIEW_CHILDREN)
                         .toList()
+                        // Documents only fill what media leaves empty, so a picture folder's
+                        // collage doesn't change because a text file was touched more recently.
+                        .partition { (_, mime) -> mime.isImage || mime.isVideo }
+                        .let { (media, documents) -> media + documents }
+                        .take(MAX_PREVIEW_CHILDREN)
+                        .map { it.first }
                 }
             }
         } catch (e: CancellationException) {

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/core/preview/FolderPreviewResolverTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/core/preview/FolderPreviewResolverTest.kt
@@ -154,6 +154,67 @@ class FolderPreviewResolverTest : BaseTest() {
     }
 
     @Test
+    fun `document children fill the slots media leaves empty`() = runTest {
+        val gateway = mockk<GatewaySwitch>()
+        coEvery { gateway.lookupFiles(dir, any()) } returns listOf(
+            fileLookup("pic1.jpg", mtime = 500L),
+            fileLookup("pic2.png", mtime = 400L),
+            fileLookup("doc.pdf", mtime = 900L),
+            fileLookup("notes.txt", mtime = 800L),
+            fileLookup("app.apk", mtime = 700L),
+        )
+        val resolver = create(backgroundScope, gatewaySwitch = gateway)
+
+        val children = resolver.observe(dir).first()
+
+        children.map { it.name } shouldBe listOf("pic1.jpg", "pic2.png", "doc.pdf", "notes.txt")
+    }
+
+    @Test
+    fun `media children outrank newer documents`() = runTest {
+        val gateway = mockk<GatewaySwitch>()
+        coEvery { gateway.lookupFiles(dir, any()) } returns listOf(
+            fileLookup("a.jpg", mtime = 100L),
+            fileLookup("b.png", mtime = 200L),
+            fileLookup("c.mp4", mtime = 300L),
+            fileLookup("d.webp", mtime = 400L),
+            fileLookup("fresh.pdf", mtime = 999L),
+        )
+        val resolver = create(backgroundScope, gatewaySwitch = gateway)
+
+        val children = resolver.observe(dir).first()
+
+        children.map { it.name } shouldBe listOf("d.webp", "c.mp4", "b.png", "a.jpg")
+    }
+
+    @Test
+    fun `non-previewable children are still excluded`() = runTest {
+        val gateway = mockk<GatewaySwitch>()
+        coEvery { gateway.lookupFiles(dir, any()) } returns listOf(
+            fileLookup("report.docx", mtime = 900L),
+            fileLookup("backup.zip", mtime = 800L),
+            fileLookup("song.mp3", mtime = 700L),
+        )
+        val resolver = create(backgroundScope, gatewaySwitch = gateway)
+
+        resolver.observe(dir).first() shouldBe emptyList()
+    }
+
+    @Test
+    fun `confirmed-empty documents are excluded`() = runTest {
+        val gateway = mockk<GatewaySwitch>()
+        coEvery { gateway.lookupFiles(dir, any()) } returns listOf(
+            fileLookup("empty.txt", mtime = 900L, size = 0L),
+            fileLookup("pic.jpg", mtime = 100L),
+        )
+        val resolver = create(backgroundScope, gatewaySwitch = gateway)
+
+        val children = resolver.observe(dir).first()
+
+        children.map { it.name } shouldBe listOf("pic.jpg")
+    }
+
+    @Test
     fun `null mtimes sort last with name tiebreak`() = runTest {
         val gateway = mockk<GatewaySwitch>()
         coEvery { gateway.lookupFiles(dir, any()) } returns listOf(


### PR DESCRIPTION
## What changed

Folder tiles in the grid view used to show a blank square unless the folder directly contained a photo or video. A folder full of documents looked empty sitting next to a document file, which always shows something.

A folder tile now shows previews of what is actually inside it: PDF first pages, text and code files, and app icons, alongside photos and videos as before. Folders whose contents cannot be previewed at all — Office documents, archives, audio — show a folder icon filling the tile instead of a blank square, so no tile is ever a flat empty square.

Folders holding four or more photos or videos look exactly as they did.

This applies to folder tiles in both the Explorer and the Searcher grids.

## Technical Context

- `FolderPreviewResolver` picked collage children from `isImage || isVideo` only, even though `PathPreviewFetcher` already renders PDF pages, APK icons and text. Selection is now two-tiered over the same listing — media first, then PDF/text/APK — each tier keeping the existing `modifiedAt`-descending / name-ascending order, capped at 4. Media-first is what keeps an existing collage byte-identical: a recently touched `notes.txt` cannot displace a picture.
- Accepted cost, deliberately not mitigated: only the text branch writes Coil's disk cache. APK and PDF previews are decoded bitmaps held in the memory cache only, so they re-render after an eviction. The fetcher lane is bounded and shared with the visible file tiles, so this queues rather than spikes.
- Explorer's `DirectoryPreviewBackground` composed nothing when the collage came back empty, while the Searcher's equivalent already fell back to the thumbnail request — which yields the folder glyph for a directory lookup. Explorer now matches it, so this also closes an inconsistency between the two surfaces.
- The `Modifier.fillMaxSize()` at the Explorer call site is load-bearing rather than cosmetic: the collage path only worked without it because `FolderPreviewLayout` fills internally. `TintedAsyncImage` does not, so the glyph would have measured at the drawable's intrinsic size and sat under the tile's top bar. `DirectoryGridCollageTest` asserts the fallback's measured width and height for exactly that reason.
- Worth close review: the `partition`-based tier split in `FolderPreviewResolver.cachedOrResolve`. It depends on `partition` preserving the sorted order within each side, which is what makes the two-tier result equivalent to sorting each tier separately.
