### PR TITLE
Explorer: Add an option to hide and show hidden files

### DIFF
--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerViewStyle.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/core/ExplorerViewStyle.kt
@@ -6,11 +6,15 @@ import kotlinx.serialization.Serializable
 /**
  * [mode] is persisted under the wire key `type`, and stored payloads rely on that: renaming it
  * silently resets the saved mode of every tab and every default, keeping their density.
+ *
+ * [showHidden] defaults to true so a payload written before it existed decodes to what its author
+ * saw, which is every dot-prefixed entry on screen.
  */
 @Serializable
 data class ExplorerViewStyle(
     @SerialName("type") val mode: Mode = Mode.LIST,
     @SerialName("density") val density: Density = Density.COMFORTABLE,
+    @SerialName("showhidden") val showHidden: Boolean = true,
 ) {
 
     @Serializable

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/EmptyRecovery.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/EmptyRecovery.kt
@@ -1,0 +1,22 @@
+package eu.darken.butler.explorer.ui.explorer
+
+/**
+ * What brings rows back to a listing that filtering emptied.
+ *
+ * Classified from what each combination actually yields, never from which settings happen to be
+ * active: a listing can hide entries and filter entries and still be emptied by only one of them,
+ * and an offer that changes nothing visible is worse than no offer at all.
+ */
+enum class EmptyRecovery {
+    /** Revealing the hidden entries is enough. */
+    SHOW_HIDDEN,
+
+    /** Clearing this tab's filters is enough. */
+    RESET_FILTERS,
+
+    /** Either one on its own brings rows back. */
+    EITHER,
+
+    /** Neither on its own does; only both together. */
+    SHOW_ALL,
+}

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerViewSettingsController.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerViewSettingsController.kt
@@ -190,14 +190,40 @@ class ExplorerViewSettingsController(
         items: List<ExplorerItem>,
         filterState: FilterState,
         useRegexPatterns: Boolean,
-    ): List<ExplorerItem> {
+        showHidden: Boolean,
+    ): List<ExplorerItem> = items.filter(itemFilter(filterState, useRegexPatterns, showHidden))
+
+    /** Whether a combination of filters and [showHidden] would leave anything on screen. */
+    fun showsAnythingWhen(
+        items: List<ExplorerItem>,
+        filterState: FilterState,
+        useRegexPatterns: Boolean,
+        showHidden: Boolean,
+    ): Boolean = items.any(itemFilter(filterState, useRegexPatterns, showHidden))
+
+    /**
+     * Dot-prefixed entries in the unfiltered listing, directories included.
+     *
+     * An inventory fact about the folder, not a promise that revealing them adds exactly this many
+     * rows: the name and type filters still apply to whatever is revealed.
+     */
+    fun countHiddenEntries(items: List<ExplorerItem>): Int = items.count { it.isHiddenEntry }
+
+    private fun itemFilter(
+        filterState: FilterState,
+        useRegexPatterns: Boolean,
+        showHidden: Boolean,
+    ): (ExplorerItem) -> Boolean {
         // Compiled once per pass rather than per item; a pattern that does not compile matches nothing
         val hasExclude = filterState.excludePattern.isNotBlank()
         val excludeRegex = if (hasExclude) PatternMatcher.compile(filterState.excludePattern, useRegexPatterns) else null
         val hasInclude = filterState.includePattern.isNotBlank()
         val includeRegex = if (hasInclude) PatternMatcher.compile(filterState.includePattern, useRegexPatterns) else null
 
-        return items.filter { item ->
+        return filter@{ item ->
+            // Before the pattern and type checks, so an entry both of them would drop is dropped once.
+            if (!showHidden && item.isHiddenEntry) return@filter false
+
             val itemName = when (item) {
                 is ExplorerItem.Path -> item.path.name
                 is ExplorerItem.Trash.Root -> item.originalLookup.name
@@ -233,6 +259,13 @@ class ExplorerViewSettingsController(
             true
         }
     }
+
+    /**
+     * A dot-prefixed name on a path entry. Trashed entries are deliberately not covered: restoring
+     * acts on what the listing offers, so an entry the dot rule removes could not be restored.
+     */
+    private val ExplorerItem.isHiddenEntry: Boolean
+        get() = this is ExplorerItem.Path && path.name.startsWith(".")
 
     companion object {
         private val TAG = logTag("Explorer", "ViewSettings")

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -2472,7 +2472,7 @@ internal fun ExplorerViewSettingsController.processListing(
     useRegexPatterns: Boolean,
     showHidden: Boolean,
 ): ExplorerWorkspaceViewModel.ProcessedListing {
-    val visibleSize = items.sumOf { item ->
+    val visibleSize: Long = items.sumOf { item ->
         when {
             item is ExplorerItem.File -> item.lookup.size ?: 0L
             item is ExplorerItem.Trash.Nested && item.isFile -> item.lookup.size ?: 0L

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/ExplorerWorkspaceViewModel.kt
@@ -531,6 +531,16 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         val highlightedItemIds: Set<String> = emptySet(),
         val focusedItemIndex: Int? = null,
         val unfilteredItemCount: Int = 0,
+        /** Files and folders in the listing as displayed; the loader's own counts ignore filtering. */
+        val visibleFileCount: Int = 0,
+        val visibleDirectoryCount: Int = 0,
+        val visibleTotalSize: Long? = null,
+        /** Dot-prefixed entries this tab is hiding here, zero while it shows them. */
+        val hiddenCount: Int = 0,
+        /** The folder itself has nothing in it, as opposed to nothing surviving the filtering. */
+        val locationIsEmpty: Boolean = false,
+        /** What recovers a listing filtering emptied; null while nothing does or it is not settled. */
+        val emptyRecovery: EmptyRecovery? = null,
         val favorites: List<FavoriteItem> = emptyList(),
         val favoritePaths: List<APath<*>> = emptyList(),
         val showHomeFavoritesSection: Boolean = false,
@@ -574,10 +584,23 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         }
     }
 
-    /** A processed listing together with the location it was computed for. */
-    private data class ProcessedListing(
+    /**
+     * A processed listing together with the location it was computed for, and everything the chrome
+     * says about it.
+     *
+     * The numbers travel with the rows they describe rather than being derived further downstream:
+     * a combine of their own would pair one folder's rows with the previous folder's counts while a
+     * navigation or a hidden-files toggle works its way through the pipeline.
+     */
+    internal data class ProcessedListing(
         val locationId: String,
         val items: List<ExplorerItem>,
+        val visibleFileCount: Int,
+        val visibleDirectoryCount: Int,
+        val visibleTotalSize: Long?,
+        val hiddenCount: Int,
+        val locationIsEmpty: Boolean,
+        val emptyRecovery: EmptyRecovery?,
     )
 
     // Sorted/filtered items, shared to prevent duplicate processing
@@ -591,18 +614,30 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         favoritesRepo.favoritePaths,
         workspaceReadyState.map { it?.currentLocation }.distinctUntilChanged { a, b -> a?.locationId == b?.locationId },
         pickerConfigFlow,
-    ) { items, resolvedSort, filterState, useRegexPatterns, favoritePaths, location, pickerConfig ->
+        // Only the hidden-files flag, not the whole style: mode and density are presentation-only,
+        // and re-running filtering, sorting and favorite ordering for them would be wasted work on a
+        // folder with thousands of entries.
+        viewSettings.viewStyle.map { it.showHidden }.distinctUntilChanged(),
+    ) { items, resolvedSort, filterState, useRegexPatterns, favoritePaths, location, pickerConfig, showHidden ->
         // flatMapLatest does not clear this combine's last sort value, so items are only paired with
         // a resolution that was computed for the location they came from - otherwise the next
         // folder's listing would briefly render under the previous folder's sort.
         if (resolvedSort == null || location == null || resolvedSort.locationKey != location.locationId) {
             return@combineMany null
         }
-        items
-            ?.let { viewSettings.applyFilters(it, filterState, useRegexPatterns) }
-            ?.let { itemSorter.sortItems(it, resolvedSort.resolution.settings) }
-            ?.let { applyFavoritePriority(it, location, pickerConfig, favoritePaths) }
-            ?.let { ProcessedListing(locationId = location.locationId, items = it) }
+        items?.let { rawItems ->
+            val processed = viewSettings.applyFilters(rawItems, filterState, useRegexPatterns, showHidden)
+                .let { itemSorter.sortItems(it, resolvedSort.resolution.settings) }
+                .let { applyFavoritePriority(it, location, pickerConfig, favoritePaths) }
+            viewSettings.processListing(
+                locationId = location.locationId,
+                rawItems = rawItems,
+                items = processed,
+                filterState = filterState,
+                useRegexPatterns = useRegexPatterns,
+                showHidden = showHidden,
+            )
+        }
     }.shareIn(vmScope, SharingStarted.Lazily, replay = 1)
 
     private val processedItemsFlow: Flow<List<ExplorerItem>?> = processedListingFlow.map { it?.items }
@@ -649,7 +684,7 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
 
                 is ExplorerWorkspace.State.Ready -> combineMany(
                     flowOf(wsState),
-                    processedItemsFlow,
+                    processedListingFlow,
                     derivedSelectionStateFlow,
                     viewSettings.viewStyle,
                     dialogs.state,
@@ -666,7 +701,8 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                     favoritesRepo.favorites,
                     favoritesController.feedback,
                     directorySizes,
-                ) { wsStateInner, items, selectionState, viewStyle, dialogState, resolvedSort, upgradeInfo, filterState, useRegexPatterns, useBackButtonForNavigation, pickerConfig, recycleBinEnabled, saveAsFilename, highlightedItemIds, focusedItemIndex, favorites, favoriteFeedback, sizes ->
+                ) { wsStateInner, listing, selectionState, viewStyle, dialogState, resolvedSort, upgradeInfo, filterState, useRegexPatterns, useBackButtonForNavigation, pickerConfig, recycleBinEnabled, saveAsFilename, highlightedItemIds, focusedItemIndex, favorites, favoriteFeedback, sizes ->
+                    val items = listing?.items
                     val disabledItems = items?.let { pickerHelper.computeDisabledItems(it, pickerConfig) } ?: emptySet()
 
                     // flatMapLatest does not clear this combine's last sort value: until the new
@@ -724,6 +760,12 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
                         breadcrumbs = wsStateInner.currentBreadcrumbs ?: emptyList(),
                         items = items,
                         unfilteredItemCount = wsStateInner.currentLocation?.items?.size ?: 0,
+                        visibleFileCount = listing?.visibleFileCount ?: 0,
+                        visibleDirectoryCount = listing?.visibleDirectoryCount ?: 0,
+                        visibleTotalSize = listing?.visibleTotalSize,
+                        hiddenCount = listing?.hiddenCount ?: 0,
+                        locationIsEmpty = listing?.locationIsEmpty == true,
+                        emptyRecovery = listing?.emptyRecovery,
                         error = wsStateInner.error,
                         isRefreshing = wsStateInner.isRefreshing,
                         refreshId = wsStateInner.refreshId,
@@ -1952,6 +1994,22 @@ class ExplorerWorkspaceViewModel @AssistedInject constructor(
         viewSettings.resetFilters()
     }
 
+    fun onShowHiddenItems() = launch {
+        log(tag) { "onShowHiddenItems()" }
+        viewSettings.applyToTab(viewSettings.viewStyle.value.copy(showHidden = true))
+    }
+
+    fun onShowAllItems() = launch {
+        log(tag) { "onShowAllItems()" }
+        viewSettings.applyToTab(viewSettings.viewStyle.value.copy(showHidden = true))
+        viewSettings.resetFilters()
+    }
+
+    fun showViewOptions() = launch {
+        log(tag) { "showViewOptions()" }
+        dialogs.show(ExplorerDialogState.EditViewStyle)
+    }
+
     fun pasteClipboard(clip: ClipboardClip) = launch {
         log(tag) { "pasteClipboard($clip)" }
         dismissDialog()
@@ -2398,6 +2456,73 @@ internal fun ExplorerDialogState.withLiveNetworkItem(items: List<ExplorerItem>?)
         ?.filterIsInstance<ExplorerItem.Storage.Network>()
         ?.firstOrNull { it.location.id == context.locationId }
     return ItemInfo(context.copy(item = item))
+}
+
+/**
+ * Everything the chrome says about a listing, derived from the same raw items and settings that
+ * produced [items], so a toggle or a navigation can never pair rows with foreign numbers.
+ *
+ * Top-level for the same reason as [hasSameItemsAs]: unit-testable without VM scaffolding.
+ */
+internal fun ExplorerViewSettingsController.processListing(
+    locationId: String,
+    rawItems: List<ExplorerItem>,
+    items: List<ExplorerItem>,
+    filterState: FilterState,
+    useRegexPatterns: Boolean,
+    showHidden: Boolean,
+): ExplorerWorkspaceViewModel.ProcessedListing {
+    val visibleSize = items.sumOf { item ->
+        when {
+            item is ExplorerItem.File -> item.lookup.size ?: 0L
+            item is ExplorerItem.Trash.Nested && item.isFile -> item.lookup.size ?: 0L
+            else -> 0L
+        }
+    }
+    return ExplorerWorkspaceViewModel.ProcessedListing(
+        locationId = locationId,
+        items = items,
+        visibleFileCount = items.count { it is ExplorerItem.File || (it is ExplorerItem.Trash.Nested && it.isFile) },
+        visibleDirectoryCount = items.count {
+            it is ExplorerItem.Directory || (it is ExplorerItem.Trash.Nested && it.isDirectory)
+        },
+        // Null rather than zero, the same way the loader reports a folder that totals nothing.
+        visibleTotalSize = visibleSize.takeIf { it > 0 },
+        // Zero while the tab shows hidden entries, or the chip would offer a sheet whose switch is
+        // already on.
+        hiddenCount = if (showHidden) 0 else countHiddenEntries(rawItems),
+        locationIsEmpty = rawItems.isEmpty(),
+        emptyRecovery = emptyRecoveryFor(rawItems, items, filterState, useRegexPatterns, showHidden),
+    )
+}
+
+/**
+ * Classified by what each combination actually yields, so the empty state never offers a control
+ * that changes nothing on screen. Null means there is nothing to offer: the listing has rows, or
+ * the folder is genuinely empty, or the verdict would still be a guess.
+ *
+ * A [ExplorerItem.Peek] entry is neither a file nor a directory, so both file-type filter branches
+ * pass it through. Until the classifier has typed them all, revealing can look like it recovers
+ * rows that vanish again a moment later.
+ */
+private fun ExplorerViewSettingsController.emptyRecoveryFor(
+    rawItems: List<ExplorerItem>,
+    items: List<ExplorerItem>,
+    filterState: FilterState,
+    useRegexPatterns: Boolean,
+    showHidden: Boolean,
+): EmptyRecovery? {
+    if (items.isNotEmpty() || rawItems.isEmpty()) return null
+    if (rawItems.any { it is ExplorerItem.Peek }) return null
+
+    val revealing = !showHidden && showsAnythingWhen(rawItems, filterState, useRegexPatterns, showHidden = true)
+    val clearing = showsAnythingWhen(rawItems, FilterState(), useRegexPatterns, showHidden)
+    return when {
+        revealing && clearing -> EmptyRecovery.EITHER
+        revealing -> EmptyRecovery.SHOW_HIDDEN
+        clearing -> EmptyRecovery.RESET_FILTERS
+        else -> EmptyRecovery.SHOW_ALL
+    }
 }
 
 /**

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ViewStyleOptionsSheet.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/dialogs/ViewStyleOptionsSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -142,6 +143,21 @@ private fun ViewStyleOptionsContent(
 
         Row(
             modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.explorer_view_show_hidden_label),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(
+                checked = currentViewStyle.showHidden,
+                onCheckedChange = { onApplyToTab(currentViewStyle.copy(showHidden = it)) },
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End,
         ) {
             TextButton(
@@ -231,6 +247,20 @@ private fun ViewStyleOptionsSheetGridDetailedPreview() {
                 mode = ExplorerViewStyle.Mode.GRID,
                 density = ExplorerViewStyle.Density.DETAILED,
             ),
+            onApplyToTab = {},
+            onSetAsDefault = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ViewStyleOptionsSheetHiddenFilesOffPreview() {
+    PreviewWrapper {
+        ViewStyleOptionsContent(
+            currentViewStyle = ExplorerViewStyle(showHidden = false),
             onApplyToTab = {},
             onSetAsDefault = {},
             onDismiss = {},

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/EmptyFilteredState.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/EmptyFilteredState.kt
@@ -40,13 +40,25 @@ import androidx.compose.ui.unit.dp
 import eu.darken.butler.common.compose.ButlerPreviewWrapper
 import eu.darken.butler.common.compose.Preview2
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.common.R as CommonR
 import eu.darken.butler.explorer.R
+import eu.darken.butler.explorer.ui.explorer.EmptyRecovery
 import kotlinx.coroutines.delay
 
+/**
+ * Shown when filtering emptied a listing that has content.
+ *
+ * [recovery] decides what is offered, because it is classified from what each control would
+ * actually bring back. A null verdict - the listing is still being typed - gets no button rather
+ * than a guess that may turn out to change nothing.
+ */
 @Composable
 fun EmptyFilteredState(
     modifier: Modifier = Modifier,
+    recovery: EmptyRecovery?,
     onResetFilters: () -> Unit,
+    onShowHidden: () -> Unit,
+    onShowAll: () -> Unit,
     initiallyVisible: Boolean = false,
 ) {
     var visible by remember { mutableStateOf(initiallyVisible) }
@@ -111,7 +123,7 @@ fun EmptyFilteredState(
                 }
 
                 Text(
-                    text = stringResource(R.string.explorer_empty_filtered_title),
+                    text = stringResource(titleFor(recovery)),
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center,
@@ -119,22 +131,66 @@ fun EmptyFilteredState(
                 )
 
                 Text(
-                    text = stringResource(R.string.explorer_empty_filtered_caption),
+                    text = stringResource(captionFor(recovery)),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                     textAlign = TextAlign.Center,
                     modifier = Modifier.padding(top = 4.dp)
                 )
 
-                FilledTonalButton(
-                    onClick = onResetFilters,
-                    modifier = Modifier.padding(top = 16.dp),
-                ) {
-                    Text(text = stringResource(eu.darken.butler.common.R.string.general_reset_action))
+                when (recovery) {
+                    EmptyRecovery.SHOW_HIDDEN -> RecoveryButton(
+                        label = R.string.explorer_empty_show_hidden_action,
+                        onClick = onShowHidden,
+                    )
+                    EmptyRecovery.RESET_FILTERS -> RecoveryButton(
+                        label = CommonR.string.general_reset_action,
+                        onClick = onResetFilters,
+                    )
+                    // Named rather than "Reset": with two buttons, neither can rely on the caption
+                    EmptyRecovery.EITHER -> {
+                        RecoveryButton(
+                            label = R.string.explorer_empty_show_hidden_action,
+                            onClick = onShowHidden,
+                        )
+                        RecoveryButton(
+                            label = R.string.explorer_empty_clear_filters_action,
+                            onClick = onResetFilters,
+                        )
+                    }
+                    EmptyRecovery.SHOW_ALL -> RecoveryButton(
+                        label = R.string.explorer_empty_show_all_action,
+                        onClick = onShowAll,
+                    )
+                    null -> Unit
                 }
             }
         }
     }
+}
+
+@Composable
+private fun RecoveryButton(label: Int, onClick: () -> Unit) {
+    FilledTonalButton(
+        onClick = onClick,
+        modifier = Modifier.padding(top = 16.dp),
+    ) {
+        Text(text = stringResource(label))
+    }
+}
+
+private fun titleFor(recovery: EmptyRecovery?): Int = when (recovery) {
+    EmptyRecovery.SHOW_HIDDEN -> R.string.explorer_empty_hidden_title
+    EmptyRecovery.EITHER -> R.string.explorer_empty_hidden_or_filtered_title
+    EmptyRecovery.SHOW_ALL -> R.string.explorer_empty_hidden_and_filtered_title
+    EmptyRecovery.RESET_FILTERS, null -> R.string.explorer_empty_filtered_title
+}
+
+private fun captionFor(recovery: EmptyRecovery?): Int = when (recovery) {
+    EmptyRecovery.SHOW_HIDDEN -> R.string.explorer_empty_hidden_caption
+    EmptyRecovery.EITHER -> R.string.explorer_empty_hidden_or_filtered_caption
+    EmptyRecovery.SHOW_ALL -> R.string.explorer_empty_hidden_and_filtered_caption
+    EmptyRecovery.RESET_FILTERS, null -> R.string.explorer_empty_filtered_caption
 }
 
 @Preview2
@@ -142,7 +198,62 @@ fun EmptyFilteredState(
 @Composable
 private fun EmptyFilteredStatePreview() {
     EmptyFilteredState(
+        recovery = EmptyRecovery.RESET_FILTERS,
         onResetFilters = {},
+        onShowHidden = {},
+        onShowAll = {},
+        initiallyVisible = true,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun EmptyFilteredStateShowHiddenPreview() {
+    EmptyFilteredState(
+        recovery = EmptyRecovery.SHOW_HIDDEN,
+        onResetFilters = {},
+        onShowHidden = {},
+        onShowAll = {},
+        initiallyVisible = true,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun EmptyFilteredStateEitherPreview() {
+    EmptyFilteredState(
+        recovery = EmptyRecovery.EITHER,
+        onResetFilters = {},
+        onShowHidden = {},
+        onShowAll = {},
+        initiallyVisible = true,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun EmptyFilteredStateShowAllPreview() {
+    EmptyFilteredState(
+        recovery = EmptyRecovery.SHOW_ALL,
+        onResetFilters = {},
+        onShowHidden = {},
+        onShowAll = {},
+        initiallyVisible = true,
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun EmptyFilteredStateUnclassifiedPreview() {
+    EmptyFilteredState(
+        recovery = null,
+        onResetFilters = {},
+        onShowHidden = {},
+        onShowAll = {},
         initiallyVisible = true,
     )
 }

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerFloatingBars.kt
@@ -48,6 +48,10 @@ internal fun FloatingBarScope.ExplorerTopBars(
 ) {
     val isLoadingItems = state.items == null && state.error == null
 
+    // Numbers derived from the listing wait for the listing to settle: `isLoadingItems` goes false as
+    // soon as the first peek rows arrive, and `showProgress` is masked behind a delay.
+    val isListingPending = isLoadingItems || state.progress != null
+
     // Determine if info bar should be visible
     val showInfoBar = state.info != null ||
         state.selectionState.selectedItems.isNotEmpty() ||
@@ -95,8 +99,15 @@ internal fun FloatingBarScope.ExplorerTopBars(
         ExplorerInfoBar(
             info = state.info,
             isLoading = isLoadingItems,
+            isListingPending = isListingPending,
             progress = if (showProgress) state.progress else null,
             onCancel = { vm?.navigate(ExplorerNavigation.Cancel) },
+            visibleFileCount = state.visibleFileCount,
+            visibleDirectoryCount = state.visibleDirectoryCount,
+            visibleTotalSize = state.visibleTotalSize,
+            hiddenCount = state.hiddenCount,
+            locationIsEmpty = state.locationIsEmpty,
+            onShowViewOptions = { vm?.showViewOptions() },
             selectedCount = state.selectionState.selectedItems.size,
             selectedSize = state.selectionState.selectedSize,
             onClearSelection = { vm?.clearSelection() },

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerGridContent.kt
@@ -124,7 +124,10 @@ internal fun ExplorerGridContent(
                 ) {
                     when {
                         state.isFilteredEmpty -> EmptyFilteredState(
+                            recovery = state.emptyRecovery,
                             onResetFilters = { vm?.resetFilters() },
+                            onShowHidden = { vm?.onShowHiddenItems() },
+                            onShowAll = { vm?.onShowAllItems() },
                         )
 
                         state.currentLocation is ExplorerLocation.Network -> EmptyNetworkState(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerInfoBar.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerInfoBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.twotone.Lan
 import androidx.compose.material.icons.twotone.PauseCircle
 import androidx.compose.material.icons.twotone.Scale
 import androidx.compose.material.icons.twotone.Storage
+import androidx.compose.material.icons.twotone.VisibilityOff
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -37,8 +38,23 @@ fun ExplorerInfoBar(
     modifier: Modifier = Modifier,
     info: ExplorerLocation.LocationInfo?,
     isLoading: Boolean = false,
+    /**
+     * The listing is not final yet, so nothing derived from it may be shown. Separate from
+     * [isLoading], which goes false as soon as the first peek rows arrive, and from [progress],
+     * which the page masks behind a delay to keep short loads from flashing.
+     */
+    isListingPending: Boolean = false,
     progress: Progress.Data? = null,
     onCancel: () -> Unit = {},
+    /** Files, folders and total size of the listing as displayed, i.e. after filtering and hiding. */
+    visibleFileCount: Int = 0,
+    visibleDirectoryCount: Int = 0,
+    visibleTotalSize: Long? = null,
+    /** Dot-prefixed entries being hidden here, zero while they are shown. */
+    hiddenCount: Int = 0,
+    /** The folder itself has nothing in it, as opposed to nothing surviving the filtering. */
+    locationIsEmpty: Boolean = false,
+    onShowViewOptions: () -> Unit = {},
     selectedCount: Int = 0,
     selectedSize: Long? = null,
     onClearSelection: () -> Unit = {},
@@ -87,29 +103,44 @@ fun ExplorerInfoBar(
             when (info) {
                 is ExplorerLocation.Directory.Info -> {
                     if (selectedCount == 0) {
-                        if (info.directoryCount != null && info.directoryCount > 0) {
+                        if (visibleDirectoryCount > 0) {
                             InfoChip(
                                 icon = Icons.TwoTone.Folder,
                                 label = pluralStringResource(
                                     CommonR.plurals.common_folders_count,
-                                    info.directoryCount,
-                                    info.directoryCount
+                                    visibleDirectoryCount,
+                                    visibleDirectoryCount
                                 ),
                                 onClick = selectFolders,
                             )
                         }
-                        if (info.fileCount != null && info.fileCount > 0) {
+                        if (visibleFileCount > 0) {
                             InfoChip(
                                 icon = Icons.TwoTone.Description,
                                 label = pluralStringResource(
                                     CommonR.plurals.common_files_count,
-                                    info.fileCount,
-                                    info.fileCount
+                                    visibleFileCount,
+                                    visibleFileCount
                                 ),
                                 onClick = selectFiles,
                             )
                         }
-                        if (info.directoryCount == 0 && info.fileCount == 0) {
+                        if (hiddenCount > 0 && !isListingPending) {
+                            // Opens the sheet the switch lives in rather than toggling: the count is
+                            // the reason to go there, not a control of its own.
+                            InfoChip(
+                                icon = Icons.TwoTone.VisibilityOff,
+                                label = pluralStringResource(
+                                    R.plurals.explorer_infobar_hidden_count,
+                                    hiddenCount,
+                                    hiddenCount
+                                ),
+                                onClick = onShowViewOptions,
+                            )
+                        }
+                        // Reads the unfiltered listing, so it only shows for a folder that is
+                        // actually empty rather than for one the filtering emptied.
+                        if (locationIsEmpty) {
                             InfoChip(
                                 icon = Icons.TwoTone.Folder,
                                 label = stringResource(R.string.explorer_empty_folder_label),
@@ -163,24 +194,24 @@ fun ExplorerInfoBar(
 
                 is ExplorerLocation.Trash.Nested.Info -> {
                     if (selectedCount == 0) {
-                        if (info.directoryCount != null && info.directoryCount > 0) {
+                        if (visibleDirectoryCount > 0) {
                             InfoChip(
                                 icon = Icons.TwoTone.Folder,
                                 label = pluralStringResource(
                                     CommonR.plurals.common_folders_count,
-                                    info.directoryCount,
-                                    info.directoryCount
+                                    visibleDirectoryCount,
+                                    visibleDirectoryCount
                                 ),
                                 onClick = selectFolders,
                             )
                         }
-                        if (info.fileCount != null && info.fileCount > 0) {
+                        if (visibleFileCount > 0) {
                             InfoChip(
                                 icon = Icons.TwoTone.Description,
                                 label = pluralStringResource(
                                     CommonR.plurals.common_files_count,
-                                    info.fileCount,
-                                    info.fileCount
+                                    visibleFileCount,
+                                    visibleFileCount
                                 ),
                                 onClick = selectFiles,
                             )
@@ -217,10 +248,10 @@ fun ExplorerInfoBar(
                 is ExplorerLocation.Directory.Info -> {
                     Spacer(modifier = Modifier.weight(1f))
 
-                    if (info.totalSize != null && selectedCount == 0) {
+                    if (visibleTotalSize != null && selectedCount == 0) {
                         InfoChip(
                             icon = Icons.TwoTone.Scale,
-                            label = formatFileSize(info.totalSize),
+                            label = formatFileSize(visibleTotalSize),
                             onClick = selectAll,
                         )
                     }
@@ -291,10 +322,10 @@ fun ExplorerInfoBar(
                 is ExplorerLocation.Trash.Nested.Info -> {
                     if (selectedCount > 0) return@WorkspaceInfoBar
                     Spacer(modifier = Modifier.weight(1f))
-                    if (info.totalSize != null && info.totalSize > 0) {
+                    if (visibleTotalSize != null) {
                         InfoChip(
                             icon = Icons.TwoTone.Scale,
-                            label = formatFileSize(info.totalSize),
+                            label = formatFileSize(visibleTotalSize),
                             onClick = selectAll,
                         )
                     }
@@ -314,6 +345,22 @@ fun ExplorerInfoBar(
 private fun ExplorerInfoBarDirectoryPreview() {
     ExplorerInfoBar(
         info = MockDataProvider.createMockDirectoryInfo(fileCount = 42, directoryCount = 7),
+        visibleFileCount = 42,
+        visibleDirectoryCount = 7,
+        visibleTotalSize = MockDataProvider.MockSizes.mb(250),
+    )
+}
+
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
+@Composable
+private fun ExplorerInfoBarWithHiddenItemsPreview() {
+    ExplorerInfoBar(
+        info = MockDataProvider.createMockDirectoryInfo(fileCount = 42, directoryCount = 7),
+        visibleFileCount = 39,
+        visibleDirectoryCount = 6,
+        visibleTotalSize = MockDataProvider.MockSizes.mb(220),
+        hiddenCount = 4,
     )
 }
 
@@ -323,6 +370,9 @@ private fun ExplorerInfoBarDirectoryPreview() {
 private fun ExplorerInfoBarWithSelectionPreview() {
     ExplorerInfoBar(
         info = MockDataProvider.createMockDirectoryInfo(fileCount = 42, directoryCount = 7),
+        visibleFileCount = 42,
+        visibleDirectoryCount = 7,
+        visibleTotalSize = MockDataProvider.MockSizes.mb(250),
         selectedCount = 3,
         selectedSize = MockDataProvider.MockSizes.mb(128),
     )
@@ -332,7 +382,10 @@ private fun ExplorerInfoBarWithSelectionPreview() {
 @ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
 private fun ExplorerInfoBarEmptyFolderPreview() {
-    ExplorerInfoBar(info = MockDataProvider.createMockEmptyDirectoryInfo())
+    ExplorerInfoBar(
+        info = MockDataProvider.createMockEmptyDirectoryInfo(),
+        locationIsEmpty = true,
+    )
 }
 
 @Preview2

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/elements/ExplorerListContent.kt
@@ -95,7 +95,10 @@ internal fun ExplorerListContent(
                 ) {
                     when {
                         state.isFilteredEmpty -> EmptyFilteredState(
+                            recovery = state.emptyRecovery,
                             onResetFilters = { vm?.resetFilters() },
+                            onShowHidden = { vm?.onShowHiddenItems() },
+                            onShowAll = { vm?.onShowAllItems() },
                         )
 
                         state.currentLocation is ExplorerLocation.Network -> EmptyNetworkState(

--- a/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
+++ b/app-workspace-explorer/src/main/java/eu/darken/butler/explorer/ui/explorer/preview/MockDataProvider.kt
@@ -1210,6 +1210,15 @@ object MockDataProvider {
         items = location.items,
         availableActions = actions,
         selectionState = selectionState,
+        // Derived from the listing, the way the pipeline derives them for a real tab, so the info
+        // bar of a preview or a store screenshot carries the same chips a user sees.
+        visibleFileCount = location.items?.count { it is ExplorerItem.File } ?: 0,
+        visibleDirectoryCount = location.items?.count { it is ExplorerItem.Directory } ?: 0,
+        visibleTotalSize = location.items
+            ?.filterIsInstance<ExplorerItem.File>()
+            ?.sumOf { it.lookup.size ?: 0L }
+            ?.takeIf { it > 0 },
+        locationIsEmpty = location.items?.isEmpty() == true,
     )
 
     fun createEmptyState(

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
     <string name="explorer_view_density_compact_label">Compact</string>
     <string name="explorer_view_density_comfortable_label">Comfortable</string>
     <string name="explorer_view_density_detailed_label">Detailed</string>
+    <string name="explorer_view_show_hidden_label">Show hidden files</string>
     <string name="explorer_view_set_default_action">Set as default</string>
     <string name="explorer_view_detail_created_label">Created</string>
     <string name="explorer_view_detail_modified_label">Modified</string>

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -234,6 +234,10 @@
         <item quantity="one">%d location</item>
         <item quantity="other">%d locations</item>
     </plurals>
+    <plurals name="explorer_infobar_hidden_count">
+        <item quantity="one">%d hidden</item>
+        <item quantity="other">%d hidden</item>
+    </plurals>
     <string name="explorer_infobar_storage_free">%1$s free</string>
     <string name="explorer_infobar_loading">Loading…</string>
 

--- a/app-workspace-explorer/src/main/res/values/strings.xml
+++ b/app-workspace-explorer/src/main/res/values/strings.xml
@@ -336,6 +336,15 @@
     <string name="explorer_empty_folder_label">Empty folder</string>
     <string name="explorer_empty_filtered_title">No matching items</string>
     <string name="explorer_empty_filtered_caption">Try adjusting your filters</string>
+    <string name="explorer_empty_hidden_title">Only hidden items here</string>
+    <string name="explorer_empty_hidden_caption">This tab hides items whose name starts with a dot</string>
+    <string name="explorer_empty_show_hidden_action">Show hidden items</string>
+    <string name="explorer_empty_hidden_or_filtered_title">Nothing left to show</string>
+    <string name="explorer_empty_hidden_or_filtered_caption">Hidden items and your filters each exclude part of this folder</string>
+    <string name="explorer_empty_clear_filters_action">Clear filters</string>
+    <string name="explorer_empty_hidden_and_filtered_title">Hidden items and filters exclude everything here</string>
+    <string name="explorer_empty_hidden_and_filtered_caption">Showing hidden items and clearing this tab\'s filters brings them back</string>
+    <string name="explorer_empty_show_all_action">Show all items</string>
     <string name="explorer_path_not_found_title">This folder is gone</string>
     <string name="explorer_path_not_found_caption">It was deleted, renamed or moved somewhere else.</string>
     <string name="explorer_path_not_found_back_action">Go back</string>

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerTabViewStoreTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerTabViewStoreTest.kt
@@ -53,7 +53,7 @@ class ExplorerTabViewStoreTest : BaseTest() {
     )
 
     private val goldenStylePayload = """
-        {"type":"grid","density":"detailed"}
+        {"type":"grid","density":"detailed","showhidden":true}
     """.trimIndent()
 
     private val goldenStyle = ExplorerViewStyle(

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerViewStyleTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/core/ExplorerViewStyleTest.kt
@@ -23,7 +23,8 @@ class ExplorerViewStyleTest : BaseTest() {
         serialized.toComparableJson() shouldBe """
             {
                 "type": "list",
-                "density": "comfortable"
+                "density": "comfortable",
+                "showhidden": true
             }
         """.toComparableJson()
     }
@@ -33,13 +34,15 @@ class ExplorerViewStyleTest : BaseTest() {
         val style = ExplorerViewStyle(
             mode = ExplorerViewStyle.Mode.GRID,
             density = ExplorerViewStyle.Density.DETAILED,
+            showHidden = false,
         )
         val serialized = json.encodeToString(style)
 
         serialized.toComparableJson() shouldBe """
             {
                 "type": "grid",
-                "density": "detailed"
+                "density": "detailed",
+                "showhidden": false
             }
         """.toComparableJson()
     }
@@ -49,13 +52,15 @@ class ExplorerViewStyleTest : BaseTest() {
         val jsonString = """
             {
                 "type": "grid",
-                "density": "compact"
+                "density": "compact",
+                "showhidden": false
             }
         """
 
         json.decodeFromString<ExplorerViewStyle>(jsonString) shouldBe ExplorerViewStyle(
             mode = ExplorerViewStyle.Mode.GRID,
             density = ExplorerViewStyle.Density.COMPACT,
+            showHidden = false,
         )
     }
 
@@ -63,6 +68,19 @@ class ExplorerViewStyleTest : BaseTest() {
     fun `deserialize with missing optional fields uses defaults`() {
         json.decodeFromString<ExplorerViewStyle>("""{"type":"list"}""") shouldBe ExplorerViewStyle()
         json.decodeFromString<ExplorerViewStyle>("{}") shouldBe ExplorerViewStyle()
+    }
+
+    /** Nobody has ever chosen to hide anything, so a payload from before the switch shows everything. */
+    @Test
+    fun `a payload without the hidden-files key shows hidden files`() {
+        val stored = """
+            {
+                "type": "grid",
+                "density": "compact"
+            }
+        """
+
+        productionJson.decodeFromString<ExplorerViewStyle>(stored).showHidden shouldBe true
     }
 
     /** A list user keeps both the mode and the density they had. */
@@ -101,9 +119,11 @@ class ExplorerViewStyleTest : BaseTest() {
     fun `all modes and densities roundtrip correctly`() {
         ExplorerViewStyle.Mode.entries.forEach { mode ->
             ExplorerViewStyle.Density.entries.forEach { density ->
-                val original = ExplorerViewStyle(mode = mode, density = density)
+                listOf(true, false).forEach { showHidden ->
+                    val original = ExplorerViewStyle(mode = mode, density = density, showHidden = showHidden)
 
-                json.decodeFromString<ExplorerViewStyle>(json.encodeToString(original)) shouldBe original
+                    json.decodeFromString<ExplorerViewStyle>(json.encodeToString(original)) shouldBe original
+                }
             }
         }
     }
@@ -113,6 +133,7 @@ class ExplorerViewStyleTest : BaseTest() {
         ExplorerViewStyle.default() shouldBe ExplorerViewStyle(
             mode = ExplorerViewStyle.Mode.LIST,
             density = ExplorerViewStyle.Density.COMFORTABLE,
+            showHidden = true,
         )
     }
 }

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerViewSettingsControllerTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ExplorerViewSettingsControllerTest.kt
@@ -1,9 +1,12 @@
 package eu.darken.butler.explorer.ui.explorer
 
+import eu.darken.butler.common.ca.toCaString
 import eu.darken.butler.common.datastore.DataStoreValue
 import eu.darken.butler.common.files.APathLookup
 import eu.darken.butler.common.files.LocalPath
 import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
 import eu.darken.butler.common.serialization.SerializationIOModule
 import eu.darken.butler.explorer.core.ExplorerSettings
 import eu.darken.butler.explorer.core.ExplorerTabViewStore
@@ -13,6 +16,7 @@ import eu.darken.butler.explorer.core.FilterState
 import eu.darken.butler.explorer.core.SortSettings
 import eu.darken.butler.explorer.core.engine.ExplorerItem
 import eu.darken.butler.explorer.core.engine.ExplorerLocation
+import eu.darken.butler.explorer.core.engine.TrashItemReference
 import eu.darken.butler.explorer.core.sorting.rules.ExplorerTabSortStore
 import eu.darken.butler.explorer.core.sorting.rules.FolderSortRulesRepo
 import eu.darken.butler.explorer.core.sorting.rules.SortRuleLayer
@@ -38,6 +42,8 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.mockDataStoreValue
 import java.io.File
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 class ExplorerViewSettingsControllerTest : BaseTest() {
 
@@ -136,7 +142,136 @@ class ExplorerViewSettingsControllerTest : BaseTest() {
         return ExplorerItem.RegularDirectory(lookup = lookup)
     }
 
-    private fun names(items: List<ExplorerItem>) = items.map { (it as ExplorerItem.Path).path.name }
+    private fun trashRootItem(name: String): ExplorerItem.Trash.Root {
+        val lookup = LocalPathLookup(
+            lookedUp = LocalPath.build(File("/tmp/filter-test", name)),
+            fileType = FileType.FILE,
+            size = 16L,
+            modifiedAt = null,
+        )
+        return ExplorerItem.Trash.Root(
+            itemId = Uuid.random(),
+            deletedAt = Instant.fromEpochMilliseconds(0),
+            originalLookup = lookup,
+            trashLookup = lookup,
+        )
+    }
+
+    private fun trashNestedItem(name: String): ExplorerItem.Trash.Nested {
+        val lookup = LocalPathLookup(
+            lookedUp = LocalPath.build(File("/tmp/filter-test", name)),
+            fileType = FileType.FILE,
+            size = 16L,
+            modifiedAt = null,
+        )
+        return ExplorerItem.Trash.Nested(
+            inner = ExplorerItem.RegularFile(lookup = lookup, mimeType = MimeInfo("text/plain")),
+            parentRef = TrashItemReference(
+                itemId = Uuid.random(),
+                displayName = "deleted".toCaString(),
+                originalPath = LocalPath.build("/tmp/filter-test"),
+                trashPath = LocalPath.build("/tmp/trash"),
+                deletedAt = Instant.fromEpochMilliseconds(0),
+            ),
+            relativePath = name,
+        )
+    }
+
+    private fun names(items: List<ExplorerItem>) = items.map {
+        when (it) {
+            is ExplorerItem.Path -> it.path.name
+            is ExplorerItem.Trash.Root -> it.originalLookup.name
+            is ExplorerItem.Trash.Nested -> it.lookup.name
+            else -> error("Unexpected item: $it")
+        }
+    }
+
+    @Test
+    fun `hiding drops dot-prefixed files and folders`() = runTest {
+        val controller = controller()
+        val items = listOf(fileItem(".env"), fileItem("notes.txt"), directoryItem(".git"), directoryItem("docs"))
+
+        val result = controller.applyFilters(
+            items = items,
+            filterState = FilterState(),
+            useRegexPatterns = false,
+            showHidden = false,
+        )
+
+        names(result) shouldContainExactly listOf("notes.txt", "docs")
+    }
+
+    @Test
+    fun `showing hidden entries keeps dot-prefixed files and folders`() = runTest {
+        val controller = controller()
+        val items = listOf(fileItem(".env"), fileItem("notes.txt"), directoryItem(".git"), directoryItem("docs"))
+
+        val result = controller.applyFilters(
+            items = items,
+            filterState = FilterState(),
+            useRegexPatterns = false,
+            showHidden = true,
+        )
+
+        names(result) shouldContainExactly listOf(".env", "notes.txt", ".git", "docs")
+    }
+
+    /** An entry hiding removes is an entry that cannot be restored, so the dot rule stops here. */
+    @Test
+    fun `hiding never drops trashed entries`() = runTest {
+        val controller = controller()
+        val items = listOf(trashRootItem(".env"), trashNestedItem(".git"), trashRootItem("notes.txt"))
+
+        val result = controller.applyFilters(
+            items = items,
+            filterState = FilterState(),
+            useRegexPatterns = false,
+            showHidden = false,
+        )
+
+        names(result) shouldContainExactly listOf(".env", ".git", "notes.txt")
+    }
+
+    @Test
+    fun `hiding and an exclude pattern both apply`() = runTest {
+        val controller = controller()
+        val items = listOf(fileItem(".env"), fileItem("notes.txt"), fileItem("secret.txt"))
+
+        val result = controller.applyFilters(
+            items = items,
+            filterState = FilterState(excludePattern = "secret"),
+            useRegexPatterns = false,
+            showHidden = false,
+        )
+
+        names(result) shouldContainExactly listOf("notes.txt")
+    }
+
+    @Test
+    fun `showsAnythingWhen reports what a combination would leave on screen`() = runTest {
+        val controller = controller()
+        val items = listOf(fileItem(".env"), fileItem("notes.txt"))
+
+        controller.showsAnythingWhen(items, FilterState(), false, showHidden = false) shouldBe true
+        controller.showsAnythingWhen(items, FilterState(excludePattern = "notes"), false, showHidden = false) shouldBe false
+        controller.showsAnythingWhen(items, FilterState(excludePattern = "notes"), false, showHidden = true) shouldBe true
+    }
+
+    /** The chip counts what the folder holds, not what revealing would add on top of the filters. */
+    @Test
+    fun `the hidden count ignores the active filters`() = runTest {
+        val controller = controller()
+        val items = listOf(fileItem(".env"), directoryItem(".git"), fileItem("notes.txt"))
+
+        controller.countHiddenEntries(items) shouldBe 2
+    }
+
+    @Test
+    fun `the hidden count ignores trashed entries`() = runTest {
+        val controller = controller()
+
+        controller.countHiddenEntries(listOf(trashRootItem(".env"), trashNestedItem(".git"))) shouldBe 0
+    }
 
     @Test
     fun `include pattern keeps only matching names`() = runTest {
@@ -148,6 +283,7 @@ class ExplorerViewSettingsControllerTest : BaseTest() {
             items = items,
             filterState = FilterState(includePattern = ".TXT"),
             useRegexPatterns = false,
+            showHidden = true,
         )
 
         names(result) shouldContainExactly listOf("notes.txt", "todo.txt")
@@ -162,6 +298,7 @@ class ExplorerViewSettingsControllerTest : BaseTest() {
             items = items,
             filterState = FilterState(includePattern = ".txt", excludePattern = "secret"),
             useRegexPatterns = false,
+            showHidden = true,
         )
 
         names(result) shouldContainExactly listOf("notes.txt")
@@ -176,6 +313,7 @@ class ExplorerViewSettingsControllerTest : BaseTest() {
             items = items,
             filterState = FilterState(fileTypeFilter = FileTypeFilter.FILES_ONLY),
             useRegexPatterns = false,
+            showHidden = true,
         )
 
         names(result) shouldContainExactly listOf("a.txt")
@@ -190,6 +328,7 @@ class ExplorerViewSettingsControllerTest : BaseTest() {
             items = items,
             filterState = FilterState(fileTypeFilter = FileTypeFilter.FOLDERS_ONLY),
             useRegexPatterns = false,
+            showHidden = true,
         )
 
         names(result) shouldContainExactly listOf("folder")
@@ -204,6 +343,7 @@ class ExplorerViewSettingsControllerTest : BaseTest() {
             items = items,
             filterState = FilterState(includePattern = "img_\\d+\\.png"),
             useRegexPatterns = true,
+            showHidden = true,
         )
 
         names(result) shouldContainExactly listOf("img_001.png")

--- a/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ProcessedListingTest.kt
+++ b/app-workspace-explorer/src/test/java/eu/darken/butler/explorer/ui/explorer/ProcessedListingTest.kt
@@ -1,0 +1,255 @@
+package eu.darken.butler.explorer.ui.explorer
+
+import eu.darken.butler.common.files.LocalPath
+import eu.darken.butler.common.files.MimeInfo
+import eu.darken.butler.common.files.local.LocalPathLookup
+import eu.darken.butler.common.files.metadata.FileType
+import eu.darken.butler.common.serialization.SerializationIOModule
+import eu.darken.butler.explorer.core.ExplorerSettings
+import eu.darken.butler.explorer.core.ExplorerTabViewStore
+import eu.darken.butler.explorer.core.ExplorerViewStyle
+import eu.darken.butler.explorer.core.FilterState
+import eu.darken.butler.explorer.core.SortSettings
+import eu.darken.butler.explorer.core.engine.ExplorerItem
+import eu.darken.butler.explorer.core.engine.ExplorerLocation
+import eu.darken.butler.explorer.core.sorting.rules.ExplorerTabSortStore
+import eu.darken.butler.explorer.core.sorting.rules.FolderSortRulesRepo
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.ui.restore.WorkspaceViewPrefs
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.mockDataStoreValue
+import java.io.File
+
+class ProcessedListingTest : BaseTest() {
+
+    private val json = SerializationIOModule().json()
+    private val viewPrefs = WorkspaceViewPrefs()
+
+    private fun TestScope.controller() = ExplorerViewSettingsController(
+        explorerSettings = mockk<ExplorerSettings>().apply {
+            every { defaultViewStyle } returns mockDataStoreValue(ExplorerViewStyle.default())
+            every { sortSettings } returns mockDataStoreValue(SortSettings())
+        },
+        folderSortRules = mockk<FolderSortRulesRepo>().apply {
+            every { observeRulesFor(any()) } returns flowOf(emptyList())
+        },
+        tabSortStore = ExplorerTabSortStore(viewPrefs, json),
+        tabViewStore = ExplorerTabViewStore(viewPrefs, json),
+        json = json,
+        workspaceId = Workspace.Id(),
+        currentLocation = flowOf<ExplorerLocation?>(null),
+        scope = backgroundScope,
+        doLaunch = { block -> backgroundScope.launch { block() } },
+    )
+
+    private fun lookup(name: String, size: Long) = LocalPathLookup(
+        lookedUp = LocalPath.build(File("/tmp/listing-test", name)),
+        fileType = FileType.FILE,
+        size = size,
+        modifiedAt = null,
+    )
+
+    private fun file(name: String, size: Long = 1_024L) = ExplorerItem.RegularFile(
+        lookup = lookup(name, size),
+        mimeType = MimeInfo("text/plain"),
+    )
+
+    private fun directory(name: String) = ExplorerItem.RegularDirectory(
+        lookup = lookup(name, 0L).copy(fileType = FileType.DIRECTORY),
+    )
+
+    private fun peek(name: String) = ExplorerItem.Peek(LocalPath.build(File("/tmp/listing-test", name)))
+
+    /** What the ViewModel's pipeline does: filter with the tab's settings, then describe the result. */
+    private fun ExplorerViewSettingsController.listingOf(
+        locationId: String,
+        rawItems: List<ExplorerItem>,
+        filterState: FilterState = FilterState(),
+        showHidden: Boolean = true,
+    ) = processListing(
+        locationId = locationId,
+        rawItems = rawItems,
+        items = applyFilters(rawItems, filterState, useRegexPatterns = false, showHidden = showHidden),
+        filterState = filterState,
+        useRegexPatterns = false,
+        showHidden = showHidden,
+    )
+
+    @Test
+    fun `the counts describe the listing as displayed`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(file("notes.txt", 100L), file(".env", 50L), directory("docs"), directory(".git")),
+            showHidden = false,
+        )
+
+        listing.visibleFileCount shouldBe 1
+        listing.visibleDirectoryCount shouldBe 1
+        listing.visibleTotalSize shouldBe 100L
+        listing.hiddenCount shouldBe 2
+        listing.locationIsEmpty shouldBe false
+    }
+
+    /** Null rather than zero, the same way the loader reports a folder that totals nothing. */
+    @Test
+    fun `a listing without files has no total size`() = runTest {
+        val controller = controller()
+
+        controller.listingOf("location://directory/tmp", listOf(directory("docs"))).visibleTotalSize shouldBe null
+    }
+
+    @Test
+    fun `nothing is hidden while the tab shows hidden entries`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(file(".env"), file("notes.txt")),
+            showHidden = true,
+        )
+
+        listing.hiddenCount shouldBe 0
+        listing.items.size shouldBe 2
+    }
+
+    @Test
+    fun `an empty folder is not a filtered-empty one`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf("location://directory/tmp", emptyList())
+
+        listing.locationIsEmpty shouldBe true
+        listing.emptyRecovery shouldBe null
+    }
+
+    @Test
+    fun `revealing recovers a listing only hiding emptied`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(file(".env"), directory(".git")),
+            showHidden = false,
+        )
+
+        listing.emptyRecovery shouldBe EmptyRecovery.SHOW_HIDDEN
+    }
+
+    @Test
+    fun `clearing the filters recovers a listing only they emptied`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(file("notes.txt")),
+            filterState = FilterState(excludePattern = "notes"),
+            showHidden = true,
+        )
+
+        listing.emptyRecovery shouldBe EmptyRecovery.RESET_FILTERS
+    }
+
+    @Test
+    fun `either control recovers a listing hiding and filters emptied between them`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(file(".env"), file("notes.txt")),
+            filterState = FilterState(excludePattern = "notes"),
+            showHidden = false,
+        )
+
+        listing.emptyRecovery shouldBe EmptyRecovery.EITHER
+    }
+
+    /** Hiding and the filters both exclude everything, so neither control alone brings a row back. */
+    @Test
+    fun `only both together recover a listing each of them empties`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(file(".env"), file(".gitignore")),
+            // The dot every hidden name starts with, so the pattern excludes exactly what hiding does
+            filterState = FilterState(excludePattern = "."),
+            showHidden = false,
+        )
+
+        listing.emptyRecovery shouldBe EmptyRecovery.SHOW_ALL
+    }
+
+    /** Peek entries pass every type filter, so a verdict taken now can be reversed by the classifier. */
+    @Test
+    fun `no recovery is offered while the listing still holds peek entries`() = runTest {
+        val controller = controller()
+
+        val listing = controller.listingOf(
+            locationId = "location://directory/tmp",
+            rawItems = listOf(peek(".env"), peek(".git")),
+            showHidden = false,
+        )
+
+        listing.items.shouldBeEmpty()
+        listing.emptyRecovery shouldBe null
+    }
+
+    /** Rows, counts and verdict come from one pass, so no emission can mix two folders. */
+    @Test
+    fun `navigating never pairs a folder's rows with another folder's numbers`() = runTest {
+        val controller = controller()
+        val folderA = listOf(file("a1.txt", 10L), file("a2.txt", 20L))
+        val folderB = listOf(file(".b1"), file(".b2"))
+
+        val listings = listOf(
+            controller.listingOf("location://directory/a", folderA, showHidden = false),
+            controller.listingOf("location://directory/b", folderB, showHidden = false),
+        )
+
+        listings.forEach { listing ->
+            listing.visibleFileCount shouldBe listing.items.count { it is ExplorerItem.File }
+            listing.visibleTotalSize shouldBe
+                listing.items.filterIsInstance<ExplorerItem.File>().sumOf { it.lookup.size ?: 0L }.takeIf { it > 0 }
+        }
+
+        listings[0].locationId shouldBe "location://directory/a"
+        listings[0].hiddenCount shouldBe 0
+        listings[0].emptyRecovery shouldBe null
+        listings[1].locationId shouldBe "location://directory/b"
+        listings[1].items.shouldBeEmpty()
+        listings[1].hiddenCount shouldBe 2
+        listings[1].emptyRecovery shouldBe EmptyRecovery.SHOW_HIDDEN
+    }
+
+    @Test
+    fun `revealing from an empty filtered listing drops the verdict with the same emission`() = runTest {
+        val controller = controller()
+        val rawItems = listOf(file(".env", 30L), directory(".git"))
+
+        val hiding = controller.listingOf("location://directory/tmp", rawItems, showHidden = false)
+        val showing = controller.listingOf("location://directory/tmp", rawItems, showHidden = true)
+
+        hiding.items.shouldBeEmpty()
+        hiding.hiddenCount shouldBe 2
+        hiding.emptyRecovery shouldBe EmptyRecovery.SHOW_HIDDEN
+
+        showing.items shouldContainExactly rawItems
+        showing.visibleFileCount shouldBe 1
+        showing.visibleDirectoryCount shouldBe 1
+        showing.visibleTotalSize shouldBe 30L
+        showing.hiddenCount shouldBe 0
+        showing.emptyRecovery shouldBe null
+    }
+}


### PR DESCRIPTION
## What changed

The Explorer can now hide files and folders whose name starts with a dot. The switch lives in the View options sheet next to the layout and density controls, and it works per tab, so one tab can show them while another keeps them out of the way. "Set as default" saves the choice for new tabs.

Nothing changes unless you turn it on. Hidden files stay visible by default, so an existing install looks exactly as it did.

While a tab is hiding things, a "3 hidden" chip appears in the info bar and opens the View options sheet when tapped, so a missing file is always explained on screen. If hiding leaves a folder with nothing to show, the empty state offers whichever action actually brings the files back — show hidden items, clear filters, or both — rather than a button that does nothing.

Hiding only affects what a listing displays. A hidden folder still opens normally from a typed path, a breadcrumb, a favorite or a file picker. The trash never hides anything either, so a deleted dot-file can always be found and restored.

The info bar's folder, file and size chips now describe what the listing is showing rather than the folder's totals. That also fixes an older inconsistency: tapping the file-count chip selects the visible files, so under a filter the chip and its own tap action used to disagree.

## Technical Context

- `showHidden` is a third field on `ExplorerViewStyle` rather than a new store, so it inherits that type's existing per-tab slot, global default and "set as default" wiring. It defaults to `true`, which is what makes a payload written before this change decode to show-hidden.
- The dot rule lives in `ExplorerViewSettingsController.itemFilter` and is scoped to `ExplorerItem.Path`. `Trash.Root` and `Trash.Nested` are a separate branch of the sealed hierarchy, so trash listings are excluded structurally rather than by a convention a later change could quietly break. This is deliberate: Restore acts on entries selected in the listing, so an entry hiding removes could not be restored at all.
- `ProcessedListing` carries the derived counts, hidden count, size and empty-state verdict alongside the rows they describe. Deriving them in a separate downstream `combine` let a toggle or a navigation briefly pair one folder's rows with another folder's numbers.
- The empty state is classified by evaluating what each recovery would actually yield, not by which settings are switched on — a folder can have both hiding and a filter active and still be emptied by only one of them. The verdict is withheld while `ExplorerItem.Peek` rows are present, because type filters do not apply to them and revealing would appear to recover rows that vanish once classification finishes.
- The pipeline observes `viewStyle.map { it.showHidden }.distinctUntilChanged()` rather than the whole view style, so changing density or switching between list and grid does not re-run filtering, sorting and favorite ordering on a large directory.
- Known wart, accepted: for roughly the first 200 ms of a folder load the info bar shows no count chip, where it previously showed the peeked item count. That count was miscategorised — it came from `listFiles().size` and labelled subfolders as files — and restoring it would reintroduce that, so it was left alone.
