### PR TITLE
Workspace: Let the Butler button sit at the end of the tab rail

### DIFF
--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceSettings.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/WorkspaceSettings.kt
@@ -10,6 +10,7 @@ import eu.darken.butler.common.datastore.PreferenceStoreMapper
 import eu.darken.butler.common.datastore.createValue
 import eu.darken.butler.common.debug.DebugSettings
 import eu.darken.butler.common.debug.logging.logTag
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -51,6 +52,12 @@ class WorkspaceSettings @Inject constructor(
 
     val paneClickToFocus = dataStore.createValue("workspace.pane.clicktofocus.enabled", true)
 
+    val railButtonPlacement = dataStore.createValue(
+        "workspace.rail.button.placement",
+        RailButtonPlacement.LEADING,
+        json,
+    )
+
     val sessionRestoreEnabled = dataStore.createValue("workspace.session.restore.enabled", true)
 
     val autoPauseEnabled = dataStore.createValue("workspace.session.autopause.enabled", true)
@@ -73,6 +80,7 @@ class WorkspaceSettings @Inject constructor(
         layoutModePortrait,
         layoutModeLandscape,
         paneClickToFocus,
+        railButtonPlacement,
         sessionRestoreEnabled,
         autoPauseEnabled,
         autoPauseIdleTimeout,

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/core/layout/RailButtonPlacement.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/core/layout/RailButtonPlacement.kt
@@ -1,0 +1,13 @@
+package eu.darken.butler.workspace.core.layout
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class RailButtonPlacement {
+    @SerialName("LEADING")
+    LEADING,
+
+    @SerialName("TRAILING")
+    TRAILING,
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/RailButtonPlacementExtensions.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/RailButtonPlacementExtensions.kt
@@ -1,0 +1,34 @@
+package eu.darken.butler.workspace.ui.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import eu.darken.butler.workspace.R
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
+
+
+@Composable
+fun RailButtonPlacement.label(): String {
+    return when (this) {
+        RailButtonPlacement.LEADING -> stringResource(R.string.workspace_settings_rail_button_leading)
+        RailButtonPlacement.TRAILING -> stringResource(R.string.workspace_settings_rail_button_trailing)
+    }
+}
+
+@Composable
+fun RailButtonPlacement.description(): String {
+    return when (this) {
+        RailButtonPlacement.LEADING -> stringResource(R.string.workspace_settings_rail_button_leading_desc)
+        RailButtonPlacement.TRAILING -> stringResource(R.string.workspace_settings_rail_button_trailing_desc)
+    }
+}
+
+/** [landscape] picks the rail edge the glyph draws: bottom in portrait, start in landscape. */
+fun RailButtonPlacement.icon(landscape: Boolean = false): ImageVector = when (this) {
+    RailButtonPlacement.LEADING -> {
+        if (landscape) WorkspacePanelIcons.RailButtonSideLeading else WorkspacePanelIcons.RailButtonBottomLeading
+    }
+    RailButtonPlacement.TRAILING -> {
+        if (landscape) WorkspacePanelIcons.RailButtonSideTrailing else WorkspacePanelIcons.RailButtonBottomTrailing
+    }
+}

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/layout/WorkspacePanelIcons.kt
@@ -83,6 +83,134 @@ object WorkspacePanelIcons {
             }
         }.build()
 
+    val RailButtonBottomLeading: ImageVector
+        get() = ImageVector.Builder(
+            name = "RailButtonBottomLeading",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            autoMirror = true
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 4f)
+                lineTo(20f, 4f)
+                lineTo(20f, 15f)
+                lineTo(4f, 15f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 17f)
+                lineTo(7f, 17f)
+                lineTo(7f, 20f)
+                lineTo(4f, 20f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(9f, 17f)
+                lineTo(20f, 17f)
+                lineTo(20f, 20f)
+                lineTo(9f, 20f)
+                close()
+            }
+        }.build()
+
+    val RailButtonBottomTrailing: ImageVector
+        get() = ImageVector.Builder(
+            name = "RailButtonBottomTrailing",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            autoMirror = true
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 4f)
+                lineTo(20f, 4f)
+                lineTo(20f, 15f)
+                lineTo(4f, 15f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 17f)
+                lineTo(15f, 17f)
+                lineTo(15f, 20f)
+                lineTo(4f, 20f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(17f, 17f)
+                lineTo(20f, 17f)
+                lineTo(20f, 20f)
+                lineTo(17f, 20f)
+                close()
+            }
+        }.build()
+
+    val RailButtonSideLeading: ImageVector
+        get() = ImageVector.Builder(
+            name = "RailButtonSideLeading",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            autoMirror = true
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(9f, 4f)
+                lineTo(20f, 4f)
+                lineTo(20f, 20f)
+                lineTo(9f, 20f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 4f)
+                lineTo(7f, 4f)
+                lineTo(7f, 7f)
+                lineTo(4f, 7f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 9f)
+                lineTo(7f, 9f)
+                lineTo(7f, 20f)
+                lineTo(4f, 20f)
+                close()
+            }
+        }.build()
+
+    val RailButtonSideTrailing: ImageVector
+        get() = ImageVector.Builder(
+            name = "RailButtonSideTrailing",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            autoMirror = true
+        ).apply {
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(9f, 4f)
+                lineTo(20f, 4f)
+                lineTo(20f, 20f)
+                lineTo(9f, 20f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 4f)
+                lineTo(7f, 4f)
+                lineTo(7f, 15f)
+                lineTo(4f, 15f)
+                close()
+            }
+            path(fill = SolidColor(Color.Black)) {
+                moveTo(4f, 17f)
+                lineTo(7f, 17f)
+                lineTo(7f, 20f)
+                lineTo(4f, 20f)
+                close()
+            }
+        }.build()
+
     val DualVertical: ImageVector
         get() = ImageVector.Builder(
             name = "LayoutDualVertical",

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesign.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/manager/WorkspaceDesign.kt
@@ -1,9 +1,13 @@
 package eu.darken.butler.workspace.ui.manager
 
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
+
 data class WorkspaceDesign(
     val layout: Layout = Layout.SINGLE,
     val paneEdges: PaneEdges = PaneEdges.All,
     val railPlacement: RailPlacement = RailPlacement.START,
+    /** Which end of the rail's main axis the Butler button sits at. */
+    val railButtonPlacement: RailButtonPlacement = RailButtonPlacement.LEADING,
     /**
      * Whether the window composes the navigation rail. Always true for multi-pane layouts, a single
      * pane opts into it via the single-with-rail panel mode. Chrome a page supplies only when there

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -455,6 +455,7 @@ private fun WorkspaceSettingsScreenPinnedLayoutPreview() {
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
         onTogglePaneClickToFocus = {},
+        onSetRailButtonPlacement = {},
         onToggleSessionRestore = {},
         onToggleAutoPause = {},
         onSetAutoPauseIdleTimeout = {},

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.twotone.AlignHorizontalRight
 import androidx.compose.material.icons.twotone.AddCircle
 import androidx.compose.material.icons.twotone.AdsClick
 import androidx.compose.material.icons.twotone.AutoAwesome
@@ -48,6 +49,7 @@ import androidx.compose.runtime.collectAsState
 import eu.darken.butler.workspace.R
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.icon
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.ui.layout.LayoutPickerDialog
 import eu.darken.butler.workspace.ui.layout.LayoutPickerOption
@@ -75,6 +77,7 @@ fun WorkspaceSettingsScreen(
     onSetLayoutModePortrait: (WorkspacePanelMode) -> Unit,
     onSetLayoutModeLandscape: (WorkspacePanelMode) -> Unit,
     onTogglePaneClickToFocus: () -> Unit,
+    onToggleRailButtonPlacement: () -> Unit,
     onToggleSessionRestore: () -> Unit,
     onToggleAutoPause: () -> Unit,
     onSetAutoPauseIdleTimeout: (Duration) -> Unit,
@@ -173,6 +176,16 @@ fun WorkspaceSettingsScreen(
                     subtitle = stringResource(R.string.workspace_settings_pane_click_to_focus_desc),
                     checked = state.paneClickToFocus,
                     onCheckedChange = { onTogglePaneClickToFocus() },
+                )
+            }
+
+            item {
+                SettingsSwitchItem(
+                    icon = Icons.AutoMirrored.TwoTone.AlignHorizontalRight,
+                    title = stringResource(R.string.workspace_settings_rail_button_trailing_title),
+                    subtitle = stringResource(R.string.workspace_settings_rail_button_trailing_desc),
+                    checked = state.railButtonPlacement == RailButtonPlacement.TRAILING,
+                    onCheckedChange = { onToggleRailButtonPlacement() },
                 )
             }
 
@@ -385,6 +398,7 @@ private fun WorkspaceSettingsScreenPreview() {
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
         onTogglePaneClickToFocus = {},
+        onToggleRailButtonPlacement = {},
         onToggleSessionRestore = {},
         onToggleAutoPause = {},
         onSetAutoPauseIdleTimeout = {},
@@ -451,6 +465,7 @@ private fun WorkspaceSettingsScreenNewTabTypePreview() {
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
         onTogglePaneClickToFocus = {},
+        onToggleRailButtonPlacement = {},
         onToggleSessionRestore = {},
         onToggleAutoPause = {},
         onSetAutoPauseIdleTimeout = {},
@@ -476,6 +491,7 @@ fun WorkspaceSettingsScreenHost(vm: WorkspaceSettingsViewModel = hiltViewModel()
             onSetLayoutModePortrait = { mode -> vm.setLayoutModePortrait(mode) },
             onSetLayoutModeLandscape = { mode -> vm.setLayoutModeLandscape(mode) },
             onTogglePaneClickToFocus = { vm.togglePaneClickToFocus() },
+            onToggleRailButtonPlacement = { vm.toggleRailButtonPlacement() },
             onToggleSessionRestore = { vm.toggleSessionRestore() },
             onToggleAutoPause = { vm.toggleAutoPause() },
             onSetAutoPauseIdleTimeout = { timeout -> vm.setAutoPauseIdleTimeout(timeout) },

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsScreen.kt
@@ -1,5 +1,6 @@
 package eu.darken.butler.workspace.ui.settings
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -30,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -77,7 +79,7 @@ fun WorkspaceSettingsScreen(
     onSetLayoutModePortrait: (WorkspacePanelMode) -> Unit,
     onSetLayoutModeLandscape: (WorkspacePanelMode) -> Unit,
     onTogglePaneClickToFocus: () -> Unit,
-    onToggleRailButtonPlacement: () -> Unit,
+    onSetRailButtonPlacement: (RailButtonPlacement) -> Unit,
     onToggleSessionRestore: () -> Unit,
     onToggleAutoPause: () -> Unit,
     onSetAutoPauseIdleTimeout: (Duration) -> Unit,
@@ -86,7 +88,9 @@ fun WorkspaceSettingsScreen(
     var showNewTabTypeDialog by remember { mutableStateOf(false) }
     var showPortraitDialog by remember { mutableStateOf(false) }
     var showLandscapeDialog by remember { mutableStateOf(false) }
+    var showRailButtonDialog by remember { mutableStateOf(false) }
     var showAutoPauseTimeoutDialog by remember { mutableStateOf(false) }
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     Scaffold(
         topBar = {
             TopAppBar(
@@ -180,12 +184,12 @@ fun WorkspaceSettingsScreen(
             }
 
             item {
-                SettingsSwitchItem(
+                SettingsPreferenceItem(
                     icon = Icons.AutoMirrored.TwoTone.AlignHorizontalRight,
-                    title = stringResource(R.string.workspace_settings_rail_button_trailing_title),
-                    subtitle = stringResource(R.string.workspace_settings_rail_button_trailing_desc),
-                    checked = state.railButtonPlacement == RailButtonPlacement.TRAILING,
-                    onCheckedChange = { onToggleRailButtonPlacement() },
+                    title = stringResource(R.string.workspace_settings_rail_button_title),
+                    subtitle = stringResource(R.string.workspace_settings_rail_button_desc),
+                    value = state.railButtonPlacement.label(),
+                    onClick = { showRailButtonDialog = true },
                 )
             }
 
@@ -336,6 +340,25 @@ fun WorkspaceSettingsScreen(
         )
     }
 
+    if (showRailButtonDialog) {
+        LayoutPickerDialog(
+            title = stringResource(R.string.workspace_settings_rail_button_title),
+            options = RailButtonPlacement.entries.map { placement ->
+                LayoutPickerOption(
+                    icon = placement.icon(landscape = isLandscape),
+                    label = placement.label(),
+                    description = placement.description(),
+                    selected = state.railButtonPlacement == placement,
+                    onSelect = {
+                        onSetRailButtonPlacement(placement)
+                        showRailButtonDialog = false
+                    },
+                )
+            },
+            onDismiss = { showRailButtonDialog = false },
+        )
+    }
+
     if (showAutoPauseTimeoutDialog) {
         MinutesDurationInputDialog(
             title = stringResource(R.string.workspace_settings_autopause_delay_title),
@@ -398,7 +421,7 @@ private fun WorkspaceSettingsScreenPreview() {
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
         onTogglePaneClickToFocus = {},
-        onToggleRailButtonPlacement = {},
+        onSetRailButtonPlacement = {},
         onToggleSessionRestore = {},
         onToggleAutoPause = {},
         onSetAutoPauseIdleTimeout = {},
@@ -465,7 +488,7 @@ private fun WorkspaceSettingsScreenNewTabTypePreview() {
         onSetLayoutModePortrait = {},
         onSetLayoutModeLandscape = {},
         onTogglePaneClickToFocus = {},
-        onToggleRailButtonPlacement = {},
+        onSetRailButtonPlacement = {},
         onToggleSessionRestore = {},
         onToggleAutoPause = {},
         onSetAutoPauseIdleTimeout = {},
@@ -491,7 +514,7 @@ fun WorkspaceSettingsScreenHost(vm: WorkspaceSettingsViewModel = hiltViewModel()
             onSetLayoutModePortrait = { mode -> vm.setLayoutModePortrait(mode) },
             onSetLayoutModeLandscape = { mode -> vm.setLayoutModeLandscape(mode) },
             onTogglePaneClickToFocus = { vm.togglePaneClickToFocus() },
-            onToggleRailButtonPlacement = { vm.toggleRailButtonPlacement() },
+            onSetRailButtonPlacement = { placement -> vm.setRailButtonPlacement(placement) },
             onToggleSessionRestore = { vm.toggleSessionRestore() },
             onToggleAutoPause = { vm.toggleAutoPause() },
             onSetAutoPauseIdleTimeout = { timeout -> vm.setAutoPauseIdleTimeout(timeout) },

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsViewModel.kt
@@ -96,14 +96,8 @@ class WorkspaceSettingsViewModel @Inject constructor(
         workspaceSettings.paneClickToFocus.value(!current)
     }
 
-    fun toggleRailButtonPlacement() = launch {
-        val current = workspaceSettings.railButtonPlacement.value()
-        workspaceSettings.railButtonPlacement.value(
-            when (current) {
-                RailButtonPlacement.LEADING -> RailButtonPlacement.TRAILING
-                RailButtonPlacement.TRAILING -> RailButtonPlacement.LEADING
-            },
-        )
+    fun setRailButtonPlacement(placement: RailButtonPlacement) = launch {
+        workspaceSettings.railButtonPlacement.value(placement)
     }
 
     fun toggleSessionRestore() = launch {

--- a/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsViewModel.kt
+++ b/app-workspace/src/main/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsViewModel.kt
@@ -8,6 +8,7 @@ import eu.darken.butler.common.flow.combine
 import eu.darken.butler.common.ui.ViewModel4
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceSettings
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.core.session.WorkspaceSessionStorage
 import eu.darken.butler.workspace.ui.template.WorkspaceTemplate
@@ -34,13 +35,14 @@ class WorkspaceSettingsViewModel @Inject constructor(
         workspaceSettings.layoutModePortrait.flow,
         workspaceSettings.layoutModeLandscape.flow,
         workspaceSettings.paneClickToFocus.flow,
+        workspaceSettings.railButtonPlacement.flow,
         workspaceSettings.sessionRestoreEnabled.flow,
         workspaceSettings.autoPauseEnabled.flow,
         workspaceSettings.autoPauseIdleTimeout.flow,
         workspaceSettings.undoCloseEnabled.flow,
         sessionStorage.getWorkspaceCount(WorkspaceSessionStorage.DEFAULT_SESSION_ID),
         sessionStorage.getDatabaseSizeBytes(WorkspaceSessionStorage.DEFAULT_SESSION_ID),
-    ) { swipeGesturesEnabled, onDemandWorkspaceCreation, defaultNewTabType, templates, livePreview, layoutModePortrait, layoutModeLandscape, paneClickToFocus, sessionRestoreEnabled, autoPauseEnabled, autoPauseIdleTimeout, undoCloseEnabled, sessionWorkspaceCount, sessionDatabaseSizeBytes ->
+    ) { swipeGesturesEnabled, onDemandWorkspaceCreation, defaultNewTabType, templates, livePreview, layoutModePortrait, layoutModeLandscape, paneClickToFocus, railButtonPlacement, sessionRestoreEnabled, autoPauseEnabled, autoPauseIdleTimeout, undoCloseEnabled, sessionWorkspaceCount, sessionDatabaseSizeBytes ->
         State(
             swipeGesturesEnabled = swipeGesturesEnabled,
             onDemandWorkspaceCreation = onDemandWorkspaceCreation,
@@ -52,6 +54,7 @@ class WorkspaceSettingsViewModel @Inject constructor(
             layoutModePortrait = layoutModePortrait,
             layoutModeLandscape = layoutModeLandscape,
             paneClickToFocus = paneClickToFocus,
+            railButtonPlacement = railButtonPlacement,
             sessionRestoreEnabled = sessionRestoreEnabled,
             autoPauseEnabled = autoPauseEnabled,
             autoPauseIdleTimeout = WorkspaceSettings.clampIdleTimeout(autoPauseIdleTimeout),
@@ -93,6 +96,16 @@ class WorkspaceSettingsViewModel @Inject constructor(
         workspaceSettings.paneClickToFocus.value(!current)
     }
 
+    fun toggleRailButtonPlacement() = launch {
+        val current = workspaceSettings.railButtonPlacement.value()
+        workspaceSettings.railButtonPlacement.value(
+            when (current) {
+                RailButtonPlacement.LEADING -> RailButtonPlacement.TRAILING
+                RailButtonPlacement.TRAILING -> RailButtonPlacement.LEADING
+            },
+        )
+    }
+
     fun toggleSessionRestore() = launch {
         val current = workspaceSettings.sessionRestoreEnabled.value()
         workspaceSettings.sessionRestoreEnabled.value(!current)
@@ -124,6 +137,7 @@ class WorkspaceSettingsViewModel @Inject constructor(
         val layoutModePortrait: WorkspacePanelMode,
         val layoutModeLandscape: WorkspacePanelMode,
         val paneClickToFocus: Boolean,
+        val railButtonPlacement: RailButtonPlacement = RailButtonPlacement.LEADING,
         val sessionRestoreEnabled: Boolean,
         val autoPauseEnabled: Boolean = true,
         val autoPauseIdleTimeout: Duration = WorkspaceSettings.AUTO_PAUSE_IDLE_TIMEOUT_DEFAULT,

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -391,7 +391,7 @@
     <string name="workspace_settings_pane_click_to_focus_desc">The first click on an unfocused pane only focuses it, and unfocused panes don\'t react to a mouse pointer. Turn off to interact with them directly.</string>
 
     <string name="workspace_settings_rail_button_trailing_title">Butler button at the end of the tab rail</string>
-    <string name="workspace_settings_rail_button_trailing_desc">Move the Butler button from the start of the tab rail to its end, within reach of your thumb. Only applies while a tab rail is shown, the classic layout keeps the button in the toolbar.</string>
+    <string name="workspace_settings_rail_button_trailing_desc">Move the Butler button from the start of the tab rail to its end, within reach of your thumb. Only applies while a tab rail is shown. The classic layout keeps the button in the toolbar.</string>
 
     <!-- Session -->
     <string name="workspace_settings_session_title">Session</string>

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -390,6 +390,9 @@
     <string name="workspace_settings_pane_click_to_focus_title">Click to focus</string>
     <string name="workspace_settings_pane_click_to_focus_desc">The first click on an unfocused pane only focuses it, and unfocused panes don\'t react to a mouse pointer. Turn off to interact with them directly.</string>
 
+    <string name="workspace_settings_rail_button_trailing_title">Butler button at the end of the tab rail</string>
+    <string name="workspace_settings_rail_button_trailing_desc">Move the Butler button from the start of the tab rail to its end, within reach of your thumb. Only applies while a tab rail is shown, the classic layout keeps the button in the toolbar.</string>
+
     <!-- Session -->
     <string name="workspace_settings_session_title">Session</string>
     <string name="workspace_settings_session_restore_title">Restore tabs on startup</string>

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -390,8 +390,12 @@
     <string name="workspace_settings_pane_click_to_focus_title">Click to focus</string>
     <string name="workspace_settings_pane_click_to_focus_desc">The first click on an unfocused pane only focuses it, and unfocused panes don\'t react to a mouse pointer. Turn off to interact with them directly.</string>
 
-    <string name="workspace_settings_rail_button_trailing_title">Butler button at the end of the tab rail</string>
-    <string name="workspace_settings_rail_button_trailing_desc">Move the Butler button from the start of the tab rail to its end, within reach of your thumb. Only applies while a tab rail is shown. The classic layout keeps the button in the toolbar.</string>
+    <string name="workspace_settings_rail_button_title">Butler button</string>
+    <string name="workspace_settings_rail_button_desc">Choose where the Butler button sits on the tab rail.</string>
+    <string name="workspace_settings_rail_button_leading">Start</string>
+    <string name="workspace_settings_rail_button_leading_desc">Left of the tabs in portrait, above them in landscape.</string>
+    <string name="workspace_settings_rail_button_trailing">End</string>
+    <string name="workspace_settings_rail_button_trailing_desc">Right of the tabs in portrait, below them in landscape. Within thumb reach for one-handed use.</string>
 
     <!-- Session -->
     <string name="workspace_settings_session_title">Session</string>

--- a/app-workspace/src/main/res/values/strings.xml
+++ b/app-workspace/src/main/res/values/strings.xml
@@ -393,9 +393,9 @@
     <string name="workspace_settings_rail_button_title">Butler button</string>
     <string name="workspace_settings_rail_button_desc">Choose where the Butler button sits on the tab rail.</string>
     <string name="workspace_settings_rail_button_leading">Start</string>
-    <string name="workspace_settings_rail_button_leading_desc">Left of the tabs in portrait, above them in landscape.</string>
+    <string name="workspace_settings_rail_button_leading_desc">Before the tabs in portrait, above them in landscape.</string>
     <string name="workspace_settings_rail_button_trailing">End</string>
-    <string name="workspace_settings_rail_button_trailing_desc">Right of the tabs in portrait, below them in landscape. Within thumb reach for one-handed use.</string>
+    <string name="workspace_settings_rail_button_trailing_desc">After the tabs in portrait, below them in landscape. Within thumb reach for one-handed use.</string>
 
     <!-- Session -->
     <string name="workspace_settings_session_title">Session</string>

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
@@ -1,14 +1,22 @@
 package eu.darken.butler.workspace.ui.settings
 
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -26,8 +34,12 @@ import testhelpers.ComposeTest
 class WorkspaceSettingsLayoutTest : ComposeTest() {
 
     private val portraitModes = mutableListOf<WorkspacePanelMode>()
+    private var railButtonToggles = 0
 
-    private fun setScreen(portraitMode: WorkspacePanelMode) {
+    private fun setScreen(
+        portraitMode: WorkspacePanelMode,
+        railButtonPlacement: RailButtonPlacement = RailButtonPlacement.LEADING,
+    ) {
         composeTestRule.setContent {
             PreviewWrapper {
                 WorkspaceSettingsScreen(
@@ -38,6 +50,7 @@ class WorkspaceSettingsLayoutTest : ComposeTest() {
                         layoutModePortrait = portraitMode,
                         layoutModeLandscape = WorkspacePanelMode.SINGLE,
                         paneClickToFocus = true,
+                        railButtonPlacement = railButtonPlacement,
                         sessionRestoreEnabled = true,
                     ),
                     onNavigateUp = {},
@@ -48,6 +61,7 @@ class WorkspaceSettingsLayoutTest : ComposeTest() {
                     onSetLayoutModePortrait = { portraitModes += it },
                     onSetLayoutModeLandscape = {},
                     onTogglePaneClickToFocus = {},
+                    onToggleRailButtonPlacement = { railButtonToggles++ },
                     onToggleSessionRestore = {},
                     onToggleAutoPause = {},
                     onSetAutoPauseIdleTimeout = {},
@@ -110,5 +124,38 @@ class WorkspaceSettingsLayoutTest : ComposeTest() {
         setScreen(WorkspacePanelMode.SINGLE_RAIL)
 
         composeTestRule.onNodeWithText("Adaptive (Single with tab rail)").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the rail button switch follows the stored placement`() {
+        setScreen(WorkspacePanelMode.AUTO, RailButtonPlacement.TRAILING)
+
+        railButtonSwitch().assertIsOn()
+    }
+
+    @Test
+    fun `toggling the rail button switch reports the change`() {
+        setScreen(WorkspacePanelMode.AUTO)
+
+        railButtonSwitch().assertIsOff()
+        railButtonSwitch().performClick()
+
+        railButtonToggles shouldBe 1
+    }
+
+    /**
+     * The row sits below the fold of the settings list, so it is scrolled to before it is read.
+     *
+     * The switch is its own merge boundary, so the title lives on the merged row root and the
+     * ToggleableState only on the switch below it. Several rows on this screen are switches, so
+     * the switch is identified through its row rather than by [isToggleable] alone.
+     */
+    private fun railButtonSwitch(): SemanticsNodeInteraction {
+        composeTestRule.onNode(hasScrollAction()).performScrollToNode(hasText(RAIL_BUTTON_TITLE))
+        return composeTestRule.onNode(isToggleable() and hasAnyAncestor(hasText(RAIL_BUTTON_TITLE)))
+    }
+
+    companion object {
+        private const val RAIL_BUTTON_TITLE = "Butler button at the end of the tab rail"
     }
 }

--- a/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
+++ b/app-workspace/src/test/java/eu/darken/butler/workspace/ui/settings/WorkspaceSettingsLayoutTest.kt
@@ -4,14 +4,11 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsOff
-import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelectable
-import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
@@ -34,7 +31,7 @@ import testhelpers.ComposeTest
 class WorkspaceSettingsLayoutTest : ComposeTest() {
 
     private val portraitModes = mutableListOf<WorkspacePanelMode>()
-    private var railButtonToggles = 0
+    private val railButtonPlacements = mutableListOf<RailButtonPlacement>()
 
     private fun setScreen(
         portraitMode: WorkspacePanelMode,
@@ -61,7 +58,7 @@ class WorkspaceSettingsLayoutTest : ComposeTest() {
                     onSetLayoutModePortrait = { portraitModes += it },
                     onSetLayoutModeLandscape = {},
                     onTogglePaneClickToFocus = {},
-                    onToggleRailButtonPlacement = { railButtonToggles++ },
+                    onSetRailButtonPlacement = { railButtonPlacements += it },
                     onToggleSessionRestore = {},
                     onToggleAutoPause = {},
                     onSetAutoPauseIdleTimeout = {},
@@ -127,35 +124,29 @@ class WorkspaceSettingsLayoutTest : ComposeTest() {
     }
 
     @Test
-    fun `the rail button switch follows the stored placement`() {
+    fun `the rail button row names the stored placement`() {
         setScreen(WorkspacePanelMode.AUTO, RailButtonPlacement.TRAILING)
 
-        railButtonSwitch().assertIsOn()
+        railButtonRow().assertTextContains("End")
     }
 
     @Test
-    fun `toggling the rail button switch reports the change`() {
-        setScreen(WorkspacePanelMode.AUTO)
+    fun `picking a rail button placement reports it`() {
+        setScreen(WorkspacePanelMode.AUTO, RailButtonPlacement.TRAILING)
 
-        railButtonSwitch().assertIsOff()
-        railButtonSwitch().performClick()
+        railButtonRow().performClick()
+        composeTestRule.onNode(isSelectable() and hasText("Start")).performClick()
 
-        railButtonToggles shouldBe 1
+        railButtonPlacements shouldBe listOf(RailButtonPlacement.LEADING)
     }
 
-    /**
-     * The row sits below the fold of the settings list, so it is scrolled to before it is read.
-     *
-     * The switch is its own merge boundary, so the title lives on the merged row root and the
-     * ToggleableState only on the switch below it. Several rows on this screen are switches, so
-     * the switch is identified through its row rather than by [isToggleable] alone.
-     */
-    private fun railButtonSwitch(): SemanticsNodeInteraction {
+    /** The row sits below the fold of the settings list, so it is scrolled to before it is read. */
+    private fun railButtonRow(): SemanticsNodeInteraction {
         composeTestRule.onNode(hasScrollAction()).performScrollToNode(hasText(RAIL_BUTTON_TITLE))
-        return composeTestRule.onNode(isToggleable() and hasAnyAncestor(hasText(RAIL_BUTTON_TITLE)))
+        return composeTestRule.onNodeWithText(RAIL_BUTTON_TITLE)
     }
 
     companion object {
-        private const val RAIL_BUTTON_TITLE = "Butler button at the end of the tab rail"
+        private const val RAIL_BUTTON_TITLE = "Butler button"
     }
 }

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesScreen.kt
@@ -320,6 +320,7 @@ fun rememberWorkspaceDesign(state: WorkspacesViewModel.State): WorkspaceDesign {
         } else {
             WorkspaceDesign.RailPlacement.BOTTOM
         },
+        railButtonPlacement = state.railButtonPlacement,
         hasNavigationRail = effectivePaneLayout != WorkspaceDesign.Layout.SINGLE ||
             effectivePanelMode == WorkspacePanelMode.SINGLE_RAIL ||
             effectivePanelMode == WorkspacePanelMode.ADAPTIVE,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModel.kt
@@ -48,6 +48,7 @@ import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.layout.WorkspacePanelMode
 import eu.darken.butler.workspace.core.session.SessionRestorationException
 import eu.darken.butler.workspace.ui.WorkspacePageManager
@@ -390,6 +391,7 @@ class WorkspacesViewModel @Inject constructor(
         workspaceSettings.swipeGesturesEnabled.flow,
         workspaceSettings.onDemandWorkspaceCreation.flow,
         workspaceSettings.paneClickToFocus.flow,
+        workspaceSettings.railButtonPlacement.flow,
         workspacePageManager.state,
         visibleMotd,
         sessionManager.state,
@@ -398,7 +400,7 @@ class WorkspacesViewModel @Inject constructor(
         guidedTourController.session,
         workspaceSettings.defaultNewTabType.flow,
         workspaceTemplates.availableTemplates(),
-    ) { repoState, upgradeInfo, swipeGesturesEnabled, onDemandWorkspaceCreation, paneClickToFocus, uiState, motd, restorationState, dialogs, review, tourSession, defaultNewTabType, templates ->
+    ) { repoState, upgradeInfo, swipeGesturesEnabled, onDemandWorkspaceCreation, paneClickToFocus, railButtonPlacement, uiState, motd, restorationState, dialogs, review, tourSession, defaultNewTabType, templates ->
         val base = State(
             state = repoState,
             focusedWorkspace = uiState.focusedWorkspaceId,
@@ -408,6 +410,7 @@ class WorkspacesViewModel @Inject constructor(
             swipeGesturesEnabled = swipeGesturesEnabled,
             onDemandWorkspaceCreation = swipeGesturesEnabled && onDemandWorkspaceCreation,
             paneClickToFocus = paneClickToFocus,
+            railButtonPlacement = railButtonPlacement,
             motd = motd,
             currentPaneCount = uiState.currentPaneCount,
             isRestoring = restorationState == WorkspaceSessionManager.State.Restoring,
@@ -745,6 +748,7 @@ class WorkspacesViewModel @Inject constructor(
         val swipeGesturesEnabled: Boolean = true,
         val onDemandWorkspaceCreation: Boolean = true,
         val paneClickToFocus: Boolean = true,
+        val railButtonPlacement: RailButtonPlacement = RailButtonPlacement.LEADING,
         val motd: MotdState? = null,
         val currentPaneCount: Int = 1,
         val isRestoring: Boolean = false,

--- a/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
+++ b/app/src/main/java/eu/darken/butler/workspace/ui/workspaces/adaptive/WorkspaceNavigationRail.kt
@@ -89,6 +89,7 @@ import eu.darken.butler.common.compose.tour.guidedTourTarget
 import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceAction
 import eu.darken.butler.workspace.core.icon
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.ui.common.CutoutTopRightCornerShape
 import eu.darken.butler.workspace.ui.manager.PaneLayoutGlyph
 import eu.darken.butler.workspace.ui.manager.WorkspaceButton
@@ -374,34 +375,55 @@ fun WorkspaceNavigationRail(
     ) { listModifier ->
         // Unconditional: the rail exists once per screen and is that screen's Butler button;
         // pages composed beside it supply none of their own.
-        WorkspaceButton(
-            modifier = when (placement) {
-                RailPlacement.START -> Modifier.padding(vertical = RailSectionPadding)
-                RailPlacement.BOTTOM -> Modifier.padding(horizontal = RailSectionPadding)
-            }.guidedTourTarget(WorkspaceTourTargets.BUTLER_BUTTON),
-            currentWorkspaceId = focusedId,
-            showLayoutEntry = true,
-        )
-
-        RailSectionDivider(placement = placement)
-
-        when (placement) {
-            RailPlacement.START -> LazyColumn(
-                modifier = listModifier
-                    .padding(vertical = RailSectionPadding)
-                    .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
-                state = lazyListState,
-                verticalArrangement = Arrangement.spacedBy(RailItemSpacing),
-                content = railItems,
+        val butler: @Composable () -> Unit = {
+            WorkspaceButton(
+                modifier = when (placement) {
+                    RailPlacement.START -> Modifier.padding(vertical = RailSectionPadding)
+                    RailPlacement.BOTTOM -> Modifier.padding(horizontal = RailSectionPadding)
+                }.guidedTourTarget(WorkspaceTourTargets.BUTLER_BUTTON),
+                currentWorkspaceId = focusedId,
+                showLayoutEntry = true,
             )
-            RailPlacement.BOTTOM -> LazyRow(
-                modifier = listModifier
-                    .padding(horizontal = RailSectionPadding)
-                    .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
-                state = lazyListState,
-                horizontalArrangement = Arrangement.spacedBy(RailItemSpacing),
-                content = railItems,
-            )
+        }
+
+        val divider: @Composable () -> Unit = {
+            RailSectionDivider(placement = placement)
+        }
+
+        // The only weighted child, so it takes the leftover space either way and pushes the button
+        // against whichever end of the rail it is not emitted from.
+        val list: @Composable () -> Unit = {
+            when (placement) {
+                RailPlacement.START -> LazyColumn(
+                    modifier = listModifier
+                        .padding(vertical = RailSectionPadding)
+                        .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
+                    state = lazyListState,
+                    verticalArrangement = Arrangement.spacedBy(RailItemSpacing),
+                    content = railItems,
+                )
+                RailPlacement.BOTTOM -> LazyRow(
+                    modifier = listModifier
+                        .padding(horizontal = RailSectionPadding)
+                        .testTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG),
+                    state = lazyListState,
+                    horizontalArrangement = Arrangement.spacedBy(RailItemSpacing),
+                    content = railItems,
+                )
+            }
+        }
+
+        when (design.railButtonPlacement) {
+            RailButtonPlacement.LEADING -> {
+                butler()
+                divider()
+                list()
+            }
+            RailButtonPlacement.TRAILING -> {
+                list()
+                divider()
+                butler()
+            }
         }
     }
 }
@@ -1094,8 +1116,20 @@ private fun WorkspaceNavigationRailPreview() = WorkspaceNavigationRailStates(Rai
 @Composable
 private fun WorkspaceNavigationRailBottomPreview() = WorkspaceNavigationRailStates(RailPlacement.BOTTOM)
 
+/** The one-handed position: the button in the corner the thumb reaches. */
+@Preview2
+@ComposePreviewWrapper(ButlerPreviewWrapper::class)
 @Composable
-private fun WorkspaceNavigationRailStates(placement: RailPlacement) {
+private fun WorkspaceNavigationRailBottomTrailingPreview() = WorkspaceNavigationRailStates(
+    placement = RailPlacement.BOTTOM,
+    buttonPlacement = RailButtonPlacement.TRAILING,
+)
+
+@Composable
+private fun WorkspaceNavigationRailStates(
+    placement: RailPlacement,
+    buttonPlacement: RailButtonPlacement = RailButtonPlacement.LEADING,
+) {
     val tabs = listOf(
         Workspace.Info(
             id = Workspace.Id(),
@@ -1122,6 +1156,7 @@ private fun WorkspaceNavigationRailStates(placement: RailPlacement) {
         design = WorkspaceDesign(
             layout = WorkspaceDesign.Layout.TRIPLE_MAIN_LEFT,
             railPlacement = placement,
+            railButtonPlacement = buttonPlacement,
         ),
         onTabAction = {},
         onPaneAssignment = { _, _ -> },

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailButtonPlacementTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailButtonPlacementTest.kt
@@ -88,6 +88,9 @@ class WorkspaceRailButtonPlacementTest : ComposeTest() {
             workspaces = emptyList(),
         )
 
+        withClue("The button should follow the tab list") {
+            (button().left >= list().right) shouldBe true
+        }
         assertAtEdge(content().right - button().right)
     }
 

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailButtonPlacementTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspaceRailButtonPlacementTest.kt
@@ -1,0 +1,161 @@
+package eu.darken.butler.workspace.ui.workspaces
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import eu.darken.butler.common.ca.toCaString
+import eu.darken.butler.common.compose.PreviewWrapper
+import eu.darken.butler.workspace.core.Workspace
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
+import eu.darken.butler.workspace.ui.manager.WorkspaceButtonDefaults
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign
+import eu.darken.butler.workspace.ui.manager.WorkspaceDesign.RailPlacement
+import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceNavigationRail
+import eu.darken.butler.workspace.ui.workspaces.adaptive.WorkspaceNavigationRailDefaults
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.ComposeTest
+import kotlin.math.abs
+
+/**
+ * Which end of the rail the Butler button takes. The tab list is the rail's only weighted child, so
+ * both the order the two are emitted in and the button's own distance to the rail's far edge are
+ * asserted: a button that merely follows a list too short to fill the rail would pass the order
+ * check while sitting in the middle of the rail, which is not the corner the setting promises.
+ */
+@Config(qualifiers = "w411dp-h891dp")
+class WorkspaceRailButtonPlacementTest : ComposeTest() {
+
+    @Test
+    fun `a leading button sits at the start of a bottom rail`() {
+        setRail(placement = RailPlacement.BOTTOM, buttonPlacement = RailButtonPlacement.LEADING)
+
+        withClue("The button should precede the tab list") {
+            (button().right <= list().left) shouldBe true
+        }
+        assertAtEdge(button().left - content().left)
+    }
+
+    @Test
+    fun `a trailing button sits at the end of a bottom rail`() {
+        setRail(placement = RailPlacement.BOTTOM, buttonPlacement = RailButtonPlacement.TRAILING)
+
+        withClue("The button should follow the tab list") {
+            (button().left >= list().right) shouldBe true
+        }
+        assertAtEdge(content().right - button().right)
+    }
+
+    @Test
+    fun `a trailing button follows the layout direction`() {
+        setRail(
+            placement = RailPlacement.BOTTOM,
+            buttonPlacement = RailButtonPlacement.TRAILING,
+            layoutDirection = LayoutDirection.Rtl,
+        )
+
+        withClue("The end of the rail is its left side in a right to left layout") {
+            (button().right <= list().left) shouldBe true
+        }
+        assertAtEdge(button().left - content().left)
+    }
+
+    @Test
+    fun `a trailing button sits at the bottom of a start rail`() {
+        setRail(placement = RailPlacement.START, buttonPlacement = RailButtonPlacement.TRAILING)
+
+        withClue("The button should follow the tab list") {
+            (button().top >= list().bottom) shouldBe true
+        }
+        assertAtEdge(content().bottom - button().bottom)
+    }
+
+    @Test
+    fun `a trailing button reaches the far edge without any tabs`() {
+        setRail(
+            placement = RailPlacement.BOTTOM,
+            buttonPlacement = RailButtonPlacement.TRAILING,
+            workspaces = emptyList(),
+        )
+
+        assertAtEdge(content().right - button().right)
+    }
+
+    private fun button() = composeTestRule
+        .onNodeWithTag(WorkspaceButtonDefaults.TEST_TAG)
+        .getUnclippedBoundsInRoot()
+
+    private fun list() = composeTestRule
+        .onNodeWithTag(WorkspaceNavigationRailDefaults.LIST_TEST_TAG)
+        .getUnclippedBoundsInRoot()
+
+    private fun content() = composeTestRule
+        .onNodeWithTag(WorkspaceNavigationRailDefaults.CONTENT_TEST_TAG)
+        .getUnclippedBoundsInRoot()
+
+    private fun assertAtEdge(gap: Dp) = withClue("The button is $gap from the rail's far edge") {
+        (abs(gap.value) <= EDGE_TOLERANCE.value) shouldBe true
+    }
+
+    private fun setRail(
+        placement: RailPlacement,
+        buttonPlacement: RailButtonPlacement,
+        layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+        workspaces: List<Workspace.Info> = tabs,
+    ) {
+        // The mascot on the Butler button animates on an endless loop, which never lets the clock idle.
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        WorkspaceNavigationRail(
+                            modifier = Modifier.align(
+                                when (placement) {
+                                    RailPlacement.START -> Alignment.CenterStart
+                                    RailPlacement.BOTTOM -> Alignment.BottomCenter
+                                },
+                            ),
+                            workspaces = workspaces,
+                            selected = emptyMap(),
+                            focusedId = workspaces.firstOrNull()?.id,
+                            design = WorkspaceDesign(
+                                layout = WorkspaceDesign.Layout.DUAL_HORIZONTAL,
+                                railPlacement = placement,
+                                railButtonPlacement = buttonPlacement,
+                            ),
+                            onTabAction = {},
+                            onPaneAssignment = { _, _ -> },
+                            onPaneUnassign = {},
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private val tabs = (0 until 3).map {
+        Workspace.Info(
+            id = Workspace.Id(),
+            type = Workspace.Type.EXPLORER,
+            title = "Explorer $it".toCaString(),
+            lifecycleState = Workspace.LifecycleState.Ready,
+        )
+    }
+
+    companion object {
+        /** What the rail's own section padding and content inset leave between button and edge. */
+        private val EDGE_TOLERANCE = 16.dp
+    }
+}

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelDialogTest.kt
@@ -18,6 +18,7 @@ import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
 import eu.darken.butler.workspace.core.WorkspaceStacks
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import eu.darken.butler.workspace.ui.WorkspacePageManager
 import eu.darken.butler.workspace.ui.WorkspaceVisibilityTracker
@@ -80,8 +81,8 @@ class WorkspacesViewModelDialogTest : BaseTest() {
         Dispatchers.resetMain()
     }
 
-    private fun boolSetting(value: Boolean): DataStoreValue<Boolean> =
-        mockk<DataStoreValue<Boolean>>(relaxed = true).apply {
+    private fun <T> setting(value: T): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>(relaxed = true).apply {
             every { flow } returns flowOf(value)
         }
 
@@ -99,9 +100,10 @@ class WorkspacesViewModelDialogTest : BaseTest() {
         every { workspaceRepo.peekStacks() } answers { WorkspaceStacks(infos) }
 
         val workspaceSettings = mockk<WorkspaceSettings>(relaxed = true).apply {
-            every { swipeGesturesEnabled } returns boolSetting(true)
-            every { onDemandWorkspaceCreation } returns boolSetting(true)
-            every { paneClickToFocus } returns boolSetting(true)
+            every { swipeGesturesEnabled } returns setting(true)
+            every { onDemandWorkspaceCreation } returns setting(true)
+            every { paneClickToFocus } returns setting(true)
+            every { railButtonPlacement } returns setting(RailButtonPlacement.LEADING)
         }
         every { pageManager.state } returns pageManagerState
         val sessionManager = mockk<WorkspaceSessionManager>(relaxed = true).apply {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelErrorIncidentTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelErrorIncidentTest.kt
@@ -17,6 +17,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.session.SessionRestorationException
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import eu.darken.butler.workspace.ui.WorkspacePageManager
@@ -74,8 +75,8 @@ class WorkspacesViewModelErrorIncidentTest : BaseTest() {
         Dispatchers.resetMain()
     }
 
-    private fun boolSetting(value: Boolean): DataStoreValue<Boolean> =
-        mockk<DataStoreValue<Boolean>>(relaxed = true).apply {
+    private fun <T> setting(value: T): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>(relaxed = true).apply {
             every { flow } returns flowOf(value)
         }
 
@@ -85,9 +86,10 @@ class WorkspacesViewModelErrorIncidentTest : BaseTest() {
         every { workspaceRepo.pendingConfirmations } returns flowOf(emptyMap())
 
         val workspaceSettings = mockk<WorkspaceSettings>(relaxed = true).apply {
-            every { swipeGesturesEnabled } returns boolSetting(true)
-            every { onDemandWorkspaceCreation } returns boolSetting(true)
-            every { paneClickToFocus } returns boolSetting(true)
+            every { swipeGesturesEnabled } returns setting(true)
+            every { onDemandWorkspaceCreation } returns setting(true)
+            every { paneClickToFocus } returns setting(true)
+            every { railButtonPlacement } returns setting(RailButtonPlacement.LEADING)
         }
         every { pageManager.state } returns MutableStateFlow(WorkspacePageManager.State())
         val sessionManager = mockk<WorkspaceSessionManager>(relaxed = true).apply {

--- a/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/butler/workspace/ui/workspaces/WorkspacesViewModelReviewCardTest.kt
@@ -24,6 +24,7 @@ import eu.darken.butler.workspace.core.Workspace
 import eu.darken.butler.workspace.core.WorkspaceRemote
 import eu.darken.butler.workspace.core.WorkspaceRepo
 import eu.darken.butler.workspace.core.WorkspaceSettings
+import eu.darken.butler.workspace.core.layout.RailButtonPlacement
 import eu.darken.butler.workspace.core.undo.ClosedWorkspaceStash
 import eu.darken.butler.workspace.ui.WorkspacePageManager
 import eu.darken.butler.workspace.ui.WorkspaceVisibilityTracker
@@ -82,13 +83,8 @@ class WorkspacesViewModelReviewCardTest : BaseTest() {
         Dispatchers.resetMain()
     }
 
-    private fun boolSetting(value: Boolean): DataStoreValue<Boolean> =
-        mockk<DataStoreValue<Boolean>>(relaxed = true).apply {
-            every { flow } returns flowOf(value)
-        }
-
-    private fun typeSetting(value: Workspace.Type): DataStoreValue<Workspace.Type> =
-        mockk<DataStoreValue<Workspace.Type>>(relaxed = true).apply {
+    private fun <T> setting(value: T): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>(relaxed = true).apply {
             every { flow } returns flowOf(value)
         }
 
@@ -142,10 +138,11 @@ class WorkspacesViewModelReviewCardTest : BaseTest() {
             every { pendingConfirmations } returns flowOf(confirmations)
         }
         val workspaceSettings = mockk<WorkspaceSettings>(relaxed = true).apply {
-            every { swipeGesturesEnabled } returns boolSetting(true)
-            every { onDemandWorkspaceCreation } returns boolSetting(true)
-            every { paneClickToFocus } returns boolSetting(true)
-            every { defaultNewTabType } returns typeSetting(Workspace.Type.TEMPLATES)
+            every { swipeGesturesEnabled } returns setting(true)
+            every { onDemandWorkspaceCreation } returns setting(true)
+            every { paneClickToFocus } returns setting(true)
+            every { defaultNewTabType } returns setting(Workspace.Type.TEMPLATES)
+            every { railButtonPlacement } returns setting(RailButtonPlacement.LEADING)
         }
         val pageManager = mockk<WorkspacePageManager>(relaxed = true).apply {
             every { state } returns MutableStateFlow(


### PR DESCRIPTION
## What changed

The Butler button can now sit at the far end of the tab rail instead of its start. On a phone in
portrait that puts it in the bottom-right corner, within thumb reach, instead of the bottom-left.

Tabs settings gains a **Butler button** row under Layout, alongside the portrait and landscape
layout-mode pickers. It opens a dialog with two options, each showing a small diagram of where the
button lands:

- **Start** — before the tabs in portrait, above them in landscape.
- **End** — after the tabs in portrait, below them in landscape. Within thumb reach for one-handed use.

The default is Start, so nothing moves unless you ask for it.

The setting follows the rail rather than the screen, so it works in both rail orientations and
mirrors correctly under a right-to-left layout. It only has an effect while a tab rail is shown,
which means the Adaptive and "Single with tab rail" layouts — the classic single-pane layout has no
rail and keeps its button in the toolbar.

Requested by a beta tester who asked for the Butler icon in the bottom-right for one-handed use.

## Technical Context

- The rail's tab list is its only weighted child, so placement is expressed purely as emission
  order: `button, divider, list` or `list, divider, button`. The weighted list takes the leftover
  space either way and pushes the unweighted button against the opposite end. One code path covers
  both `RailPlacement` values and both layout directions with no alignment logic of its own.
- `RailButtonPlacement` is an enum rather than a boolean so `WorkspaceDesign` reads as a position
  and a third placement would not need a preference migration.
- The setting is plumbed through `WorkspacesViewModel.State`, not `WorkspaceRemote.State`. It is
  consumed only inside `:app`'s workspace UI, so it follows `paneClickToFocus` rather than the
  cross-module path `layoutModePortrait` uses.
- Adding a source to the `WorkspacesViewModel` combine is a trap worth knowing about: the three
  ViewModel test classes build it from a relaxed `mockk<WorkspaceSettings>` that stubs only the
  settings the combine reads. An unstubbed one yields a flow that completes without emitting, and
  `combine` then never runs its transform, so `state` silently never emits and every test in those
  classes burns its 10s timeout instead of failing fast. Their builders are updated here.
- The option descriptions deliberately say "before/after the tabs" rather than left/right. The
  placement is direction-relative, so a physical direction would be false under RTL while the
  auto-mirrored glyph beside it stayed correct.
- Worth a close look: `WorkspaceRailButtonPlacementTest` asserts both the button's order against the
  tab list and its distance to the rail's far edge. The order check alone would pass for a button
  stranded mid-rail behind a short list, and the edge check alone would pass for a button that
  happens to sit near an edge in the wrong order — the empty-tab-list case needs both.
